### PR TITLE
[de] add 'Huftsteak'

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -3212,6 +3212,7 @@ HR
 HSV/S
 Hubble
 Hufgetrappel/S
+Huftsteak/S
 Hülsenauszieher/NS
 Hummersahne
 Hündchenstellung


### PR DESCRIPTION
"Hüftsteak" is already in the dictionary but "Huftsteak" (which seems also valid) is missing.