### PR TITLE
[de/en] Added check for future dates with verbs in past tense

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractFutureDateFilter.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractFutureDateFilter.java
@@ -1,0 +1,122 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2018 Fabian Richter
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules;
+
+import org.apache.commons.lang3.StringUtils;
+import org.languagetool.AnalyzedTokenReadings;
+import org.languagetool.rules.patterns.RuleFilter;
+
+import java.util.Calendar;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Checks if a given date is in the future
+ * Used for mismatch detection between verb tense and a given date
+ * @since 4.3
+ */
+public abstract class AbstractFutureDateFilter extends RuleFilter {
+
+  private static final Pattern DAY_OF_MONTH_PATTERN = Pattern.compile("(\\d+).*");
+  /**
+   * Implement so that "first" returns {@code 1}, second returns {@code 2} etc.
+   * @param localizedDayOfMonth name of day of the month or abbreviation thereof
+   */
+  protected int getDayOfMonth(String localizedDayOfMonth) {
+    return 0;
+  }
+
+  /**
+   * Implement so that January returns {@code 1}, February {@code 2} etc.
+   * @param localizedMonth name of a month or abbreviation thereof
+   */
+  protected abstract int getMonth(String localizedMonth);
+
+  protected abstract Calendar getCalendar();
+
+  /**
+   * @param args a map with values for {@code year}, {@code month}, {@code day} (day of month), {@code weekDay}
+   */
+  @Override
+  public RuleMatch acceptRuleMatch(RuleMatch match, Map<String, String> args, AnalyzedTokenReadings[] patternTokens) {
+    Calendar dateFromDate = getDate(args);
+    Calendar currentDate = getCalendar();
+    if (TestHackHelper.isJUnitTest()) {
+      currentDate = new Calendar.Builder().setDate(2014, 0, 1).build();
+    }
+    try {
+      if (dateFromDate.after(currentDate)) {
+        return match;
+      } else {
+        return null;
+      }
+    } catch (IllegalArgumentException ignore) {
+      // happens with 'dates' like '32.8.2014' - those should be caught by a different rule
+      return null;
+    }
+  }
+
+  protected String getRequired(String key, Map<String, String> map) {
+    String result = map.get(key);
+    if (result == null) {
+      throw new IllegalArgumentException("Missing key '" + key + "'");
+    }
+    return result;
+  }
+
+  private Calendar getDate(Map<String, String> args) {
+    int year = Integer.parseInt(getRequired("year", args));
+    int month = getMonthFromArguments(args);
+    int dayOfMonth = getDayOfMonthFromArguments(args);
+
+    Calendar calendar = getCalendar();
+    calendar.setLenient(false);  // be strict about validity of dates
+    //noinspection MagicConstant
+    calendar.set(year, month, dayOfMonth, 0, 0, 0);
+    return calendar;
+  }
+
+  private int getDayOfMonthFromArguments(Map<String, String> args) {
+    String dayOfMonthString = getRequired("day", args);
+    int dayOfMonth;
+    Matcher matcherDayOfMonth = DAY_OF_MONTH_PATTERN.matcher(dayOfMonthString);
+    if (matcherDayOfMonth.matches()) {
+      // The day of the month is a number, possibly with a suffix such
+      // as "22nd" for example.
+      dayOfMonth = Integer.parseInt(matcherDayOfMonth.group(1));
+    } else {
+      // In some languages, the day of the month can also be written with
+      // letters rather than with digits, so parse localized numbers.
+      dayOfMonth = getDayOfMonth(dayOfMonthString);
+    }
+    return dayOfMonth;
+  }
+
+  private int getMonthFromArguments(Map<String, String> args) {
+    String monthStr = getRequired("month", args);
+    int month;
+    if (StringUtils.isNumeric(monthStr)) {
+      month = Integer.parseInt(monthStr);
+    } else {
+      month = getMonth(monthStr);
+    }
+    return month - 1;
+  }
+}

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/FutureDateFilter.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/FutureDateFilter.java
@@ -1,0 +1,40 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2018 Fabian Richter
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.de;
+
+import org.languagetool.rules.AbstractFutureDateFilter;
+
+import java.util.Calendar;
+
+/**
+ * @since 4.3
+ */
+public class FutureDateFilter extends AbstractFutureDateFilter {
+  private final DateFilterHelper dateFilterHelper = new DateFilterHelper();
+
+  @Override
+  protected int getMonth(String localizedMonth) {
+    return dateFilterHelper.getMonth(localizedMonth);
+  }
+
+  @Override
+  protected Calendar getCalendar() {
+    return dateFilterHelper.getCalendar();
+  }
+}

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -96,6 +96,34 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
     for local testing of an external file - also see below:
     <!ENTITY UserRules SYSTEM "file:///lt/git/languagetool/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar-test.xml">
     -->
