### PR TITLE
Added a typo check for save/safe to ignore

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -6471,6 +6471,16 @@ USA
             <example type="correct">He buys a car from time to time.</example>
             <example type="incorrect" correction="from time to time">He buys a car <marker>for time to time</marker>.</example>
         </rule>
+        <rule id="CONFUSION_OF_SAVE_SAFE_TO_IGNORE" name="confusion of save/safe to ignore">
+            <pattern>
+                <token>save</token>
+                <token>to</token>
+                <token>ignore</token>
+            </pattern>
+            <message>Did you mean <suggestion>safe to ignore</suggestion>?</message>
+            <example type="incorrect">It is <marker>save to ignore</marker> trivial code when writing unit tests.</example>
+            <example type="correct">It is safe to ignore trivial code when writing unit tests.</example>
+        </rule>
     </category>
     <!-- ====================================================================== -->
     <!-- Grammar -->


### PR DESCRIPTION
Created using http://languagetool.org/ruleeditor and tested with standalone version 2.5.0 as instructed by http://wiki.languagetool.org/development-overview#toc0 It was a little hard to find the grammar.xml here. Maybe also add the location to the wiki documentation.
