### PR TITLE
Add HTML file for allowing to filter false friends by language (issue #58)

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/rules/false-friends.htm
+++ b/languagetool-core/src/main/resources/org/languagetool/rules/false-friends.htm
@@ -1,0 +1,63 @@
+<!-- [False Friends - filter by language]
+
+  Allowing to filter false friends by a certain language,
+  attaching a parameter to the URL in this way:
+
+  ./false-friends.htm?lang=xx
+
+  where "xx" is the code of the desired language. For example:
+
+  ./false-friends.htm?lang=en
+
+  for viewing all the false friends that have an English form.
+  If there is no parameter provided, it shows all the elements. -->
+
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>languagetools.org: False Friends</title>
+  <script>
+    function getLangFromURL() {
+      var param = location.search.split("?lang=")[1];
+      return param ? param : "all";
+    }
+
+    function loadXMLDoc(filename) {
+      if (window.ActiveXObject) {
+        xhttp = new ActiveXObject("Msxml2.XMLHTTP");
+      } else {
+        xhttp = new XMLHttpRequest();
+      }
+      xhttp.open("GET", filename, false);
+      try {
+        xhttp.responseType = "msxml-document"
+      } catch (err) {}  // helping IE11
+      xhttp.send("");
+      return xhttp.responseXML;
+    }
+
+    function displayResult() {
+      lang = getLangFromURL();
+      xml = loadXMLDoc("false-friends.xml");
+      xsl = loadXMLDoc("print-ff.xsl");
+      // code for IE
+      if (window.ActiveXObject || xhttp.responseType == "msxml-document") {
+        ex = xml.transformNode(xsl);
+        document.getElementById("container").innerHTML = ex;
+      }
+      // code for Chrome, Firefox, Opera, etc.
+      else if (document.implementation && document.implementation.createDocument) {
+        xsltProcessor = new XSLTProcessor();
+        xsltProcessor.importStylesheet(xsl);
+        xsltProcessor.setParameter(null, "lang", lang);
+        resultDocument = xsltProcessor.transformToFragment(xml, document);
+        document.getElementById("container").appendChild(resultDocument);
+      }
+    }
+  </script>
+</head>
+<body onload="displayResult()">
+  <div id="container" />
+</body>
+</html>

--- a/languagetool-core/src/main/resources/org/languagetool/rules/print-ff.xsl
+++ b/languagetool-core/src/main/resources/org/languagetool/rules/print-ff.xsl
@@ -8,6 +8,8 @@
 		java -jar saxon8.jar false-friends.xml print-ff.xsl
 		
 	-->
+	<xsl:param name="lang" select="'all'" />
+
 	<xsl:output method="html" encoding="UTF-8" indent="no" />
 
 	<xsl:template match="text()" />
@@ -37,7 +39,9 @@
 	</xsl:template>
 
 	<xsl:template match="//rule">
-		<xsl:apply-templates select="*"/>
+		<xsl:if test="$lang='all' or pattern[@lang=$lang] or translation[@lang=$lang]">
+			<xsl:apply-templates select="*"/>
+		</xsl:if>
 	</xsl:template>
 	
 	<xsl:template match="translation">


### PR DESCRIPTION
Hey,

This PR is a tentative solution for the issue #58, labeled as "easy fix".  It doesn't remove the possibility of accessing to the `false-friends.xml`, but it adds a new file (`false-friends.htm`) that allows to filter by language, attaching a parameter to the URL in this way: `false-friends.htm?lang=en`. If there is no parameter provided, it shows all the elements.

Please tell me if this fit into the idea.