### PR TITLE
Fix NullPointerException on canceling rule dialog

### DIFF
--- a/languagetool-standalone/src/main/java/org/languagetool/gui/LanguageManagerDialog.java
+++ b/languagetool-standalone/src/main/java/org/languagetool/gui/LanguageManagerDialog.java
@@ -161,6 +161,9 @@ public class LanguageManagerDialog implements ActionListener {
       } else {
           ruleFile = Tools.openFileDialog(owner, new XMLFileFilter());
       }
+      if (ruleFile == null) {
+        return; // dialog was canceled
+      }
       if (config != null) {
         config.setExternalRuleDirectory(ruleFile.getParent());
         try {


### PR DESCRIPTION
A NullPointerException was thrown on "Text Checking" -> "Load Rule File..." -> "Add..." -> "Cancel".
