### PR TITLE
New rules for 'licence' when used as a noun in en-GB.

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-GB/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-GB/grammar.xml
@@ -91,7 +91,7 @@ USA
 			<url>http://www.learnenglish.de/mistakes/USvsBrEnglish.html</url>
 			<example correction="cinema">Let's go to a <marker>movie theater</marker>.</example>
 			<example>Edward Norton – not appearing in a cinema near you.</example>
-		</rule>		
+		</rule>
 		<rule id="GOT_GOTTEN" name="gotten/got">
 			<pattern>
 				<marker>
@@ -113,4 +113,26 @@ USA
             <example correction="petrol">More <marker>gas</marker>.</example>
         </rule>
 	</category>
+	<category name="American English spelling">
+	  <rule id="LICENCE_LICENSE_NOUN_SINGULAR" name="License/Licence (noun)">
+	    <pattern>
+	      <token negate_pos="yes" postag="VB|VBD|VBG|VBN|VBP|VBZ" postag_regexp="yes">license</token>
+	    </pattern>
+	    <message><match no="1"/>
+	      must be spelled with a "C" when used as a noun in British English. Did you mean
+	      <suggestion>licence</suggestion>?</message>
+	    <example correction="licence">Please show me your <marker>license</marker>.</example>
+	  </rule>
+		<rule id="LICENCE_LICENSE_NOUN_PLURAL" name="Licenses/Licences (noun)">
+	    <pattern>
+	      <token negate_pos="yes" postag="VB|VBD|VBG|VBN|VBP|VBZ" postag_regexp="yes">licenses</token>
+	    </pattern>
+	    <message><match no="1"/>
+	      must be spelled with a "C" when used as a noun in British English. Did you mean
+	      <suggestion>licences</suggestion>?</message>
+	    <example correction="licences">Please show me your <marker>licenses</marker>.</example>
+	  </rule>
+
+	</category>
+
 </rules>


### PR DESCRIPTION
New category, and two new rules to catch instances of the word 'licence' when it is used as a noun and inadvertently spelled with an 's' instead of a 'c'.

Reference for spelling usage in en-GB:
http://www.oxforddictionaries.com/definition/english/licence
http://www.grammar-monster.com/easily_confused/licence_license.htm

Thanks,

Graeme