### PR TITLE
Enforce DependencyConvergence in parent pom

### DIFF
--- a/languagetool-commandline/pom.xml
+++ b/languagetool-commandline/pom.xml
@@ -77,7 +77,7 @@
                  see http://www.slf4j.org/codes.html#StaticLoggerBinder -->
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>1.7.9</version>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>

--- a/languagetool-core/pom.xml
+++ b/languagetool-core/pom.xml
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>
@@ -110,6 +109,12 @@
             <groupId>org.carrot2</groupId>
             <artifactId>morfologik-speller</artifactId>
             <version>${morfologik.version}</version>
+            <exclusions>
+                <exclusion><!-- see https://github.com/morfologik/morfologik-stemming/pull/78 -->
+                    <groupId>org.carrot2</groupId>
+                    <artifactId>morfologik-polish</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.carrot2</groupId>

--- a/languagetool-dev/pom.xml
+++ b/languagetool-dev/pom.xml
@@ -35,6 +35,83 @@
         </developer>
     </developers>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <!-- resolve convergence issue within org.apache.hadoop:hadoop-common -->
+                <groupId>javax.servlet</groupId>
+                <artifactId>servlet-api</artifactId>
+                <version>2.5</version>
+            </dependency>
+            <dependency>
+                <!-- resolve convergence issue within org.apache.hadoop:hadoop-common -->
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>1.7.5</version>
+            </dependency>
+            <dependency>
+                <!-- resolve convergence issue within org.apache.hadoop:hadoop-common -->
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-core-asl</artifactId>
+                <version>1.9.13</version>
+            </dependency>
+            <dependency>
+                <!-- resolve convergence between languagetool-wikipedia and hadoop-mapreduce-client-core -->
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.4</version>
+            </dependency>
+            <dependency>
+                <!-- resolve convergence between languagetool-wikipedia and hadoop-xz -->
+                <groupId>org.tukaani</groupId>
+                <artifactId>xz</artifactId>
+                <version>1.5</version>
+            </dependency>
+            <dependency>
+                <!-- resolve convergence between encog-core and hadoop-common -->
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-math3</artifactId>
+                <version>3.1.1</version>
+            </dependency>
+            <dependency>
+                <!-- resolve convergence between hadoop-common and hadoop-mapreduce-client-core -->
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
+                <version>1.9.13</version>
+            </dependency>
+            <dependency>
+                <!-- resolve convergence between hadoop-common and rome-fetcher -->
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>1.1.3</version>
+            </dependency>
+            <dependency>
+                <!-- resolve convergence between hadoop-common and rome-fetcher -->
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.4</version>
+            </dependency>
+            <dependency>
+                <!-- resolve convergence between hadoop-common and rome-fetcher -->
+                <groupId>commons-httpclient</groupId>
+                <artifactId>commons-httpclient</artifactId>
+                <version>3.1</version>
+            </dependency>
+            <dependency>
+                <!-- resolve convergence between slf4j-nop and hadoop-common -->
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <!-- resolve convergence between hadoop-common and hadoop-mapreduce-client-core -->
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>1.2.17</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.languagetool</groupId>
@@ -49,7 +126,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.rome</groupId>
@@ -98,6 +174,12 @@
             <groupId>io.sensesecure</groupId>
             <artifactId>hadoop-xz</artifactId>
             <version>1.4</version>
+            <exclusions>
+                <exclusion><!-- we add this ourselves -->
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/languagetool-server/pom.xml
+++ b/languagetool-server/pom.xml
@@ -80,7 +80,7 @@
                  see http://www.slf4j.org/codes.html#StaticLoggerBinder -->
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>1.7.9</version>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>

--- a/languagetool-standalone/pom.xml
+++ b/languagetool-standalone/pom.xml
@@ -133,7 +133,7 @@
                  see http://www.slf4j.org/codes.html#StaticLoggerBinder -->
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>1.7.9</version>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <!-- Some tests are used at runtime for rule developers, thus no 'test' scope here: -->

--- a/languagetool-tools/pom.xml
+++ b/languagetool-tools/pom.xml
@@ -77,7 +77,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
         </dependency>
         <dependency>
             <groupId>org.encog</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,13 @@
       <maven.compiler.target>1.8</maven.compiler.target>
       <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
       <maven.jar.plugin>2.6</maven.jar.plugin>
+      <commons.cli.version>1.2</commons.cli.version>
+      <commons.lang.version>2.6</commons.lang.version>
+      <guava.version>18.0</guava.version>
       <junit.version>4.12</junit.version>
       <morfologik.version>2.1.0</morfologik.version>
       <languagetool.version>3.4-SNAPSHOT</languagetool.version>
+      <slf4j.version>1.7.6</slf4j.version><!-- lines up with com.optimaize.languagedetector:language-detector -->
   </properties>
   
   <build>
@@ -79,7 +83,50 @@
               
           </plugins>
       </pluginManagement>
+
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <version>1.4.1</version>
+              <configuration>
+                  <rules>
+                      <DependencyConvergence/>
+                  </rules>
+              </configuration>
+              <executions>
+                  <execution>
+                      <id>enforce-dependency-convergence</id>
+                      <goals>
+                          <goal>enforce</goal>
+                      </goals>
+                  </execution>
+              </executions>
+          </plugin>
+      </plugins>
+
   </build>
+
+  <dependencyManagement>
+      <dependencies>
+          <dependency>
+              <groupId>commons-lang</groupId>
+              <artifactId>commons-lang</artifactId>
+              <version>${commons.lang.version}</version>
+          </dependency>
+          <dependency>
+              <groupId>com.google.guava</groupId>
+              <artifactId>guava</artifactId>
+              <version>${guava.version}</version>
+          </dependency>
+          <dependency>
+              <groupId>junit</groupId>
+              <artifactId>junit</artifactId>
+              <version>${junit.version}</version>
+              <scope>test</scope>
+          </dependency>
+      </dependencies>
+  </dependencyManagement>
 
   <distributionManagement>
     <repository>


### PR DESCRIPTION
Enforce [dependency convergence](https://maven.apache.org/enforcer/enforcer-rules/dependencyConvergence.html) in parent pom. Runs during `validate` phase, which is the default for the plugin.

Changes needed to get convergence passing:
- downgrade `slf4j.version` from 1.7.9 to 1.7.6 so that it lines up with dependencies
  - only used for slf4j-nop, so I figured version doesn't matter
- exclude `morfologik-polish` from `morfologik-speller`
  - this was a bug in morfologik that will be fixed soon, see https://github.com/morfologik/morfologik-stemming/pull/78
- pull guava, commons-lang, junit up to parent dependencyManagement to resolve most convergence issues
- add special dependencyManagement to `languagetool-dev` because there are so many more conflicts there than any other package

See https://github.com/languagetool-org/languagetool/pull/342#issuecomment-205813554 for additional context