### PR TITLE
Clean up the Japanese language initialisation somewhat

### DIFF
--- a/languagetool-language-modules/ja/src/main/java/org/languagetool/language/Japanese.java
+++ b/languagetool-language-modules/ja/src/main/java/org/languagetool/language/Japanese.java
@@ -37,7 +37,14 @@ public class Japanese extends Language {
 
   private Tagger tagger;
   private SentenceTokenizer sentenceTokenizer;
+  private Tokenizer tokenizer;
   private String name = "Japanese";
+
+  public Japanese() {
+    this.tagger = new JapaneseTagger();
+    this.tokenizer = new JapaneseWordTokenizer();
+    this.sentenceTokenizer = new SRXSentenceTokenizer(this);
+  }
 
   @Override
   public String getShortName() {
@@ -74,22 +81,16 @@ public class Japanese extends Language {
 
   @Override
   public final Tagger getTagger() {
-    if (tagger == null) {
-      tagger = new JapaneseTagger();
-    }
     return tagger;
   }
 
   @Override
   public final Tokenizer getWordTokenizer() {
-    return new JapaneseWordTokenizer();
+    return tokenizer;
   }
 
   @Override
   public final SentenceTokenizer getSentenceTokenizer() {
-    if (sentenceTokenizer == null) {
-      sentenceTokenizer = new SRXSentenceTokenizer(this);
-    }
     return sentenceTokenizer;
   }
 

--- a/languagetool-language-modules/ja/src/main/java/org/languagetool/tagging/ja/JapaneseTagger.java
+++ b/languagetool-language-modules/ja/src/main/java/org/languagetool/tagging/ja/JapaneseTagger.java
@@ -30,14 +30,12 @@ public class JapaneseTagger implements Tagger {
 
   @Override
   public List<AnalyzedTokenReadings> tag(List<String> sentenceTokens) throws IOException {
-    final List<AnalyzedTokenReadings> tokenReadings = new ArrayList<>();
+    final List<AnalyzedTokenReadings> tokenReadings = new ArrayList<>(sentenceTokens.size());
     int pos = 0;
 
     for (String word : sentenceTokens) {
-      final List<AnalyzedToken> l = new ArrayList<>();
       AnalyzedToken at = asAnalyzedToken(word);
-      l.add(at);
-      tokenReadings.add(new AnalyzedTokenReadings(l, pos));
+      tokenReadings.add(new AnalyzedTokenReadings(at, pos));
       pos += at.getToken().length();
     }
 

--- a/languagetool-language-modules/ja/src/main/java/org/languagetool/tokenizers/ja/JapaneseWordTokenizer.java
+++ b/languagetool-language-modules/ja/src/main/java/org/languagetool/tokenizers/ja/JapaneseWordTokenizer.java
@@ -30,15 +30,12 @@ public class JapaneseWordTokenizer implements Tokenizer {
 
   private StringTagger stringtagger;
 
-  private void init(){
-    if(stringtagger == null){
-      stringtagger = SenFactory.getStringTagger(null);
-    }
+  public JapaneseWordTokenizer(){
+    stringtagger = SenFactory.getStringTagger(null);
   }
 
   @Override  
   public List<String> tokenize(String text){
-    init();
     final List<String> ret = new ArrayList<>();
     List<Token> tokens = new ArrayList<>();
     String basicForm;


### PR DESCRIPTION
Instead of init functions we use class constructors to set up the
necessary fields.

Additionally, we avoid using a single-element ArrayList in the tag
function to build new AnalyzedTokenReadings by simply passing the
AnalyzedToken directly to the constructor of AnalyzedTokenReadings.
