### PR TITLE
Removed starting slash to resolve Maven error when packaging on Windows.

### DIFF
--- a/languagetool-office-extension/src/main/assembly/oxt.xml
+++ b/languagetool-office-extension/src/main/assembly/oxt.xml
@@ -22,7 +22,7 @@
         </fileSet>
         <fileSet>
             <directory>src/main/resources/third-party-licenses</directory>
-            <outputDirectory>/third-party-licenses</outputDirectory>
+            <outputDirectory>third-party-licenses</outputDirectory>
         </fileSet>
     </fileSets>
     <containerDescriptorHandlers>

--- a/languagetool-wikipedia/src/main/assembly/zip.xml
+++ b/languagetool-wikipedia/src/main/assembly/zip.xml
@@ -15,7 +15,7 @@
         </fileSet>
         <fileSet>
             <directory>src/main/resources/third-party-licenses</directory>
-            <outputDirectory>/third-party-licenses</outputDirectory>
+            <outputDirectory>third-party-licenses</outputDirectory>
         </fileSet>
     </fileSets>
     <containerDescriptorHandlers>


### PR DESCRIPTION
"[ERROR] OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference (starting with slash) /third-party-licenses"