+    <!ENTITY date_allnumbers_skip '
+        <marker>
+            <token regexp="yes">\d\d?</token>
+            <token>.</token>
+            <token regexp="yes">\d\d?</token>
+            <token>.</token>
+            <token regexp="yes" skip="-1">\d\d\d\d</token>
+        </marker>
+    '>
+
+    <!ENTITY date_month_shortened_skip '
+        <marker>
+        <token regexp="yes">\d\d?</token>
+        <token>.</token>
+        <token regexp="yes">&abgekMonate;</token>
+        <token>.</token>
+        <token regexp="yes" skip="-1">\d\d\d\d</token>
+        </marker>
+    '>
+
+    <!ENTITY date_month_full_skip '
+        <marker>
+        <token regexp="yes">\d\d?</token>
+        <token>.</token>
+        <token regexp="yes">&monate;</token>
+        <token regexp="yes" skip="-1">\d\d\d\d</token>
+        </marker>
+    '>
 ]>
 
 <!--suppress ProblematicWhitespace -->
@@ -11122,6 +11150,162 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 <example correction="">Bei <marker>warmen Temperaturen</marker> zieht es mich nach draußen.</example>
                 <example correction="">Die <marker>kältesten Temperaturen</marker> werden im Winter erreicht.</example>
                 <example>Bei Temperaturen um 25° C ist es warm.</example>
