### PR TITLE
Initialize elementMatchers in the constructor

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleMatcher.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleMatcher.java
@@ -41,18 +41,20 @@ class PatternRuleMatcher extends AbstractPatternRulePerformer {
   private static final String MISTAKE = "<mistake/>";
 
   private final boolean useList;
+  private List<ElementMatcher> elementMatchers;
+  private int patternSize;
 
   PatternRuleMatcher(PatternRule rule, boolean useList) {
     super(rule, rule.getLanguage().getUnifier());
     this.useList = useList;
+    this.elementMatchers = createElementMatchers();
+    this.patternSize = elementMatchers.size();
   }
 
   final RuleMatch[] match(final AnalyzedSentence sentence) throws IOException {
-    final List<ElementMatcher> elementMatchers = createElementMatchers();
     final List<RuleMatch> ruleMatches = new ArrayList<>();
     final AnalyzedTokenReadings[] tokens = sentence.getTokensWithoutWhitespace();
     List<Integer> tokenPositions = new ArrayList<>(tokens.length + 1);
-    final int patternSize = elementMatchers.size();
     final int limit = Math.max(0, tokens.length - patternSize + 1);
     ElementMatcher elem = null;
     int i = 0;


### PR DESCRIPTION
Initializing them in the match function results in the List being
initialized anew on each analyzed sentence. By populating the list during
the PatternRuleMatcher construction, this inefficiency can be avoided.
