### PR TITLE
[de/en] added rule for date checks with missing year

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ pom.xml.versionsBackup
 pom.xml.asc
 .DS_Store
 languagetool-standalone/test.txt
+languagetool-standalone/test_de.txt
+languagetool-standalone/test_en.txt

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .project
 .settings
 .metadata
+.vscode/
 build
 target
 atomFeedChecksDB
@@ -17,3 +18,4 @@ derby.log
 pom.xml.versionsBackup
 pom.xml.asc
 .DS_Store
+languagetool-standalone/test.txt

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -11101,6 +11101,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 <example>Bei Temperaturen um 25° C ist es warm.</example>
             </rule>
         </rulegroup>
+
+
         <rulegroup id="DATUM_WOCHENTAG" name="Wochentag passt nicht zum Datum">
             <antipattern case_sensitive="yes">
                 <!-- Zeitung "der freitag" -->
@@ -11241,6 +11243,130 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             </rule>
             <!-- TODO: weitere regel auch ohne Jahr (Annahme: dieses Jahr (auch am jahresende bei "2.1."?)) -->
         </rulegroup>
+
+        <rulegroup id="DATUM_WOCHENTAG_OHNE_JAHR" name="Wochentag passt nicht zum Datum dieses Jahres">
+            <antipattern case_sensitive="yes">
+                <!-- Zeitung "der freitag" -->
+                <token>der</token>
+                <token>freitag</token>
+            </antipattern>
+            <antipattern case_sensitive="yes">
+                <!-- z.B. "lemonde.fr" -->
+                <token>.</token>
+                <token spacebefore="no">fr</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">\d\d\d\d</token>
+                <token>v</token>
+                <token>.</token>
+                <token min="0">&nbsp;</token>
+                <token>Chr</token>
+                <token>.</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">\d\d\d\d</token>
+                <token>v</token>
+                <token>.</token>
+                <token min="0">&nbsp;</token>
+                <token>u</token>
+                <token>.</token>
+                <token min="0">&nbsp;</token>
+                <token>Z</token>
+                <token>.</token>
+            </antipattern>
+            <rule>
+                <pattern>
+                    <token regexp="yes">&wochentage;|&abgekWochentage;</token>
+                    <token>,</token>
+                    <token regexp="yes" min="0">de[mnrs]</token>
+                    <token regexp="yes">\d\d?</token>
+                    <token>.</token>
+                    <token regexp="yes">\d\d?</token>
+                    <token>.</token>
+                </pattern>
+                <filter class="org.languagetool.rules.de.DateCheckFilter" args="month:\6 day:\4 weekDay:\1"/>
+                <!-- TODO change examples -->
+                <message>Bezieht sich dieses Datum auf das aktuelle Jahr? Der \4.\6.{currentYear} fällt nicht auf einen {day}, sondern auf einen {realDay}.</message>
+                <example correction="">Termin: <marker>Sonntag, 23.08.</marker></example>
+                <example correction="">Termin: <marker>Sonntag, 23.8.</marker></example>
+                <example correction="">Termin: <marker>So, 23.08.</marker></example>
+                <example correction="">Termin: <marker>Sonntag, den 23.08.</marker></example>
+                <example correction="">Termin: <marker>So, den 23.08.</marker></example>
+                <example>Termin: Sonnabend, 23.08.</example>
+                <example>Termin: Samstag, 23.08.</example>
+                <example>Termin: Sa, 23.08.</example>
+                <example>Termin: Sa, 33.08.</example><!-- invalid, but ignored by this rule -->
+                <example>Termin: Sa, 11.13.</example><!-- invalid, but ignored by this rule -->
+                <example>Termin: Sa, 12.13.</example><!-- invalid, but ignored by this rule -->
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">&abgekWochentage;</token>
+                    <token>.</token>
+                    <token>,</token>
+                    <token regexp="yes" min="0">de[nmrs]</token>
+                    <token regexp="yes">\d\d?</token>
+                    <token>.</token>
+                    <token regexp="yes">\d\d?</token>
+                    <token>.</token>
+                </pattern>
+                <filter class="org.languagetool.rules.de.DateCheckFilter" args="month:\7 day:\5 weekDay:\1"/>
+                <message>Bezieht sich dieses Datum auf das aktuelle Jahr?
+                    Der \5.\7.{currentYear} fällt nicht auf einen {day}, sondern auf einen {realDay}.</message>
+                <example correction="">Termin: <marker>So., 23.08.</marker></example>
+                <example correction="">Termin: <marker>So., den 23.08.</marker></example>
+                <example>Termin: Sa., 23.08.</example>
+                <example>Termin: Sa., 34.08.</example><!-- invalid, but ignored by this rule -->
+                <example>Termin: Sa., 35.08.</example><!-- invalid, but ignored by this rule -->
+            </rule>
+            <rule>
+                <antipattern case_sensitive="yes">
+                    <!-- Wochenzeitung -->
+                    <token>Der</token>
+                    <token>Freitag</token>
+                </antipattern>
+                <pattern>
+                    <token regexp="yes">&wochentage;|&abgekWochentage;</token>
+                    <token>,</token>
+                    <token regexp="yes" min="0">de[nmrs]</token>
+                    <token regexp="yes">\d\d?</token>
+                    <token>.</token>
+                    <token regexp="yes">&monate;</token>
+                </pattern>
+                <filter class="org.languagetool.rules.de.DateCheckFilter" args="month:\6 day:\4 weekDay:\1"/>
+                <message>Bezieht sich dieses Datum auf das aktuelle Jahr? Der \4. \6 {currentYear} fällt nicht auf einen {day}, sondern auf einen {realDay}.</message>
+                <example correction="">Termin: <marker>Donnerstag, 1. Jänner</marker></example>
+                <example correction="">Termin: <marker>Sonntag, 23. August</marker></example>
+                <example correction="">Termin: <marker>So, 23. August</marker></example>
+                <example correction="">Termin: <marker>Sonntag, den 23. August</marker></example>
+                <example>Termin: <marker>Mittwoch, 1. Jänner</marker></example>
+                <example>Termin: <marker>Samstag, 23. August</marker></example>
+                <example>Termin: <marker>Sa, 23. August</marker></example>
+                <example>Termin: <marker>Samstag, den 23. August</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">&wochentage;|&abgekWochentage;</token>
+                    <token>,</token>
+                    <token regexp="yes" min="0">de[nmrs]</token>
+                    <token regexp="yes">\d\d?</token>
+                    <token>.</token>
+                    <token regexp="yes">&abgekMonate;</token>
+                    <token>.</token>
+                </pattern>
+                <filter class="org.languagetool.rules.de.DateCheckFilter" args="month:\6 day:\4 weekDay:\1"/>
+                <message>Bezieht sich dieses Datum auf das aktuelle Jahr? Der \4. \6 {currentYear} fällt nicht auf einen {day}, sondern auf einen {realDay}.</message>
+                <example correction="">Termin: <marker>Donnerstag, 1. Jän.</marker></example>
+                <example correction="">Termin: <marker>Sonntag, 23. Aug.</marker></example>
+                <example correction="">Termin: <marker>So, 23. Aug.</marker></example>
+                <example correction="">Termin: <marker>Sonntag, den 23. Aug.</marker></example>
+                <example>Termin: <marker>Mittwoch, 1. Jän.</marker></example>
+                <example>Termin: <marker>Samstag, 23. Aug.</marker></example>
+                <example>Termin: <marker>Sa, 23. Aug.</marker></example>
+                <example>Termin: <marker>Samstag, den 23. Aug.</marker></example>
+            </rule>
+        </rulegroup>
+
         <rulegroup id="UNGUELTIGES_DATUM" name="Ungültiges Datum, z.B. '31. Februar'">
             <rule>
                 <pattern>

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -11274,6 +11274,49 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 <token>Z</token>
                 <token>.</token>
             </antipattern>