+            </rule>
+        </rulegroup>
+
+        <rulegroup id="DATUM_ZUKUNFT_VERB_VERGANGENHEIT" name="Datum in der Zukunft, Verb in der Vergangenheitsform">
+            <rule> <!-- am DD.MM.JJJJ haben -->
+                <pattern>
+                    &date_allnumbers_skip;
+                    <token inflected="yes" postag="VER:AUX:.*" postag_regexp="yes" skip="-1">haben</token>
+                    <token postag="VER:PA2:.*" postag_regexp="yes"/>
+                </pattern>
+                <filter class="org.languagetool.rules.de.FutureDateFilter" args="year:\5 month:\3 day:\1"/>
+                <message>Das Datum liegt in der Zukunft, aber das Verb ist in der Vergangenheitsform.</message>
+                <example correction="">Am <marker>7.8.2025</marker> haben wir den Kunden informiert.</example>
+                <example correction="">Am <marker>7.8.2025</marker> habe ich den Kunden informiert.</example>
+                <example correction="">Am <marker>7.8.2025</marker> um 12:00 Uhr haben wir den Kunden informiert.</example>
+                <example>Am 7.8.2010 haben wir den Kunden informiert.</example>
+                <example>Ich habe gestern Kuchen gegessen.</example>
+                <example>Am 7.8.2025 werden wir den Kunden informieren.</example>
+                <example>Am 7.8.2025 werden wir den Kunden informiert haben.</example>
+            </rule>
+            <rule><!-- am DD.MM.JJJJ waren/sind -->
+                <pattern>
+                    &date_allnumbers_skip;
+                    <token inflected="yes" postag="VER:AUX:.*" postag_regexp="yes" skip="-1">sein</token>
+                    <or>
+                        <token postag="VER:INF:.*" postag_regexp="yes"/>
+                        <token postag="VER:PA2:.*" postag_regexp="yes"/>
+                    </or>
+                </pattern>
+                <filter class="org.languagetool.rules.de.FutureDateFilter" args="year:\5 month:\3 day:\1"/>
+                <message>Das Datum liegt in der Zukunft, aber das Verb ist in der Vergangenheitsform.</message>
+                <example correction="">Am <marker>7.8.2025</marker> sind wir zum Kunden geflogen.</example>
+                <example correction="">Am <marker>7.8.2025</marker> war ich schwimmen.</example>
+                <example correction="">Am <marker>7.8.2025</marker> um 12:00 Uhr sind wir zum Kunden geflogen.</example>
+                <example correction="">Am <marker>7.8.2025</marker> um 12:00 Uhr war er schwimmen.</example>
+                <example>Am 7.8.2010 waren wir zum Kunden geflogen.</example>
+                <example>Am 7.8.2025 bin ich im Urlaub.</example>
+                <example>Ich war gestern Kuchen essen.</example>
+                <example>Am 7.8.2025 werden wir den Kunden informieren.</example>
+                <example>Am 7.8.2025 werden wir den Kunden informiert haben.</example>
+                <example>Am 12.12.2023 wird es unter Umständen möglich sein. </example>
+            </rule>
+            <rule><!-- am DD.MM.JJJJ VER:PRT -->
+                <pattern>
+                    &date_allnumbers_skip;
+                    <token postag="VER:.*:PRT.*" postag_regexp="yes" skip="-1"/>
+                </pattern>
+                <filter class="org.languagetool.rules.de.FutureDateFilter" args="year:\5 month:\3 day:\1"/>
+                <message>Das Datum liegt in der Zukunft, aber das Verb ist in der Vergangenheitsform.</message>
+                <example correction="">Am <marker>7.8.2025</marker> war ich im Pool.</example>
+                <example correction="">Am <marker>7.8.2025</marker> um 12 Uhr schwamm ich im Pool.</example>
+                <example>Am 7.8.2010 war ich im Pool.</example>
+                <example>Am 7.8.2025 bin ich im Urlaub.</example>
+                <example>Ich war gestern Kuchen essen.</example>
+            </rule>
+            <rule><!-- am 23. Feb. 2020 haben -->
+                <pattern>
+                    &date_month_shortened_skip;
+                    <token inflected="yes" postag="VER:AUX:.*" postag_regexp="yes" skip="-1">haben</token>
+                    <token postag="VER:PA2:.*" postag_regexp="yes"/>
+                </pattern>
+                <filter class="org.languagetool.rules.de.FutureDateFilter" args="year:\5 month:\3 day:\1"/>
+                <message>Das Datum liegt in der Zukunft, aber das Verb ist in der Vergangenheitsform.</message>
+                <example correction="">Am <marker>7. Feb. 2025</marker> haben wir den Kunden informiert.</example>
+                <example correction="">Am <marker>7. Aug. 2025</marker> habe ich den Kunden informiert.</example>
+                <example correction="">Am <marker>7. Sep. 2025</marker> um 12:00 Uhr haben wir den Kunden informiert.</example>
+                <example>Am 7. Feb. 2010 haben wir den Kunden informiert.</example>
+                <example>Ich habe gestern Kuchen gegessen.</example>
+                <example>Am 7. Feb. 2025 werden wir den Kunden informieren.</example>
+                <example>Am 7. Feb. 2025 werden wir den Kunden informiert haben.</example>
+            </rule>
+            <rule><!-- am 23. Feb. 2020 waren/sind -->
+                <pattern>
+                    &date_month_shortened_skip;
+                    <token inflected="yes" postag="VER:AUX:.*" postag_regexp="yes" skip="-1">sein</token>
+                    <or>
+                        <token postag="VER:INF:.*" postag_regexp="yes"/>
+                        <token postag="VER:PA2:.*" postag_regexp="yes"/>
+                    </or>
+                </pattern>
+                <filter class="org.languagetool.rules.de.FutureDateFilter" args="year:\5 month:\3 day:\1"/>
+                <message>Das Datum liegt in der Zukunft, aber das Verb ist in der Vergangenheitsform.</message>
+                <example correction="">Am <marker>7. Feb. 2025</marker> sind wir zum Kunden geflogen.</example>
+                <example correction="">Am <marker>7. Aug. 2025</marker> war ich in Urlaub geflogen.</example>
+                <example correction="">Am <marker>7. Sep. 2025</marker> um 12:00 Uhr waren wir zum Kunden geflogen.</example>
+                <example>Am 7. Feb. 2010 sind wir zum Kunden geflogen.</example>
+                <example>Ich war gestern Kuchen essen.</example>
+                <example>Am 7. Aug. 2025 bin ich im Urlaub.</example>
+                <example>Am 7. Feb. 2025 werden wir den Kunden informieren.</example>
+                <example>Am 7. Feb. 2025 werden wir den Kunden informiert haben.</example>
+                <example>Am 12. Dez. 2023 wird es unter Umständen möglich sein. </example>
+            </rule>
+            <rule><!-- am 23. Feb. VER:PRT -->
+                <pattern>
+                    &date_month_shortened_skip;
+                    <token postag="VER:.*:PRT.*" postag_regexp="yes" skip="-1"/>
+                </pattern>
+                <filter class="org.languagetool.rules.de.FutureDateFilter" args="year:\5 month:\3 day:\1"/>
+                <message>Das Datum liegt in der Zukunft, aber das Verb ist in der Vergangenheitsform.</message>
+                <example correction="">Am <marker>7. Feb. 2025</marker> war ich im Pool.</example>
+                <example correction="">Am <marker>7. Feb. 2025</marker> um 12 Uhr schwamm ich im Pool.</example>
+                <example>Am 7. Aug. 2010 war ich im Pool.</example>
+                <example>Am 7. Aug. 2025 bin ich im Urlaub.</example>
+                <example>Ich war gestern Kuchen essen.</example>
+            </rule>
+            <rule><!-- am 23. Februar 2020 haben -->
+                <pattern>
+                    &date_month_full_skip;
+                    <token inflected="yes" postag="VER:AUX:.*" postag_regexp="yes" skip="-1">haben</token>
+                    <token postag="VER:PA2:.*" postag_regexp="yes"/>
+                </pattern>
+                <filter class="org.languagetool.rules.de.FutureDateFilter" args="year:\4 month:\3 day:\1"/>
+                <message>Das Datum liegt in der Zukunft, aber das Verb (\5 \6) ist in der Vergangenheitsform.</message>
+                <example correction="">Am <marker>7. Februar 2025</marker> haben wir den Kunden informiert.</example>
+                <example correction="">Am <marker>7. Februar 2025</marker> habe ich den Kunden informiert.</example>
+                <example correction="">Am <marker>7. Februar 2025</marker> um 12:00 Uhr haben wir den Kunden informiert.</example>
+                <example>Am 7. Februar 2010 haben wir den Kunden informiert.</example>
+                <example>Ich habe gestern Kuchen gegessen.</example>
+                <example>Am 7. Februar 2025 werden wir den Kunden informieren.</example>
+                <example>Am 7. Februar 2025 werden wir den Kunden informiert haben.</example>
+            </rule>
+            <rule><!-- am 23. Februar 2020 waren/sind -->
+                <pattern>
+                    &date_month_full_skip;
+                    <token inflected="yes" postag="VER:AUX:.*" postag_regexp="yes" skip="-1">sein</token>
+                    <or>
+                        <token postag="VER:PA2:.*" postag_regexp="yes"/>
+                        <token postag="VER:INF:.*" postag_regexp="yes"/>
+                    </or>
+                </pattern>
+                <filter class="org.languagetool.rules.de.FutureDateFilter" args="year:\4 month:\3 day:\1"/>
+                <message>Das Datum liegt in der Zukunft, aber das Verb (\5 \6) ist in der Vergangenheitsform.</message>
+                <example correction="">Am <marker>7. Februar 2025</marker> sind wir zum Kunden geflogen.</example>
+                <example correction="">Am <marker>7. August 2025</marker> war ich in den Urlaub geflogen.</example>
+                <example correction="">Am <marker>7. September 2025</marker> um 12:00 Uhr waren wir zum Kunden geflogen.</example>
+                <!--<example type="triggers_error">Anlässlich einer Bedeckung von Beteigeuze durch den Asteroiden Leona am <marker>12. Dezember 2023</marker> wird es unter Umständen möglich sein,-->
+                    <!--die Verteilung der Helligkeit über die Sternenscheibe genauer zu bestimmen, als dies mit der aktuellen Technik möglich ist.</example>-->
+                <example>Am 7. Februar 2010 sind wir zum Kunden geflogen.</example>
+                <example>Ich war gestern Kuchen essen.</example>
+                <example>Am 7. August 2025 bin ich im Urlaub.</example>
+                <example>Am 7. Februar 2025 werden wir den Kunden informieren.</example>
+                <example>Am 7. Februar 2025 werden wir den Kunden informiert haben.</example>
+                <example>Am 12. Dezember 2023 wird es unter Umständen möglich sein.</example>
+            </rule>
+            <rule><!-- am 23. Februar VER:PRT -->
+                <pattern>
+                    &date_month_full_skip;
+                    <token postag="VER:.*:PRT.*" postag_regexp="yes" skip="-1"/>
+                </pattern>
+                <filter class="org.languagetool.rules.de.FutureDateFilter" args="year:\4 month:\3 day:\1"/>
+                <message>Das Datum liegt in der Zukunft, aber das Verb ist in der Vergangenheitsform.</message>
+                <example correction="">Am <marker>7. Februar 2025</marker> war ich im Pool.</example>
+                <example correction="">Am <marker>7. Februar 2025</marker> um 12 Uhr schwamm ich im Pool.</example>
+                <example>Am 7. August 2010 war ich im Pool.</example>
+                <example>Am 7. August 2025 bin ich im Urlaub.</example>
+                <example>Ich war gestern Kuchen essen.</example>
             </rule>
         </rulegroup>
 

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/FutureDateFilter.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/FutureDateFilter.java
@@ -1,0 +1,40 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2018 Fabian Richter
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.en;
+
+import org.languagetool.rules.AbstractFutureDateFilter;
+
+import java.util.Calendar;
+
+/**
+ * @since 4.3
+ */
+public class FutureDateFilter extends AbstractFutureDateFilter {
+  private final DateFilterHelper dateFilterHelper = new DateFilterHelper();
+
+  @Override
+  protected int getMonth(String localizedMonth) {
+    return dateFilterHelper.getMonth(localizedMonth);
+  }
+
+  @Override
+  protected Calendar getCalendar() {
+    return dateFilterHelper.getCalendar();
+  }
+}

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -37,6 +37,42 @@ USA
     <!ENTITY languages "Akan|Amharic|Arabic|Assamese|Awadhi|Azerbaijani|Balochi|Bangla|Belarusian|Bengali|Bhojpuri|Burmese|Cantonese|Cebuano|Chewa|Chhattisgarhi|Chittagonian|Czech|Deccan|Dhundhari|Dutch|English|Filipino|French|Fula|Gaelic|German|Greek|Gujarati|Hakka|Haryanvi|Hausa|Hiligaynon|Hindi|Hmong|Hunanese|Hungarian|Igbo|Ilocano|Ilonggo|Indonesian|Italian|Ja[pv]anese|Jin|Kannada|Kazakh|Khmer|Kinyarwanda|Kirundi|Konkani|Korean|Kurdish|Madurese|Magahi|Maithili|Malagasy|Malay(alam)?|Malaysian|Mandarin|Marathi|Marwari|Mossi|Nepali|Odia|Oriya|Oromo|Pashto|Persian|Polish|Portuguese|Punjabi|Quechua|Romanian|Russian|Saraiki|Serbo-Croatian|Shona|Sindhi|Sinhalese|Somali|Spanish|Sundanese|Swedish|Sylheti|Tagalog|Tamil|Telugu|Thai|Turk(ish|men)|Ukrainian|Urdu|Uyghur|Uzbek|Vietnamese|Visayan|Wu|Xhosa|Xiang|Yoruba|Yue|Zhuang|Zulu"><!-- Most are from https://en.wikipedia.org/wiki/List_of_languages_by_number_of_native_speakers -->
     <!ENTITY short_adjectives "bad|big|black|bland|blue|bold|brave|brief|bright|broad|calm|cheap|chewy|clean|close|coarse|cold|cool|cruel|cute|damp|dark|deep|dense|dry|dull|dumb|early|easy|faint|fair|far|fast|fat|few|fierce|fine|firm|fit|flat|fresh|full|good|grand|grave|great|gross|hard|harsh|high|hip|hot|humble|kind|large|late|light|little|long|loud|low|mad|mean|mild|moist|narrow|near|neat|new|nice|odd|old|plain|poor|proud|pure|quick|quiet|rare|raw|rich|ripe|rough|rude|sad|safe|sane|shallow|sharp|short|shy|silly|simple|sincere|slim|slow|small|smart|smooth|soft|soon|sore|sour|steep|strange|strict|strong|sweet|tall|tan|thick|thin|tiny|tough|true|ugly|warm|weak|weird|wet|wide|wild|wise|young">
     <!ENTITY optional_short_adjectives "angry|bitter|bloody|bossy|busy|chubby|classy|clear|clever|cloudy|clumsy|crazy|creamy|creepy|crispy|crunchy|curly|curvy|deadly|dirty|dusty|fancy|filthy|flaky|friendly|funny|gentle|gloomy|greasy|greedy|guilty|hairy|handy|happy|healthy|heavy|hungry|icy|itchy|juicy|lazy|likely|lively|lonely|lovely|messy|nasty|naughty|needy|noisy|oily|polite|pretty|risky|roomy|rusty|salty|scary|shiny|skinny|sleepy|slimy|smelly|smoky|sorry|spicy|stingy|sunny|sweaty|tasty|thirsty|wealthy|windy|worldly|worthy">
