### PR TITLE
Added checks for missing comma after linking adverb on a new sentence

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -11257,6 +11257,22 @@ USA
             <example type="incorrect"><marker>By default</marker> this setting is enabled.</example>
             <example type="correct">By default, this setting is enabled.</example>
         </rule>
+        <rule id="SENT_START_CONJUNCTIVE_LINKING_ADVERB_COMMA" name="Commas after conjunctive/linking adverbs in front of a new sentence.">
+            <pattern>
+                <marker>
+                    <!-- TODO: also cover the case where a new sub-clause is connected by ";|, $adverb," and detect missing punctuation -->
+                    <token postag="SENT_START"/>
+                    <!-- now, next, then and yet are not solely linking adverbs and result in too many false positives -->
+                    <token regexp="yes">accordingly|additionally|also|besides|comparatively|consequently|conversely|elsewhere|equally|finally|further|furthermore|hence|henceforth|however|in addition|in comparision|in contrast|indeed|instead|likewise|meanwhile|moreover|namely|nevertheless|nonetheless|otherwise|rather|similiarly|still|subsequently|thereafter|therefore|thus</token>
+                </marker>
+                <token negate="yes">,</token>
+            </pattern>
+            <message>Did you forgot a <suggestion>,</suggestion> after a conjunctive/linking adverb?</message>
+            <url>https://writing.wisc.edu/Handbook/ConjAdv.html</url>
+            <short>Punctuation error</short>
+            <example type="incorrect"><marker>Nonetheless</marker> you should set commas to enhance readability.</example>
+            <example type="correct">Nonetheless, you should set commas to enhance readability.</example>
+        </rule>
     </category>
     <category name="Commonly Confused Words" type="misspelling">
         <rule id="WITCH_IS_WRONG" name="witch (which) is wrong">


### PR DESCRIPTION
There are more sources to get help, but it seems only 1 url tag is allowed.
- http://www.grammarerrors.com/punctuation/commas-with-conjunctive-adverbs-however-furthermore-etc/
- http://www.bbc.co.uk/worldservice/learningenglish/grammar/learnit/learnitv288.shtml

I also added the bigger list of http://grammar.yourdictionary.com/parts-of-speech/adverbs/list-of-conjunctive-adverbs.html but removed the ones which triggered positives with http://tatoeba.org/

Tested against a self-compiled 2.6.0-Snapshot with the standalone GUI.
