### PR TITLE
Remove rules that are not appropriate for en-GB

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-GB/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-GB/grammar.xml
@@ -61,27 +61,6 @@ USA
             <url>http://www.learnenglish.de/mistakes/USvsBrEnglish.html</url>
             <example correction="minced">Do vegetarians eat <marker>ground</marker> beef?</example>
         </rule>
-        <rule id="FIRST_GROUND_FLOOR" name="first floor/ground floor">
-            <pattern>
-                <marker>
-                    <token>first</token>
-                </marker>
-                <token>floor</token>
-            </pattern>
-            <message>This word is common for American English. Did you mean <suggestion>ground</suggestion>?</message>
-            <url>http://www.learnenglish.de/mistakes/USvsBrEnglish.html</url>
-            <example correction="ground">The room is on the <marker>first</marker> floor.</example>
-        </rule>
-        <rule id="VACUUM_CLEANER_HOOVER" name="vacuum cleaner/hoover">
-            <pattern>
-                <token>vacuum</token>
-                <token inflected="yes">cleaner</token>
-            </pattern>
-            <message>This expression is common for American English. Did you mean <suggestion>hoover</suggestion>?</message>
-            <url>http://www.learnenglish.de/mistakes/USvsBrEnglish.html</url>
-            <example correction="hoover">Buy me a <marker>vacuum cleaner</marker>.</example>
-            <example>All I need is a hoover.</example>
-        </rule>
         <rule id="MOVIE_THEATER_CINEMA" name="movie theater/cinema">
             <pattern>
                 <token>movie</token>


### PR DESCRIPTION
These maybe more appropriate for a en-GB en-US bitext 
first floor - floor counting is different
hoover is a brand name, maybe the rule should be reversed.