+    <!ENTITY ambiguous_date '
+        <token regexp="yes">0?[1-9]|1[0-2]</token>
+        <token>/</token>
+        <token regexp="yes">0?[1-9]|1[0-2]</token>
+        <token>/</token>
+        <token regexp="yes">\d\d\d\d</token>
+    '>
+    <!-- "7 October 2014" -->
+    <!ENTITY date_dmy '
+        <token regexp="yes">\d\d?</token>
+        <token regexp="yes">&months;|&abbrevMonths;</token>
+        <token regexp="yes">\d\d\d\d</token>
+    '>
+    <!-- "October 7, 2014" -->
+    <!ENTITY date_mdy '
+        <token regexp="yes">&months;|&abbrevMonths;</token>
+        <token regexp="yes">\d\d?</token>
+        <token>,</token>
+        <token regexp="yes">\d\d\d\d</token>
+    '>
+    <!-- "31/10/2014" -->
+    <!ENTITY date_dmy_numbers '
+        <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
+        <token>/</token>
+        <token regexp="yes">0?[1-9]|1[0-2]</token>
+        <token>/</token>
+        <token regexp="yes">\d\d\d\d</token>
+    '>
+    <!-- "10/31/2014" -->
+    <!ENTITY date_mdy_numbers '
+        <token regexp="yes">0?[1-9]|1[0-2]</token>
+        <token>/</token>
+        <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
+        <token>/</token>
+        <token regexp="yes">\d\d\d\d</token>
+    '>
 ]>
 
 <rules lang="en" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -25326,6 +25362,117 @@ USA
             <example>It allows us to <marker>both</marker> grow and focus, and later flourish.</example>
         </rule>
 
