### PR TITLE
Added tokenizer rule to not split up e-mail addresses.

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
@@ -5841,8 +5841,16 @@
 <afterbreak>\p{Lu}\p{Ll}</afterbreak>
 </rule>
 </languagerule>
+<languagerule languagerulename="GeneralImportant">
+<!--Don't split up e-mail addresses.-->
+<rule break="no">
+<beforebreak>[\.!?]</beforebreak>
+<afterbreak>\S*@</afterbreak>
+</rule>
+</languagerule>
 </languagerules>
 <maprules>
+<languagemap languagepattern=".*" languagerulename="GeneralImportant"></languagemap>
 <languagemap languagepattern="[a-z]{2,3}_one" languagerulename="ByLineBreak"></languagemap>
 <languagemap languagepattern="[a-z]{2,3}_two" languagerulename="ByTwoLineBreaks"></languagemap>
 <languagemap languagepattern="(EL|el).*" languagerulename="Greek"></languagemap>

--- a/languagetool-language-modules/de/src/test/java/org/languagetool/tokenizers/de/GermanSRXSentenceTokenizerTest.java
+++ b/languagetool-language-modules/de/src/test/java/org/languagetool/tokenizers/de/GermanSRXSentenceTokenizerTest.java
@@ -98,6 +98,9 @@ public class GermanSRXSentenceTokenizerTest {
     testSplit("»Nun also, wie ist's?« ", "fragte Lushin und blickte sie fest an.");
     testSplit("»Nun also, wie ist es?« ", "fragte Lushin und blickte sie fest an.");
 //    testSplit(new String[] { "gezeigt hat.« ", "… ", "Hm! " });
+
+    testSplit("Dies ist ein Satz mit einer EMail.Addresse@example.com!");
+    testSplit("Sonderbarerweise sind auch Beispiel!Eins@example.com und Foo?Bar@example.com valide.");
   }
 
   private void testSplit(String... sentences) {


### PR DESCRIPTION
Fixed an issue where in multiple languages, e-mail addresses like John.Smith@example.com (with an uppercase letter after a dot) would be split up into multiple sentences by the tokenizer.
I added a new ruleset for all languages with high priority. It contains one rule to prevents this.