### PR TITLE
languagetool-standalone: Remove unneeded null check

### DIFF
--- a/languagetool-standalone/src/main/java/org/languagetool/gui/LanguageManagerDialog.java
+++ b/languagetool-standalone/src/main/java/org/languagetool/gui/LanguageManagerDialog.java
@@ -164,13 +164,11 @@ public class LanguageManagerDialog implements ActionListener {
       if (ruleFile == null) {
         return; // dialog was canceled
       }
-      if (config != null) {
-        config.setExternalRuleDirectory(ruleFile.getParent());
-        try {
-          config.saveConfiguration(null);
-        } catch (IOException e1) {
-          throw new RuntimeException(e1);
-        }
+      config.setExternalRuleDirectory(ruleFile.getParent());
+      try {
+        config.saveConfiguration(null);
+      } catch (IOException e1) {
+        throw new RuntimeException(e1);
       }
       if (!ruleFiles.contains(ruleFile)) {
         ruleFiles.add(ruleFile);


### PR DESCRIPTION
config can never be null here. This fixes a warning from FindBugs.

Signed-off-by: Stefan Weil <sw@weilnetz.de>