+
+            <!-- all patterns for DATUM_WOCHENTAG are antipatterns, otherwise both trigger for the same date -->
+            <antipattern>
+                <token regexp="yes">&wochentage;|&abgekWochentage;</token>
+                <token>,</token>
+                <token regexp="yes" min="0">de[mnrs]</token>
+                <token regexp="yes">\d\d?</token>
+                <token>.</token>
+                <token regexp="yes">\d\d?</token>
+                <token>.</token>
+                <token regexp="yes">\d\d\d\d</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">&abgekWochentage;</token>
+                <token>.</token>
+                <token>,</token>
+                <token regexp="yes" min="0">de[nmrs]</token>
+                <token regexp="yes">\d\d?</token>
+                <token>.</token>
+                <token regexp="yes">\d\d?</token>
+                <token>.</token>
+                <token regexp="yes">\d\d\d\d</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">&wochentage;|&abgekWochentage;</token>
+                <token>,</token>
+                <token regexp="yes" min="0">de[nmrs]</token>
+                <token regexp="yes">\d\d?</token>
+                <token>.</token>
+                <token regexp="yes">&monate;</token>
+                <token regexp="yes">\d\d\d\d</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">&wochentage;|&abgekWochentage;</token>
+                <token>,</token>
+                <token regexp="yes" min="0">de[nmrs]</token>
+                <token regexp="yes">\d\d?</token>
+                <token>.</token>
+                <token regexp="yes">&abgekMonate;</token>
+                <token>.</token>
+                <token regexp="yes">\d\d\d\d</token>
+            </antipattern>
+
             <rule>
                 <pattern>
                     <token regexp="yes">&wochentage;|&abgekWochentage;</token>
