### PR TITLE
Fix typo 'statistic suggests' to 'statistics suggest'

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/MessagesBundle.properties
+++ b/languagetool-core/src/main/resources/org/languagetool/MessagesBundle.properties
@@ -444,9 +444,9 @@ fa = Persian
 # note that the statistics rule is not offered for all languages, see
 # http://wiki.languagetool.org/finding-errors-using-n-gram-data
 statistics_rule_description = Statistically detect wrong use of words that are easily confused
-statistics_suggest1 = Statistic suggests that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
-statistics_suggest2 = Statistic suggests that '{0}' ({1}) might be the correct word here. Please check.
-statistics_suggest3 = Statistic suggests that '{0}' might be the correct word here. Please check.
+statistics_suggest1 = Statistics suggest that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
+statistics_suggest2 = Statistics suggest that '{0}' ({1}) might be the correct word here. Please check.
+statistics_suggest3 = Statistics suggest that '{0}' might be the correct word here. Please check.
 
 unsupportedWarning = Note: This language isn't fully supported in LanguageTool as there's nobody who actively maintains it. <a href="https://languagetool.org/contribute/">See how you can help.</a>
 

--- a/languagetool-core/src/main/resources/org/languagetool/MessagesBundle_en.properties
+++ b/languagetool-core/src/main/resources/org/languagetool/MessagesBundle_en.properties
@@ -444,9 +444,9 @@ fa = Persian
 # note that the statistics rule is not offered for all languages, see
 # http://wiki.languagetool.org/finding-errors-using-n-gram-data
 statistics_rule_description = Statistically detect wrong use of words that are easily confused
-statistics_suggest1 = Statistic suggests that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
-statistics_suggest2 = Statistic suggests that '{0}' ({1}) might be the correct word here. Please check.
-statistics_suggest3 = Statistic suggests that '{0}' might be the correct word here. Please check.
+statistics_suggest1 = Statistics suggest that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
+statistics_suggest2 = Statistics suggest that '{0}' ({1}) might be the correct word here. Please check.
+statistics_suggest3 = Statistics suggest that '{0}' might be the correct word here. Please check.
 
 unsupportedWarning = Note: This language isn't fully supported in LanguageTool as there's nobody who actively maintains it. <a href="https://languagetool.org/contribute/">See how you can help.</a>
 

--- a/languagetool-language-modules/el/src/main/resources/org/languagetool/MessagesBundle_el_GR.properties
+++ b/languagetool-language-modules/el/src/main/resources/org/languagetool/MessagesBundle_el_GR.properties
@@ -444,9 +444,9 @@ fa = \u03a0\u03b5\u03c1\u03c3\u03b9\u03ba\u03ac
 # note that the statistics rule is not offered for all languages, see
 # http://wiki.languagetool.org/finding-errors-using-n-gram-data
 statistics_rule_description = \u03a3\u03c4\u03b1\u03c4\u03b9\u03c3\u03c4\u03b9\u03ba\u03ae \u03bc\u03ad\u03b8\u03bf\u03b4\u03bf\u03c2 \u03b5\u03cd\u03c1\u03b5\u03c3\u03b7\u03c2 \u03bb\u03b1\u03bd\u03b8\u03b1\u03c3\u03bc\u03ad\u03bd\u03b7\u03c2 \u03c7\u03c1\u03ae\u03c3\u03b7\u03c2 \u03bb\u03ad\u03be\u03b5\u03c9\u03bd \u03c0\u03bf\u03c5 \u03c3\u03c5\u03b3\u03c7\u03ad\u03bf\u03bd\u03c4\u03b1\u03b9 \u03c3\u03c5\u03c7\u03bd\u03ac.
