### PR TITLE
Fix an exception rule for English in the SRX file

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
@@ -1169,7 +1169,7 @@ It [really!] works. This is e.g. Mr. Smith, who talks slowly... And this is anot
 <!--"Etc." can end the sentence, so we check for the uppercase letter after it.-->
 <rule break="no">
 <beforebreak>\b[Ee]tc\.\s</beforebreak>
-<afterbreak>[^p{Lu}]</afterbreak>
+<afterbreak>[^\p{Lu}]</afterbreak>
 </rule>
 <rule break="no">
 <beforebreak>\bJan\.\s</beforebreak>


### PR DESCRIPTION
Added a missing backslash in an afterbreak regex.