### PR TITLE
[sv] Avoid including . in match

### DIFF
--- a/languagetool-language-modules/sv/src/main/resources/org/languagetool/resource/sv/hunspell/sv_SE.aff
+++ b/languagetool-language-modules/sv/src/main/resources/org/languagetool/resource/sv/hunspell/sv_SE.aff
@@ -1,7 +1,7 @@
 SET ISO8859-1
 TRY aerndtislogmkpbhfjuv‰cˆÂyqxzvwÈ‚‡·Ë
 
-WORDCHARS -0123456789.:
+WORDCHARS -0123456789:
 
 BREAK 4
 BREAK -


### PR DESCRIPTION
Matches found during Swedish spell checking included period (.) if at the end of a sentence. This commit fixes that.

Not sure if the intention of including it was to allow for abbreviations such as "t.ex.", but this change does not seem to affect that. Mostly since they were not handled correctly even before this change.