### PR TITLE
Don't suggest a comma between "rather than"

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -11263,6 +11263,10 @@ USA
                 <token>of</token>
             </antipattern>
             <antipattern>
+                <marker><token>rather</token></marker>
+                <token>than</token>
+            </antipattern>
+            <antipattern>
                 <marker><token chunk="B-PP">besides</token></marker>
             </antipattern>
             <antipattern>


### PR DESCRIPTION
Fixes https://languagetool.org/regression-tests/20140427/result_en_20140427.html

```
+Line 1, column 1, Rule ID: SENT_START_CONJUNCTIVE_LINKING_ADVERB_COMMA[1]
+Message: Did you forgot a ',' after a conjunctive/linking adverb?
+Suggestion: ,
+Rather than focus on formal causes, as Aristotle did, Th...
+^^^^^^                                                  
+
+Title: Aristotle
```
