### PR TITLE
Stop dispositioning of vertical scrolls when expanding the checkbox

### DIFF
--- a/languagetool-gui-commons/src/main/java/org/languagetool/gui/ConfigurationDialog.java
+++ b/languagetool-gui-commons/src/main/java/org/languagetool/gui/ConfigurationDialog.java
@@ -174,7 +174,7 @@ public class ConfigurationDialog implements ActionListener {
     cons.gridx = 0;
     cons.weightx = 1.0;
     cons.weighty = 1.0;
-    cons.fill = GridBagConstraints.BOTH;
+    cons.fill = GridBagConstraints.HORIZONTAL;
     Collections.sort(rules, new CategoryComparator());
     DefaultMutableTreeNode rootNode = createTree(rules, false);   //  grammar options
     configTree[0] = new JTree(getTreeModel(rootNode));
@@ -199,7 +199,7 @@ public class ConfigurationDialog implements ActionListener {
     cons.gridx = 0;
     cons.weightx = 1.0;
     cons.weighty = 1.0;
-    cons.fill = GridBagConstraints.BOTH;
+    cons.fill = GridBagConstraints.HORIZONTAL;
     Collections.sort(rules, new CategoryComparator());
     rootNode = createTree(rules, true);  //  Style options
     configTree[1] = new JTree(getTreeModel(rootNode));

--- a/languagetool-standalone/CHANGES.md
+++ b/languagetool-standalone/CHANGES.md
@@ -152,6 +152,7 @@
   * show line numbers in the text area
   * a directory with word2vec language model for neural network rules can now be
     specified in the configuration dialog, see https://forum.languagetool.org/t/neural-network-rules/2225
+  * Stop disposition of vertical scroll when expanding the checkbox.
 
 #### Java API
   * A `RuleMatch` can now have a URL, too. The URL usually points to a page that


### PR DESCRIPTION
Fixes issue #908 

By making a contribution to this project, I certify that:
(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

Signed-off-by: Heet Sankesara<heetsankesara3@gmail.com>

Stop disposition of vertical scroll when expanding the checkbox in GUI.