### PR TITLE
Added fasttext as an option for language identification

### DIFF
--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineOptions.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineOptions.java
@@ -66,6 +66,11 @@ public class CommandLineOptions {
   private File languageModel = null;
   @Nullable
   private File word2vecModel = null;
+
+  @Nullable
+  private File fasttextModel = null;
+  @Nullable
+  private File fasttextBinary = null;
   @Nullable
   private String encoding = null;
   @Nullable
@@ -253,6 +258,38 @@ public class CommandLineOptions {
   public void setWord2VecModel(File neuralNetworkLanguageModel) {
     this.word2vecModel = neuralNetworkLanguageModel;
   }
+
+
+  /**
+   * @since 4.3
+   */
+  @Nullable
+  public File getFasttextModel() {
+    return fasttextModel;
+  }
+
+  /**
+   * @since 4.3
+   */
+  public void setFasttextModel(File fasttextModel) {
+    this.fasttextModel = fasttextModel;
+  }
+
+  /**
+   * @since 4.3
+   */
+  @Nullable
+  public File getFasttextBinary() {
+    return fasttextBinary;
+  }
+
+  /**
+   * @since 4.3
+   */
+  public void setFasttextBinary(File fasttextBinary) {
+    this.fasttextBinary = fasttextBinary;
+  }
+
 
   /**
    * @return an additional rule file name to use

--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineParser.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineParser.java
@@ -96,6 +96,12 @@ public class CommandLineParser {
       } else if (args[i].equals("--word2vecmodel")) {
         checkArguments("--word2vecmodel", i, args);
         options.setWord2VecModel(new File(args[++i]));
+      } else if (args[i].equals("--fasttextModel")) {
+        checkArguments("--fasttextModel", i, args);
+        options.setFasttextModel(new File(args[++i]));
+      } else if (args[i].equals("--fasttextBinary")) {
+        checkArguments("--fasttextBinary", i, args);
+        options.setFasttextBinary(new File(args[++i]));
       } else if (args[i].equals("--rulefile")) {
         checkArguments("--rulefile", i, args);
         options.setRuleFile(args[++i]);
@@ -216,6 +222,8 @@ public class CommandLineParser {
             + "                           ngram occurrence counts; activates the confusion rule if supported\n"
             + "  --word2vecmodel DIR      a directory with e.g. 'en' sub directory (i.e. a language code) that contains\n"
             + "                           final_embeddings.txt and dictionary.txt; activates neural network based rules\n"
+            + "  --fasttextModel FILE     fasttext language detection model (optional), see https://fasttext.cc/docs/en/language-identification.html\n"
+            + "  --fasttextBinary FILE    fasttext executable (optional), see https://fasttext.cc/docs/en/support.html\n"
             + "  --xmlfilter              remove XML/HTML elements from input before checking (deprecated)\n"
             + "  --line-by-line           work on file line by line (for development, e.g. inside an IDE)"
     );

--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/Main.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/Main.java
@@ -477,8 +477,9 @@ class Main {
     }
   }
 
-  private static Language detectLanguageOfString(String text) {
+  private Language detectLanguageOfString(String text) {
     LanguageIdentifier identifier = new LanguageIdentifier();
+    identifier.enableFasttext(options.getFasttextBinary(), options.getFasttextModel());
     return identifier.detectLanguage(text);
   }
 

--- a/languagetool-dev/src/test/java/org/languagetool/dev/eval/LanguageDetectionEval.java
+++ b/languagetool-dev/src/test/java/org/languagetool/dev/eval/LanguageDetectionEval.java
@@ -35,16 +35,22 @@ import java.util.List;
  */
 class LanguageDetectionEval {
 
+  private static final int MIN_CHARACTERS = 10;
+
   private final LanguageIdentifier languageIdentifier;
 
   private int totalInputs = 0;
   private int totalFailures = 0;
+  private int misclassifications = 0;
+  private int numClassifications = 0;
 
   private LanguageDetectionEval() {
     languageIdentifier = new LanguageIdentifier();
+//    languageIdentifier.enableFasttext(new File("/path/to/fasttext/binary"), new File("/path/to/fasttext/model"));
   }
 
-  private int evaluate(Language language) throws IOException {
+  private float evaluate(Language language) throws IOException {
+//    String evalTextFile = "/org/languagetool/dev/eval/lang/" + language.getShortCode() + "_long.txt";
     String evalTextFile = "/org/languagetool/dev/eval/lang/" + language.getShortCode() + ".txt";
     InputStream stream = LanguageDetectionEval.class.getResourceAsStream(evalTextFile);
     System.out.println("=== " + language + " ===");
@@ -53,48 +59,75 @@ class LanguageDetectionEval {
     } else {
       int minChars = 0;
       int failures = 0;
+      float errors = 0;
       List<String> list = getLines(stream);
       for (String line : list) {
         try {
-          int minChar = getShortestCorrectDetection(line, language);
-          minChars += minChar;
+//          int minChar = getShortestCorrectDetection(line, language);
+//          minChars += minChar;
+          errors += getNumberOfWrongDetections(line, language, MIN_CHARACTERS);
         } catch (DetectionException e) {
           //System.out.println("FAIL: " + e.getMessage());
           failures++;
         }
       }
-      int avgMinChars = minChars / list.size();
-      System.out.println("Average minimum size still correctly detected: " + avgMinChars);
-      System.out.println("Detection failures: " + failures + " of " + list.size());
+//      float avgMinChars = (float) minChars / list.size();
+      float avgErrors = errors / list.size();
+//      System.out.println("Average minimum size still correctly detected: " + avgMinChars);
+//      System.out.println("Detection failures: " + failures + " of " + list.size());
       totalFailures += failures;
-      return avgMinChars;
+//      return avgMinChars;
+      return avgErrors;
     }
   }
 
   private int getShortestCorrectDetection(String line, Language expectedLanguage) {
     totalInputs++;
+    int textLength = 1;
     for (int i = line.length(); i > 0; i--) {
       String text = line.substring(0, i);
       Language detectedLangObj = languageIdentifier.detectLanguage(text);
+      numClassifications++;
       String detectedLang = null;
       if (detectedLangObj != null) {
         detectedLang = detectedLangObj.getShortCode();
       }
       if (detectedLang == null && i == line.length()) {
         throw new DetectionException("Detection failed for '" + line + "', detected <null>");
-      } else if (detectedLang == null || !expectedLanguage.getShortCode().equals(detectedLang)) {
-        int textLength = i + 1;
+      } else if (detectedLang == null) {
+        textLength = i + 1;
         //System.out.println("minLen: " + textLength);
         //System.out.println("TEXT     : " + line);
         //System.out.println("TOO SHORT : " + text + " => " + detectedLang + " (" + textLength + ")");
-        return textLength;
+      } else if (!expectedLanguage.getShortCode().equals(detectedLang)){
+        misclassifications++;
+        System.out.printf("WRONG: Expected %s, but got %s -> %s%n", expectedLanguage.getShortCode(), detectedLang, text);
       } else {
         //System.out.println("STILL OKAY: " + text + " => " + detectedLang);
       }
     }
-    return 1;
+    return textLength;
   }
 
+  private float getNumberOfWrongDetections(String line, Language expectedLanguage, int threshold) {
+    int errors = 0;
+    int checks = 0;
+    for (int i = threshold; i < line.length(); i++) {
+      String text = line.substring(0, i);
+      Language detectedLangObj = languageIdentifier.detectLanguage(text);
+      checks++;
+      totalInputs++;
+      String detectedLang = null;
+      if (detectedLangObj != null) {
+        detectedLang = detectedLangObj.getShortCode();
+      }
+      if (detectedLang == null || !expectedLanguage.getShortCode().equals(detectedLang)) {
+        //System.out.printf("detected %s, expected %s: %s%n", detectedLang, expectedLanguage.getShortCode(), text);
+        errors++;
+      }
+    }
+    return (float) errors / checks;
+  }
   private List<String> getLines(InputStream stream) throws IOException {
     List<String> lines = CharStreams.readLines(new InputStreamReader(stream));
     List<String> result = new ArrayList<>();
@@ -109,16 +142,20 @@ class LanguageDetectionEval {
   public static void main(String[] args) throws IOException {
     LanguageDetectionEval eval = new LanguageDetectionEval();
     long startTime = System.currentTimeMillis();
-    int minCharsTotal = 0;
+    float minCharsTotal = 0;
+    float errorsTotal = 0.0f;
     int languageCount = 0;
     for (Language language : Languages.get()) {
-      //if (!language.getShortCode().equals("de")) {
+      //if (!(language.getShortCode().equals("de") || language.getShortCode().equals("en"))) {
       //  continue;
       //}
       if (language.isVariant()) {
         continue;
       }
-      minCharsTotal += eval.evaluate(language);
+      //minCharsTotal += eval.evaluate(language);
+      float errors = eval.evaluate(language);
+      System.out.printf("Average Errors: %.2f%%%n", errors * 100f);
+      errorsTotal += errors;
       languageCount++;
     }
     long endTime = System.currentTimeMillis();
@@ -126,9 +163,12 @@ class LanguageDetectionEval {
     long totalTime = endTime - startTime;
     float timePerInput = (float)totalTime / eval.totalInputs;
     System.out.printf("Time: " + totalTime + "ms = %.2fms per input\n", timePerInput);
-    System.out.println("Total detection failures: " + eval.totalFailures + "/" + eval.totalInputs);
-    float avgMinChars = (float) minCharsTotal / languageCount;
-    System.out.printf("Avg. minimum chars: %.2f\n", avgMinChars);
+    //System.out.println("Total detection failures: " + eval.totalFailures + "/" + eval.totalInputs);
+    //float avgMinChars = (float) minCharsTotal / languageCount;
+    float avgErrors =  errorsTotal / languageCount;
+    //System.out.printf("Avg. minimum chars: %.5f\n", avgMinChars);
+    System.out.printf("Total avg. errors: %.2f%%\n", avgErrors * 100f);
+    //System.out.printf("Misclassifications: %d / %d (%.5f) \n", eval.misclassifications, eval.numClassifications, (float) eval.misclassifications / eval.numClassifications);
   }
 
   class DetectionException extends RuntimeException {

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
@@ -36,6 +36,9 @@ import java.util.*;
  */
 public class HTTPServerConfig {
 
+  private File fasttextModel;
+  private File fasttextBinary;
+
   enum Mode { LanguageTool }
 
   public static final String DEFAULT_HOST = "localhost";
@@ -182,6 +185,11 @@ public class HTTPServerConfig {
         if (word2vecModel != null && loadWord2VecModel) {
           setWord2VecModelDirectory(word2vecModel);
         }
+        String fasttextModel = getOptionalProperty(props, "fasttextModel", null);
+        String fasttextBinary = getOptionalProperty(props, "fasttextBinary", null);
+        if (fasttextBinary != null && fasttextModel != null) {
+          setFasttextPaths(fasttextModel, fasttextBinary);
+        }
         maxCheckThreads = Integer.parseInt(getOptionalProperty(props, "maxCheckThreads", "10"));
         if (maxCheckThreads < 1) {
           throw new IllegalArgumentException("Invalid value for maxCheckThreads, must be >= 1: " + maxCheckThreads);
@@ -242,6 +250,17 @@ public class HTTPServerConfig {
     word2vecModelDir = new File(w2vModelDir);
     if (!word2vecModelDir.exists() || !word2vecModelDir.isDirectory()) {
       throw new RuntimeException("Word2Vec directory not found or is not a directory: " + word2vecModelDir);
+    }
+  }
+
+  private void setFasttextPaths(String fasttextModelPath, String fasttextBinaryPath) {
+    fasttextModel = new File(fasttextModelPath);
+    fasttextBinary = new File(fasttextBinaryPath);
+    if (!fasttextModel.exists() || fasttextModel.isDirectory()) {
+      throw new RuntimeException("Fasttext model path not valid (file doesn't exist or is a directory): " + fasttextModelPath);
+    }
+    if (!fasttextBinary.exists() || fasttextBinary.isDirectory() || !fasttextBinary.canExecute()) {
+      throw new RuntimeException("Fasttext binary path not valid (file doesn't exist, is a directory or not executable): " + fasttextBinaryPath);
     }
   }
 
@@ -387,6 +406,26 @@ public class HTTPServerConfig {
   File getWord2VecModelDir() {
     return word2vecModelDir;
   }
+
+
+  /**
+   * Get model path for fasttext language detection
+   * @since 4.3
+   */
+  @Nullable
+  public File getFasttextModel() {
+    return fasttextModel;
+  }
+
+  /**
+   * Get binary path for fasttext language detection
+   * @since 4.3
+   */
+  @Nullable
+  public File getFasttextBinary() {
+    return fasttextBinary;
+  }
+
 
   /** @since 2.7 */
   Mode getMode() {

--- a/languagetool-server/src/main/java/org/languagetool/server/Server.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/Server.java
@@ -135,6 +135,10 @@ abstract class Server {
     System.out.println("                  each with ngram occurrence counts; activates the confusion rule if supported (optional)");
     System.out.println("                 'word2vecModel' - a directory with word2vec data (optional), see");
     System.out.println("                  https://github.com/languagetool-org/languagetool/blob/master/languagetool-standalone/CHANGES.md#word2vec");
+    System.out.println("                 'fasttextModel' - a model file for better language detection (optional), see");
+    System.out.println("                  https://fasttext.cc/docs/en/language-identification.html");
+    System.out.println("                 'fasttextBinary' - compiled fasttext executable for language detection (optional), see");
+    System.out.println("                  https://fasttext.cc/docs/en/support.html");
     System.out.println("                 'maxWorkQueueSize' - reject request if request queue gets larger than this (optional)");
     System.out.println("                 'rulesFile' - a file containing rules configuration, such as .langugagetool.cfg (optional)");
     System.out.println("                 'warmUp' - set to 'true' to warm up server at start, i.e. run a short check with all languages (optional)");

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -78,6 +78,7 @@ abstract class TextChecker {
     this.workQueue = workQueue;
     this.reqCounter = reqCounter;
     this.identifier = new LanguageIdentifier();
+    this.identifier.enableFasttext(config.getFasttextBinary(), config.getFasttextModel());
     this.executorService = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("lt-textchecker-thread-%d").build());
     this.cache = config.getCacheSize() > 0 ? new ResultCache(config.getCacheSize()) : null;
   }

--- a/languagetool-standalone/src/test/java/org/languagetool/language/LanguageIdentifierTest.java
+++ b/languagetool-standalone/src/test/java/org/languagetool/language/LanguageIdentifierTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.languagetool.Language;
 import org.languagetool.Languages;
 
+import java.io.File;
 import java.util.Objects;
 
 import static org.junit.Assert.fail;
@@ -32,8 +33,11 @@ public class LanguageIdentifierTest {
 
   @Test
   public void testDetection() {
+//    identifier.enableFasttext(new File("/path/to/fasttext/binary"), new File("/path/to/fasttext/model"));
+    // fasttext just assumes english, ignore / comment out
     langAssert(null, "");
     langAssert(null, "X");
+
     langAssert("de", "Das ist ein deutscher Text");
     langAssert("en", "This is an English text");
     langAssert("fr", "Le mont Revard est un sommet du département français ...");


### PR DESCRIPTION
I added optional support for language identification using the model available [here](https://fasttext.cc/docs/en/language-identification.html). Integration is done by starting the fasttext executable and communicating via stdin/stdout. When an error is encountered, we immediately fall back to the old approach based on character n-grams. Configuration is done via command line arguments for the CLI version or in configuration file for the server version.