### PR TITLE
Update SRX rules for the German language

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
@@ -4636,7 +4636,7 @@ It [really!] works. This is e.g. Mr. Smith, who talks slowly... And this is anot
 <!-- ähnliche Fälle außerhalb der Monatsnamen -->
 <rule break="no">
 <beforebreak>\d+\.\s</beforebreak>
-<afterbreak>Amtsperiode|Breitengrad|Breitengrads|Breitengrades|Jubiläum|Jh|Jhd|Jhdt|Tag|Tages|Tags|(Jahres|Spiel|Partei|Geburts)tag|(Jahres|Spiel|Partei|Geburts)tages|(Jahres|Spiel|Partei|Geburts)tags|Jahrhundert|Jahrhunderts|Jahrtausend|Platz|Platzes|Lebensjahr|Lebensjahrs|Lebensjahres|Loch|Lochs|Loches|Grads|Grades|Obergeschoss|Stock(werk)?s?|Etage|Klasse|Runde|Bezirk</afterbreak>
+<afterbreak>Amtsperiode|Breitengrad|Breitengrads|Breitengrades|Jubiläum|Jh|Jhd|Jhdt|Konferenz|(Jahres|Spiel|Partei)(-K|k)onferenz|Tag|Tages|Tags|(Jahres|Spiel|Partei|Geburts)tag|(Jahres|Spiel|Partei|Geburts)tages|(Jahres|Spiel|Partei|Geburts)tags|Jahrhundert|Jahrhunderts|Jahrtausend|Platz|Platzes|Lebensjahr|Lebensjahrs|Lebensjahres|Loch|Lochs|Loches|Grads|Grades|Obergeschoss|Stock(werk)?s?|Etage|Klasse|Runde|Bezirk</afterbreak>
 </rule>
 <!-- English abbreviations - but these work globally for all languages -->
 <rule break="no">


### PR DESCRIPTION
Added 'Konferenz' and corresponding compounds.