+        <rulegroup id="DATE_FUTURE_VERB_PAST" name="Future date, but verb in past tense">
+            <rule> <!-- We have visited the client on 7 October 2020 -->
+                <pattern>
+                    <token inflected="yes" postag="VBD?" postag_regexp="yes" skip="-1">have</token>
+                    <token postag="VBN" skip="-1"/>
+                    <marker> &date_dmy; </marker>
+                </pattern>
+                <filter class="org.languagetool.rules.en.FutureDateFilter" args="year:\5 month:\4 day:\3"/>
+                <message>The given date is in the future, but the verb is in past tense.</message>
+                <example correction="">We have visited the client on <marker>7 October 2020</marker>.</example>
+                <example correction="">I had already informed the customer on <marker>7 October 2025</marker>.</example>
+                <example>We have visited the client on <marker>7 October 2010</marker>.</example>
+                <example>I had already informed the customer on <marker>7 October 2010</marker>.</example>
+                <example>We will inform the client on 7 October 2010.</example>
+            </rule>
+            <rule> <!-- We visited the client on 7 October 2020 -->
+                <pattern>
+                    <token postag="VBD" skip="-1"/>
+                    <marker> &date_dmy; </marker>
+                </pattern>
+                <filter class="org.languagetool.rules.en.FutureDateFilter" args="year:\4 month:\3 day:\2"/>
+                <message>The given date is in the future, but the verb is in past tense.</message>
+                <example correction="">We visited the client on <marker>7 October 2020</marker>.</example>
+                <example correction="">I already informed the customer on <marker>7 October 2025</marker>.</example>
+                <example>We visited the client on <marker>7 October 2010</marker>.</example>
+                <example>I already informed the customer on <marker>7 October 2010</marker>.</example>
+                <example>We will inform the client on 7 October 2010.</example>
+            </rule>
+            <rule> <!-- We have visited the client on October 7, 2020 -->
+                <pattern>
+                    <token inflected="yes" postag="VBD?" postag_regexp="yes" skip="-1">have</token>
+                    <token postag="VBN" skip="-1"/>
+                    <marker> &date_mdy; </marker>
+                </pattern>
+                <filter class="org.languagetool.rules.en.FutureDateFilter" args="year:\6 month:3 day:\4"/>
+                <message>The given date is in the future, but the verb is in past tense.</message>
+                <example correction="">We have visited the client on <marker>October 7, 2020</marker>.</example>
+                <example correction="">I had already informed the customer on <marker>October 7, 2020</marker>.</example>
+                <example>We have visited the client on <marker>October 7, 2010</marker>.</example>
+                <example>I had already informed the customer on <marker>October 7, 2010</marker>.</example>
+                <example>We will inform the client on October 7, 2010.</example>
+            </rule>
+            <rule> <!-- We visited the client on October 7, 2020 -->
+                <pattern>
+                    <token postag="VBD" skip="-1"/>
+                    <marker> &date_mdy; </marker>
+                </pattern>
+                <filter class="org.languagetool.rules.en.FutureDateFilter" args="year:\5 month:\2 day:\3"/>
+                <message>The given date is in the future, but the verb is in past tense.</message>
+                <example correction="">We visited the client on <marker>October 7, 2020</marker>.</example>
+                <example correction="">I already informed the customer on <marker>October 7, 2020</marker>.</example>
+                <example>We visited the client on <marker>October 7, 2010</marker>.</example>
+                <example>I already informed the customer on <marker>October 7, 2010</marker>.</example>
+                <example>We will inform the client on October 7, 2010.</example>
+            </rule>
+            <rule> <!-- We have visited the client on 27/10/2040 -->
+                <pattern>
+                    <token inflected="yes" postag="VBD?" postag_regexp="yes" skip="-1">have</token>
+                    <token postag="VBN" skip="-1"/>
+                    <marker> &date_dmy_numbers; </marker>
+                </pattern>
+                <filter class="org.languagetool.rules.en.FutureDateFilter" args="year:\7 month:\5 day:\3"/>
+                <message>The given date is in the future, but the verb is in past tense.</message>
+                <example correction="">We have visited the client on <marker>27/10/2040</marker>.</example>
+                <example correction="">I had already informed the customer on <marker>27/10/2040</marker>.</example>
+                <example>We have visited the client on <marker>27/10/2010</marker>.</example>
+                <example>I had already informed the customer on <marker>27/10/2010</marker>.</example>
+                <example>We will inform the client on 27/10/2010.</example>
+            </rule>
+            <rule> <!-- We visited the client on 27/10/2040  -->
+                <pattern>
+                    <token postag="VBD" skip="-1"/>
+                    <marker> &date_dmy_numbers; </marker>
+                </pattern>
+                <filter class="org.languagetool.rules.en.FutureDateFilter" args="year:\6 month:\4 day:\2"/>
+                <message>The given date is in the future, but the verb is in past tense.</message>
+                <example correction="">We visited the client on <marker>27/10/2040</marker>.</example>
+                <example correction="">I already informed the customer on <marker>27/10/2040</marker>.</example>
+                <example>We visited the client on <marker>27/10/2010</marker>.</example>
+                <example>I already informed the customer on <marker>27/10/2010</marker>.</example>
+                <example>We will inform the client on 27/10/2010.</example>
+            </rule>
+            <rule> <!-- We have visited the client on 10/27/2040 -->
+                <pattern>
+                    <token inflected="yes" postag="VBD?" postag_regexp="yes" skip="-1">have</token>
+                    <token postag="VBN" skip="-1"/>
+                    <marker> &date_mdy_numbers; </marker>
+                </pattern>
+                <filter class="org.languagetool.rules.en.FutureDateFilter" args="year:\7 month:\3 day:\5"/>
+                <message>The given date is in the future, but the verb is in past tense.</message>
+                <example correction="">We have visited the client on <marker>10/27/2040</marker>.</example>
+                <example correction="">I had already informed the customer on <marker>10/27/2040</marker>.</example>
+                <example>We have visited the client on <marker>10/27/2010</marker>.</example>
+                <example>I had already informed the customer on <marker>10/27/2010</marker>.</example>
+                <example>We will inform the client on 10/27/2010.</example>
+            </rule>
+            <rule> <!-- We visited the client on 27/10/2040  -->
+                <pattern>
+                    <token postag="VBD" skip="-1"/>
+                    <marker> &date_mdy_numbers; </marker>
+                </pattern>
+                <filter class="org.languagetool.rules.en.FutureDateFilter" args="year:\6 month:\2 day:\4"/>
+                <message>The given date is in the future, but the verb is in past tense.</message>
+                <example correction="">We visited the client on <marker>10/27/2040</marker>.</example>
+                <example correction="">I already informed the customer on <marker>10/27/2040</marker>.</example>
+                <example>We visited the client on <marker>10/27/2010</marker>.</example>
+                <example>I already informed the customer on <marker>10/27/2010</marker>.</example>
+                <example>We will inform the client on 10/27/2010.</example>
+            </rule>
+        </rulegroup>
+
         <rulegroup id="DATE_NEW_YEAR" name="A new year has begun">
             <antipattern>
                 <token regexp="yes">\d\d\d\d</token>
