### PR TITLE
Support embedding languagetool-core in Java EE containers

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
@@ -210,9 +210,9 @@ public class HunspellRule extends SpellingCheckRule {
 
     final URL dictURL = JLanguageTool.getDataBroker().getFromResourceDirAsUrl(originalPath);
     String dictionaryPath;
-    //in the webstart version, we need to copy the files outside the jar
+    //in the webstart or java EE container version, we need to copy the files outside the jar
     //to the local temporary directory
-    if ("jar".equals(dictURL.getProtocol())) {
+    if ("jar".equals(dictURL.getProtocol()) || "vfs".equals(dictURL.getProtocol())) {
       final File tempDir = new File(System.getProperty("java.io.tmpdir"));
       File tempDicFile = new File(tempDir, dicName + ".dic");
       JLanguageTool.addTemporaryFile(tempDicFile);


### PR DESCRIPTION
Support embedding languagetool-core in Java EE containers that use VFS file systems for deployments. If the file protocol of the .dic and .aff files is vfs:, the Dictionary should behave similar to webstart, by moving the files to a temporary folder.