### PR TITLE
Use token to replace the given apostroph

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -22254,7 +22254,7 @@ though, and has since been slightly modified)-->
         <token regexp="yes">[aà]</token>
         <token>dire</token>
       </pattern>
-      <message>« C’est à dire » est une faute de typographie. Employez <suggestion>c’est-à-dire</suggestion>.</message>
+      <message>« C’est à dire » est une faute de typographie. Employez <suggestion>c\2est-à-dire</suggestion>.</message>
       <example type="incorrect"><marker>C’est à dire</marker></example>
       <example type="correct"><marker>C’est-à-dire</marker></example>
     </rule>


### PR DESCRIPTION
And not a fixed apostroph that can be problematic in Vim, TexStudio...
knowing that french keybord gives simple quote as apostroph in raw
editors...
