### PR TITLE
fixed NullPointerException in AbstractUnitConversionRule

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractUnitConversionRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractUnitConversionRule.java
@@ -277,8 +277,9 @@ public abstract class AbstractUnitConversionRule extends Rule {
       }
       return feet + inch / 12.0;
     };
-    specialPatterns.put(Pattern.compile("(?:(?<=[^º°\\d]))\\s(\\d+)(?:ft|′|')\\s*(\\d+)\\s*(?:in|\"|″)?|(?:(?<=[^º°\\d\\s]))(\\d+)(?:ft|′|')\\s*(\\d+)\\s*(?:in|\"|″)?"),
-      new AbstractMap.SimpleImmutableEntry<>( FEET, parseFeetAndInch ));
+    Map.Entry<Unit, Function<MatchResult, Double>> feetAndInchEntry = new AbstractMap.SimpleImmutableEntry<>( FEET, parseFeetAndInch );
+    specialPatterns.put(Pattern.compile("(?:(?<=[^º°\\d]))\\s(\\d+)(?:ft|′|')\\s*(\\d+)\\s*(?:in|\"|″)?"), feetAndInchEntry);
+    specialPatterns.put(Pattern.compile("(?:(?<=[^º°\\d\\s]))(\\d+)(?:ft|′|')\\s*(\\d+)\\s*(?:in|\"|″)?"), feetAndInchEntry);
   }
 
   /**


### PR DESCRIPTION
 because of grouping in regex for feet and inch measurement, see comments [here](https://github.com/languagetool-org/languagetool/commit/46ee136fdc50a74f17abab1d5cbecf04832c97c9)