### PR TITLE
[de/en] Added check for correct year shortly after New Year's

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractDateCheckFilter.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractDateCheckFilter.java
@@ -33,6 +33,8 @@ import java.util.regex.Pattern;
  * @since 2.7
  */
 public abstract class AbstractDateCheckFilter extends RuleFilter {
+
+  private final TestHackHelper testHackHelper = new TestHackHelper();
   // The day of the month may contain not only digits but also extra letters
   // such as"22nd" in English or "22-an" in Esperanto. The regexp extracts
   // the numerical part.
@@ -100,22 +102,11 @@ public abstract class AbstractDateCheckFilter extends RuleFilter {
     return result;
   }
 
-  private boolean isJUnitTest() {
-    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-    List<StackTraceElement> list = Arrays.asList(stackTrace);
-    for (StackTraceElement element : list) {
-      if (element.getClassName().startsWith("org.junit.")) {
-        return true;
-      }
-    }
-    return false;
-  }
-
 
   private Calendar getDate(Map<String, String> args) {
     String yearArg = args.get("year");
     int year;
-    if (yearArg == null && isJUnitTest()) {
+    if (yearArg == null && testHackHelper.isJUnitTest()) {
       // Volkswagen-style testing
       // Hack for tests of date - weekday match with missing year
       // in production, we assume the current year

--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractDateCheckFilter.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractDateCheckFilter.java
@@ -34,7 +34,6 @@ import java.util.regex.Pattern;
  */
 public abstract class AbstractDateCheckFilter extends RuleFilter {
 
-  private final TestHackHelper testHackHelper = new TestHackHelper();
   // The day of the month may contain not only digits but also extra letters
   // such as"22nd" in English or "22-an" in Esperanto. The regexp extracts
   // the numerical part.
@@ -106,7 +105,7 @@ public abstract class AbstractDateCheckFilter extends RuleFilter {
   private Calendar getDate(Map<String, String> args) {
     String yearArg = args.get("year");
     int year;
-    if (yearArg == null && testHackHelper.isJUnitTest()) {
+    if (yearArg == null && TestHackHelper.isJUnitTest()) {
       // Volkswagen-style testing
       // Hack for tests of date - weekday match with missing year
       // in production, we assume the current year

--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractNewYearDateFilter.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractNewYearDateFilter.java
@@ -29,48 +29,28 @@ import java.util.regex.Pattern;
 /**
  * Accepts rule matches if we are in the first days of a new year and the user
  * may have entered a date with the old year
- * * @since 4.2
+ * @since 4.3
  */
 public abstract class AbstractNewYearDateFilter extends RuleFilter {
-  private final TestHackHelper testHackHelper = new TestHackHelper();
-
-  /**
-   * Return true if the year recently changed (= it is January)
-  */
-  protected boolean isNewYear() {
-    if (testHackHelper.isJUnitTest())
-      return true;
-    return getCalendar().get(Calendar.MONTH) == Calendar.JANUARY;
-  }
-
-  protected int getCurrentYear() {
-    if (testHackHelper.isJUnitTest())
-      return 2014;
-    return getCalendar().get(Calendar.YEAR);
-  }
-
   // The day of the month may contain not only digits but also extra letters
   // such as"22nd" in English or "22-an" in Esperanto. The regexp extracts
   // the numerical part.
   private static final Pattern DAY_OF_MONTH_PATTERN = Pattern.compile("(\\d+).*");
 
   /**
-   * Implement so that Sunday returns {@code 1}, Monday {@code 2} etc.
-   * @param localizedWeekDayString a week day name or abbreviation thereof
-   */
-  protected abstract int getDayOfWeek(String localizedWeekDayString);
+   * Return true if the year recently changed (= it is January)
+  */
+  protected boolean isJanuary() {
+    if (TestHackHelper.isJUnitTest()) {
+      return true;
+    }
+    return getCalendar().get(Calendar.MONTH) == Calendar.JANUARY;
+  }
 
-  /**
-   * Get the localized name of the day of week for the given date.
-   */
-  protected abstract String getDayOfWeek(Calendar date);
-
-  /**
-   * Implement so that "first" returns {@code 1}, second returns {@code 2} etc.
-   * @param localizedDayOfMonth name of day of the month or abbreviation thereof
-   */
-  protected int getDayOfMonth(String localizedDayOfMonth) {
-    return 0;
+  protected int getCurrentYear() {
+    if (TestHackHelper.isJUnitTest())
+      return 2014;
+    return getCalendar().get(Calendar.YEAR);
   }
 
   /**
@@ -82,20 +62,27 @@ public abstract class AbstractNewYearDateFilter extends RuleFilter {
   protected abstract Calendar getCalendar();
 
   /**
+   * Implement so that "first" returns {@code 1}, second returns {@code 2} etc.
+   * @param localizedDayOfMonth name of day of the month or abbreviation thereof
+   */
+  protected int getDayOfMonth(String localizedDayOfMonth) {
+    return 0;
+  }
+
+  /**
    * @param args a map with values for {@code year}, {@code month}, {@code day} (day of month)
    */
   @Override
   public RuleMatch acceptRuleMatch(RuleMatch match, Map<String, String> args, AnalyzedTokenReadings[] patternTokens) {
-
     Calendar dateFromDate = getDate(args);
     int yearFromDate;
     try {
       yearFromDate = dateFromDate.get(Calendar.YEAR);
-    } catch(IllegalArgumentException e) {
+    } catch (IllegalArgumentException e) {
       return null; // date is not valid; another rule is responsible
     }
     int currentYear = getCurrentYear();
-    if (isNewYear() && yearFromDate + 1 == currentYear) {
+    if (isJanuary() && yearFromDate + 1 == currentYear) {
       String message = match.getMessage()
               .replace("{year}", Integer.toString(yearFromDate))
               .replace("{realYear}", Integer.toString(currentYear));

--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractNewYearDateFilter.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractNewYearDateFilter.java
@@ -32,18 +32,19 @@ import java.util.regex.Pattern;
  * * @since 4.2
  */
 public abstract class AbstractNewYearDateFilter extends RuleFilter {
-  /** 
+  private final TestHackHelper testHackHelper = new TestHackHelper();
+
+  /**
    * Return true if the year recently changed (= it is January)
   */
   protected boolean isNewYear() {
-    if (isJUnitTest()) // TODO think about how to test rule
+    if (testHackHelper.isJUnitTest())
       return true;
-    // TODO
-    return getCalendar().get(Calendar.MONTH) == Calendar.JANUARY;// || true;
+    return getCalendar().get(Calendar.MONTH) == Calendar.JANUARY;
   }
 
   protected int getCurrentYear() {
-    if (isJUnitTest()) 
+    if (testHackHelper.isJUnitTest())
       return 2014;
     return getCalendar().get(Calendar.YEAR);
   }
@@ -111,18 +112,6 @@ public abstract class AbstractNewYearDateFilter extends RuleFilter {
     }
     return result;
   }
-
-  private boolean isJUnitTest() {
-    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-    List<StackTraceElement> list = Arrays.asList(stackTrace);
-    for (StackTraceElement element : list) {
-      if (element.getClassName().startsWith("org.junit.")) {
-        return true;
-      }
-    }
-    return false;
-  }
-
 
   private Calendar getDate(Map<String, String> args) {
     int year = Integer.parseInt(getRequired("year", args));

--- a/languagetool-core/src/main/java/org/languagetool/rules/TestHackHelper.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/TestHackHelper.java
@@ -1,0 +1,21 @@
+package org.languagetool.rules;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TestHackHelper {
+  public TestHackHelper() {
+  }
+
+  public boolean isJUnitTest() {
+    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+    List<StackTraceElement> list = Arrays.asList(stackTrace);
+    for (StackTraceElement element : list) {
+      if (element.getClassName().startsWith("org.junit.") ||
+              element.getClassName().equals("org.languagetool.rules.patterns.PatternRuleTest")) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/languagetool-core/src/main/java/org/languagetool/rules/TestHackHelper.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/TestHackHelper.java
@@ -1,13 +1,32 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2018 Fabian Richter
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
 package org.languagetool.rules;
 
 import java.util.Arrays;
 import java.util.List;
 
-public class TestHackHelper {
-  public TestHackHelper() {
+final class TestHackHelper {
+
+  private TestHackHelper() {
   }
 
-  public boolean isJUnitTest() {
+  static boolean isJUnitTest() {
     StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
     List<StackTraceElement> list = Arrays.asList(stackTrace);
     for (StackTraceElement element : list) {

--- a/languagetool-core/src/main/java/org/languagetool/rules/YMDDateHelper.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/YMDDateHelper.java
@@ -1,20 +1,42 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2018 Fabian Richter
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
 package org.languagetool.rules;
 
 import java.util.Calendar;
 import java.util.Map;
 
+/**
+ * @since 4.3
+ */
 public class YMDDateHelper {
+
   public YMDDateHelper() {
   }
 
   public Map<String, String> parseDate(Map<String, String> args) {
-    java.lang.String dateString = args.get("date");
+    String dateString = args.get("date");
     if (dateString == null) {
       throw new IllegalArgumentException("Missing key 'date'");
     }
-    java.lang.String[] parts = dateString.split("-");
+    String[] parts = dateString.split("-");
     if (parts.length != 3) {
-      throw new java.lang.RuntimeException("Expected date in format 'yyyy-mm-dd': '" + dateString + "'");
+      throw new RuntimeException("Expected date in format 'yyyy-mm-dd': '" + dateString + "'");
     }
     args.put("year", parts[0]);
     args.put("month", parts[1]);

--- a/languagetool-core/src/main/java/org/languagetool/rules/YMDDateHelper.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/YMDDateHelper.java
@@ -1,0 +1,36 @@
+package org.languagetool.rules;
+
+import java.util.Calendar;
+import java.util.Map;
+
+public class YMDDateHelper {
+  public YMDDateHelper() {
+  }
+
+  public Map<String, String> parseDate(Map<String, String> args) {
+    java.lang.String dateString = args.get("date");
+    if (dateString == null) {
+      throw new IllegalArgumentException("Missing key 'date'");
+    }
+    java.lang.String[] parts = dateString.split("-");
+    if (parts.length != 3) {
+      throw new java.lang.RuntimeException("Expected date in format 'yyyy-mm-dd': '" + dateString + "'");
+    }
+    args.put("year", parts[0]);
+    args.put("month", parts[1]);
+    args.put("day", parts[2]);
+    return args;
+  }
+
+  public RuleMatch correctDate(RuleMatch match, Map<String, String> args) {
+    String year = args.get("year");
+    String month = args.get("month");
+    String day = args.get("day");
+    int correctYear = Integer.parseInt(year) + 1;
+    String correctDate = String.format("%d-%s-%s", correctYear, month, day);
+    String message = match.getMessage()
+            .replace("{realDate}", correctDate);
+    return new RuleMatch(match.getRule(), match.getSentence(), match.getFromPos(),
+            match.getToPos(), message, match.getShortMessage());
+  }
+}

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/DateCheckFilter.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/DateCheckFilter.java
@@ -21,7 +21,6 @@ package org.languagetool.rules.de;
 import org.languagetool.rules.AbstractDateCheckFilter;
 
 import java.util.Calendar;
-import java.util.Locale;
 
 /**
  * German localization of {@link AbstractDateCheckFilter}.
@@ -29,48 +28,27 @@ import java.util.Locale;
  */
 public class DateCheckFilter extends AbstractDateCheckFilter {
 
+  private final DateFilterHelper dateFilterHelper = new DateFilterHelper();
+
   @Override
   protected Calendar getCalendar() {
-    return Calendar.getInstance(Locale.GERMANY);
+    return dateFilterHelper.getCalendar();
   }
 
   @SuppressWarnings("ControlFlowStatementWithoutBraces")
   @Override
   protected int getDayOfWeek(String dayStr) {
-    String day = dayStr.toLowerCase();
-    if (day.startsWith("sonnabend")) return Calendar.SATURDAY;
-    if (day.startsWith("so")) return Calendar.SUNDAY;
-    if (day.startsWith("mo")) return Calendar.MONDAY;
-    if (day.startsWith("di")) return Calendar.TUESDAY;
-    if (day.startsWith("mi")) return Calendar.WEDNESDAY;
-    if (day.startsWith("do")) return Calendar.THURSDAY;
-    if (day.startsWith("fr")) return Calendar.FRIDAY;
-    if (day.startsWith("sa")) return Calendar.SATURDAY;
-    throw new RuntimeException("Could not find day of week for '" + dayStr + "'");
+    return dateFilterHelper.getDayOfWeek(dayStr);
   }
 
   @Override
   protected String getDayOfWeek(Calendar date) {
-    return date.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.LONG, Locale.GERMAN);
+    return dateFilterHelper.getDayOfWeek(date);
   }
 
   @SuppressWarnings({"ControlFlowStatementWithoutBraces", "MagicNumber"})
   @Override
   protected int getMonth(String monthStr) {
-    String mon = monthStr.toLowerCase();
-    if (mon.startsWith("jän")) return 1;
-    if (mon.startsWith("jan")) return 1;
-    if (mon.startsWith("feb")) return 2;
-    if (mon.startsWith("mär")) return 3;
-    if (mon.startsWith("apr")) return 4;
-    if (mon.startsWith("mai")) return 5;
-    if (mon.startsWith("jun")) return 6;
-    if (mon.startsWith("jul")) return 7;
-    if (mon.startsWith("aug")) return 8;
-    if (mon.startsWith("sep")) return 9;
-    if (mon.startsWith("okt")) return 10;
-    if (mon.startsWith("nov")) return 11;
-    if (mon.startsWith("dez")) return 12;
-    throw new RuntimeException("Could not find month '" + monthStr + "'");
+    return dateFilterHelper.getMonth(monthStr);
   }
 }

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/DateFilterHelper.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/DateFilterHelper.java
@@ -1,0 +1,51 @@
+package org.languagetool.rules.de;
+
+import java.util.Calendar;
+import java.util.Locale;
+
+class DateFilterHelper {
+    public DateFilterHelper() {
+    }
+
+    protected Calendar getCalendar() {
+        return Calendar.getInstance(Locale.GERMANY);
+    }
+
+
+    @SuppressWarnings("ControlFlowStatementWithoutBraces")
+    protected int getDayOfWeek(String dayStr) {
+        String day = dayStr.toLowerCase();
+        if (day.startsWith("sonnabend")) return Calendar.SATURDAY;
+        if (day.startsWith("so")) return Calendar.SUNDAY;
+        if (day.startsWith("mo")) return Calendar.MONDAY;
+        if (day.startsWith("di")) return Calendar.TUESDAY;
+        if (day.startsWith("mi")) return Calendar.WEDNESDAY;
+        if (day.startsWith("do")) return Calendar.THURSDAY;
+        if (day.startsWith("fr")) return Calendar.FRIDAY;
+        if (day.startsWith("sa")) return Calendar.SATURDAY;
+        throw new RuntimeException("Could not find day of week for '" + dayStr + "'");
+    }
+
+    protected String getDayOfWeek(Calendar date) {
+        return date.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.LONG, Locale.GERMAN);
+    }
+
+    @SuppressWarnings({"ControlFlowStatementWithoutBraces", "MagicNumber"})
+    protected int getMonth(String monthStr) {
+        String mon = monthStr.toLowerCase();
+        if (mon.startsWith("jän")) return 1;
+        if (mon.startsWith("jan")) return 1;
+        if (mon.startsWith("feb")) return 2;
+        if (mon.startsWith("mär")) return 3;
+        if (mon.startsWith("apr")) return 4;
+        if (mon.startsWith("mai")) return 5;
+        if (mon.startsWith("jun")) return 6;
+        if (mon.startsWith("jul")) return 7;
+        if (mon.startsWith("aug")) return 8;
+        if (mon.startsWith("sep")) return 9;
+        if (mon.startsWith("okt")) return 10;
+        if (mon.startsWith("nov")) return 11;
+        if (mon.startsWith("dez")) return 12;
+        throw new RuntimeException("Could not find month '" + monthStr + "'");
+    }
+}

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/DateFilterHelper.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/DateFilterHelper.java
@@ -1,51 +1,72 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2018 Fabian Richter
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
 package org.languagetool.rules.de;
 
 import java.util.Calendar;
 import java.util.Locale;
 
+/**
+ * @since 4.3
+ */
 class DateFilterHelper {
-    public DateFilterHelper() {
-    }
+  public DateFilterHelper() {
+  }
 
-    protected Calendar getCalendar() {
-        return Calendar.getInstance(Locale.GERMANY);
-    }
+  protected Calendar getCalendar() {
+    return Calendar.getInstance(Locale.GERMANY);
+  }
 
 
-    @SuppressWarnings("ControlFlowStatementWithoutBraces")
-    protected int getDayOfWeek(String dayStr) {
-        String day = dayStr.toLowerCase();
-        if (day.startsWith("sonnabend")) return Calendar.SATURDAY;
-        if (day.startsWith("so")) return Calendar.SUNDAY;
-        if (day.startsWith("mo")) return Calendar.MONDAY;
-        if (day.startsWith("di")) return Calendar.TUESDAY;
-        if (day.startsWith("mi")) return Calendar.WEDNESDAY;
-        if (day.startsWith("do")) return Calendar.THURSDAY;
-        if (day.startsWith("fr")) return Calendar.FRIDAY;
-        if (day.startsWith("sa")) return Calendar.SATURDAY;
-        throw new RuntimeException("Could not find day of week for '" + dayStr + "'");
-    }
+  @SuppressWarnings("ControlFlowStatementWithoutBraces")
+  protected int getDayOfWeek(String dayStr) {
+    String day = dayStr.toLowerCase();
+    if (day.startsWith("sonnabend")) return Calendar.SATURDAY;
+    if (day.startsWith("so")) return Calendar.SUNDAY;
+    if (day.startsWith("mo")) return Calendar.MONDAY;
+    if (day.startsWith("di")) return Calendar.TUESDAY;
+    if (day.startsWith("mi")) return Calendar.WEDNESDAY;
+    if (day.startsWith("do")) return Calendar.THURSDAY;
+    if (day.startsWith("fr")) return Calendar.FRIDAY;
+    if (day.startsWith("sa")) return Calendar.SATURDAY;
+    throw new RuntimeException("Could not find day of week for '" + dayStr + "'");
+  }
 
-    protected String getDayOfWeek(Calendar date) {
-        return date.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.LONG, Locale.GERMAN);
-    }
+  protected String getDayOfWeek(Calendar date) {
+    return date.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.LONG, Locale.GERMAN);
+  }
 
-    @SuppressWarnings({"ControlFlowStatementWithoutBraces", "MagicNumber"})
-    protected int getMonth(String monthStr) {
-        String mon = monthStr.toLowerCase();
-        if (mon.startsWith("jän")) return 1;
-        if (mon.startsWith("jan")) return 1;
-        if (mon.startsWith("feb")) return 2;
-        if (mon.startsWith("mär")) return 3;
-        if (mon.startsWith("apr")) return 4;
-        if (mon.startsWith("mai")) return 5;
-        if (mon.startsWith("jun")) return 6;
-        if (mon.startsWith("jul")) return 7;
-        if (mon.startsWith("aug")) return 8;
-        if (mon.startsWith("sep")) return 9;
-        if (mon.startsWith("okt")) return 10;
-        if (mon.startsWith("nov")) return 11;
-        if (mon.startsWith("dez")) return 12;
-        throw new RuntimeException("Could not find month '" + monthStr + "'");
-    }
+  @SuppressWarnings({"ControlFlowStatementWithoutBraces", "MagicNumber"})
+  protected int getMonth(String monthStr) {
+    String mon = monthStr.toLowerCase();
+    if (mon.startsWith("jän")) return 1;
+    if (mon.startsWith("jan")) return 1;
+    if (mon.startsWith("feb")) return 2;
+    if (mon.startsWith("mär")) return 3;
+    if (mon.startsWith("apr")) return 4;
+    if (mon.startsWith("mai")) return 5;
+    if (mon.startsWith("jun")) return 6;
+    if (mon.startsWith("jul")) return 7;
+    if (mon.startsWith("aug")) return 8;
+    if (mon.startsWith("sep")) return 9;
+    if (mon.startsWith("okt")) return 10;
+    if (mon.startsWith("nov")) return 11;
+    if (mon.startsWith("dez")) return 12;
+    throw new RuntimeException("Could not find month '" + monthStr + "'");
+  }
 }

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/NewYearDateFilter.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/NewYearDateFilter.java
@@ -1,0 +1,48 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2018 Daniel Naber (http://www.danielnaber.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.de;
+
+import org.languagetool.rules.AbstractNewYearDateFilter;
+
+import java.util.Calendar;
+
+public class NewYearDateFilter extends AbstractNewYearDateFilter {
+
+    private final DateFilterHelper dateFilterHelper = new DateFilterHelper();
+
+    @Override
+    protected int getDayOfWeek(String localizedWeekDayString) {
+        return dateFilterHelper.getDayOfWeek(localizedWeekDayString);
+    }
+
+    @Override
+    protected String getDayOfWeek(Calendar date) {
+        return dateFilterHelper.getDayOfWeek(date);
+    }
+
+    @Override
+    protected int getMonth(String localizedMonth) {
+        return dateFilterHelper.getMonth(localizedMonth);
+    }
+
+    @Override
+    protected Calendar getCalendar() {
+        return dateFilterHelper.getCalendar();
+    }
+}

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/NewYearDateFilter.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/NewYearDateFilter.java
@@ -1,5 +1,5 @@
 /* LanguageTool, a natural language style checker
- * Copyright (C) 2018 Daniel Naber (http://www.danielnaber.de)
+ * Copyright (C) 2018 Fabian Richter
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,27 +22,20 @@ import org.languagetool.rules.AbstractNewYearDateFilter;
 
 import java.util.Calendar;
 
+/**
+ * @since 4.3
+ */
 public class NewYearDateFilter extends AbstractNewYearDateFilter {
 
-    private final DateFilterHelper dateFilterHelper = new DateFilterHelper();
+  private final DateFilterHelper dateFilterHelper = new DateFilterHelper();
 
-    @Override
-    protected int getDayOfWeek(String localizedWeekDayString) {
-        return dateFilterHelper.getDayOfWeek(localizedWeekDayString);
-    }
-
-    @Override
-    protected String getDayOfWeek(Calendar date) {
-        return dateFilterHelper.getDayOfWeek(date);
-    }
-
-    @Override
-    protected int getMonth(String localizedMonth) {
+  @Override
+  protected int getMonth(String localizedMonth) {
         return dateFilterHelper.getMonth(localizedMonth);
     }
 
-    @Override
-    protected Calendar getCalendar() {
+  @Override
+  protected Calendar getCalendar() {
         return dateFilterHelper.getCalendar();
     }
 }

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/YMDNewYearDateFilter.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/YMDNewYearDateFilter.java
@@ -1,5 +1,5 @@
 /* LanguageTool, a natural language style checker
- * Copyright (C) 2015 Daniel Naber (http://www.danielnaber.de)
+ * Copyright (C) 2018 Fabian Richter
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -25,9 +25,9 @@ import org.languagetool.rules.YMDDateHelper;
 import java.util.Map;
 
 /**
- * Date filter that expects a 'date' argument in the format 'yyyy-mm-dd'.
+ * New year date filter that expects a 'date' argument in the format 'yyyy-mm-dd'.
  *
- * @since 3.2
+ * @since 4.3
  */
 public class YMDNewYearDateFilter extends NewYearDateFilter {
 

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/YMDNewYearDateFilter.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/YMDNewYearDateFilter.java
@@ -26,9 +26,10 @@ import java.util.Map;
 
 /**
  * Date filter that expects a 'date' argument in the format 'yyyy-mm-dd'.
+ *
  * @since 3.2
  */
-public class YMDDateCheckFilter extends DateCheckFilter {
+public class YMDNewYearDateFilter extends NewYearDateFilter {
 
   private final org.languagetool.rules.YMDDateHelper YMDDateHelper = new YMDDateHelper();
 
@@ -37,7 +38,8 @@ public class YMDDateCheckFilter extends DateCheckFilter {
     if (args.containsKey("year") || args.containsKey("month") || args.containsKey("day")) {
       throw new RuntimeException("Set only 'weekDay' and 'date' for " + YMDDateCheckFilter.class.getSimpleName());
     }
-    return super.acceptRuleMatch(match, YMDDateHelper.parseDate(args), patternTokens);
+    args = YMDDateHelper.parseDate(args);
+    return super.acceptRuleMatch(YMDDateHelper.correctDate(match, args), args, patternTokens);
   }
 
 }

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -11112,6 +11112,100 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             </rule>
         </rulegroup>
 
+        <rulegroup id="DATUM_NEUES_JAHR" name="Ein neues Jahr hat begonnen">
+            <antipattern>
+                <token regexp="yes">\d\d\d\d</token>
+                <token>v</token>
+                <token>.</token>
+                <token min="0">&nbsp;</token>
+                <token>Chr</token>
+                <token>.</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">\d\d\d\d</token>
+                <token>v</token>
+                <token>.</token>
+                <token min="0">&nbsp;</token>
+                <token>u</token>
+                <token>.</token>
+                <token min="0">&nbsp;</token>
+                <token>Z</token>
+                <token>.</token>
+            </antipattern>
+            <rule>
+                <pattern>
+                    <token regexp="yes">\d\d?</token>
+                    <token>.</token>
+                    <token regexp="yes">\d\d?</token>
+                    <token>.</token>
+                    <token regexp="yes">\d\d\d\d</token>
+                </pattern>
+                <filter class="org.languagetool.rules.de.NewYearDateFilter" args="year:\5 month:\3 day:\1"/>
+                <message>Ein neues Jahr hat begonnen. Meinten Sie den 
+                    <suggestion>\1.\3.{realYear}</suggestion>?
+                </message>
+                <example correction="23.08.2014">Termin: <marker>23.08.2013</marker></example>
+                <example>Termin: 23.08.2014</example>
+                <example>Termin: 23.08.2018</example>
+                <example>Termin: 23.08.2012</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">\d\d?</token>
+                    <token>.</token>
+                    <token regexp="yes">&monate;</token>
+                    <token regexp="yes">\d\d\d\d</token>
+                </pattern>
+                <filter class="org.languagetool.rules.de.NewYearDateFilter" args="year:\4 month:\3 day:\1"/>
+                <message>
+                    Ein neues Jahr hat begonnen. Meinten Sie den
+                    <suggestion>\1. \3 {realYear}</suggestion>?
+                </message>
+                <example correction="1. Jänner 2014">Termin: <marker>1. Jänner 2013</marker></example>
+                <example correction="23. Februar 2014">Termin: Sonntag, <marker>23. Februar 2013</marker></example>
+                <example>Termin: Mittwoch, <marker>1. Jänner 2014</marker></example>
+                <example>Termin: Samstag, <marker>23. August 2014</marker></example>
+                <example>Termin: Samstag, <marker>23. August 2018</marker></example>
+                <example>Termin: Samstag, <marker>23. August 2012</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">\d\d?</token>
+                    <token>.</token>
+                    <token regexp="yes">&abgekMonate;</token>
+                    <token>.</token>
+                    <token regexp="yes">\d\d\d\d</token>
+                </pattern>
+                <filter class="org.languagetool.rules.de.NewYearDateFilter" args="year:\5 month:\3 day:\1"/>
+                <message>
+                    Ein neues Jahr hat begonnen. Meinten Sie den 
+                    <suggestion>\1. \3. {realYear}</suggestion>?
+                </message>
+                <example correction="1. Feb. 2014">Termin: Donnerstag, <marker>1. Feb. 2013</marker></example>
+                <example correction="23. Aug. 2014">Termin: Sonntag, <marker>23. Aug. 2013</marker></example>
+                <example>Termin: Mittwoch, <marker>1. Jän. 2014</marker></example>
+                <example>Termin: Samstag, <marker>23. Aug. 2014</marker></example>
+                <example>Termin: Sa, <marker>23. Aug. 2014</marker></example>
+                <example>Termin: Samstag, den <marker>23. Aug. 2014</marker></example>
+                <example>Termin: Samstag, den <marker>23. Aug. 2017</marker></example>
+                <example>Termin: Samstag, den <marker>23. Aug. 2012</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">\d\d\d\d-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])</token>
+                </pattern>
+                <filter class="org.languagetool.rules.de.YMDNewYearDateFilter" args="date:\1"/>
+                <message>
+                    Ein neues Jahr hat begonnen. Meinten Sie 
+                    <suggestion>{realDate}</suggestion>?
+                </message>
+                <example correction="2014-09-28">Ein Termin am Dienstag, <marker>2013-09-28</marker>.</example>
+                <example>Ein Termin am Montag, <marker>2014-09-28</marker>.</example>
+                <example>Ein Termin am Montag, <marker>2017-09-28</marker>.</example>
+                <example>Ein Termin am Montag, <marker>2011-09-28</marker>.</example>
+            </rule> 
+            <!-- TODO: weitere regel auch ohne Jahr (Annahme: dieses Jahr (auch am jahresende bei "2.1."?)) -->
+        </rulegroup>
 
         <rulegroup id="DATUM_WOCHENTAG" name="Wochentag passt nicht zum Datum">
             <antipattern case_sensitive="yes">
@@ -11421,6 +11515,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         </rulegroup>
 
         <rulegroup id="UNGUELTIGES_DATUM" name="Ungültiges Datum, z.B. '31. Februar'">
+            <!-- <antipattern>
+                DOI regex 
+                <token regexp="yes">10.\d{4,9}/[-._;()/:A-Z0-9]+</token> 
+                does not work because of <regexp> rules in this rulegroup 
+            </antipattern>-->
             <rule>
                 <pattern>
                     <token>31</token>
@@ -11430,6 +11529,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 <message>Der Monat \3 hat nur 30 Tage.</message>
                 <example correction="">Es geschah am <marker>31. November</marker>.</example>
                 <example>Es geschah am <marker>30. November</marker>.</example>
+                <!-- <example>Band 89, Nr. 9, 2002, S. 1531–1546, DOI: 10.3732/ajb.89.9.1531.</example> -->
             </rule>
             <rule>
                 <pattern>

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/DateCheckFilter.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/DateCheckFilter.java
@@ -21,7 +21,6 @@ package org.languagetool.rules.en;
 import org.languagetool.rules.AbstractDateCheckFilter;
 
 import java.util.Calendar;
-import java.util.Locale;
 
 /**
  * English localization of {@link AbstractDateCheckFilter}.
@@ -29,47 +28,28 @@ import java.util.Locale;
  */
 public class DateCheckFilter extends AbstractDateCheckFilter {
 
+  private final DateFilterHelper dateFilterHelper = new DateFilterHelper();
+
   @Override
   protected Calendar getCalendar() {
-    return Calendar.getInstance(Locale.UK);
+    return dateFilterHelper.getCalendar();
   }
 
   @SuppressWarnings("ControlFlowStatementWithoutBraces")
   @Override
   protected int getDayOfWeek(String dayStr) {
-    String day = dayStr.toLowerCase();
-    if (day.startsWith("su")) return Calendar.SUNDAY;
-    if (day.startsWith("mo")) return Calendar.MONDAY;
-    if (day.startsWith("tu")) return Calendar.TUESDAY;
-    if (day.startsWith("we")) return Calendar.WEDNESDAY;
-    if (day.startsWith("th")) return Calendar.THURSDAY;
-    if (day.startsWith("fr")) return Calendar.FRIDAY;
-    if (day.startsWith("sa")) return Calendar.SATURDAY;
-    throw new RuntimeException("Could not find day of week for '" + dayStr + "'");
+    return dateFilterHelper.getDayOfWeek(dayStr);
   }
 
   @Override
   protected String getDayOfWeek(Calendar date) {
-    return date.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.LONG, Locale.UK);
+    return dateFilterHelper.getDayOfWeek(date);
   }
 
   @SuppressWarnings({"ControlFlowStatementWithoutBraces", "MagicNumber"})
   @Override
   protected int getMonth(String monthStr) {
-    String mon = monthStr.toLowerCase();
-    if (mon.startsWith("jan")) return 1;
-    if (mon.startsWith("feb")) return 2;
-    if (mon.startsWith("mar")) return 3;
-    if (mon.startsWith("apr")) return 4;
-    if (mon.startsWith("may")) return 5;
-    if (mon.startsWith("jun")) return 6;
-    if (mon.startsWith("jul")) return 7;
-    if (mon.startsWith("aug")) return 8;
-    if (mon.startsWith("sep")) return 9;
-    if (mon.startsWith("oct")) return 10;
-    if (mon.startsWith("nov")) return 11;
-    if (mon.startsWith("dec")) return 12;
-    throw new RuntimeException("Could not find month '" + monthStr + "'");
+    return dateFilterHelper.getMonth(monthStr);
   }
 
 }

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/DateFilterHelper.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/DateFilterHelper.java
@@ -1,0 +1,48 @@
+package org.languagetool.rules.en;
+
+import java.util.Calendar;
+import java.util.Locale;
+
+class DateFilterHelper {
+    public DateFilterHelper() {
+    }
+
+    protected Calendar getCalendar() {
+        return Calendar.getInstance(Locale.UK);
+    }
+
+    @SuppressWarnings("ControlFlowStatementWithoutBraces")
+    protected int getDayOfWeek(String dayStr) {
+        String day = dayStr.toLowerCase();
+        if (day.startsWith("su")) return Calendar.SUNDAY;
+        if (day.startsWith("mo")) return Calendar.MONDAY;
+        if (day.startsWith("tu")) return Calendar.TUESDAY;
+        if (day.startsWith("we")) return Calendar.WEDNESDAY;
+        if (day.startsWith("th")) return Calendar.THURSDAY;
+        if (day.startsWith("fr")) return Calendar.FRIDAY;
+        if (day.startsWith("sa")) return Calendar.SATURDAY;
+        throw new RuntimeException("Could not find day of week for '" + dayStr + "'");
+    }
+
+    protected String getDayOfWeek(Calendar date) {
+        return date.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.LONG, Locale.UK);
+    }
+
+    @SuppressWarnings({"ControlFlowStatementWithoutBraces", "MagicNumber"})
+    protected int getMonth(String monthStr) {
+        String mon = monthStr.toLowerCase();
+        if (mon.startsWith("jan")) return 1;
+        if (mon.startsWith("feb")) return 2;
+        if (mon.startsWith("mar")) return 3;
+        if (mon.startsWith("apr")) return 4;
+        if (mon.startsWith("may")) return 5;
+        if (mon.startsWith("jun")) return 6;
+        if (mon.startsWith("jul")) return 7;
+        if (mon.startsWith("aug")) return 8;
+        if (mon.startsWith("sep")) return 9;
+        if (mon.startsWith("oct")) return 10;
+        if (mon.startsWith("nov")) return 11;
+        if (mon.startsWith("dec")) return 12;
+        throw new RuntimeException("Could not find month '" + monthStr + "'");
+    }
+}

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/DateFilterHelper.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/DateFilterHelper.java
@@ -1,48 +1,69 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2018 Fabian Richter
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
 package org.languagetool.rules.en;
 
 import java.util.Calendar;
 import java.util.Locale;
 
+/**
+ * @since 4.3
+ */
 class DateFilterHelper {
-    public DateFilterHelper() {
-    }
+  public DateFilterHelper() {
+  }
 
-    protected Calendar getCalendar() {
-        return Calendar.getInstance(Locale.UK);
-    }
+  protected Calendar getCalendar() {
+    return Calendar.getInstance(Locale.UK);
+  }
 
-    @SuppressWarnings("ControlFlowStatementWithoutBraces")
-    protected int getDayOfWeek(String dayStr) {
-        String day = dayStr.toLowerCase();
-        if (day.startsWith("su")) return Calendar.SUNDAY;
-        if (day.startsWith("mo")) return Calendar.MONDAY;
-        if (day.startsWith("tu")) return Calendar.TUESDAY;
-        if (day.startsWith("we")) return Calendar.WEDNESDAY;
-        if (day.startsWith("th")) return Calendar.THURSDAY;
-        if (day.startsWith("fr")) return Calendar.FRIDAY;
-        if (day.startsWith("sa")) return Calendar.SATURDAY;
-        throw new RuntimeException("Could not find day of week for '" + dayStr + "'");
-    }
+  @SuppressWarnings("ControlFlowStatementWithoutBraces")
+  protected int getDayOfWeek(String dayStr) {
+    String day = dayStr.toLowerCase();
+    if (day.startsWith("su")) return Calendar.SUNDAY;
+    if (day.startsWith("mo")) return Calendar.MONDAY;
+    if (day.startsWith("tu")) return Calendar.TUESDAY;
+    if (day.startsWith("we")) return Calendar.WEDNESDAY;
+    if (day.startsWith("th")) return Calendar.THURSDAY;
+    if (day.startsWith("fr")) return Calendar.FRIDAY;
+    if (day.startsWith("sa")) return Calendar.SATURDAY;
+    throw new RuntimeException("Could not find day of week for '" + dayStr + "'");
+  }
 
-    protected String getDayOfWeek(Calendar date) {
-        return date.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.LONG, Locale.UK);
-    }
+  protected String getDayOfWeek(Calendar date) {
+    return date.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.LONG, Locale.UK);
+  }
 
-    @SuppressWarnings({"ControlFlowStatementWithoutBraces", "MagicNumber"})
-    protected int getMonth(String monthStr) {
-        String mon = monthStr.toLowerCase();
-        if (mon.startsWith("jan")) return 1;
-        if (mon.startsWith("feb")) return 2;
-        if (mon.startsWith("mar")) return 3;
-        if (mon.startsWith("apr")) return 4;
-        if (mon.startsWith("may")) return 5;
-        if (mon.startsWith("jun")) return 6;
-        if (mon.startsWith("jul")) return 7;
-        if (mon.startsWith("aug")) return 8;
-        if (mon.startsWith("sep")) return 9;
-        if (mon.startsWith("oct")) return 10;
-        if (mon.startsWith("nov")) return 11;
-        if (mon.startsWith("dec")) return 12;
-        throw new RuntimeException("Could not find month '" + monthStr + "'");
-    }
+  @SuppressWarnings({"ControlFlowStatementWithoutBraces", "MagicNumber"})
+  protected int getMonth(String monthStr) {
+    String mon = monthStr.toLowerCase();
+    if (mon.startsWith("jan")) return 1;
+    if (mon.startsWith("feb")) return 2;
+    if (mon.startsWith("mar")) return 3;
+    if (mon.startsWith("apr")) return 4;
+    if (mon.startsWith("may")) return 5;
+    if (mon.startsWith("jun")) return 6;
+    if (mon.startsWith("jul")) return 7;
+    if (mon.startsWith("aug")) return 8;
+    if (mon.startsWith("sep")) return 9;
+    if (mon.startsWith("oct")) return 10;
+    if (mon.startsWith("nov")) return 11;
+    if (mon.startsWith("dec")) return 12;
+    throw new RuntimeException("Could not find month '" + monthStr + "'");
+  }
 }

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/NewYearDateFilter.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/NewYearDateFilter.java
@@ -1,5 +1,5 @@
 /* LanguageTool, a natural language style checker
- * Copyright (C) 2018 Daniel Naber (http://www.danielnaber.de)
+ * Copyright (C) 2018 Fabian Richter
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,27 +22,20 @@ import org.languagetool.rules.AbstractNewYearDateFilter;
 
 import java.util.Calendar;
 
+/**
+ * @since 4.3
+ */
 public class NewYearDateFilter extends AbstractNewYearDateFilter {
 
-    private final DateFilterHelper dateFilterHelper = new DateFilterHelper();
+  private final DateFilterHelper dateFilterHelper = new DateFilterHelper();
 
-    @Override
-    protected int getDayOfWeek(String localizedWeekDayString) {
-        return dateFilterHelper.getDayOfWeek(localizedWeekDayString);
-    }
+  @Override
+  protected int getMonth(String localizedMonth) {
+    return dateFilterHelper.getMonth(localizedMonth);
+  }
 
-    @Override
-    protected String getDayOfWeek(Calendar date) {
-        return dateFilterHelper.getDayOfWeek(date);
-    }
-
-    @Override
-    protected int getMonth(String localizedMonth) {
-        return dateFilterHelper.getMonth(localizedMonth);
-    }
-
-    @Override
-    protected Calendar getCalendar() {
-        return dateFilterHelper.getCalendar();
-    }
+  @Override
+  protected Calendar getCalendar() {
+    return dateFilterHelper.getCalendar();
+  }
 }

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/NewYearDateFilter.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/NewYearDateFilter.java
@@ -1,0 +1,48 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2018 Daniel Naber (http://www.danielnaber.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.en;
+
+import org.languagetool.rules.AbstractNewYearDateFilter;
+
+import java.util.Calendar;
+
+public class NewYearDateFilter extends AbstractNewYearDateFilter {
+
+    private final DateFilterHelper dateFilterHelper = new DateFilterHelper();
+
+    @Override
+    protected int getDayOfWeek(String localizedWeekDayString) {
+        return dateFilterHelper.getDayOfWeek(localizedWeekDayString);
+    }
+
+    @Override
+    protected String getDayOfWeek(Calendar date) {
+        return dateFilterHelper.getDayOfWeek(date);
+    }
+
+    @Override
+    protected int getMonth(String localizedMonth) {
+        return dateFilterHelper.getMonth(localizedMonth);
+    }
+
+    @Override
+    protected Calendar getCalendar() {
+        return dateFilterHelper.getCalendar();
+    }
+}

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/YMDDateCheckFilter.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/YMDDateCheckFilter.java
@@ -20,6 +20,7 @@ package org.languagetool.rules.en;
 
 import org.languagetool.AnalyzedTokenReadings;
 import org.languagetool.rules.RuleMatch;
+import org.languagetool.rules.YMDDateHelper;
 
 import java.util.Map;
 
@@ -29,20 +30,14 @@ import java.util.Map;
  */
 public class YMDDateCheckFilter extends DateCheckFilter {
 
+  private final org.languagetool.rules.YMDDateHelper YMDDateHelper = new YMDDateHelper();
+
   @Override
   public RuleMatch acceptRuleMatch(RuleMatch match, Map<String, String> args, AnalyzedTokenReadings[] patternTokens) {
     if (args.containsKey("year") || args.containsKey("month") || args.containsKey("day")) {
       throw new RuntimeException("Set only 'weekDay' and 'date' for " + YMDDateCheckFilter.class.getSimpleName());
     }
-    String dateString = getRequired("date", args);
-    String[] parts = dateString.split("-");
-    if (parts.length != 3) {
-      throw new RuntimeException("Expected date in format 'dd-mm-yyyy': '" + dateString + "'");
-    }
-    args.put("year", parts[0]);
-    args.put("month", parts[1]);
-    args.put("day", parts[2]);
-    return super.acceptRuleMatch(match, args, patternTokens);
+    return super.acceptRuleMatch(match, YMDDateHelper.parseDate(args), patternTokens);
   }
 
 }

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/YMDNewYearDateFilter.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/YMDNewYearDateFilter.java
@@ -16,7 +16,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
  * USA
  */
-package org.languagetool.rules.de;
+package org.languagetool.rules.en;
 
 import org.languagetool.AnalyzedTokenReadings;
 import org.languagetool.rules.RuleMatch;
@@ -28,7 +28,7 @@ import java.util.Map;
  * Date filter that expects a 'date' argument in the format 'yyyy-mm-dd'.
  * @since 3.2
  */
-public class YMDDateCheckFilter extends DateCheckFilter {
+public class YMDNewYearDateFilter extends NewYearDateFilter {
 
   private final org.languagetool.rules.YMDDateHelper YMDDateHelper = new YMDDateHelper();
 
@@ -37,7 +37,8 @@ public class YMDDateCheckFilter extends DateCheckFilter {
     if (args.containsKey("year") || args.containsKey("month") || args.containsKey("day")) {
       throw new RuntimeException("Set only 'weekDay' and 'date' for " + YMDDateCheckFilter.class.getSimpleName());
     }
-    return super.acceptRuleMatch(match, YMDDateHelper.parseDate(args), patternTokens);
+    args = YMDDateHelper.parseDate(args);
+    return super.acceptRuleMatch(YMDDateHelper.correctDate(match, args), args, patternTokens);
   }
 
 }

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/YMDNewYearDateFilter.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/YMDNewYearDateFilter.java
@@ -1,5 +1,5 @@
 /* LanguageTool, a natural language style checker
- * Copyright (C) 2015 Daniel Naber (http://www.danielnaber.de)
+ * Copyright (C) 2018 Fabian Richter
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -25,8 +25,8 @@ import org.languagetool.rules.YMDDateHelper;
 import java.util.Map;
 
 /**
- * Date filter that expects a 'date' argument in the format 'yyyy-mm-dd'.
- * @since 3.2
+ * New year date filter that expects a 'date' argument in the format 'yyyy-mm-dd'.
+ * @since 4.3
  */
 public class YMDNewYearDateFilter extends NewYearDateFilter {
 

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -25597,6 +25597,7 @@ USA
                 <token>,</token>
                 <token regexp="yes">\d\d?</token>
                 <token regexp="yes">&months;|&abbrevMonths;</token>
+                <token min="0">,</token>
                 <token regexp="yes">\d\d\d\d</token>
             </antipattern>
             <antipattern>

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -25325,6 +25325,134 @@ USA
             <example correction="">It allows us to <marker>both grow a lot, focus some, and</marker> flourish.</example>
             <example>It allows us to <marker>both</marker> grow and focus, and later flourish.</example>
         </rule>
+
+        <rulegroup id="DATE_NEW_YEAR" name="A new year has begun">
+            <antipattern>
+                <token regexp="yes">\d\d\d\d</token>
+                <token>BC</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">\d\d\d\d</token>
+                <token>B</token>
+                <token>.</token>
+                <token>C</token>
+                <token>.</token>
+            </antipattern>
+            <rule>
+                <pattern>
+                    <!-- "7 October 2014" -->
+                    <token regexp="yes">\d\d?</token>
+                    <token regexp="yes">&months;|&abbrevMonths;</token>
+                    <token regexp="yes">\d\d\d\d</token>
+                </pattern>
+                <filter class="org.languagetool.rules.en.NewYearDateFilter" args="year:\3 month:\2 day:\1"/>
+                <message>
+                    A new year has begun. Did you mean
+                    <suggestion>\1 \2 {realYear}</suggestion>?
+                </message>
+                <example correction="7 October 2014">IGD Convention - <marker>7 October 2013</marker></example>
+                <example correction="7 Oct 2014">IGD Convention - <marker>7 Oct 2013</marker></example>
+                <example>IGD Convention - Tuesday, <marker>7 October 2014</marker></example>
+                <example>IGD Convention - Tuesday, <marker>7 Oct 2014</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <!-- "October 7, 2014" -->
+                    <token regexp="yes">&months;|&abbrevMonths;</token>
+                    <token regexp="yes">\d\d?</token>
+                    <token>,</token>
+                    <token regexp="yes">\d\d\d\d</token>
+                </pattern>
+                <filter class="org.languagetool.rules.en.NewYearDateFilter" args="year:\4 month:\1 day:\2"/>
+                <message>
+                    A new year has begun. Did you mean
+                    <suggestion>\1 \2, {realYear}</suggestion>?
+                </message>
+                <example correction="October 7, 2014">IGD Convention - <marker>October 7, 2013</marker></example>
+                <example correction="Oct 7, 2014">IGD Convention - <marker>Oct 7, 2013</marker></example>
+                <example>IGD Convention - Tuesday, <marker>Oct 7, 2014</marker></example>
+                <example>IGD Convention - Tuesday, <marker>Oct 7, 2018</marker></example>
+                <example>IGD Convention - Tuesday, <marker>October 7, 2012</marker></example>
+            </rule>
+            <!-- "31/10/2014" -->
+            <!-- the ambiguous forms have been antipatterned -->
+            <rule>
+                <antipattern>
+                    <token regexp="yes">&weekdays;</token>
+                    <token>,</token>
+                    <token regexp="yes">0?[1-9]|1[0-2]</token>
+                    <token>/</token>
+                    <token regexp="yes">0?[1-9]|1[0-2]</token>
+                    <token>/</token>
+                    <token regexp="yes">\d\d\d\d</token>
+                </antipattern>
+                <pattern>
+                    <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
+                    <token>/</token>
+                    <token regexp="yes">0?[1-9]|1[0-2]</token>
+                    <token>/</token>
+                    <token regexp="yes">\d\d\d\d</token>
+                </pattern>
+                <filter class="org.languagetool.rules.en.NewYearDateFilter" args="year:\5 month:\3 day:\1"/>
+                <message>
+                    A new year has begun. Did you mean
+                    <suggestion>\1/\3/{realYear}</suggestion>?
+                </message>
+                <example correction="31/10/2014">IGD Convention 2014 - <marker>31/10/2013</marker></example>
+                <example>IGD Convention 2014 - <marker>31/10/2014</marker></example>
+                <example>IGD Convention 2014 - <marker>31/10/2018</marker></example>
+                <example>IGD Convention 2014 - <marker>31/10/2012</marker></example>
+                <example>IGD Convention 2014 - <marker>10/09/2014</marker></example><!-- not correct, but ambiguous -->
+                <example>IGD Convention 2014 - <marker>9/10/2014</marker></example><!-- not correct, but ambiguous -->
+            </rule>
+            <rule>
+                <!-- "10/31/2014" -->
+                <!-- the ambiguous forms have been antipatterned -->
+                <antipattern>
+                    <token regexp="yes">&weekdays;</token>
+                    <token>,</token>
+                    <token regexp="yes">0?[1-9]|1[0-2]</token>
+                    <token>/</token>
+                    <token regexp="yes">0?[1-9]|1[0-2]</token>
+                    <token>/</token>
+                    <token regexp="yes">\d\d\d\d</token>
+                </antipattern>
+                <pattern>
+                    <token regexp="yes">0?[1-9]|1[0-2]</token>
+                    <token>/</token>
+                    <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
+                    <token>/</token>
+                    <token regexp="yes">\d\d\d\d</token>
+                </pattern>
+                <filter class="org.languagetool.rules.en.NewYearDateFilter" args="year:\5 month:\1 day:\3"/>
+                <message>
+                    A new year has begun. Did you mean
+                    <suggestion>\1/\3/{realYear}</suggestion>?
+                </message>
+                <example correction="10/31/2014">IGD Convention 2014 - <marker>10/31/2013</marker></example>
+                <example>IGD Convention 2014 - <marker>10/31/2014</marker></example>
+                <example>IGD Convention 2014 - <marker>10/31/2018</marker></example>
+                <example>IGD Convention 2014 - <marker>10/31/2012</marker></example>
+                <example>IGD Convention 2014 - <marker>10/09/2014</marker></example><!-- not correct, but ambiguous -->
+                <example>IGD Convention 2014 - <marker>9/10/2014</marker></example><!-- not correct, but ambiguous -->
+            </rule>
+            <rule>
+                <!-- "2014-10-31" -->
+                <pattern>
+                    <token regexp="yes">\d\d\d\d-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])</token>
+                </pattern>
+                <filter class="org.languagetool.rules.en.YMDNewYearDateFilter" args="date:\1"/>
+                <message>
+                    A new year has begun. Did you mean
+                    <suggestion>{realDate}</suggestion>?
+                </message>
+                <example correction="2014-10-31">IGD Convention 2014 - <marker>2013-10-31</marker></example>
+                <example>IGD Convention 2014 - <marker>2014-10-31</marker></example>
+                <example>IGD Convention 2014 - <marker>2018-10-31</marker></example>
+                <example>IGD Convention 2014 - <marker>2012-10-31</marker></example>
+            </rule>             
+        </rulegroup>
+
         <rulegroup id="DATE_WEEKDAY" name="Weekday doesn't match date">
             <antipattern>
                 <token regexp="yes">\d\d\d\d</token>
@@ -25587,7 +25715,12 @@ USA
                 <example>IGD Convention 2014 - <marker>Monday, 9/10</marker></example><!-- not correct, but ambiguous -->
             </rule>
         </rulegroup>
+
         <rulegroup id="INVALID_DATE" name="Invalid date, like 'February 31, 2014'">
+            <antipattern>
+                <!-- DOI regex -->
+                <token regexp="yes">10.\d{4,9}/[-._;()/:A-Z0-9]+</token>
+            </antipattern>
             <rule>
                 <pattern>
                     <!-- "June 31, 2014" -->
@@ -25600,6 +25733,7 @@ USA
                 <message>The month of \1 only has 30 days.</message>
                 <example correction="">It happened on <marker>November 31</marker>, 2014.</example>
                 <example>It happened on <marker>November 30</marker>, 2014.</example>
+                <example>Band 89, Nr. 9, 2002, S. 1531–1546, DOI: 10.3732/ajb.89.9.1531.</example>
             </rule>
             <rule>
                 <pattern>


### PR DESCRIPTION
I added a new rule that only matches dates in the past year as long as it is currently January and suggests correcting the year part of the date to the new year.