### PR TITLE
[en] added some redundancy rules

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -22842,6 +22842,66 @@ USA
                 <example>ATMs are quite common in the Netherlands,</example>
             </rule>
         </rulegroup>
+		<rulegroup id="PIN_NUMBER" name="PIN number (PIN)">
+            <rule>
+                <pattern>
+                    <token>PIN</token>
+                    <token>number</token>
+                </pattern>
+                <message>This phrase is redundant ('N' stands for 'number'). Consider using <suggestion>\1</suggestion>.</message>
+                <short>Redundant phrase</short>
+                <example correction="PIN">Please input your <marker>PIN number</marker> to access.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>PIN</token>
+                    <token>numbers</token>
+                </pattern>
+                <message>This phrase is redundant ('N' stands for 'number'). Consider using <suggestion>\1s</suggestion>.</message>
+                <short>Redundant phrase</short>
+                <example correction="PINs">You can create multiple <marker>PIN numbers</marker> to enhance the security.</example>
+            </rule>
+        </rulegroup>
+		<rulegroup id="ISBN_NUMBER" name="ISBN number (ISBN)">
+            <rule>
+                <pattern>
+                    <token>ISBN</token>
+                    <token>number</token>
+                </pattern>
+                <message>This phrase is redundant ('N' stands for 'number'). Consider using <suggestion>\1</suggestion>.</message>
+                <short>Redundant phrase</short>
+                <example correction="ISBN">Could you let me know the <marker>ISBN number</marker> of the book?</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>ISBN</token>
+                    <token>numbers</token>
+                </pattern>
+                <message>This phrase is redundant ('N' stands for 'number'). Consider using <suggestion>\1s</suggestion>.</message>
+                <short>Redundant phrase</short>
+                <example correction="ISBNs"><marker>ISBN numbers</marker> are assigned to text-based monographic publications.</example>
+            </rule>
+        </rulegroup>
+		<rulegroup id="LCD_DISPLAY" name="LCD display (LCD)">
+            <rule>
+                <pattern>
+                    <token>LCD</token>
+                    <token>display</token>
+                </pattern>
+                <message>This phrase is redundant ('D' stands for 'display'). Consider using <suggestion>\1</suggestion>.</message>
+                <short>Redundant phrase</short>
+                <example correction="LCD">The result is printed on this <marker>LCD display</marker>.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>LCD</token>
+                    <token>displays</token>
+                </pattern>
+                <message>This phrase is redundant ('D' stands for 'display'). Consider using <suggestion>\1s</suggestion>.</message>
+                <short>Redundant phrase</short>
+                <example correction="LCDs"><marker>LCD displays</marker> have sources of light behind the screens.</example>
+            </rule>
+        </rulegroup>
         <rule id="ABSOLUTELY_ESSENTIAL" name="absolutely essential/necessary (essential/necessary)">
             <pattern>
                 <token>absolutely</token>


### PR DESCRIPTION
Hello.

I added some redundancy rules to the English grammar.xml

The rules I wrote are:
correcting PIN Number -> PIN ('N' stands for 'number')
correcting ISBN Number -> ISBN ('N' stands for 'number')
correcting LCD Display -> LCD ('D' stands for 'display')

I tested this by changing grammar.xml and restarting "languagetool.jar", and It worked.