@@ -25341,9 +25488,7 @@ USA
             <rule>
                 <pattern>
                     <!-- "7 October 2014" -->
-                    <token regexp="yes">\d\d?</token>
-                    <token regexp="yes">&months;|&abbrevMonths;</token>
-                    <token regexp="yes">\d\d\d\d</token>
+                    &date_dmy;
                 </pattern>
                 <filter class="org.languagetool.rules.en.NewYearDateFilter" args="year:\3 month:\2 day:\1"/>
                 <message>
@@ -25358,10 +25503,7 @@ USA
             <rule>
                 <pattern>
                     <!-- "October 7, 2014" -->
-                    <token regexp="yes">&months;|&abbrevMonths;</token>
-                    <token regexp="yes">\d\d?</token>
-                    <token>,</token>
-                    <token regexp="yes">\d\d\d\d</token>
+                    &date_mdy;
                 </pattern>
                 <filter class="org.languagetool.rules.en.NewYearDateFilter" args="year:\4 month:\1 day:\2"/>
                 <message>
@@ -25378,20 +25520,10 @@ USA
             <!-- the ambiguous forms have been antipatterned -->
             <rule>
                 <antipattern>
-                    <token regexp="yes">&weekdays;</token>
-                    <token>,</token>
-                    <token regexp="yes">0?[1-9]|1[0-2]</token>
-                    <token>/</token>
-                    <token regexp="yes">0?[1-9]|1[0-2]</token>
-                    <token>/</token>
-                    <token regexp="yes">\d\d\d\d</token>
+                    &ambiguous_date;
                 </antipattern>
                 <pattern>
