### PR TITLE
#8 Extend pattern rule test for short messages

### DIFF
--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
@@ -18,20 +18,44 @@
  */
 package org.languagetool.rules.patterns;
 
-import org.junit.Test;
-import org.languagetool.*;
-import org.languagetool.databroker.ResourceDataBroker;
-import org.languagetool.rules.*;
-import org.languagetool.rules.spelling.SpellingCheckRule;
-import org.languagetool.tagging.disambiguation.rules.DisambiguationPatternRule;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.*;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.languagetool.AnalyzedSentence;
+import org.languagetool.AnalyzedTokenReadings;
+import org.languagetool.FakeLanguage;
+import org.languagetool.JLanguageTool;
+import org.languagetool.Language;
+import org.languagetool.Languages;
+import org.languagetool.MultiThreadedJLanguageTool;
+import org.languagetool.TestTools;
+import org.languagetool.XMLValidator;
+import org.languagetool.databroker.ResourceDataBroker;
+import org.languagetool.rules.Category;
+import org.languagetool.rules.CorrectExample;
+import org.languagetool.rules.ErrorTriggeringExample;
+import org.languagetool.rules.IncorrectExample;
+import org.languagetool.rules.Rule;
+import org.languagetool.rules.RuleMatch;
+import org.languagetool.rules.spelling.SpellingCheckRule;
+import org.languagetool.tagging.disambiguation.rules.DisambiguationPatternRule;
 
 /**
  * @author Daniel Naber
@@ -64,6 +88,36 @@ public class PatternRuleTest {
     assertFalse(patternRuleVariant1.supportsLanguage(fakeLanguage1));
     assertFalse(patternRuleVariant1.supportsLanguage(fakeLanguage2));
     assertFalse(patternRuleVariant1.supportsLanguage(fakeLanguage1WithVariant2));
+  }
+  
+  @Ignore
+  @Test
+  public void shortMessageIsSmallerThanErrorMessage() throws IOException {
+    for (Language lang : Languages.get()) {
+      MultiThreadedJLanguageTool languageTool = new MultiThreadedJLanguageTool(lang);
+      for (AbstractPatternRule rule : getAllPatternRules(lang, languageTool)) {
+        failIfShortMessageSmallerThanErrorMessage(rule);
+      }
+    }
+  }
+
+  private void failIfShortMessageSmallerThanErrorMessage(AbstractPatternRule rule) {
+      if (rule instanceof PatternRule) {
+        int sizeOfShortMessage = ((PatternRule) rule).getShortMessage().length();
+        int sizeOfErrorMessage = ((PatternRule) rule).getMessage().length();
+        if (sizeOfShortMessage >= sizeOfErrorMessage) {
+          fail("The content of <short> should be smaller than the content of <message>). "
+              + "Language: " + rule.language.getName() + ". Rule: " + rule.getId());
+        }
+    }
+  }
+  
+  private List<AbstractPatternRule> getAllPatternRules(Language language, MultiThreadedJLanguageTool languageTool) throws IOException {
+    List<AbstractPatternRule> rules = new ArrayList<>();
+    for (String patternRuleFileName : language.getRuleFileNames()) {
+      rules.addAll(languageTool.loadPatternRules(patternRuleFileName));
+    }
+    return rules;
   }
 
   /**
@@ -160,10 +214,7 @@ public class PatternRuleTest {
     }
     MultiThreadedJLanguageTool allRulesLanguageTool = new MultiThreadedJLanguageTool(lang);
     validateRuleIds(lang, allRulesLanguageTool);
-    List<AbstractPatternRule> rules = new ArrayList<>();
-    for (String patternRuleFileName : lang.getRuleFileNames()) {
-      rules.addAll(languageTool.loadPatternRules(patternRuleFileName));
-    }
+    List<AbstractPatternRule> rules = getAllPatternRules(lang, languageTool);
     for (AbstractPatternRule rule : rules) {
       // Test the rule pattern.
       /* check for useless 'marker' elements commented out - too slow to always run:

--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.languagetool.AnalyzedSentence;
 import org.languagetool.AnalyzedTokenReadings;
@@ -90,24 +89,23 @@ public class PatternRuleTest {
     assertFalse(patternRuleVariant1.supportsLanguage(fakeLanguage1WithVariant2));
   }
   
-  @Ignore
   @Test
   public void shortMessageIsSmallerThanErrorMessage() throws IOException {
     for (Language lang : Languages.get()) {
       MultiThreadedJLanguageTool languageTool = new MultiThreadedJLanguageTool(lang);
       for (AbstractPatternRule rule : getAllPatternRules(lang, languageTool)) {
-        failIfShortMessageSmallerThanErrorMessage(rule);
+        warnIfShortMessageSmallerThanErrorMessage(rule);
       }
     }
   }
 
-  private void failIfShortMessageSmallerThanErrorMessage(AbstractPatternRule rule) {
+  private void warnIfShortMessageSmallerThanErrorMessage(AbstractPatternRule rule) {
       if (rule instanceof PatternRule) {
         int sizeOfShortMessage = ((PatternRule) rule).getShortMessage().length();
         int sizeOfErrorMessage = ((PatternRule) rule).getMessage().length();
         if (sizeOfShortMessage >= sizeOfErrorMessage) {
-          fail("The content of <short> should be smaller than the content of <message>). "
-              + "Language: " + rule.language.getName() + ". Rule: " + rule.getId());
+          System.err.println("Warning: The content of <short> should be smaller than the content of"
+              + " <message>). Language: " + rule.language.getName() + ". Rule: " + rule.getId());
         }
     }
   }

--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
@@ -105,7 +105,7 @@ public class PatternRuleTest {
         int sizeOfErrorMessage = ((PatternRule) rule).getMessage().length();
         if (sizeOfShortMessage >= sizeOfErrorMessage) {
           System.err.println("Warning: The content of <short> should be smaller than the content of"
-              + " <message>). Language: " + rule.language.getName() + ". Rule: " + rule.getId());
+              + " <message>. Language: " + rule.language.getName() + ". Rule: " + rule.getId());
         }
     }
   }


### PR DESCRIPTION
- Extend the pattern rule test to make sure that the short message
(<short> in the grammar XML file), if any, is actually shorter than the
other error message (<message>).
- Leave the test initially deactivated (@Ignore).