### PR TITLE
Fix typo in a Spanish rule description

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -2108,7 +2108,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 
       <message>En español, la expresión «en relación a / al» no existe. Puede cambiarse por <suggestion>en relación con</suggestion>, <suggestion>con relación a</suggestion> o <suggestion>en lo que se refiere a</suggestion>.</message>
 
-      <short>En español, la expresión «en relación a» no esiste.</short>
+      <short>En español, la expresión «en relación a» no existe.</short>
 
       <example correction="en relación con|con relación a|en lo que se refiere a">Es muy austero <marker>en relación a</marker> su indumentaria</example>
 


### PR DESCRIPTION
The short description had “esiste” instead of “existe”, which is an embarrassingly prominent typo. I detected it while using the LibreOffice extension.