### PR TITLE
Add missing variable declarations for JavaScript code

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/rules/false-friends.html
+++ b/languagetool-core/src/main/resources/org/languagetool/rules/false-friends.html
@@ -10,6 +10,7 @@
     }
 
     function loadXMLDoc(filename) {
+      var xhttp;
       if (window.ActiveXObject) {
         xhttp = new ActiveXObject("Msxml2.XMLHTTP");
       } else {
@@ -24,20 +25,20 @@
     }
 
     function displayResult() {
-      lang = getLangFromURL();
-      xml = loadXMLDoc("false-friends.xml");
-      xsl = loadXMLDoc("print-ff.xsl");
+      var lang = getLangFromURL();
+      var xml = loadXMLDoc("false-friends.xml");
+      var xsl = loadXMLDoc("print-ff.xsl");
       // code for IE
       if (window.ActiveXObject || xhttp.responseType == "msxml-document") {
-        ex = xml.transformNode(xsl);
+        var ex = xml.transformNode(xsl);
         document.getElementById("container").innerHTML = ex;
       }
       // code for Chrome, Firefox, Opera, etc.
       else if (document.implementation && document.implementation.createDocument) {
-        xsltProcessor = new XSLTProcessor();
+        var xsltProcessor = new XSLTProcessor();
         xsltProcessor.importStylesheet(xsl);
         xsltProcessor.setParameter(null, "lang", lang);
-        resultDocument = xsltProcessor.transformToFragment(xml, document);
+        var resultDocument = xsltProcessor.transformToFragment(xml, document);
         document.getElementById("container").appendChild(resultDocument);
       }
     }


### PR DESCRIPTION
This fixes several error messages like the following one from LGTM:

    Variable xhttp is used like a local variable,
    but is missing a declaration.

Signed-off-by: Stefan Weil <sw@weilnetz.de>