### PR TITLE
Handle OSGi bundled dictionaries to copy to temporary directories

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
@@ -210,9 +210,9 @@ public class HunspellRule extends SpellingCheckRule {
 
     final URL dictURL = JLanguageTool.getDataBroker().getFromResourceDirAsUrl(originalPath);
     String dictionaryPath;
-    //in the webstart or java EE container version, we need to copy the files outside the jar
+    //in the webstart, java EE or OSGi bundle version, we need to copy the files outside the jar
     //to the local temporary directory
-    if ("jar".equals(dictURL.getProtocol()) || "vfs".equals(dictURL.getProtocol())) {
+    if ("jar".equals(dictURL.getProtocol()) || "vfs".equals(dictURL.getProtocol()) || "bundle".equals(dictURL.getProtocol())) {
       final File tempDir = new File(System.getProperty("java.io.tmpdir"));
       File tempDicFile = new File(tempDir, dicName + ".dic");
       JLanguageTool.addTemporaryFile(tempDicFile);


### PR DESCRIPTION
When using LanguageTool within an OSGi bundle, the dictionaries were failing to load. This is due to the same issues as when they are contained within a JAR file - the URI returned isn't a file URI so fails to load.

The fix here is to handle OSGi bundle loading (protocol of `bundle`) the same as JAR files. Tests out ok :ok_hand: 