-# statistics_suggest1 = Statistic suggests that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
-# statistics_suggest2 = Statistic suggests that '{0}' ({1}) might be the correct word here. Please check.
-# statistics_suggest3 = Statistic suggests that '{0}' might be the correct word here. Please check.
+# statistics_suggest1 = Statistics suggest that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
+# statistics_suggest2 = Statistics suggest that '{0}' ({1}) might be the correct word here. Please check.
+# statistics_suggest3 = Statistics suggest that '{0}' might be the correct word here. Please check.
 
 unsupportedWarning = \u03a0\u03b1\u03c1\u03b1\u03c4\u03ae\u03c1\u03b7\u03c3\u03b7\: \u0391\u03c5\u03c4\u03ae \u03b7 \u03b3\u03bb\u03ce\u03c3\u03c3\u03b1 \u03b4\u03b5\u03bd \u03c5\u03c0\u03bf\u03c3\u03c4\u03b7\u03c1\u03af\u03b6\u03b5\u03c4\u03b1\u03b9 \u03c0\u03bb\u03ae\u03c1\u03c9\u03c2 \u03b1\u03c6\u03bf\u03cd \u03b4\u03b5\u03bd \u03c5\u03c0\u03ac\u03c1\u03c7\u03b5\u03b9 \u03ba\u03ac\u03c0\u03bf\u03b9\u03bf\u03c2 \u03bd\u03b1 \u03c4\u03b7\u03bd \u03c3\u03c5\u03bd\u03c4\u03b7\u03c1\u03ae\u03c3\u03b5\u03b9. <a href\="https\://languagetool.org/contribute/">\u0394\u03b5\u03af\u03c4\u03b5 \u03c0\u03c9\u03c2 \u03bc\u03c0\u03bf\u03c1\u03b5\u03af\u03c4\u03b5 \u03bd\u03b1 \u03b2\u03bf\u03b7\u03b8\u03ae\u03c3\u03b5\u03c4\u03b5.</a>
 

--- a/languagetool-language-modules/fa/src/main/resources/org/languagetool/MessagesBundle_fa.properties
+++ b/languagetool-language-modules/fa/src/main/resources/org/languagetool/MessagesBundle_fa.properties
@@ -444,9 +444,9 @@ fa = \u0641\u0627\u0631\u0633\u06cc
 # note that the statistics rule is not offered for all languages, see
 # http://wiki.languagetool.org/finding-errors-using-n-gram-data
 # statistics_rule_description = Statistically detect wrong use of words that are easily confused
-# statistics_suggest1 = Statistic suggests that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
-# statistics_suggest2 = Statistic suggests that '{0}' ({1}) might be the correct word here. Please check.
-# statistics_suggest3 = Statistic suggests that '{0}' might be the correct word here. Please check.
+# statistics_suggest1 = Statistics suggest that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
+# statistics_suggest2 = Statistics suggest that '{0}' ({1}) might be the correct word here. Please check.
+# statistics_suggest3 = Statistics suggest that '{0}' might be the correct word here. Please check.
 
 # unsupportedWarning = Note\: This language isn't fully supported in LanguageTool as there's nobody who actively maintains it. <a href\="https\://languagetool.org/contribute/">See how you can help.</a>
 

--- a/languagetool-language-modules/is/src/main/resources/org/languagetool/MessagesBundle_is.properties
+++ b/languagetool-language-modules/is/src/main/resources/org/languagetool/MessagesBundle_is.properties
@@ -438,9 +438,9 @@ FontChooser.label.size = St\u00e6r\u00f0\:
 # note that the statistics rule is not offered for all languages, see
 # http://wiki.languagetool.org/finding-errors-using-n-gram-data
 # statistics_rule_description = Statistically detect wrong use of words that are easily confused
-# statistics_suggest1 = Statistic suggests that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
-# statistics_suggest2 = Statistic suggests that '{0}' ({1}) might be the correct word here. Please check.
-# statistics_suggest3 = Statistic suggests that '{0}' might be the correct word here. Please check.
+# statistics_suggest1 = Statistics suggest that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
+# statistics_suggest2 = Statistics suggest that '{0}' ({1}) might be the correct word here. Please check.
+# statistics_suggest3 = Statistics suggest that '{0}' might be the correct word here. Please check.
 
 # unsupportedWarning = Note\: This language isn't fully supported in LanguageTool as there's nobody who actively maintains it. <a href\="https\://languagetool.org/contribute/">See how you can help.</a>
 

--- a/languagetool-language-modules/km/src/main/resources/org/languagetool/MessagesBundle_km.properties
+++ b/languagetool-language-modules/km/src/main/resources/org/languagetool/MessagesBundle_km.properties
@@ -444,9 +444,9 @@ ja = \u1797\u17b6\u179f\u17b6\u1787\u1794\u17c9\u17bb\u1793 \u17ac \u1794\u17d2\
 # note that the statistics rule is not offered for all languages, see
 # http://wiki.languagetool.org/finding-errors-using-n-gram-data
 # statistics_rule_description = Statistically detect wrong use of words that are easily confused
