### PR TITLE
fixed inconsistency with HunspellRule.isMisspelled, added prohibited compounds to german

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
@@ -151,18 +151,18 @@ public class HunspellRule extends SpellingCheckRule {
    */
   @Experimental
   public boolean isMisspelled(String word) {
-    if (needsInit) {
-      try {
+    try {
+      if (needsInit) {
         init();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
       }
+      boolean isAlphabetic = true;
+      if (word.length() == 1) { // hunspell dictionaries usually do not contain punctuation
+        isAlphabetic = Character.isAlphabetic(word.charAt(0));
+      }
+      return (isAlphabetic && !"--".equals(word) && hunspellDict.misspelled(word) && !ignoreWord(word)) || isProhibited(removeTrailingDot(word));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
-    boolean isAlphabetic = true;
-    if (word.length() == 1) { // hunspell dictionaries usually do not contain punctuation
-      isAlphabetic = Character.isAlphabetic(word.charAt(0));
-    }
-    return (isAlphabetic && !"--".equals(word) && hunspellDict.misspelled(word)) || isProhibited(removeTrailingDot(word));
   }
   
   void filterDupes(List<String> words) {

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/LineExpander.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/LineExpander.java
@@ -45,6 +45,8 @@ class LineExpander {
           result.add(word + "n");
         } else if (c == 'E') {
           result.add(word + "e");
+        } else if (c == 'F') {
+          result.add(word + "in"); // (m/f)
         } else if (c == 'A') {  // Adjektiv
           result.add(word + "e");
           result.add(word + "er");

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/ProhibitedCompoundRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/ProhibitedCompoundRule.java
@@ -44,6 +44,7 @@ public class ProhibitedCompoundRule extends Rule {
   private static final List<Pair> lowercasePairs = Arrays.asList(
           // NOTE: words here must be all-lowercase
           // NOTE: no need to add words from confusion_sets.txt, they will be used automatically (if starting with uppercase char)
+          new Pair("uhr", "Instrument zur Zeitmessung", "ur", "ursprünglich"),
           new Pair("abschluss", "Ende", "abschuss", "Vorgang des Abschießens, z.B. mit einer Waffe"),
           new Pair("brache", "verlassenes Grundstück", "branche", "Wirtschaftszweig"),
           new Pair("wieder", "erneut, wiederholt, nochmal (Wiederholung, Wiedervorlage, ...)", "wider", "gegen, entgegen (Widerwille, Widerstand, Widerspruch, ...)"),

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -9,6 +9,7 @@
 # /S will add s
 # /N will add n
 # /A will add e, er, es, en, em (for adjectives - no comparative, no superlative)
+# /F will add in (for gendered nouns)
 α
 β
 ɣ
@@ -26741,3 +26742,8 @@ zuzumüllen
 zwangsbeschallt/A
 Zwergenstadt
 Zwergenstädte/N
+Urberliner/F
+Urkölner/F
+Urmünchner/F
+Urfrankfurter/F
+Urhamburger/F

--- a/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/ProhibitedCompoundRuleTest.java
+++ b/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/ProhibitedCompoundRuleTest.java
@@ -39,10 +39,14 @@ public class ProhibitedCompoundRuleTest {
   public void testRule() throws IOException {
     Map<String,Integer> map = new HashMap<>();
     map.put("Leerzeile", 100);
+    map.put("Urberliner", 100);
+    map.put("Ureinwohner", 100);
     map.put("Wohnungsleerstand", 50);
     map.put("Xliseihflehrstand", 50);
     ProhibitedCompoundRule rule = new ProhibitedCompoundRule(TestTools.getEnglishMessages(), new FakeLanguageModel(map));
     JLanguageTool lt = new JLanguageTool(new German());
+    assertMatches("Er ist Uhrberliner.", 1, rule, lt);
+    assertMatches("Hier leben die Uhreinwohner.", 1, rule, lt);
     assertMatches("Eine Leerzeile einfügen.", 0, rule, lt);
     assertMatches("Eine Lehrzeile einfügen.", 1, rule, lt);
     assertMatches("Viel Wohnungsleerstand.", 0, rule, lt);


### PR DESCRIPTION
HunspellRule.isMissspelled ignored words in ignoredWords, e.g. additions to spelling.txt
ProhibitedCompoundRule depended on this function and thus would not suggest corrections
for these words
Added Urberliner and some other words to spelling.txt, Uhr/ur confusion to ProhibitedCompoundRule