### PR TITLE
Add 'rulesFile' option to config properties

### DIFF
--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPSServer.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPSServer.java
@@ -80,6 +80,7 @@ public class HTTPSServer extends Server {
       }
       httpHandler.setLanguageModel(config.getLanguageModelDir());
       httpHandler.setMaxWorkQueueSize(config.getMaxWorkQueueSize());
+      httpHandler.setRulesConfigurationFile(config.getRulesConfigFile());
       server.createContext("/", httpHandler);
       executorService = getExecutorService(workQueue, config);
       server.setExecutor(executorService);

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServer.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServer.java
@@ -106,6 +106,7 @@ public class HTTPServer extends Server {
       }
       httpHandler.setLanguageModel(config.getLanguageModelDir());
       httpHandler.setMaxWorkQueueSize(config.getMaxWorkQueueSize());
+      httpHandler.setRulesConfigurationFile(config.getRulesConfigFile());
       server.createContext("/", httpHandler);
       executorService = getExecutorService(workQueue, config);
       server.setExecutor(executorService);

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
@@ -53,6 +53,7 @@ public class HTTPServerConfig {
   protected int requestLimitPeriodInSeconds;
   protected boolean trustXForwardForHeader;
   protected int maxWorkQueueSize;
+  protected File rulesConfigFile = null;
 
   /**
    * Create a server configuration for the default port ({@link #DEFAULT_PORT}).
@@ -130,6 +131,13 @@ public class HTTPServerConfig {
         mode = getOptionalProperty(props, "mode", "LanguageTool").equalsIgnoreCase("AfterTheDeadline") ? Mode.AfterTheDeadline : Mode.LanguageTool;
         if (mode == Mode.AfterTheDeadline) {
           atdLanguage = Languages.getLanguageForShortName(getProperty(props, "afterTheDeadlineLanguage", file));
+        }
+        String rulesConfigFilePath = getOptionalProperty(props, "rulesFile", null);
+        if (rulesConfigFilePath != null) {
+          rulesConfigFile = new File(rulesConfigFilePath);
+          if (!rulesConfigFile.exists() || !rulesConfigFile.isFile()) {
+            throw new RuntimeException("Rules Configuration file can not be found: " + rulesConfigFile);
+          }
         }
       }
     } catch (IOException e) {
@@ -244,6 +252,15 @@ public class HTTPServerConfig {
   /** @since 2.9 */
   int getMaxWorkQueueSize() {
     return maxWorkQueueSize;
+  }
+
+  /**
+   * @return the file from which server rules configuration should be loaded, or {@code null}
+   * @since 3.0
+   */
+  @Nullable
+  File getRulesConfigFile() {
+    return rulesConfigFile;
   }
 
   /**

--- a/languagetool-server/src/main/java/org/languagetool/server/Server.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/Server.java
@@ -113,6 +113,7 @@ abstract class Server {
     System.out.println("                 'languageModel' - a directory with '1grams', '2grams', '3grams' sub directories which contain a Lucene index");
     System.out.println("                  each with ngram occurrence counts; activates the confusion rule if supported (optional)");
     System.out.println("                 'maxWorkQueueSize' - reject request if request queue gets larger than this (optional)");
+    System.out.println("                 'rulesFile' - a file containing rules configuration, such as .langugagetool.cfg (optional)");
   }
   
   protected static void printCommonOptions() {


### PR DESCRIPTION
First attempt at a fix for issue #280.

This adds a new option, `rulesFile`, to the server configuration file specified with `--config`.  The `rulesFile` option points to the location of a .languagetool.cfg-style rules file.

This is a little odd (the config file now points to another config file), but my thinking was that it was better to keep the server options consolidated in the `--config` file, rather than adding a new top-level switch.  I am also allowing the `rulesFile` param to point to an arbitrary file location, since that's more convenient for server deployment scenarios where we don't want to depend on things like the location of the home directory of the "user" running the service.

I'm happy to rework any portion of this if you'd like it to work a different way.