### PR TITLE
[fa] Persian double punctuation rule

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/DoublePunctuationRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/DoublePunctuationRule.java
@@ -47,6 +47,10 @@ public class DoublePunctuationRule extends Rule {
   public final String getDescription() {
     return messages.getString("desc_double_punct");
   }
+  
+  public String getCommaCharacter() {
+    return ",";
+  }
 
   @Override
   public final RuleMatch[] match(final AnalyzedSentence sentence) {
@@ -65,7 +69,7 @@ public class DoublePunctuationRule extends Rule {
         dotCount++;
         commaCount = 0;
         startPos = tokens[i].getStartPos();
-      } else if (",".equals(token)) {
+      } else if (getCommaCharacter().equals(token)) {
         commaCount++;
         dotCount = 0;
         startPos = tokens[i].getStartPos();
@@ -77,15 +81,15 @@ public class DoublePunctuationRule extends Rule {
         ruleMatch.setSuggestedReplacement(".");
         ruleMatches.add(ruleMatch);
         dotCount = 0;
-      } else if (commaCount == 2 && !",".equals(nextToken)) {
+      } else if (commaCount == 2 && !getCommaCharacter().equals(nextToken)) {
         final int fromPos = Math.max(0, startPos - 1);
         final RuleMatch ruleMatch = new RuleMatch(this, fromPos, startPos + 1,
             getCommaMessage(), messages.getString("double_commas_short"));
-        ruleMatch.setSuggestedReplacement(",");
+        ruleMatch.setSuggestedReplacement(getCommaCharacter());
         ruleMatches.add(ruleMatch);
         commaCount = 0;
       }
-      if (!".".equals(token) && !",".equals(token)) {
+      if (!".".equals(token) && !getCommaCharacter().equals(token)) {
         dotCount = 0;
         commaCount = 0;
       }

--- a/languagetool-language-modules/fa/src/main/java/org/languagetool/language/Persian.java
+++ b/languagetool-language-modules/fa/src/main/java/org/languagetool/language/Persian.java
@@ -95,6 +95,7 @@ public class Persian extends Language {
         new LongSentenceRule(messages),
         // specific to Persian:
         new PersianCommaWhitespaceRule(messages),
+        new PersianDoublePunctuationRule(messages),
         new PersianWordRepeatBeginningRule(messages, this),
         new PersianWordRepeatRule(messages, this),
         new SimpleReplaceRule(messages),

--- a/languagetool-language-modules/fa/src/main/java/org/languagetool/rules/fa/PersianDoublePunctuationRule.java
+++ b/languagetool-language-modules/fa/src/main/java/org/languagetool/rules/fa/PersianDoublePunctuationRule.java
@@ -1,0 +1,48 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2014 Ebrahim Byagowi <ebrahim@gnu.org>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.fa;
+
+import java.util.ResourceBundle;
+
+import org.languagetool.rules.CommaWhitespaceRule;
+import org.languagetool.rules.DoublePunctuationRule;
+
+/**
+ * A rule that matches ".." (but not "..." etc) and "،،".
+ * 
+ * @author Ebrahim Byagowi
+ * @since 2.7
+ */
+public class PersianDoublePunctuationRule extends DoublePunctuationRule {
+
+  public PersianDoublePunctuationRule(final ResourceBundle messages) {
+    super(messages);
+  }
+  
+  @Override
+  public final String getId() {
+    return "PERSIAN_DOUBLE_PUNCTUATION";
+  }
+
+  @Override
+  public String getCommaCharacter() {
+    return "،";
+  }
+
+}


### PR DESCRIPTION
Persian variant for double punctuation which recognize "،" instead "," 