@@ -11283,7 +11326,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token>.</token>
                     <token regexp="yes">\d\d?</token>
                     <token>.</token>
-                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.de.DateCheckFilter" args="month:\6 day:\4 weekDay:\1"/>
                 <!-- TODO change examples -->
@@ -11310,7 +11352,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token>.</token>
                     <token regexp="yes">\d\d?</token>
                     <token>.</token>
-                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.de.DateCheckFilter" args="month:\7 day:\5 weekDay:\1"/>
                 <message>Bezieht sich dieses Datum auf das aktuelle Jahr?
@@ -11334,7 +11375,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token regexp="yes">\d\d?</token>
                     <token>.</token>
                     <token regexp="yes">&monate;</token>
-                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.de.DateCheckFilter" args="month:\6 day:\4 weekDay:\1"/>
                 <message>Bezieht sich dieses Datum auf das aktuelle Jahr? Der \4. \6 {currentYear} fällt nicht auf einen {day}, sondern auf einen {realDay}.</message>
@@ -11356,7 +11396,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token>.</token>
                     <token regexp="yes">&abgekMonate;</token>
                     <token>.</token>
-                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.de.DateCheckFilter" args="month:\6 day:\4 weekDay:\1"/>
                 <message>Bezieht sich dieses Datum auf das aktuelle Jahr? Der \4. \6 {currentYear} fällt nicht auf einen {day}, sondern auf einen {realDay}.</message>

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -11283,6 +11283,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token>.</token>
                     <token regexp="yes">\d\d?</token>
                     <token>.</token>
+                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.de.DateCheckFilter" args="month:\6 day:\4 weekDay:\1"/>
                 <!-- TODO change examples -->
@@ -11309,6 +11310,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token>.</token>
                     <token regexp="yes">\d\d?</token>
                     <token>.</token>
+                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.de.DateCheckFilter" args="month:\7 day:\5 weekDay:\1"/>
                 <message>Bezieht sich dieses Datum auf das aktuelle Jahr?
@@ -11332,6 +11334,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token regexp="yes">\d\d?</token>
                     <token>.</token>
                     <token regexp="yes">&monate;</token>
+                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.de.DateCheckFilter" args="month:\6 day:\4 weekDay:\1"/>
                 <message>Bezieht sich dieses Datum auf das aktuelle Jahr? Der \4. \6 {currentYear} fällt nicht auf einen {day}, sondern auf einen {realDay}.</message>
@@ -11353,6 +11356,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token>.</token>
                     <token regexp="yes">&abgekMonate;</token>
                     <token>.</token>
+                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.de.DateCheckFilter" args="month:\6 day:\4 weekDay:\1"/>
                 <message>Bezieht sich dieses Datum auf das aktuelle Jahr? Der \4. \6 {currentYear} fällt nicht auf einen {day}, sondern auf einen {realDay}.</message>

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -25461,6 +25461,44 @@ USA
                 <token>C</token>
                 <token>.</token>
             </antipattern>
