### PR TITLE
Bad prolonged soud mark

### DIFF
--- a/languagetool-language-modules/ja/src/main/resources/org/languagetool/rules/ja/grammar.xml
+++ b/languagetool-language-modules/ja/src/main/resources/org/languagetool/rules/ja/grammar.xml
@@ -74,7 +74,7 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		</rule>
 		<rule id="SINGLE-MARKON" name="長音">
 		  <pattern case_sensitive="no">
-		    <token regexp="yes">[^\u3040-\u30FF]+</token>
+		    <token regexp="yes">[^\p{IsKatakana}\p{IsHiragana}]+</token>
 		    <token >ー</token>
 		  </pattern>
 		  <message>不適切な長音符</message>

--- a/languagetool-language-modules/ja/src/main/resources/org/languagetool/rules/ja/grammar.xml
+++ b/languagetool-language-modules/ja/src/main/resources/org/languagetool/rules/ja/grammar.xml
@@ -72,6 +72,15 @@ Japanese Grammar and Typo Rules file for LanguageTool
 			<example><marker>おぼつかないです</marker></example>
 			<example correction=""><marker>おぼつきません</marker></example>
 		</rule>
+		<rule id="SINGLE-MARKON" name="長音">
+		  <pattern case_sensitive="no">
+		    <token regexp="yes">[^\u3040-\u30FF]+</token>
+		    <token >ー</token>
+		  </pattern>
+		  <message>不適切な長音符</message>
+		  <example><marker>隣家</marker>ー</example>
+		  <example correction="リンカ"><marker>リンカ</marker>ー</example>
+		</rule>
 	</category>
 	<!-- ============================== -->
 	<!-- 誤字 -->


### PR DESCRIPTION
A prolounged soud mark "ー" is placed before Katakana/Hiragana character.
This rule comes from the following discussion:
https://sourceforge.net/p/languagetool/mailman/message/34107974/
