### PR TITLE
Fix no case bug.

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/SpellingCheckRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/SpellingCheckRule.java
@@ -164,7 +164,7 @@ public abstract class SpellingCheckRule extends Rule {
 
   private boolean isIgnoredNoCase(String word) {
     return wordsToBeIgnored.contains(word) ||
-           (convertsCase && wordsToBeIgnored.contains(word.toLowerCase(language.getLocale())));
+            (convertsCase && wordsToBeIgnored.stream().anyMatch(s -> s.toLowerCase(language.getLocale()).equals(word.toLowerCase(language.getLocale()))));
   }
 
   /**


### PR DESCRIPTION
I think that this is a bug.

`SpellingCheckRule#isIgnoredNoCase` means that case is ignored in spellchecking, in other words, case-no-sensitive.

To realize above, comparing word and compared word are both change to lower case.