-# statistics_suggest1 = Statistic suggests that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
-# statistics_suggest2 = Statistic suggests that '{0}' ({1}) might be the correct word here. Please check.
-# statistics_suggest3 = Statistic suggests that '{0}' might be the correct word here. Please check.
+# statistics_suggest1 = Statistics suggest that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
+# statistics_suggest2 = Statistics suggest that '{0}' ({1}) might be the correct word here. Please check.
+# statistics_suggest3 = Statistics suggest that '{0}' might be the correct word here. Please check.
 
 # unsupportedWarning = Note\: This language isn't fully supported in LanguageTool as there's nobody who actively maintains it. <a href\="https\://languagetool.org/contribute/">See how you can help.</a>
 

--- a/languagetool-language-modules/lt/src/main/resources/org/languagetool/MessagesBundle_lt.properties
+++ b/languagetool-language-modules/lt/src/main/resources/org/languagetool/MessagesBundle_lt.properties
@@ -444,9 +444,9 @@ fa = Pers\u0173
 # note that the statistics rule is not offered for all languages, see
 # http://wiki.languagetool.org/finding-errors-using-n-gram-data
 # statistics_rule_description = Statistically detect wrong use of words that are easily confused
-# statistics_suggest1 = Statistic suggests that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
-# statistics_suggest2 = Statistic suggests that '{0}' ({1}) might be the correct word here. Please check.
-# statistics_suggest3 = Statistic suggests that '{0}' might be the correct word here. Please check.
+# statistics_suggest1 = Statistics suggest that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
+# statistics_suggest2 = Statistics suggest that '{0}' ({1}) might be the correct word here. Please check.
+# statistics_suggest3 = Statistics suggest that '{0}' might be the correct word here. Please check.
 
 # unsupportedWarning = Note\: This language isn't fully supported in LanguageTool as there's nobody who actively maintains it. <a href\="https\://languagetool.org/contribute/">See how you can help.</a>
 

--- a/languagetool-language-modules/nl/src/main/resources/org/languagetool/MessagesBundle_nl.properties
+++ b/languagetool-language-modules/nl/src/main/resources/org/languagetool/MessagesBundle_nl.properties
@@ -444,9 +444,9 @@ fa = Perzisch
 # note that the statistics rule is not offered for all languages, see
 # http://wiki.languagetool.org/finding-errors-using-n-gram-data
 # statistics_rule_description = Statistically detect wrong use of words that are easily confused
-# statistics_suggest1 = Statistic suggests that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
-# statistics_suggest2 = Statistic suggests that '{0}' ({1}) might be the correct word here. Please check.
-# statistics_suggest3 = Statistic suggests that '{0}' might be the correct word here. Please check.
+# statistics_suggest1 = Statistics suggest that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
+# statistics_suggest2 = Statistics suggest that '{0}' ({1}) might be the correct word here. Please check.
+# statistics_suggest3 = Statistics suggest that '{0}' might be the correct word here. Please check.
 
 # unsupportedWarning = Note\: This language isn't fully supported in LanguageTool as there's nobody who actively maintains it. <a href\="https\://languagetool.org/contribute/">See how you can help.</a>
 

--- a/languagetool-language-modules/ro/src/main/resources/org/languagetool/MessagesBundle_ro.properties
+++ b/languagetool-language-modules/ro/src/main/resources/org/languagetool/MessagesBundle_ro.properties
@@ -444,9 +444,9 @@ tray_tooltip_server_running = LanguageTool (server-ul HTTP ruleaz\u0103)
 # note that the statistics rule is not offered for all languages, see
 # http://wiki.languagetool.org/finding-errors-using-n-gram-data
 # statistics_rule_description = Statistically detect wrong use of words that are easily confused
-# statistics_suggest1 = Statistic suggests that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
-# statistics_suggest2 = Statistic suggests that '{0}' ({1}) might be the correct word here. Please check.
-# statistics_suggest3 = Statistic suggests that '{0}' might be the correct word here. Please check.
+# statistics_suggest1 = Statistics suggest that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
+# statistics_suggest2 = Statistics suggest that '{0}' ({1}) might be the correct word here. Please check.
+# statistics_suggest3 = Statistics suggest that '{0}' might be the correct word here. Please check.
 
 # unsupportedWarning = Note\: This language isn't fully supported in LanguageTool as there's nobody who actively maintains it. <a href\="https\://languagetool.org/contribute/">See how you can help.</a>
 

