### PR TITLE
[de] Add rule Priese -> Prise

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -3451,6 +3451,18 @@ $Id$
             <example type="correct">Der Sauerstoff ist <marker>zur Neige</marker> gegangen.</example>
             <example type="incorrect" correction="zur Neige">Der Sauerstoff ist <marker>zu Neige</marker> gegangen.</example>
         </rule>
+        <rule id="PRIESE" name="Möglicher Tippfehler: 'Priese (Prise) Salz'">
+            <pattern>
+                <token postag="ART:.*" postag_regexp="yes"/>
+                <marker>
+                    <token>Priese</token>
+                </marker>
+                <token postag_regexp="yes" postag="SUB:.*"/>
+            </pattern>
+            <message>Meinten Sie eine <suggestion>Prise</suggestion>?</message>
+            <example type="incorrect">Eine <marker>Priese</marker> Salz.</example>
+            <example type="correct">Eine Prise Salz.</example>
+        </rule>
     </category>
 
     <!-- ====================================================================== -->


### PR DESCRIPTION
Writing "Priese" instead of "Prise" (both pronounced the same way) was a
common mistake in the german "Rezepte-Wiki".
