### PR TITLE
Fixed false positive General Public License (use simply General)

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -13453,6 +13453,11 @@ USA
                 <token>general</token>
                 <token regexp="yes">public|consensus</token>
             </pattern>
+            <antipattern>
+                <token>General</token>
+                <token>Public</token>
+                <token>License</token>
+            </antipattern>
             <message>Use simply <suggestion>\2</suggestion>.</message>
             <short>Redundant phrase</short>
             <example correction="public" type="incorrect">We should show this to the <marker>general public</marker>.</example>


### PR DESCRIPTION
This is a frequent false positive in software documentation, because the https://en.wikipedia.org/wiki/GNU_General_Public_License is very popular:

![image](https://cloud.githubusercontent.com/assets/756669/2821198/4818d22e-cf03-11e3-9535-d2c805284486.png)
