### PR TITLE
RequestLimiter with fingerprints

### DIFF
--- a/languagetool-server/scripts/database/migrations/20181010_extend_access_limits_reason_column_size.sql
+++ b/languagetool-server/scripts/database/migrations/20181010_extend_access_limits_reason_column_size.sql
@@ -1,0 +1,1 @@
+alter table access_limits modify column `reason` varchar(512) default null;

--- a/languagetool-server/src/main/java/org/languagetool/server/ErrorRequestLimiter.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/ErrorRequestLimiter.java
@@ -21,6 +21,8 @@ package org.languagetool.server;
 import org.languagetool.JLanguageTool;
 
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Limit the maximum number of request per IP address for a given time range.
@@ -39,9 +41,9 @@ class ErrorRequestLimiter extends RequestLimiter {
    * @param ipAddress the client's IP address
    * @return true if access is allowed because the request limit is not reached yet
    */
-  boolean wouldAccessBeOkay(String ipAddress) {
+  boolean wouldAccessBeOkay(String ipAddress, Map<String, List<String>> httpHeader) {
     try {
-      checkLimit(ipAddress);
+      checkLimit(ipAddress, httpHeader);
       return true;
     } catch (TooManyRequestsException e) {
       return false;
@@ -51,11 +53,11 @@ class ErrorRequestLimiter extends RequestLimiter {
   /**
    * @param ipAddress the client's IP address
    */
-  void logAccess(String ipAddress) {
+  void logAccess(String ipAddress, Map<String, List<String>> httpHeader) {
     while (requestEvents.size() > REQUEST_QUEUE_SIZE) {
       requestEvents.remove(0);
     }
-    requestEvents.add(new RequestEvent(ipAddress, new Date(), 0, JLanguageTool.Mode.ALL));
+    requestEvents.add(new RequestEvent(ipAddress, new Date(), 0, computeFingerprint(httpHeader), JLanguageTool.Mode.ALL));
   }
   
 }

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
@@ -67,6 +67,7 @@ public class HTTPServerConfig {
   protected int requestLimitInBytes;
   protected int timeoutRequestLimit;
   protected int requestLimitPeriodInSeconds;
+  protected int ipFingerprintFactor = 1;
   protected boolean trustXForwardForHeader;
   protected int maxWorkQueueSize;
   protected File rulesConfigFile = null;
@@ -172,6 +173,7 @@ public class HTTPServerConfig {
         requestLimitInBytes = Integer.parseInt(getOptionalProperty(props, "requestLimitInBytes", "0"));
         timeoutRequestLimit = Integer.parseInt(getOptionalProperty(props, "timeoutRequestLimit", "0"));
         requestLimitPeriodInSeconds = Integer.parseInt(getOptionalProperty(props, "requestLimitPeriodInSeconds", "0"));
+        ipFingerprintFactor = Integer.parseInt(getOptionalProperty(props, "ipFingerprintFactor", "1"));
         trustXForwardForHeader = Boolean.valueOf(getOptionalProperty(props, "trustXForwardForHeader", "false"));
         maxWorkQueueSize = Integer.parseInt(getOptionalProperty(props, "maxWorkQueueSize", "0"));
         if (maxWorkQueueSize < 0) {
@@ -367,6 +369,11 @@ public class HTTPServerConfig {
 
   int getRequestLimitPeriodInSeconds() {
     return requestLimitPeriodInSeconds;
+  }
+
+  /** since 4.4 */
+  int getIpFingerprintFactor() {
+    return ipFingerprintFactor;
   }
 
   /**

--- a/languagetool-server/src/main/java/org/languagetool/server/LanguageToolHttpHandler.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/LanguageToolHttpHandler.java
@@ -115,7 +115,7 @@ class LanguageToolHttpHandler implements HttpHandler {
       parameters = getRequestQuery(httpExchange, requestedUri);
       if (requestLimiter != null) {
         try {
-          requestLimiter.checkAccess(remoteAddress, parameters);
+          requestLimiter.checkAccess(remoteAddress, parameters, httpExchange.getRequestHeaders());
         } catch (TooManyRequestsException e) {
           String errorMessage = "Error: Access from " + remoteAddress + " denied: " + e.getMessage();
           int code = HttpURLConnection.HTTP_FORBIDDEN;
@@ -124,7 +124,7 @@ class LanguageToolHttpHandler implements HttpHandler {
           return;
         }
       }
-      if (errorRequestLimiter != null && !errorRequestLimiter.wouldAccessBeOkay(remoteAddress)) {
+      if (errorRequestLimiter != null && !errorRequestLimiter.wouldAccessBeOkay(remoteAddress, httpExchange.getRequestHeaders())) {
         String textSizeMessage = getTextOrDataSizeMessage(parameters);
         String errorMessage = "Error: Access from " + remoteAddress + " denied - too many recent timeouts. " +
                 textSizeMessage +

--- a/languagetool-server/src/main/java/org/languagetool/server/Server.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/Server.java
@@ -95,8 +95,9 @@ abstract class Server {
     int requestLimit = config.getRequestLimit();
     int requestLimitInBytes = config.getRequestLimitInBytes();
     int requestLimitPeriodInSeconds = config.getRequestLimitPeriodInSeconds();
-    if ((requestLimit > 0 || requestLimitInBytes > 0) && requestLimitPeriodInSeconds > 0) {
-      return new RequestLimiter(requestLimit, requestLimitInBytes, requestLimitPeriodInSeconds);
+    int ipFingerprintFactor = config.getIpFingerprintFactor();
+    if ((requestLimit > 0 || requestLimitInBytes > 0) && requestLimitPeriodInSeconds > 0 && ipFingerprintFactor >= 1) {
+      return new RequestLimiter(requestLimit, requestLimitInBytes, requestLimitPeriodInSeconds, ipFingerprintFactor);
     }
     return null;
   }

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -219,7 +219,7 @@ abstract class TextChecker {
         Path loadFile = Paths.get("/proc/loadavg");  // works in Linux only(?)
         String loadInfo = loadFile.toFile().exists() ? Files.readAllLines(loadFile).toString() : "(unknown)";
         if (errorRequestLimiter != null) {
-          errorRequestLimiter.logAccess(remoteAddress);
+          errorRequestLimiter.logAccess(remoteAddress, httpExchange.getRequestHeaders());
         }
         String message = "Text checking took longer than allowed maximum of " + limits.getMaxCheckTimeMillis() +
                          " milliseconds (cancelled: " + cancelled +

--- a/languagetool-server/src/test/java/org/languagetool/server/ErrorRequestLimiterTest.java
+++ b/languagetool-server/src/test/java/org/languagetool/server/ErrorRequestLimiterTest.java
@@ -20,6 +20,10 @@ package org.languagetool.server;
 
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.*;
 
 public class ErrorRequestLimiterTest {
@@ -27,18 +31,19 @@ public class ErrorRequestLimiterTest {
   @Test
   public void testErrorLimiter() throws InterruptedException {
     ErrorRequestLimiter limiter = new ErrorRequestLimiter(3, 1);
+    Map<String, List<String>> header = new HashMap<>(); // not relevant for test
     String ip1 = "192.168.0.1";
     String ip2 = "192.168.0.2";
-    assertTrue(limiter.wouldAccessBeOkay(ip1));
-    assertTrue(limiter.wouldAccessBeOkay(ip2));
-    limiter.logAccess(ip1);
-    limiter.logAccess(ip1);
-    limiter.logAccess(ip1);
-    limiter.logAccess(ip1);
-    assertFalse(limiter.wouldAccessBeOkay(ip1));
-    assertTrue(limiter.wouldAccessBeOkay(ip2));
+    assertTrue(limiter.wouldAccessBeOkay(ip1, header));
+    assertTrue(limiter.wouldAccessBeOkay(ip2, header));
+    limiter.logAccess(ip1, header);
+    limiter.logAccess(ip1, header);
+    limiter.logAccess(ip1, header);
+    limiter.logAccess(ip1, header);
+    assertFalse(limiter.wouldAccessBeOkay(ip1, header));
+    assertTrue(limiter.wouldAccessBeOkay(ip2, header));
     Thread.sleep(1050);
-    assertTrue(limiter.wouldAccessBeOkay(ip1));
+    assertTrue(limiter.wouldAccessBeOkay(ip1, header));
   }
 
 }

--- a/languagetool-server/src/test/java/org/languagetool/server/RequestLimiterTest.java
+++ b/languagetool-server/src/test/java/org/languagetool/server/RequestLimiterTest.java
@@ -20,7 +20,9 @@ package org.languagetool.server;
 
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.fail;
@@ -29,66 +31,84 @@ public class RequestLimiterTest {
   
   @Test
   public void testIsAccessOkay() throws Exception {
-    RequestLimiter limiter = new RequestLimiter(3, 0, 1);
+    RequestLimiter limiter = new RequestLimiter(3, 0, 1, 2);
     String firstIp = "192.168.10.1";
     String secondIp = "192.168.10.2";
+    Map<String, List<String>> firstHeader = new HashMap<>();
+    Map<String, List<String>> secondHeader = new HashMap<>();
+    secondHeader.put("User-Agent", Collections.singletonList("Test"));
     Map<String, String> params = new HashMap<>();
-    assertOkay(limiter, firstIp, params);
-    assertOkay(limiter, firstIp, params);
-    assertOkay(limiter, firstIp, params);
-    assertException(limiter, firstIp, params);
-    assertOkay(limiter, secondIp, params);
+    assertOkay(limiter, firstIp, params, firstHeader);
+    assertOkay(limiter, firstIp, params, firstHeader);
+    assertOkay(limiter, firstIp, params, firstHeader);
+    assertException(limiter, firstIp, params, firstHeader);
+    assertOkay(limiter, firstIp, params, secondHeader);
+    assertOkay(limiter, firstIp, params, secondHeader);
+    assertException(limiter, firstIp, params, secondHeader);
+    assertOkay(limiter, secondIp, params, firstHeader);
+    assertOkay(limiter, secondIp, params, secondHeader);
     Thread.sleep(1050);
-    assertOkay(limiter, firstIp, params);
-    assertOkay(limiter, secondIp, params);
-    assertOkay(limiter, secondIp, params);
-    assertOkay(limiter, secondIp, params);
-    assertException(limiter, secondIp, params);
+    assertOkay(limiter, firstIp, params, firstHeader);
+    assertOkay(limiter, secondIp, params, firstHeader);
+    assertOkay(limiter, secondIp, params, firstHeader);
+    assertOkay(limiter, secondIp, params, firstHeader);
+    assertException(limiter, secondIp, params, firstHeader);
   }
 
   @Test
   public void testIsAccessOkayWithByteLimit() throws Exception {
-    RequestLimiter limiter = new RequestLimiter(10, 35, 1);
+    RequestLimiter limiter = new RequestLimiter(10, 35, 1, 2);
     String firstIp = "192.168.10.1";
     String secondIp = "192.168.10.2";
+    Map<String, List<String>> firstHeader = new HashMap<>();
+    Map<String, List<String>> secondHeader = new HashMap<>();
+    secondHeader.put("User-Agent", Collections.singletonList("Test"));
     Map<String, String> params = new HashMap<>();
     params.putIfAbsent("text", "0123456789");
-    assertOkay(limiter, firstIp, params);  // 10 bytes
-    assertOkay(limiter, firstIp, params);  // 20 bytes
-    assertOkay(limiter, firstIp, params);  // 30 bytes
-    assertException(limiter, firstIp, params);  // 40 bytes!
-    assertOkay(limiter, secondIp, params);
+    assertOkay(limiter, firstIp, params, firstHeader);  // 10 bytes
+    assertOkay(limiter, firstIp, params, firstHeader);  // 20 bytes
+    assertOkay(limiter, firstIp, params, firstHeader);  // 30 bytes
+    assertException(limiter, firstIp, params, firstHeader);  // 40 bytes!
+    assertOkay(limiter, firstIp, params, secondHeader);
+    assertOkay(limiter, firstIp, params, secondHeader);
+    assertOkay(limiter, firstIp, params, secondHeader);
+    assertException(limiter, firstIp, params, secondHeader);  // 80 bytes!
+    assertOkay(limiter, secondIp, params, firstHeader);
+    assertOkay(limiter, secondIp, params, secondHeader);
     Thread.sleep(1050);
-    assertOkay(limiter, firstIp, params);
-    assertOkay(limiter, secondIp, params);
+    assertOkay(limiter, firstIp, params, firstHeader);
+    assertOkay(limiter, firstIp, params, secondHeader);
+    assertOkay(limiter, secondIp, params, firstHeader);
+    assertOkay(limiter, secondIp, params, secondHeader);
   }
 
   @Test
   public void testTextLevelChecksCountLess() {
-    RequestLimiter limiter = new RequestLimiter(100, 35, 100);
+    RequestLimiter limiter = new RequestLimiter(100, 35, 100, 2);
     String firstIp = "192.168.10.1";
+    Map<String, List<String>> firstHeader = new HashMap<>();
     Map<String, String> params = new HashMap<>();
     params.putIfAbsent("text", "0123456789");
-    assertOkay(limiter, firstIp, params);  // 10 bytes
-    assertOkay(limiter, firstIp, params);  // 20 bytes
-    assertOkay(limiter, firstIp, params);  // 30 bytes
+    assertOkay(limiter, firstIp, params, firstHeader);  // 10 bytes
+    assertOkay(limiter, firstIp, params, firstHeader);  // 20 bytes
+    assertOkay(limiter, firstIp, params, firstHeader);  // 30 bytes
     params.put("mode", "textLevelOnly");
-    assertOkay(limiter, firstIp, params);  // +10 bytes! but text level only, counts only a tenth of that, so okay (31 bytes)
+    assertOkay(limiter, firstIp, params, firstHeader);  // +10 bytes! but text level only, counts only a tenth of that, so okay (31 bytes)
     params.put("mode", "all");
-    assertException(limiter, firstIp, params);  // 41 bytes!
+    assertException(limiter, firstIp, params, firstHeader);  // 41 bytes!
   }
 
-  private void assertOkay(RequestLimiter limiter, String ip, Map<String, String> params) {
+  private void assertOkay(RequestLimiter limiter, String ip, Map<String, String> params, Map<String, List<String>> header) {
     try {
-      limiter.checkAccess(ip, params);
+      limiter.checkAccess(ip, params, header);
     } catch (TooManyRequestsException e) {
       fail();
     }
   }
 
-  private void assertException(RequestLimiter limiter, String ip, Map<String, String> params) {
+  private void assertException(RequestLimiter limiter, String ip, Map<String, String> params, Map<String, List<String>> header) {
     try {
-      limiter.checkAccess(ip, params);
+      limiter.checkAccess(ip, params, header);
       fail();
     } catch (TooManyRequestsException ignored) {}
   }


### PR DESCRIPTION
bigger per-ip limit
try to distinguish users by fingerprints and use smaller per-user limit
fingerprints: HTTP request headers -> User-Agent, Accept-Language, Referer
configure via: ipFingerprintFactor
1 is default behavior, n allows access by n users from the same IP using different clients