### PR TITLE
support usage of "A" as an identifier

### DIFF
--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/AvsAnRuleTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/AvsAnRuleTest.java
@@ -63,6 +63,7 @@ public class AvsAnRuleTest extends TestCase {
     assertCorrect("The Qur'an was translated into Polish.");
     assertCorrect("See an:Grammatica");
     assertCorrect("See http://www.an.com");
+    assertCorrect("Station A equals station B.");
 
     // errors:
     assertIncorrect("It was a hour ago.");


### PR DESCRIPTION
 - support for A as an identifier
   - issue was, that the "A" in the term "station A" has been seen as an indefinite article.
 - it has been recognized before as a "A_VS_AN"-A
 - added test
 - cleaned up matcher