+
+            <!-- prevent overlapping match with DATE_WEEKDAY -->
+            <antipattern>
+                <!-- "Monday, 7 October 2014" -->
+                <token regexp="yes">&weekdays;|&abbrevWeekdays;</token>
+                <token>,</token>
+                <token regexp="yes">\d\d?</token>
+                <token regexp="yes">&months;|&abbrevMonths;</token>
+                <token regexp="yes">\d\d\d\d</token>
+            </antipattern>
+            <antipattern>
+                <!-- "Monday, October 7, 2014" -->
+                <token regexp="yes">&weekdays;|&abbrevWeekdays;</token>
+                <token>,</token>
+                <token regexp="yes">&months;|&abbrevMonths;</token>
+                <token regexp="yes">\d\d?</token>
+                <token>,</token>
+                <token regexp="yes">\d\d\d\d</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">&weekdays;</token>
+                <token>,</token>
+                <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
+                <token>/</token>
+                <token regexp="yes">0?[1-9]|1[0-2]</token>
+                <token>/</token>
+                <token regexp="yes">\d\d\d\d</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">&weekdays;</token>
+                <token>,</token>
+                <token regexp="yes">0?[1-9]|1[0-2]</token>
+                <token>/</token>
+                <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
+                <token>/</token>
+                <token regexp="yes">\d\d\d\d</token>
+            </antipattern>
+
             <rule>
                 <pattern>
                     <!-- "Monday, 7 October" -->
@@ -25468,7 +25506,6 @@ USA
                     <token>,</token>
                     <token regexp="yes">\d\d?</token>
                     <token regexp="yes">&months;|&abbrevMonths;</token>
-                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.en.DateCheckFilter" args="month:\4 day:\3 weekDay:\1"/>
                 <message>Did you mean to refer to the current year? \3 \4 {currentYear} is not a {day}, but a {realDay}.</message>
@@ -25486,7 +25523,6 @@ USA
                     <token>,</token>
                     <token regexp="yes">&months;|&abbrevMonths;</token>
                     <token regexp="yes">\d\d?</token>
-                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.en.DateCheckFilter" args="month:\3 day:\4 weekDay:\1"/>
                 <message>Did you mean to refer to the current year? \3 \4, {currentYear} is not a {day}, but a {realDay}.</message>
@@ -25518,8 +25554,6 @@ USA
                     <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
                     <token>/</token>
                     <token regexp="yes">0?[1-9]|1[0-2]</token>
-                    <token neagte="yes">/</token>
-                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.en.DateCheckFilter" args="month:\5 day:\3 weekDay:\1"/>
                 <message>Did you mean to refer to the current year? \3/\5/{currentYear} is not a {day}, but a {realDay}.</message>
@@ -25544,8 +25578,6 @@ USA
                     <token regexp="yes">0?[1-9]|1[0-2]</token>
                     <token>/</token>
                     <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
-                    <token negate="yes">/</token>
-                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.en.DateCheckFilter" args="month:\3 day:\5 weekDay:\1"/>
                 <message>Did you mean to refer to the current year? \3/\5/{currentYear} is not a {day}, but a {realDay}.</message>

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -25448,6 +25448,107 @@ USA
                 <example>IGD Convention 2014 - <marker>Friday, 2014-10-31</marker></example>
             </rule>             
         </rulegroup>
