### PR TITLE
Supply alternate classloader to languagetool

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/Language.java
+++ b/languagetool-core/src/main/java/org/languagetool/Language.java
@@ -335,6 +335,7 @@ public abstract class Language {
     if (patternRules == null) {
       List<AbstractPatternRule> rules = new ArrayList<>();
       PatternRuleLoader ruleLoader = new PatternRuleLoader();
+      ruleLoader.setClassLoader(this.getClass().getClassLoader());
       for (String fileName : getRuleFileNames()) {
         InputStream is = null;
         try {

--- a/languagetool-core/src/main/java/org/languagetool/Languages.java
+++ b/languagetool-core/src/main/java/org/languagetool/Languages.java
@@ -18,16 +18,24 @@
  */
 package org.languagetool;
 
-import org.apache.commons.lang.StringUtils;
-import org.jetbrains.annotations.Nullable;
-import org.languagetool.tools.MultiKeyProperties;
-import org.languagetool.tools.StringTools;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.Nullable;
+import org.languagetool.tools.MultiKeyProperties;
+import org.languagetool.tools.StringTools;
+import org.languagetool.tools.Tools;
 
 /**
  * Helper methods to list all supported languages and to get language objects
@@ -36,7 +44,7 @@ import java.util.*;
  */
 public final class Languages {
 
-  private static final List<Language> LANGUAGES = getAllLanguages();
+  private static List<Language> LANGUAGES = getAllLanguages();
   private static final String PROPERTIES_PATH = "META-INF/org/languagetool/language-module.properties";
   private static final String PROPERTIES_KEY = "languageClasses";
 
@@ -70,11 +78,15 @@ public final class Languages {
     return LANGUAGES;
   }
 
+  public static void reloadLanguages() {
+    LANGUAGES = getAllLanguages();
+  }
+  
   private static List<Language> getAllLanguages() {
     final List<Language> languages = new ArrayList<>();
     final Set<String> languageClassNames = new HashSet<>();
     try {
-      final Enumeration<URL> propertyFiles = Language.class.getClassLoader().getResources(PROPERTIES_PATH);
+      final Enumeration<URL> propertyFiles = Tools.getClassLoader().getResources(PROPERTIES_PATH);
       while (propertyFiles.hasMoreElements()) {
         final URL url = propertyFiles.nextElement();
         try (InputStream inputStream = url.openStream()) {
@@ -108,7 +120,7 @@ public final class Languages {
 
   private static Language createLanguageObjects(URL url, String className) {
     try {
-      final Class<?> aClass = Class.forName(className);
+      final Class<?> aClass = Class.forName(className, true, Tools.getClassLoader());
       final Constructor<?> constructor = aClass.getConstructor();
       return (Language) constructor.newInstance();
     } catch (ClassNotFoundException e) {
@@ -272,5 +284,4 @@ public final class Languages {
     }
     return null;
   }
-
 }

--- a/languagetool-core/src/main/java/org/languagetool/databroker/DefaultResourceDataBroker.java
+++ b/languagetool-core/src/main/java/org/languagetool/databroker/DefaultResourceDataBroker.java
@@ -85,6 +85,8 @@ public class DefaultResourceDataBroker implements ResourceDataBroker {
    */
   private final String rulesDir;
 
+  private ClassLoader classLoader;
+  
   /**
    * Instantiates this data broker with the default resource directory names
    * as specified in:
@@ -111,6 +113,21 @@ public class DefaultResourceDataBroker implements ResourceDataBroker {
     this.rulesDir = (rulesDir == null) ? "" : rulesDir;
   }
 
+  @Override
+  public void setClassLoader(ClassLoader aClassLoader) {
+    classLoader = aClassLoader;
+  }
+  
+  @Override
+  public ClassLoader getClassLoader() {
+    return classLoader;
+  }
+  
+  private ClassLoader classLoader()
+  {
+    return classLoader != null ? classLoader : this.getClass().getClassLoader();
+  }
+  
   /**
    * See:
    * {@link ResourceDataBroker#getFromResourceDirAsStream(String)}
@@ -126,7 +143,7 @@ public class DefaultResourceDataBroker implements ResourceDataBroker {
   @Override
   public InputStream getFromResourceDirAsStream(final String path) {
     final String completePath = getCompleteResourceUrl(path);
-    final InputStream resourceAsStream = ResourceDataBroker.class.getResourceAsStream(completePath);
+    final InputStream resourceAsStream = classLoader().getResourceAsStream(completePath);
     assertNotNull(resourceAsStream, path, completePath);
     return resourceAsStream;
   }
@@ -146,7 +163,7 @@ public class DefaultResourceDataBroker implements ResourceDataBroker {
   @Override
   public URL getFromResourceDirAsUrl(final String path) {
     final String completePath = getCompleteResourceUrl(path);
-    final URL resource = ResourceDataBroker.class.getResource(completePath);
+    final URL resource = classLoader().getResource(completePath);
     assertNotNull(resource, path, completePath);
     return resource;
   }
@@ -160,7 +177,7 @@ public class DefaultResourceDataBroker implements ResourceDataBroker {
    *         {@code resource} directory.
    */
   private String getCompleteResourceUrl(final String path) {
-    return appendPath(resourceDir, path);
+    return appendPath(resourceDir, path).substring(1);
   }
 
   /**
@@ -176,7 +193,7 @@ public class DefaultResourceDataBroker implements ResourceDataBroker {
   @Override
   public InputStream getFromRulesDirAsStream(final String path) {
     final String completePath = getCompleteRulesUrl(path);
-    final InputStream resourceAsStream = ResourceDataBroker.class.getResourceAsStream(completePath);
+    final InputStream resourceAsStream = classLoader().getResourceAsStream(completePath);
     assertNotNull(resourceAsStream, path, completePath);
     return resourceAsStream;
   }
@@ -193,7 +210,7 @@ public class DefaultResourceDataBroker implements ResourceDataBroker {
   @Override
   public URL getFromRulesDirAsUrl(final String path) {
     final String completePath = getCompleteRulesUrl(path);
-    final URL resource = ResourceDataBroker.class.getResource(completePath);
+    final URL resource = classLoader().getResource(completePath);
     assertNotNull(resource, path, completePath);
     return resource;
   }
@@ -212,7 +229,7 @@ public class DefaultResourceDataBroker implements ResourceDataBroker {
    * @return The full relative path to the resource including the path to the {@code rules} directory.
    */
   private String getCompleteRulesUrl(final String path) {
-    return appendPath(rulesDir, path);
+    return appendPath(rulesDir, path).substring(1);
   }
 
   private String appendPath(String baseDir, String path) {
@@ -238,7 +255,7 @@ public class DefaultResourceDataBroker implements ResourceDataBroker {
   @Override
   public boolean resourceExists(String path) {
     final String completePath = getCompleteResourceUrl(path);
-    return ResourceDataBroker.class.getResource(completePath) != null;
+    return classLoader().getResource(completePath) != null;
   }
   
   /**
@@ -251,7 +268,7 @@ public class DefaultResourceDataBroker implements ResourceDataBroker {
   @Override
   public boolean ruleFileExists(String path) {
     final String completePath = getCompleteRulesUrl(path);
-    return ResourceDataBroker.class.getResource(completePath) != null;
+    return classLoader().getResource(completePath) != null;
   }
 
   /**

--- a/languagetool-core/src/main/java/org/languagetool/databroker/ResourceDataBroker.java
+++ b/languagetool-core/src/main/java/org/languagetool/databroker/ResourceDataBroker.java
@@ -133,4 +133,7 @@ public interface ResourceDataBroker {
    */
   String getRulesDir();
 
+  void setClassLoader(ClassLoader aClassLoader);
+  
+  ClassLoader getClassLoader();
 }

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleHandler.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleHandler.java
@@ -73,6 +73,12 @@ public class PatternRuleHandler extends XMLRuleHandler {
   private boolean relaxedMode = false;
   private boolean inAntiPattern;
 
+  private ClassLoader classLoader;
+  
+  public void setClassLoader(ClassLoader aClassLoader) {
+    classLoader = aClassLoader;
+  }
+  
   /**
    * If set to true, don't throw an exception if id or name is not set.
    * Used for online rule editor.
@@ -551,6 +557,7 @@ public class PatternRuleHandler extends XMLRuleHandler {
       }
       if (filterClassName != null && filterArgs != null) {
         RuleFilterCreator creator = new RuleFilterCreator();
+        creator.setClassLoader(classLoader);
         RuleFilter filter = creator.getFilter(filterClassName);
         rule.setFilter(filter);
         rule.setFilterArguments(filterArgs);

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleLoader.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleLoader.java
@@ -38,7 +38,12 @@ import org.xml.sax.helpers.DefaultHandler;
 public class PatternRuleLoader extends DefaultHandler {
 
   private boolean relaxedMode = false;
+  private ClassLoader classLoader;
 
+  public void setClassLoader(ClassLoader aClassLoader) {
+    classLoader = aClassLoader;
+  }
+  
   /**
    * @param file XML file with pattern rules
    */
@@ -65,6 +70,7 @@ public class PatternRuleLoader extends DefaultHandler {
   public final List<AbstractPatternRule> getRules(final InputStream is, final String filename) throws IOException {
     try {
       final PatternRuleHandler handler = new PatternRuleHandler();
+      handler.setClassLoader(classLoader);
       handler.setRelaxedMode(relaxedMode);
       final SAXParserFactory factory = SAXParserFactory.newInstance();
       final SAXParser saxParser = factory.newSAXParser();

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/RuleFilterCreator.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/RuleFilterCreator.java
@@ -26,12 +26,24 @@ import java.lang.reflect.Constructor;
  */
 public class RuleFilterCreator {
 
+  private ClassLoader classLoader;
+  
+  public void setClassLoader(ClassLoader aClassLoader) {
+    classLoader = aClassLoader;
+  }
+  
+  private ClassLoader getClassLoader() {
+    return classLoader != null ? classLoader : RuleFilterCreator.class.getClassLoader();
+  }
+  
   /**
    * @param className fully qualified class Name of a class implementing {@link RuleFilter}
    */
   public RuleFilter getFilter(String className) {
     try {
-      Class<?> aClass = Class.forName(className);
+      // Actually, it would be better here to obtain the ClassLoader from a Language instance
+      // for which the rules are created.
+      Class<?> aClass = Class.forName(className, true, getClassLoader());
       Constructor<?>[] constructors = aClass.getConstructors();
       if (constructors.length != 1) {
         throw new RuntimeException("Constructor of filter class '"

--- a/languagetool-core/src/main/java/org/languagetool/tools/Tools.java
+++ b/languagetool-core/src/main/java/org/languagetool/tools/Tools.java
@@ -21,6 +21,7 @@ package org.languagetool.tools;
 import org.languagetool.AnalyzedSentence;
 import org.languagetool.JLanguageTool;
 import org.languagetool.Language;
+import org.languagetool.Languages;
 import org.languagetool.rules.Rule;
 import org.languagetool.rules.RuleMatch;
 import org.languagetool.rules.bitext.BitextRule;
@@ -31,6 +32,7 @@ import org.languagetool.rules.patterns.bitext.FalseFriendsAsBitextLoader;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
+
 import java.io.*;
 import java.lang.reflect.Constructor;
 import java.net.Authenticator;
@@ -269,7 +271,7 @@ public final class Tools {
     // the other ways to load the stream like
     // "Tools.class.getClass().getResourceAsStream(filename)"
     // don't work in a web context (using Grails):
-    final InputStream is = Tools.class.getResourceAsStream(path);
+    final InputStream is = Tools.getClassLoader().getResourceAsStream(path.substring(1));
     if (is == null) {
       throw new IOException("Could not load file from classpath: '" + path + "'");
     }
@@ -390,4 +392,15 @@ public final class Tools {
     }
   }
 
+  public static ClassLoader getClassLoader()
+  {
+    ClassLoader cl = JLanguageTool.getDataBroker().getClassLoader();
+    if (cl == null) {
+      cl = Thread.currentThread().getContextClassLoader();
+    }
+    if (cl == null) {
+      cl = Languages.class.getClassLoader();
+    }
+    return cl;
+  }
 }


### PR DESCRIPTION
I have a case where I would like to supply languagetool with a specific classloader through which to create Language instances and to load resources. Specifically, I want to download the language JAR at runtime, create a classloader that includes the auto-loaded JAR and supply that to languagetool (JLanguageTool, Languages).

This branch includes changes where I have dabbled in doing this.

The main problem I was facing is that access to languagetool is mostly static and auto-detecting languages is static. So presently, the changes allow setting a global alternative classloader. For multi-threading on different languages that would not work well. 

If you find the idea useful, we might try to elaborate it to specify a classloader when getting a language instance, e.g. something like 

```
Languages.getLanguageForShortName("de", classLoader)
```

The changes are not for merging yet - the pull request is only for discussion at this point in time.
