### PR TITLE
Warn about a missing comma after "By default"

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -11243,6 +11243,20 @@ USA
             <example type="correct">The store closed its doors for good in October 1958.</example>
             <example type="incorrect" correction="October 1958">The store closed its doors for good in <marker>October, 1958</marker>.</example>
         </rule>
+        <rule id="BY_DEFAULT_COMMA" name="Comma after by default at the beginning of a sentence.">
+            <pattern case_sensitive="yes">
+                <marker>
+                    <token postag="SENT_START"/>
+                    <token>By</token>
+                    <token>default</token>
+                </marker>
+                <token negate="yes">,</token>
+            </pattern>
+            <message>Did you mean: <suggestion>By default,</suggestion>?</message>
+            <short>Punctuation error</short>
+            <example type="incorrect"><marker>By default</marker> this setting is enabled.</example>
+            <example type="correct">By default, this setting is enabled.</example>
+        </rule>
     </category>
     <category name="Commonly Confused Words" type="misspelling">
         <rule id="WITCH_IS_WRONG" name="witch (which) is wrong">


### PR DESCRIPTION
~~**NOTE:** This rule _does not yet work_ and I don't understand why. The error can't even be detected in the incorrect example sentence. I hope that you can help me during code review here.~~ My plan is to add followup rules for missing commas after linking adverbs once I get how this works.
