### PR TITLE
fix xlink attribute

### DIFF
--- a/languagetool-office-extension/src/main/resources/description.xml
+++ b/languagetool-office-extension/src/main/resources/description.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <description xmlns="http://openoffice.org/extensions/description/2006"
 	xmlns:d="http://openoffice.org/extensions/description/2006"
-	xmlns:xlink="http://www.w
-	org/1999/xlink">
+	xmlns:xlink="http://www.w3.org/1999/xlink">
 	<identifier value="org.openoffice.languagetool.oxt" />
 	<display-name>
 		<name lang="en-US">LanguageTool. Open source language checker</name>


### PR DESCRIPTION
Noticed this in a warning from LibreOffice on trying to update LanguageTool