### PR TITLE
Lazy initialization of "static" fields should be "synchronized"

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/Hunspell.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/Hunspell.java
@@ -60,7 +60,7 @@ public class Hunspell {
      *
      * @param libDir Optional absolute directory where the native lib can be found. 
      */
-    public static Hunspell getInstance(String libDir) throws UnsatisfiedLinkError, UnsupportedOperationException { 
+    public static synchronized Hunspell getInstance(String libDir) throws UnsatisfiedLinkError, UnsupportedOperationException {
         if (hunspell != null) {
             return hunspell;
         }

--- a/languagetool-dev/src/main/java/org/languagetool/dev/eval/SimpleCorpusEvaluator.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/eval/SimpleCorpusEvaluator.java
@@ -52,7 +52,7 @@ public class SimpleCorpusEvaluator {
   private static final double END_THRESHOLD   = 0.00000000000000001;
   private static final double STEP_FACTOR     = 0.1;
 
-  private static EnglishNgramProbabilityRule probabilityRule;
+  private static volatile EnglishNgramProbabilityRule probabilityRule;
 
   private final Evaluator evaluator;
   private final List<String> badConfusionMatchWords = new ArrayList<>();

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/chunking/EnglishChunker.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/chunking/EnglishChunker.java
@@ -49,9 +49,9 @@ public class EnglishChunker implements Chunker {
    * that is once created there will never be released. As English has several variants,
    * we'd have as many posModels etc. as we have variants -> huge waste of memory:
    */
-  private static TokenizerModel tokenModel;
-  private static POSModel posModel;
-  private static ChunkerModel chunkerModel;
+  private static volatile TokenizerModel tokenModel;
+  private static volatile POSModel posModel;
+  private static volatile ChunkerModel chunkerModel;
 
   private final EnglishChunkFilter chunkFilter;
 

--- a/languagetool-language-modules/ro/src/main/java/org/languagetool/synthesis/ro/RomanianSynthesizer.java
+++ b/languagetool-language-modules/ro/src/main/java/org/languagetool/synthesis/ro/RomanianSynthesizer.java
@@ -66,7 +66,7 @@ public class RomanianSynthesizer extends BaseSynthesizer {
     }
   }
 
-  private void initSynth() {
+  private synchronized void initSynth() {
     if (manualSynthesizer == null) {
       try {
         try (InputStream stream = JLanguageTool.getDataBroker().getFromResourceDirAsStream(USER_DICT_FILENAME)) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2444 - Lazy initialization of "static" fields should be "synchronized"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2444

Please let me know if you have any questions.

Kirill Vlasov