### PR TITLE
Removed X_IN_X redundancy

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -12802,7 +12802,7 @@ USA
             <example correction="best" type="incorrect">Top ten <marker>best ever</marker> beer names.</example>
             <example type="correct">Top ten best beer names.</example>
         </rule>
-        <rule id="BIG_IN_SIZE" name="Big in size, etc">
+        <rule id="ADJECTIVE_IN_ATTRIBUTE" name="Big in size, yellow in color, etc.">
          <pattern>
                  <token postag_regexp="yes" postag="JJ|JJR|JJS"><exception regexp="yes">similar|alone|religious|corresponding|equal|next|possible|autocratic|necessary|beautiful|rich|back|identical|more|much|second|comparable</exception><exception postag="VBN"/></token>
                   <token>in</token>
@@ -13505,17 +13505,6 @@ USA
                 <example type="correct">I enjoy exaggerating.</example>
             </rule>
         </rulegroup>
-        <rule id="X_IN_COLOR" name="black in color (black)">
-            <pattern>
-                <token regexp="yes">green|blue|red|yellow|grey|gray|orange|white|black|purple|teal|beige|tan|violet|pink</token>
-                <token>in</token>
-                <token>color</token>
-            </pattern>
-            <message>Use simply <suggestion>\1</suggestion>.</message>
-            <short>Redundant phrase</short>
-            <example correction="pink" type="incorrect">My shirt is <marker>pink in color</marker>.</example>
-            <example type="correct">My shirt is pink.</example>
-        </rule>
         <rule id="ORIGINALLY_BORN_IN" name="originally born in (born in)">
             <pattern>
                 <token>originally</token>


### PR DESCRIPTION
I played with the Wikipedia checker and figured that
- http://community.languagetool.org/rule/show/BIG_IN_SIZE?lang=en&subId=1
  and
- http://community.languagetool.org/rule/show/X_IN_COLOR?lang=en&subId=1
  are in fact redundant:

![image](https://cloud.githubusercontent.com/assets/756669/2815074/aff81ffc-ceb4-11e3-882e-aff5e7c0a43c.png)

so I removed the limited X_IN_COLOR and renamed BIG_IN_SIZE which is in fact more generic to ADJECTIVE_IN_ATTRIBUTE.
