### PR TITLE
Update segmentation rules for the German language

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
@@ -4636,7 +4636,7 @@ It [really!] works. This is e.g. Mr. Smith, who talks slowly... And this is anot
 <!-- ähnliche Fälle außerhalb der Monatsnamen -->
 <rule break="no">
 <beforebreak>\d+\.\s</beforebreak>
-<afterbreak>Amtsperiode|Breitengrad|Breitengrads|Breitengrades|Jubiläum|Jh|Jhd|Jhdt|Parteitag|Parteitags|Parteitages|Jahrhundert|Jahrhunderts|Jahrtausend|Geburtstag|Geburtstags|Platz|Platzes|Lebensjahr|Lebensjahrs|Lebensjahres|Loch|Lochs|Loches|Grads|Grades</afterbreak>
+<afterbreak>Amtsperiode|Breitengrad|Breitengrads|Breitengrades|Jubiläum|Jh|Jhd|Jhdt|Tag|Tages|Tags|Jahrestag|Jahrestages|Jahrestags|Spieltag|Spieltages|Splieltags|Parteitag|Parteitags|Parteitages|Jahrhundert|Jahrhunderts|Jahrtausend|Geburtstag|Geburtstags|Platz|Platzes|Lebensjahr|Lebensjahrs|Lebensjahres|Loch|Lochs|Loches|Grads|Grades</afterbreak>
 </rule>
 <!-- English abbreviations - but these work globally for all languages -->
 <rule break="no">


### PR DESCRIPTION
Added 'Tag', 'Jahrestag', 'Spieltag' to the German segmentation rules for keeping together e.g. 20. Tag, 40. Jahrestag, 9. Spieltag.