### PR TITLE
[es] lowercase: months, days of the week, and seasons of the year

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -52,6 +52,46 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <token postag="(P.|V.{3})[30].*" postag_regexp="yes"/>
         </equivalence>
     </unification>
+
+  <category id="CASING" name="Mayúsculas y minúsculas" type="typographical">
+    <rule id="MIN_MESES" name="Meses en minúscula">
+      <pattern case_sensitive="yes">
+        <token postag="SENT_START" negate_pos="yes"/>
+        <marker>
+          <token regexp="yes">Enero|Febrero|Marzo|Abril|Mayo|Junio|Julio|Agosto|Septiembre|Octubre|Noviembre|Diciembre</token>
+        </marker>
+      </pattern>
+      <message>Los meses del año se escriben en minúsculas: <suggestion><match no="2" case_conversion="alllower"/></suggestion>.</message>
+      <url>http://www.rae.es/consultas/mayuscula-o-minuscula-en-los-meses-los-dias-de-la-semana-y-las-estaciones-del-ano</url>
+      <example correction="julio">En <marker>Julio</marker> hace mucho calor.</example>
+      <example>El pasado <marker>diciembre</marker> estuve en Andorra.</example>
+    </rule>
+    <rule id="MIN_DIAS_SEMANA" name="Días de las semana en minúscula">
+      <pattern case_sensitive="yes">
+        <token postag="SENT_START" negate_pos="yes"/>
+        <marker>
+          <token regexp="yes">Lunes|Martes|Miércoles|Jueves|Viernes|Sábado|Domingo</token>
+        </marker>
+      </pattern>
+      <message>Los días de la semana se escriben en minúsculas: <suggestion><match no="2" case_conversion="alllower"/></suggestion>.</message>
+      <url>http://www.rae.es/consultas/mayuscula-o-minuscula-en-los-meses-los-dias-de-la-semana-y-las-estaciones-del-ano</url>
+      <example correction="lunes">Todos los <marker>Lunes</marker> son tristes.</example>
+      <example>Los <marker>martes</marker> juego un partido de tenis.</example>
+    </rule>
+    <rule id="MIN_ESTACIONES" name="Estaciones del año en minúscula">
+      <pattern case_sensitive="yes">
+        <token postag="SENT_START" negate_pos="yes"/>
+        <marker>
+          <token regexp="yes">Primavera|Verano|Otoño|Invierno</token>
+        </marker>
+      </pattern>
+      <message>Las estaciones del año se escriben en minúsculas: <suggestion><match no="2" case_conversion="alllower"/></suggestion>.</message>
+      <url>http://www.rae.es/consultas/mayuscula-o-minuscula-en-los-meses-los-dias-de-la-semana-y-las-estaciones-del-ano</url>
+      <example correction="verano">Este <marker>Verano</marker> me voy de vacaciones.</example>
+      <example>Ha sido el <marker>invierno</marker> más frío que recuerdo.</example>
+    </rule>
+  </category>
+
   <category id="TYPOS" name="Ortografía (tipográficos)" type="misspelling">
       
     <rule id="USO_HUSO" name="uso/huso horario">


### PR DESCRIPTION
Hey,

This PR adds three rules to the Spanish grammar: months, days of the week, and seasons of the year have to be written in lowercase.