--- a/languagetool-language-modules/sv/src/main/resources/org/languagetool/MessagesBundle_sv.properties
+++ b/languagetool-language-modules/sv/src/main/resources/org/languagetool/MessagesBundle_sv.properties
@@ -444,9 +444,9 @@ fa = Persiska
 # note that the statistics rule is not offered for all languages, see
 # http://wiki.languagetool.org/finding-errors-using-n-gram-data
 # statistics_rule_description = Statistically detect wrong use of words that are easily confused
-# statistics_suggest1 = Statistic suggests that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
-# statistics_suggest2 = Statistic suggests that '{0}' ({1}) might be the correct word here. Please check.
-# statistics_suggest3 = Statistic suggests that '{0}' might be the correct word here. Please check.
+# statistics_suggest1 = Statistics suggest that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
+# statistics_suggest2 = Statistics suggest that '{0}' ({1}) might be the correct word here. Please check.
+# statistics_suggest3 = Statistics suggest that '{0}' might be the correct word here. Please check.
 
 # unsupportedWarning = Note\: This language isn't fully supported in LanguageTool as there's nobody who actively maintains it. <a href\="https\://languagetool.org/contribute/">See how you can help.</a>
 

--- a/languagetool-language-modules/tl/src/main/resources/org/languagetool/MessagesBundle_tl.properties
+++ b/languagetool-language-modules/tl/src/main/resources/org/languagetool/MessagesBundle_tl.properties
@@ -444,9 +444,9 @@ tray_tooltip_server_running = LanguageTool (HTTP server running)
 # note that the statistics rule is not offered for all languages, see
 # http://wiki.languagetool.org/finding-errors-using-n-gram-data
 # statistics_rule_description = Statistically detect wrong use of words that are easily confused
-# statistics_suggest1 = Statistic suggests that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
-# statistics_suggest2 = Statistic suggests that '{0}' ({1}) might be the correct word here. Please check.
-# statistics_suggest3 = Statistic suggests that '{0}' might be the correct word here. Please check.
+# statistics_suggest1 = Statistics suggest that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
+# statistics_suggest2 = Statistics suggest that '{0}' ({1}) might be the correct word here. Please check.
+# statistics_suggest3 = Statistics suggest that '{0}' might be the correct word here. Please check.
 
 # unsupportedWarning = Note\: This language isn't fully supported in LanguageTool as there's nobody who actively maintains it. <a href\="https\://languagetool.org/contribute/">See how you can help.</a>
 

--- a/languagetool-language-modules/zh/src/main/resources/org/languagetool/MessagesBundle_zh.properties
+++ b/languagetool-language-modules/zh/src/main/resources/org/languagetool/MessagesBundle_zh.properties
@@ -444,9 +444,9 @@ tray_tooltip_server_running = LanguageTool (HTTP\u670d\u52a1\u5668\u6b63\u5728\u
 # note that the statistics rule is not offered for all languages, see
 # http://wiki.languagetool.org/finding-errors-using-n-gram-data
 # statistics_rule_description = Statistically detect wrong use of words that are easily confused
-# statistics_suggest1 = Statistic suggests that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
-# statistics_suggest2 = Statistic suggests that '{0}' ({1}) might be the correct word here. Please check.
-# statistics_suggest3 = Statistic suggests that '{0}' might be the correct word here. Please check.
+# statistics_suggest1 = Statistics suggest that '{0}' ({1}) might be the correct word here, not '{2}' ({3}). Please check.
+# statistics_suggest2 = Statistics suggest that '{0}' ({1}) might be the correct word here. Please check.
+# statistics_suggest3 = Statistics suggest that '{0}' might be the correct word here. Please check.
 
 # unsupportedWarning = Note\: This language isn't fully supported in LanguageTool as there's nobody who actively maintains it. <a href\="https\://languagetool.org/contribute/">See how you can help.</a>
 


### PR DESCRIPTION
Update to all instances of `statistic suggests` to read `statistics suggest`. If there is a preference for alternatives such as `a statistic suggests`, I'm open to thoughts. However, I do think `statistics suggest` makes the most sense in the context of the suggestion.