+        
+        <rulegroup id="DATE_WEEKDAY_WITHOUT_YEAR" name="Weekday doesn't match date for the current year">
+            <antipattern>
+                <token regexp="yes">\d\d\d\d</token>
+                <token>BC</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">\d\d\d\d</token>
+                <token>B</token>
+                <token>.</token>
+                <token>C</token>
+                <token>.</token>
+            </antipattern>
+            <rule>
+                <pattern>
+                    <!-- "Monday, 7 October" -->
+                    <token regexp="yes">&weekdays;|&abbrevWeekdays;</token>
+                    <token>,</token>
+                    <token regexp="yes">\d\d?</token>
+                    <token regexp="yes">&months;|&abbrevMonths;</token>
+                </pattern>
+                <filter class="org.languagetool.rules.en.DateCheckFilter" args="month:\4 day:\3 weekDay:\1"/>
+                <message>Did you mean to refer to the current year? \3 \4 {currentYear} is not a {day}, but a {realDay}.</message>
+                <example correction="">IGD Convention - <marker>Monday, 7 October</marker></example>
+                <example correction="">IGD Convention - <marker>Mon, 7 October</marker></example>
+                <example correction="">IGD Convention - <marker>Mo, 7 October</marker></example>
+                <example correction="">IGD Convention - <marker>Monday, 7 Oct</marker></example>
+                <example>IGD Convention - <marker>Tuesday, 7 October</marker></example>
+                <example>IGD Convention - <marker>Tuesday, 7 Oct</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <!-- "Monday, October 7" -->
+                    <token regexp="yes">&weekdays;|&abbrevWeekdays;</token>
+                    <token>,</token>
+                    <token regexp="yes">&months;|&abbrevMonths;</token>
+                    <token regexp="yes">\d\d?</token>
+                </pattern>
+                <filter class="org.languagetool.rules.en.DateCheckFilter" args="month:\3 day:\4 weekDay:\1"/>
+                <message>Did you mean to refer to the current year? \3 \4 {currentYear} is not a {day}, but a {realDay}.</message>
+                <example correction="">IGD Convention - <marker>Monday, October 7</marker></example>
+                <example correction="">IGD Convention - <marker>Mon, October 7</marker></example>
+                <example correction="">IGD Convention - <marker>Mo, October 7</marker></example>
+                <example correction="">IGD Convention - <marker>Wednesday, October 7</marker></example>
+                <example correction="">IGD Convention - <marker>Thursday, October 7</marker></example>
+                <example correction="">IGD Convention - <marker>Friday, October 7</marker></example>
+                <example correction="">IGD Convention - <marker>Saturday, October 7</marker></example>
+                <example correction="">IGD Convention - <marker>Sunday, October 7</marker></example>
+                <example correction="">IGD Convention - <marker>Sunday, Oct 7</marker></example>
+                <example>IGD Convention - <marker>Tuesday, October 7</marker></example>
+                <example>IGD Convention - <marker>Tuesday, Oct 7</marker></example>
+            </rule>
+            <!-- "Monday, 31/10" -->
+            <!-- the ambiguous forms have been antipatterned -->
+            <rule>
+                <antipattern>
+                    <token regexp="yes">&weekdays;</token>
+                    <token>,</token>
+                    <token regexp="yes">0?[1-9]|1[0-2]</token>
+                    <token>/</token>
+                    <token regexp="yes">0?[1-9]|1[0-2]</token>
+                </antipattern>
+                <pattern>
+                    <token regexp="yes">&weekdays;</token>
+                    <token>,</token>
+                    <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
+                    <token>/</token>
+                    <token regexp="yes">0?[1-9]|1[0-2]</token>
+                </pattern>
+                <filter class="org.languagetool.rules.en.DateCheckFilter" args="month:\5 day:\3 weekDay:\1"/>
+                <message>Did you mean to refer to the current year? \3/\5 {currentYear} is not a {day}, but a {realDay}.</message>
+                <example correction="">IGD Convention 2014 - <marker>Monday, 31/10</marker></example>
+                <example>IGD Convention 2014 - <marker>Friday, 31/10</marker></example>
+                <example>IGD Convention 2014 - <marker>Monday, 10/09</marker></example><!-- not correct, but ambiguous -->
+                <example>IGD Convention 2014 - <marker>Monday, 9/10</marker></example><!-- not correct, but ambiguous -->
+            </rule>
+            <rule>
+                <!-- "Monday, 10/31" -->
+                <!-- the ambiguous forms have been antipatterned -->
+                <antipattern>
+                    <token regexp="yes">&weekdays;</token>
+                    <token>,</token>
+                    <token regexp="yes">0?[1-9]|1[0-2]</token>
+                    <token>/</token>
+                    <token regexp="yes">0?[1-9]|1[0-2]</token>
+                </antipattern>
+                <pattern>
+                    <token regexp="yes">&weekdays;</token>
+                    <token>,</token>
+                    <token regexp="yes">0?[1-9]|1[0-2]</token>
+                    <token>/</token>
+                    <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
+                </pattern>
+                <filter class="org.languagetool.rules.en.DateCheckFilter" args="month:\3 day:\5 weekDay:\1"/>
+                <message>Did you mean to refer to the current year? \3/\5 {currentYear} is not a {day}, but a {realDay}.</message>
+                <example correction="">IGD Convention 2014 - <marker>Monday, 10/31</marker></example>
+                <example>IGD Convention 2014 - <marker>Friday, 10/31</marker></example>
+                <example>IGD Convention 2014 - <marker>Monday, 10/09</marker></example><!-- not correct, but ambiguous -->
+                <example>IGD Convention 2014 - <marker>Monday, 9/10</marker></example><!-- not correct, but ambiguous -->
+            </rule>
+        </rulegroup>
         <rulegroup id="INVALID_DATE" name="Invalid date, like 'February 31, 2014'">
             <rule>
                 <pattern>

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -25468,6 +25468,7 @@ USA
                     <token>,</token>
                     <token regexp="yes">\d\d?</token>
                     <token regexp="yes">&months;|&abbrevMonths;</token>
