### PR TITLE
Changed visibility on methods runTestForLanguage and testGrammarRulesFromXML to public

### DIFF
--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
@@ -145,7 +145,7 @@ public class PatternRuleTest extends TestCase {
     }
   }
 
-  protected void runTestForLanguage(Language lang) throws IOException {
+  public void runTestForLanguage(Language lang) throws IOException {
     validatePatternFile(lang);
     System.out.print("Running pattern rule tests for " + lang.getName() + "... ");
     final JLanguageTool languageTool = new MultiThreadedJLanguageTool(lang);
@@ -230,7 +230,7 @@ public class PatternRuleTest extends TestCase {
     }
   }
 
-  private void testGrammarRulesFromXML(final List<PatternRule> rules,
+  public void testGrammarRulesFromXML(final List<PatternRule> rules,
                                        final JLanguageTool languageTool,
                                        final JLanguageTool allRulesLanguageTool, final Language lang) throws IOException {
     final HashMap<String, PatternRule> complexRules = new HashMap<>();


### PR DESCRIPTION
Changing the access level of these methods to 'public' to allow greater flexibility when running tests.
- This would allow tests for a language to be run without having to create an instance of [Language]PatternRuleTest.
- And a list of pattern rules could be tested directly after being loaded from an XML file again without the need to create an instance of [Language]PatternRuleTest.
