### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/languagetool-wikipedia/src/main/resources/org/languagetool/resource/dev/SimpleWikiConfiguration.xml
+++ b/languagetool-wikipedia/src/main/resources/org/languagetool/resource/dev/SimpleWikiConfiguration.xml
@@ -2869,7 +2869,7 @@
         </Interwiki>
         <Interwiki>
             <prefix>doi</prefix>
-            <url>http://dx.doi.org/$1</url>
+            <url>https://doi.org/$1</url>
             <local>false</local>
             <trans>false</trans>
         </Interwiki>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update the code that generates new DOI links.

Cheers!