-                    <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
-                    <token>/</token>
-                    <token regexp="yes">0?[1-9]|1[0-2]</token>
-                    <token>/</token>
-                    <token regexp="yes">\d\d\d\d</token>
+                    &date_dmy_numbers;
                 </pattern>
                 <filter class="org.languagetool.rules.en.NewYearDateFilter" args="year:\5 month:\3 day:\1"/>
                 <message>
@@ -25409,20 +25541,10 @@ USA
                 <!-- "10/31/2014" -->
                 <!-- the ambiguous forms have been antipatterned -->
                 <antipattern>
-                    <token regexp="yes">&weekdays;</token>
-                    <token>,</token>
-                    <token regexp="yes">0?[1-9]|1[0-2]</token>
-                    <token>/</token>
-                    <token regexp="yes">0?[1-9]|1[0-2]</token>
-                    <token>/</token>
-                    <token regexp="yes">\d\d\d\d</token>
+                    &ambiguous_date;
                 </antipattern>
                 <pattern>
-                    <token regexp="yes">0?[1-9]|1[0-2]</token>
-                    <token>/</token>
-                    <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
-                    <token>/</token>
-                    <token regexp="yes">\d\d\d\d</token>
+                    &date_mdy_numbers;
                 </pattern>
                 <filter class="org.languagetool.rules.en.NewYearDateFilter" args="year:\5 month:\1 day:\3"/>
                 <message>
@@ -25470,9 +25592,7 @@ USA
                     <!-- "Monday, 7 October 2014" -->
                     <token regexp="yes">&weekdays;|&abbrevWeekdays;</token>
                     <token>,</token>