+                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.en.DateCheckFilter" args="month:\4 day:\3 weekDay:\1"/>
                 <message>Did you mean to refer to the current year? \3 \4 {currentYear} is not a {day}, but a {realDay}.</message>
@@ -25485,9 +25486,10 @@ USA
                     <token>,</token>
                     <token regexp="yes">&months;|&abbrevMonths;</token>
                     <token regexp="yes">\d\d?</token>
+                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.en.DateCheckFilter" args="month:\3 day:\4 weekDay:\1"/>
-                <message>Did you mean to refer to the current year? \3 \4 {currentYear} is not a {day}, but a {realDay}.</message>
+                <message>Did you mean to refer to the current year? \3 \4, {currentYear} is not a {day}, but a {realDay}.</message>
                 <example correction="">IGD Convention - <marker>Monday, October 7</marker></example>
                 <example correction="">IGD Convention - <marker>Mon, October 7</marker></example>
                 <example correction="">IGD Convention - <marker>Mo, October 7</marker></example>
@@ -25516,9 +25518,11 @@ USA
                     <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
                     <token>/</token>
                     <token regexp="yes">0?[1-9]|1[0-2]</token>
+                    <token neagte="yes">/</token>
+                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.en.DateCheckFilter" args="month:\5 day:\3 weekDay:\1"/>
-                <message>Did you mean to refer to the current year? \3/\5 {currentYear} is not a {day}, but a {realDay}.</message>
+                <message>Did you mean to refer to the current year? \3/\5/{currentYear} is not a {day}, but a {realDay}.</message>
                 <example correction="">IGD Convention 2014 - <marker>Monday, 31/10</marker></example>
                 <example>IGD Convention 2014 - <marker>Friday, 31/10</marker></example>
                 <example>IGD Convention 2014 - <marker>Monday, 10/09</marker></example><!-- not correct, but ambiguous -->
@@ -25540,9 +25544,11 @@ USA
                     <token regexp="yes">0?[1-9]|1[0-2]</token>
                     <token>/</token>
                     <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
+                    <token negate="yes">/</token>
+                    <token regexp="yes" negate="yes">(\d\d|\d\d\d\d)</token>
                 </pattern>
                 <filter class="org.languagetool.rules.en.DateCheckFilter" args="month:\3 day:\5 weekDay:\1"/>
-                <message>Did you mean to refer to the current year? \3/\5 {currentYear} is not a {day}, but a {realDay}.</message>
+                <message>Did you mean to refer to the current year? \3/\5/{currentYear} is not a {day}, but a {realDay}.</message>
                 <example correction="">IGD Convention 2014 - <marker>Monday, 10/31</marker></example>
                 <example>IGD Convention 2014 - <marker>Friday, 10/31</marker></example>
                 <example>IGD Convention 2014 - <marker>Monday, 10/09</marker></example><!-- not correct, but ambiguous -->


### PR DESCRIPTION
I extended AbstractDateCheckFilter to default to the current year when no other value is given.
There are two new XML rules (DATUM_WOCHENTAG_OHNE_JAHR for German and DATE_WEEKDAY_WITHOUT_YEAR for English) that make use of this.
They should match dates where no year is specified and check if the weekday is correct (just like the other rule).