### PR TITLE
Pipeline pool

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/UserConfig.java
+++ b/languagetool-core/src/main/java/org/languagetool/UserConfig.java
@@ -102,7 +102,8 @@ public class UserConfig {
   public LinguServices getLinguServices() {
     return linguServices;
   }
-  
+
+  // TODO: optimize this! equals on userSpecificSpellerWords can be expensive with huge dicts
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;

--- a/languagetool-server/pom.xml
+++ b/languagetool-server/pom.xml
@@ -121,6 +121,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.23.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
             <version>2.4.0</version>

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
@@ -63,6 +63,10 @@ public class HTTPServerConfig {
   protected Mode mode;
   protected File languageModelDir = null;
   protected File word2vecModelDir = null;
+  protected boolean pipelineCaching = false;
+
+  protected int maxPipelinePoolSize;
+  protected int pipelineExpireTime;
   protected int requestLimit;
   protected int requestLimitInBytes;
   protected int timeoutRequestLimit;
@@ -173,6 +177,9 @@ public class HTTPServerConfig {
         requestLimit = Integer.parseInt(getOptionalProperty(props, "requestLimit", "0"));
         requestLimitInBytes = Integer.parseInt(getOptionalProperty(props, "requestLimitInBytes", "0"));
         timeoutRequestLimit = Integer.parseInt(getOptionalProperty(props, "timeoutRequestLimit", "0"));
+        pipelineCaching = Boolean.parseBoolean(getOptionalProperty(props, "pipelineCaching", "false"));
+        maxPipelinePoolSize = Integer.parseInt(getOptionalProperty(props, "maxPipelinePoolSize", "5"));
+        pipelineExpireTime = Integer.parseInt(getOptionalProperty(props, "pipelineExpireTimeInSeconds", "10"));
         requestLimitPeriodInSeconds = Integer.parseInt(getOptionalProperty(props, "requestLimitPeriodInSeconds", "0"));
         ipFingerprintFactor = Integer.parseInt(getOptionalProperty(props, "ipFingerprintFactor", "1"));
         trustXForwardForHeader = Boolean.valueOf(getOptionalProperty(props, "trustXForwardForHeader", "false"));
@@ -491,6 +498,49 @@ public class HTTPServerConfig {
   /** @since 2.9 */
   int getMaxWorkQueueSize() {
     return maxWorkQueueSize;
+  }
+
+
+  /**
+   * @since 4.4
+   * Cache initalized JLanguageTool instances and share between non-parallel requests with identical paramenters
+   * Improves response time (especially when dealing with many small requests without specific settings),
+   * but increases memory usage
+   */
+  public boolean isPipelineCachingEnabled() {
+    return pipelineCaching;
+  }
+
+  /**
+   * @since 4.4
+   * Keep pipelines ready for this many different request settings
+   */
+  public int getMaxPipelinePoolSize() {
+    return maxPipelinePoolSize;
+  }
+
+  /**
+   * @since 4.4
+   * Expire pipelines for a specific request setting after this many seconds without any matching request elapsed
+   */
+  public int getPipelineExpireTime() {
+    return pipelineExpireTime;
+  }
+
+
+  /** @since 4.4 */
+  public void setPipelineCaching(boolean pipelineCaching) {
+    this.pipelineCaching = pipelineCaching;
+  }
+
+  /** @since 4.4 */
+  public void setMaxPipelinePoolSize(int maxPipelinePoolSize) {
+    this.maxPipelinePoolSize = maxPipelinePoolSize;
+  }
+
+  /** @since 4.4 */
+  public void setPipelineExpireTime(int pipelineExpireTime) {
+    this.pipelineExpireTime = pipelineExpireTime;
   }
 
   /**

--- a/languagetool-server/src/main/java/org/languagetool/server/Pipeline.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/Pipeline.java
@@ -22,9 +22,11 @@
 package org.languagetool.server;
 
 import org.languagetool.*;
+import org.languagetool.markup.AnnotatedText;
 import org.languagetool.rules.Category;
 import org.languagetool.rules.CategoryId;
 import org.languagetool.rules.Rule;
+import org.languagetool.rules.RuleMatch;
 import org.languagetool.rules.patterns.AbstractPatternRule;
 import org.xml.sax.SAXException;
 
@@ -46,7 +48,7 @@ public class Pipeline extends JLanguageTool {
 
   public static class IllegalPipelineMutationException extends RuntimeException {
     IllegalPipelineMutationException() {
-      super("Pipeline is frozen; mutating shared JLanguageTool instace is forbidden.");
+      super("Pipeline is frozen; mutating shared JLanguageTool instance is forbidden.");
     }
   }
 

--- a/languagetool-server/src/main/java/org/languagetool/server/Pipeline.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/Pipeline.java
@@ -1,0 +1,213 @@
+/*
+ *  LanguageTool, a natural language style checker
+ *  * Copyright (C) 2018 Fabian Richter
+ *  *
+ *  * This library is free software; you can redistribute it and/or
+ *  * modify it under the terms of the GNU Lesser General Public
+ *  * License as published by the Free Software Foundation; either
+ *  * version 2.1 of the License, or (at your option) any later version.
+ *  *
+ *  * This library is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  * Lesser General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Lesser General Public
+ *  * License along with this library; if not, write to the Free Software
+ *  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  * USA
+ *
+ */
+
+package org.languagetool.server;
+
+import org.languagetool.*;
+import org.languagetool.rules.Category;
+import org.languagetool.rules.CategoryId;
+import org.languagetool.rules.Rule;
+import org.languagetool.rules.patterns.AbstractPatternRule;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Wrapper for JLanguageTool instances that can be made immutable
+ * Use case: Setup instances once (ahead of time or on demand), cache and use when matching queries come in; work around thread safety issues by only giving out one reference at a time
+ * @see PipelinePool
+ */
+public class Pipeline extends JLanguageTool {
+
+  public static class IllegalPipelineMutationException extends RuntimeException {
+    IllegalPipelineMutationException() {
+      super("Pipeline is frozen; mutating shared JLanguageTool instace is forbidden.");
+    }
+  }
+
+  private boolean setup = false;
+
+  /**
+   * Prevents any further changes after this method was called.
+   */
+  public void setupFinished() {
+   this.setup = true;
+  }
+
+  public Pipeline(Language language, List<Language> altLanguages, Language motherTongue, ResultCache cache, UserConfig userConfig) {
+    super(language, altLanguages, motherTongue, cache, userConfig);
+  }
+
+  @Override
+  public void setCleanOverlappingMatches(boolean cleanOverlappingMatches) {
+    if (setup) {
+      throw new IllegalPipelineMutationException();
+    }
+    super.setCleanOverlappingMatches(cleanOverlappingMatches);
+  }
+
+  @Override
+  public void setMaxErrorsPerWordRate(float maxErrorsPerWordRate) {
+    if (setup) {
+      throw new IllegalPipelineMutationException();
+    }
+    super.setMaxErrorsPerWordRate(maxErrorsPerWordRate);
+  }
+
+  @Override
+  public void setOutput(PrintStream printStream) {
+    if (setup) {
+      throw new IllegalPipelineMutationException();
+    }
+    super.setOutput(printStream);
+  }
+
+  @Override
+  public List<AbstractPatternRule> loadPatternRules(String filename) throws IOException {
+    if (setup) {
+      throw new IllegalPipelineMutationException();
+    }
+    return super.loadPatternRules(filename);
+  }
+
+  @Override
+  public List<AbstractPatternRule> loadFalseFriendRules(String filename) throws ParserConfigurationException, SAXException, IOException {
+    if (setup) {
+      throw new IllegalPipelineMutationException();
+    }
+    return super.loadFalseFriendRules(filename);
+  }
+
+  @Override
+  public void activateLanguageModelRules(File indexDir) throws IOException {
+    if (setup) {
+      throw new IllegalPipelineMutationException();
+    }
+    super.activateLanguageModelRules(indexDir);
+  }
+
+  @Override
+  public void activateWord2VecModelRules(File indexDir) throws IOException {
+    if (setup) {
+      throw new IllegalPipelineMutationException();
+    }
+    super.activateWord2VecModelRules(indexDir);
+  }
+
+  @Override
+  public void addRule(Rule rule) {
+    if (setup) {
+      throw new IllegalPipelineMutationException();
+    }
+    super.addRule(rule);
+  }
+
+  @Override
+  public void disableRule(String ruleId) {
+    if (setup) {
+      throw new IllegalPipelineMutationException();
+    }
+    super.disableRule(ruleId);
+  }
+
+  @Override
+  public void disableRules(List<String> ruleIds) {
+    if (setup) {
+      throw new IllegalPipelineMutationException();
+    }
+    super.disableRules(ruleIds);
+  }
+
+  @Override
+  public void disableCategory(CategoryId id) {
+    if (setup) {
+      throw new IllegalPipelineMutationException();
+    }
+    super.disableCategory(id);
+  }
+
+  @Override
+  public Set<String> getDisabledRules() {
+    return Collections.unmodifiableSet(super.getDisabledRules());
+  }
+
+  @Override
+  public void enableRule(String ruleId) {
+    if (setup) {
+      throw new IllegalPipelineMutationException();
+    }
+    super.enableRule(ruleId);
+  }
+
+  @Override
+  public void enableRuleCategory(CategoryId id) {
+    if (setup) {
+      throw new IllegalPipelineMutationException();
+    }
+    super.enableRuleCategory(id);
+  }
+
+  @Override
+  public List<String> getUnknownWords() {
+    return Collections.unmodifiableList(super.getUnknownWords());
+  }
+
+  @Override
+  public Map<CategoryId, Category> getCategories() {
+    return Collections.unmodifiableMap(super.getCategories());
+  }
+
+  @Override
+  public List<Rule> getAllRules() {
+    return Collections.unmodifiableList(super.getAllRules());
+  }
+
+  @Override
+  public List<Rule> getAllActiveRules() {
+    return Collections.unmodifiableList(super.getAllActiveRules());
+  }
+
+  @Override
+  public List<Rule> getAllActiveOfficeRules() {
+    return Collections.unmodifiableList(super.getAllActiveOfficeRules());
+  }
+
+  @Override
+  public List<AbstractPatternRule> getPatternRulesByIdAndSubId(String Id, String subId) {
+    return Collections.unmodifiableList(super.getPatternRulesByIdAndSubId(Id, subId));
+  }
+
+  @Override
+  public void setConfigValues(Map<String, Integer> v) {
+    if (setup) {
+      throw new IllegalPipelineMutationException();
+    }
+    super.setConfigValues(v);
+  }
+
+}

--- a/languagetool-server/src/main/java/org/languagetool/server/PipelinePool.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/PipelinePool.java
@@ -1,0 +1,198 @@
+/*
+ *  LanguageTool, a natural language style checker
+ *  * Copyright (C) 2018 Fabian Richter
+ *  *
+ *  * This library is free software; you can redistribute it and/or
+ *  * modify it under the terms of the GNU Lesser General Public
+ *  * License as published by the Free Software Foundation; either
+ *  * version 2.1 of the License, or (at your option) any later version.
+ *  *
+ *  * This library is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  * Lesser General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Lesser General Public
+ *  * License along with this library; if not, write to the Free Software
+ *  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  * USA
+ *
+ */
+
+package org.languagetool.server;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.languagetool.JLanguageTool;
+import org.languagetool.Language;
+import org.languagetool.ResultCache;
+import org.languagetool.UserConfig;
+import org.languagetool.gui.Configuration;
+import org.languagetool.tools.Tools;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Caches pre-configured JLanguageTool instances to avoid costly setup time of rules, etc.
+ */
+public class PipelinePool {
+
+  public static class PipelineSettings {
+    private Language lang;
+    private Language motherTongue;
+    private TextChecker.QueryParams query;
+    private UserConfig user;
+
+    PipelineSettings(Language lang, Language motherTongue, TextChecker.QueryParams params, UserConfig userConfig) {
+      this.lang = lang;
+      this.motherTongue = motherTongue;
+      this.query = params;
+      this.user = userConfig;
+    }
+
+    @Override
+    public int hashCode() {
+      return new HashCodeBuilder(17, 31)
+        .append(lang)
+        .append(motherTongue)
+        .append(query)
+        .append(user)
+        .toHashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) return true;
+      if (obj == null || getClass() != obj.getClass()) {
+        return false;
+      }
+      PipelineSettings other = (PipelineSettings) obj;
+      return new EqualsBuilder()
+        .append(lang, other.lang)
+        .append(motherTongue, other.motherTongue)
+        .append(query, other.query)
+        .append(user, other.user)
+        .isEquals();
+    }
+
+    @Override
+    public String toString() {
+      return new ToStringBuilder(this)
+        .append("lang", lang)
+        .append("motherTongue", motherTongue)
+        .append("query", query)
+        .append("user", user)
+        .build();
+    }
+  }
+
+  private final HTTPServerConfig config;
+  private final ResultCache cache;
+  private final LoadingCache<PipelineSettings, ConcurrentLinkedQueue<Pipeline>> pool;
+  private final boolean internalServer;
+
+  public PipelinePool(HTTPServerConfig config, ResultCache cache, boolean internalServer) {
+    this.internalServer = internalServer;
+    this.config = config;
+    this.cache = cache;
+    int maxPoolSize = config.getMaxPipelinePoolSize();
+    int expireTime = config.getPipelineExpireTime();
+    // TODO: figure out how to expire elements of the queue if many build up after a load spike
+    // and then sit around unused later when there is steady, but low usage of the specific pipeline
+    if (config.isPipelineCachingEnabled()) {
+      this.pool = CacheBuilder.newBuilder()
+        .maximumSize(maxPoolSize)
+        .expireAfterAccess(expireTime, TimeUnit.SECONDS)
+        .build(new CacheLoader<PipelineSettings, ConcurrentLinkedQueue<Pipeline>>() {
+          @Override
+          public ConcurrentLinkedQueue<Pipeline> load(PipelineSettings key) {
+            return new ConcurrentLinkedQueue<>();
+          }
+        });
+    } else {
+      this.pool = null;
+    }
+  }
+
+  public Pipeline getPipeline(PipelineSettings settings) throws Exception {
+    if (pool != null) {
+      ConcurrentLinkedQueue<Pipeline> pipelines = pool.get(settings);
+      Pipeline pipeline = pipelines.poll();
+      if (pipeline == null) {
+        ServerTools.print("No prepared pipeline found; creating one.");
+        pipeline = createPipeline(settings.lang, settings.motherTongue, settings.query, settings.user);
+      } else {
+        ServerTools.print("Prepared pipeline found; using it.");
+      }
+      return pipeline;
+    } else {
+      return createPipeline(settings.lang, settings.motherTongue, settings.query, settings.user);
+    }
+  }
+
+  public void returnPipeline(PipelineSettings settings, Pipeline pipeline) throws ExecutionException {
+    if (pool == null) return;
+    ConcurrentLinkedQueue<Pipeline> pipelines = pool.get(settings);
+    pipelines.add(pipeline);
+  }
+
+  /**
+   * Create a JLanguageTool instance for a specific language, mother tongue, and rule configuration.
+   * Uses Pipeline wrapper to safely share objects
+   *
+   * @param lang the language to be used
+   * @param motherTongue the user's mother tongue or {@code null}
+   */
+  Pipeline createPipeline(Language lang, Language motherTongue, TextChecker.QueryParams params, UserConfig userConfig)
+    throws Exception { // package-private for mocking
+    Pipeline lt = new Pipeline(lang, params.altLanguages, motherTongue, cache, userConfig);
+    lt.setMaxErrorsPerWordRate(config.getMaxErrorsPerWordRate());
+    if (config.getLanguageModelDir() != null) {
+      lt.activateLanguageModelRules(config.getLanguageModelDir());
+    }
+    if (config.getWord2VecModelDir () != null) {
+      lt.activateWord2VecModelRules(config.getWord2VecModelDir());
+    }
+    if (config.getRulesConfigFile() != null) {
+      configureFromRulesFile(lt, lang);
+    } else {
+      configureFromGUI(lt, lang);
+    }
+    if (params.useQuerySettings) {
+      Tools.selectRules(lt, new HashSet<>(params.disabledCategories), new HashSet<>(params.enabledCategories),
+        new HashSet<>(params.disabledRules), new HashSet<>(params.enabledRules), params.useEnabledOnly);
+    }
+    if (pool != null) {
+      lt.setupFinished();
+    }
+    return lt;
+  }
+
+  private void configureFromRulesFile(JLanguageTool langTool, Language lang) throws IOException {
+    ServerTools.print("Using options configured in " + config.getRulesConfigFile());
+    // If we are explicitly configuring from rules, ignore the useGUIConfig flag
+    if (config.getRulesConfigFile() != null) {
+      org.languagetool.gui.Tools.configureFromRules(langTool, new Configuration(config.getRulesConfigFile()
+        .getCanonicalFile().getParentFile(), config.getRulesConfigFile().getName(), lang));
+    } else {
+      throw new RuntimeException("config.getRulesConfigFile() is null");
+    }
+  }
+
+  private void configureFromGUI(JLanguageTool langTool, Language lang) throws IOException {
+    Configuration config = new Configuration(lang);
+    if (internalServer && config.getUseGUIConfig()) {
+      ServerTools.print("Using options configured in the GUI");
+      org.languagetool.gui.Tools.configureFromRules(langTool, config);
+    }
+  }
+
+}

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -122,6 +122,10 @@ abstract class TextChecker {
     UserConfig userConfig = new UserConfig(
             limits.getPremiumUid() != null ? getUserDictWords(limits.getPremiumUid()) : Collections.emptyList(),
             new HashMap<>(), config.getMaxSpellingSuggestions());
+
+    if (limits.getPremiumUid() != null) {
+      userConfig.generateUserDictionaryIdentifier(limits.getPremiumUid(), Collections.emptyList());
+    }
     //print("Check start: " + text.length() + " chars, " + langParam);
     boolean autoDetectLanguage = getLanguageAutoDetect(parameters);
     List<String> preferredVariants = getPreferredVariants(parameters);

--- a/languagetool-server/src/test/java/org/languagetool/server/PipelinePoolTest.java
+++ b/languagetool-server/src/test/java/org/languagetool/server/PipelinePoolTest.java
@@ -28,10 +28,7 @@ import org.languagetool.Languages;
 import org.languagetool.UserConfig;
 import org.languagetool.markup.AnnotatedTextBuilder;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -67,6 +64,143 @@ public class PipelinePoolTest {
     verify(pool, times(1)).createPipeline(lang1, null, queryParams1, user1);
     verify(pool, times(2)).returnPipeline(eq(settings1), notNull());
   }
+
+  @Test
+  public void testDifferentPipelineSettings() throws Exception {
+    Map<String, String> params1 = new HashMap<>();
+    params1.put("text", "not used");
+    params1.put("language", "en-US");
+    Map<String, String> params2 = new HashMap<>();
+    params2.put("text", "not used");
+    params2.put("language", "de-DE");
+    HTTPServerConfig config1 = new HTTPServerConfig(HTTPTools.getDefaultPort());
+    config1.setPipelineCaching(true);
+    config1.setPipelineExpireTime(10);
+    config1.setMaxPipelinePoolSize(10);
+    TextChecker checker = new V2TextChecker(config1, false, null, new RequestCounter());
+    PipelinePool pool = spy(checker.pipelinePool);
+    checker.pipelinePool = pool;
+    checker.checkText(new AnnotatedTextBuilder().addText("Hello World.").build(), new FakeHttpExchange(), params1, null, null);
+    Language lang1 = Languages.getLanguageForShortCode("en-US");
+    Language lang2 = Languages.getLanguageForShortCode("de-DE");
+    TextChecker.QueryParams queryParams1 = new TextChecker.QueryParams(new LinkedList<>(), new LinkedList<>(), new LinkedList<>(),
+      new LinkedList<>(), new LinkedList<>(), false, false, false, false, JLanguageTool.Mode.ALL);
+    UserConfig user1 = new UserConfig();
+
+    PipelinePool.PipelineSettings settings1 = new PipelinePool.PipelineSettings(lang1, null, queryParams1, user1);
+    verify(pool).getPipeline(settings1);
+    verify(pool).createPipeline(lang1, null, queryParams1, user1);
+    verify(pool).returnPipeline(eq(settings1), notNull());
+
+    PipelinePool.PipelineSettings settings2 = new PipelinePool.PipelineSettings(lang2, null, queryParams1, user1);
+    checker.checkText(new AnnotatedTextBuilder().addText("Hallo Welt!").build(), new FakeHttpExchange(), params2, null, null);
+
+    verify(pool, times(1)).getPipeline(settings1);
+    verify(pool, times(1)).createPipeline(lang1, null, queryParams1, user1);
+    verify(pool, times(1)).returnPipeline(eq(settings1), notNull());
+
+    verify(pool).getPipeline(settings2);
+    verify(pool).createPipeline(lang2, null, queryParams1, user1);
+    verify(pool).returnPipeline(eq(settings2), notNull());
+
+    TextChecker.QueryParams queryParams2 = new TextChecker.QueryParams(new LinkedList<>(), new LinkedList<>(), Collections.singletonList("DE_CASE"),
+      new LinkedList<>(), new LinkedList<>(), false, true, false, false, JLanguageTool.Mode.ALL);
+    Map<String, String> params3 = new HashMap<>();
+    params3.put("language", "de-DE");
+    params3.put("text", "not used");
+    params3.put("disabledRules", "DE_CASE");
+    PipelinePool.PipelineSettings settings3 = new PipelinePool.PipelineSettings(lang2, null, queryParams2, user1);
+    checker.checkText(new AnnotatedTextBuilder().addText("Hallo Welt!").build(), new FakeHttpExchange(), params3, null, null);
+
+    verify(pool).getPipeline(settings3);
+    verify(pool).createPipeline(lang2, null, queryParams2, user1);
+    verify(pool).returnPipeline(eq(settings3), notNull());
+  }
+
+  @Test
+  public void testMaxPipelinePoolSize() throws Exception {
+    Map<String, String> params1 = new HashMap<>();
+    params1.put("text", "not used");
+    params1.put("language", "en-US");
+    Map<String, String> params2 = new HashMap<>();
+    params2.put("text", "not used");
+    params2.put("language", "de-DE");
+    HTTPServerConfig config1 = new HTTPServerConfig(HTTPTools.getDefaultPort());
+    config1.setPipelineCaching(true);
+    config1.setPipelineExpireTime(10);
+    config1.setMaxPipelinePoolSize(1);
+    Language lang1 = Languages.getLanguageForShortCode("en-US");
+    Language lang2 = Languages.getLanguageForShortCode("de-DE");
+    TextChecker.QueryParams queryParams1 = new TextChecker.QueryParams(new LinkedList<>(), new LinkedList<>(), new LinkedList<>(),
+      new LinkedList<>(), new LinkedList<>(), false, false, false, false, JLanguageTool.Mode.ALL);
+    UserConfig user1 = new UserConfig();
+    TextChecker checker = new V2TextChecker(config1, false, null, new RequestCounter());
+
+    PipelinePool pool = spy(checker.pipelinePool);
+    checker.pipelinePool = pool;
+
+    // size = 1 -> needs to create new pipeline when language changes
+
+    checker.checkText(new AnnotatedTextBuilder().addText("Hello World.").build(), new FakeHttpExchange(), params1, null, null);
+    PipelinePool.PipelineSettings settings1 = new PipelinePool.PipelineSettings(lang1, null, queryParams1, user1);
+    verify(pool).getPipeline(settings1);
+    verify(pool).createPipeline(lang1, null, queryParams1, user1);
+    verify(pool).returnPipeline(eq(settings1), notNull());
+
+    checker.checkText(new AnnotatedTextBuilder().addText("Hallo Welt!").build(), new FakeHttpExchange(), params2, null, null);
+    PipelinePool.PipelineSettings settings2 = new PipelinePool.PipelineSettings(lang2, null, queryParams1, user1);
+    verify(pool, times(1)).getPipeline(settings1);
+    verify(pool, times(1)).createPipeline(lang1, null, queryParams1, user1);
+    verify(pool, times(1)).returnPipeline(eq(settings1), notNull());
+
+    verify(pool).getPipeline(settings2);
+    verify(pool).createPipeline(lang2, null, queryParams1, user1);
+    verify(pool).returnPipeline(eq(settings2), notNull());
+
+    checker.checkText(new AnnotatedTextBuilder().addText("Hello World.").build(), new FakeHttpExchange(), params1, null, null);
+    verify(pool, times(2)).getPipeline(settings1);
+    verify(pool, times(2)).createPipeline(lang1, null, queryParams1, user1);
+    verify(pool, times(2)).returnPipeline(eq(settings1), notNull());
+
+    checker.checkText(new AnnotatedTextBuilder().addText("Hallo Welt!").build(), new FakeHttpExchange(), params2, null, null);
+    verify(pool, times(2)).getPipeline(settings2);
+    verify(pool, times(2)).createPipeline(lang2, null, queryParams1, user1);
+    verify(pool, times(2)).returnPipeline(eq(settings2), notNull());
+  }
+
+  @Test
+  public void testPipelinePoolExpireTime() throws Exception {
+    Map<String, String> params = new HashMap<>();
+    params.put("text", "not used");
+    params.put("language", "en-US");
+    int expireTime = 1;
+    HTTPServerConfig config1 = new HTTPServerConfig(HTTPTools.getDefaultPort());
+    config1.setPipelineCaching(true);
+    config1.setPipelineExpireTime(expireTime);
+    config1.setMaxPipelinePoolSize(10);
+    TextChecker checker = new V2TextChecker(config1, false, null, new RequestCounter());
+    PipelinePool pool = spy(checker.pipelinePool);
+    checker.pipelinePool = pool;
+    checker.checkText(new AnnotatedTextBuilder().addText("Hello World.").build(), new FakeHttpExchange(), params, null, null);
+    Language lang1 = Languages.getLanguageForShortCode("en-US");
+    TextChecker.QueryParams queryParams1 = new TextChecker.QueryParams(new LinkedList<>(), new LinkedList<>(), new LinkedList<>(),
+      new LinkedList<>(), new LinkedList<>(), false, false, false, false, JLanguageTool.Mode.ALL);
+    UserConfig user1 = new UserConfig();
+
+    PipelinePool.PipelineSettings settings1 = new PipelinePool.PipelineSettings(lang1,
+      null, queryParams1, user1);
+    verify(pool).getPipeline(settings1);
+    verify(pool).createPipeline(lang1, null, queryParams1, user1);
+    verify(pool).returnPipeline(eq(settings1), notNull());
+
+    Thread.sleep(expireTime * 1000L * 2);
+
+    checker.checkText(new AnnotatedTextBuilder().addText("Hello World, second time around.").build(), new FakeHttpExchange(), params, null, null);
+    verify(pool, times(2)).getPipeline(settings1);
+    verify(pool, times(2)).createPipeline(lang1, null, queryParams1, user1);
+    verify(pool, times(2)).returnPipeline(eq(settings1), notNull());
+  }
+
   @Test
   public void testPipelineMutation() {
     Pipeline pipeline = new Pipeline(Languages.getLanguageForShortCode("en-US"),

--- a/languagetool-server/src/test/java/org/languagetool/server/PipelinePoolTest.java
+++ b/languagetool-server/src/test/java/org/languagetool/server/PipelinePoolTest.java
@@ -1,0 +1,89 @@
+/*
+ *  LanguageTool, a natural language style checker
+ *  * Copyright (C) 2018 Fabian Richter
+ *  *
+ *  * This library is free software; you can redistribute it and/or
+ *  * modify it under the terms of the GNU Lesser General Public
+ *  * License as published by the Free Software Foundation; either
+ *  * version 2.1 of the License, or (at your option) any later version.
+ *  *
+ *  * This library is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  * Lesser General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Lesser General Public
+ *  * License along with this library; if not, write to the Free Software
+ *  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  * USA
+ *
+ */
+
+package org.languagetool.server;
+
+import org.junit.Test;
+import org.languagetool.JLanguageTool;
+import org.languagetool.Language;
+import org.languagetool.Languages;
+import org.languagetool.UserConfig;
+import org.languagetool.markup.AnnotatedTextBuilder;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+
+public class PipelinePoolTest {
+
+  @Test
+  public void testPipelineCreatedAndUsed() throws Exception {
+    Map<String, String> params = new HashMap<>();
+    params.put("text", "not used");
+    params.put("language", "en-US");
+    HTTPServerConfig config1 = new HTTPServerConfig(HTTPTools.getDefaultPort());
+    config1.setPipelineCaching(true);
+    config1.setPipelineExpireTime(10);
+    config1.setMaxPipelinePoolSize(10);
+    TextChecker checker = new V2TextChecker(config1, false, null, new RequestCounter());
+    PipelinePool pool = spy(checker.pipelinePool);
+    checker.pipelinePool = pool;
+    checker.checkText(new AnnotatedTextBuilder().addText("Hello World.").build(), new FakeHttpExchange(), params, null, null);
+    Language lang1 = Languages.getLanguageForShortCode("en-US");
+    TextChecker.QueryParams queryParams1 = new TextChecker.QueryParams(new LinkedList<>(), new LinkedList<>(), new LinkedList<>(),
+      new LinkedList<>(), new LinkedList<>(), false, false, false, false, JLanguageTool.Mode.ALL);
+    UserConfig user1 = new UserConfig();
+
+    PipelinePool.PipelineSettings settings1 = new PipelinePool.PipelineSettings(lang1,
+      null, queryParams1, user1);
+    verify(pool).getPipeline(settings1);
+    verify(pool).createPipeline(lang1, null, queryParams1, user1);
+    verify(pool).returnPipeline(eq(settings1), notNull());
+    checker.checkText(new AnnotatedTextBuilder().addText("Hello World, second time around.").build(), new FakeHttpExchange(), params, null, null);
+    verify(pool, times(2)).getPipeline(settings1);
+    verify(pool, times(1)).createPipeline(lang1, null, queryParams1, user1);
+    verify(pool, times(2)).returnPipeline(eq(settings1), notNull());
+  }
+  @Test
+  public void testPipelineMutation() {
+    Pipeline pipeline = new Pipeline(Languages.getLanguageForShortCode("en-US"),
+      new ArrayList<>(), null, null, null);
+    pipeline.addRule(null);
+    pipeline.setupFinished();
+    boolean thrown = false;
+    try {
+      pipeline.addRule(null);
+      fail("Expected IllegalPipelineMutationException to be thrown but nothing was thrown.");
+    } catch(Pipeline.IllegalPipelineMutationException ignored) {
+      thrown = true;
+    } catch(Exception e) {
+      fail("Expected IllegalPipelineMutationException to be thrown; got " + e);
+    } finally {
+      assertTrue("IllegalPipelineMutationException was thrown.", thrown);
+    }
+  }
+
+}


### PR DESCRIPTION
Built a pipeline cache as an optimization to save on initalization time.
PipelinePool caches JLanguageTool instances, provides them to TextChecker based on pipeline configuration (request parameters, user options, ...). It also ensures that there is no parallel access,
 since the thread safety of JLanguageTool cannot be guaranteed.

Different pool sizes were tested; 10 gives 50% hit rate, 50 ~ 97%, 100 ~ 98%.