-                    <token regexp="yes">\d\d?</token>
-                    <token regexp="yes">&months;|&abbrevMonths;</token>
-                    <token regexp="yes">\d\d\d\d</token>
+                    &date_dmy;
                 </pattern>
                 <filter class="org.languagetool.rules.en.DateCheckFilter" args="year:\5 month:\4 day:\3 weekDay:\1"/>
                 <message>The date \3 \4 \5 is not a {day}, but a {realDay}.</message>
@@ -25488,10 +25608,7 @@ USA
                     <!-- "Monday, October 7, 2014" -->
                     <token regexp="yes">&weekdays;|&abbrevWeekdays;</token>
                     <token>,</token>
-                    <token regexp="yes">&months;|&abbrevMonths;</token>
-                    <token regexp="yes">\d\d?</token>
-                    <token>,</token>
-                    <token regexp="yes">\d\d\d\d</token>
+                    &date_mdy;
                 </pattern>
                 <filter class="org.languagetool.rules.en.DateCheckFilter" args="year:\6 month:\3 day:\4 weekDay:\1"/>
                 <message>The date \3 \4, \6 is not a {day}, but a {realDay}.</message>
@@ -25513,20 +25630,12 @@ USA
                 <antipattern>
                     <token regexp="yes">&weekdays;</token>
                     <token>,</token>
-                    <token regexp="yes">0?[1-9]|1[0-2]</token>
-                    <token>/</token>
-                    <token regexp="yes">0?[1-9]|1[0-2]</token>
-                    <token>/</token>
-                    <token regexp="yes">\d\d\d\d</token>
+                    &ambiguous_date;
                 </antipattern>
                 <pattern>
                     <token regexp="yes">&weekdays;</token>
                     <token>,</token>
-                    <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
-                    <token>/</token>
-                    <token regexp="yes">0?[1-9]|1[0-2]</token>
-                    <token>/</token>
-                    <token regexp="yes">\d\d\d\d</token>
+                    &date_dmy_numbers;
                 </pattern>
                 <filter class="org.languagetool.rules.en.DateCheckFilter" args="year:\7 month:\5 day:\3 weekDay:\1"/>
                 <message>The date \3/\5/\7 is not a {day}, but a {realDay}.</message>
@@ -25541,20 +25650,12 @@ USA
                 <antipattern>
                     <token regexp="yes">&weekdays;</token>
                     <token>,</token>
-                    <token regexp="yes">0?[1-9]|1[0-2]</token>
-                    <token>/</token>
-                    <token regexp="yes">0?[1-9]|1[0-2]</token>
-                    <token>/</token>
-                    <token regexp="yes">\d\d\d\d</token>
+                    &ambiguous_date;
                 </antipattern>
                 <pattern>
                     <token regexp="yes">&weekdays;</token>
                     <token>,</token>
-                    <token regexp="yes">0?[1-9]|1[0-2]</token>
-                    <token>/</token>
-                    <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
-                    <token>/</token>
-                    <token regexp="yes">\d\d\d\d</token>
+                    &date_mdy_numbers;
                 </pattern>
                 <filter class="org.languagetool.rules.en.DateCheckFilter" args="year:\7 month:\3 day:\5 weekDay:\1"/>
                 <message>The date \3/\5/\7 is not a {day}, but a {realDay}.</message>
@@ -25595,37 +25696,23 @@ USA
                 <!-- "Monday, 7 October 2014" -->
                 <token regexp="yes">&weekdays;|&abbrevWeekdays;</token>
                 <token>,</token>
-                <token regexp="yes">\d\d?</token>
-                <token regexp="yes">&months;|&abbrevMonths;</token>
-                <token min="0">,</token>
-                <token regexp="yes">\d\d\d\d</token>
+                &date_dmy;
             </antipattern>
             <antipattern>
                 <!-- "Monday, October 7, 2014" -->
                 <token regexp="yes">&weekdays;|&abbrevWeekdays;</token>
                 <token>,</token>
-                <token regexp="yes">&months;|&abbrevMonths;</token>
-                <token regexp="yes">\d\d?</token>
-                <token>,</token>
-                <token regexp="yes">\d\d\d\d</token>
+                &date_mdy;
             </antipattern>
             <antipattern>
                 <token regexp="yes">&weekdays;</token>
                 <token>,</token>
-                <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
-                <token>/</token>
-                <token regexp="yes">0?[1-9]|1[0-2]</token>
-                <token>/</token>
-                <token regexp="yes">\d\d\d\d</token>
+                &date_dmy_numbers;
             </antipattern>
             <antipattern>
                 <token regexp="yes">&weekdays;</token>
                 <token>,</token>
-                <token regexp="yes">0?[1-9]|1[0-2]</token>
-                <token>/</token>
-                <token regexp="yes">0?[1-9]|[12][0-9]|3[01]</token>
-                <token>/</token>
-                <token regexp="yes">\d\d\d\d</token>
+                &date_mdy_numbers;
             </antipattern>
 
             <rule>


### PR DESCRIPTION
Sentences like 

> I created a pull request on July 26 2028.

will now be flagged. The new rule detects future dates in combination with verbs in past tense.