### PR TITLE
added new option and rule category for rules relying on neural networks

### DIFF
--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineOptions.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineOptions.java
@@ -29,7 +29,7 @@ import java.util.*;
  * Options that can be set via command line arguments.
  */
 public class CommandLineOptions {
-  
+
   /**
    * Constants for rule matches output in command-line.
    * @since 3.6
@@ -66,6 +66,8 @@ public class CommandLineOptions {
   private File languageModel = null;
   @Nullable
   private File word2vecModel = null;
+  @Nullable
+  private File neuralNetworkModel = null;
 
   @Nullable
   private File fasttextModel = null;
@@ -259,6 +261,21 @@ public class CommandLineOptions {
     this.word2vecModel = neuralNetworkLanguageModel;
   }
 
+
+  /**
+   * @since 4.4
+   */
+  @Nullable
+  public File getNeuralNetworkModel() {
+    return neuralNetworkModel;
+  }
+
+  /**
+   * @since 4.4
+   */
+  public void setNeuralNetworkModel(File neuralNetworkModel) {
+    this.neuralNetworkModel = neuralNetworkModel;
+  }
 
   /**
    * @since 4.3

--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineParser.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineParser.java
@@ -96,6 +96,9 @@ public class CommandLineParser {
       } else if (args[i].equals("--word2vecmodel")) {
         checkArguments("--word2vecmodel", i, args);
         options.setWord2VecModel(new File(args[++i]));
+      } else if (args[i].equals("--neuralnetworkmodel")) {
+        checkArguments("--neuralnetworkmodel", i, args);
+        options.setNeuralNetworkModel(new File(args[++i]));
       } else if (args[i].equals("--fasttextmodel")) {
         checkArguments("--fasttextmodel", i, args);
         options.setFasttextModel(new File(args[++i]));
@@ -222,6 +225,7 @@ public class CommandLineParser {
             + "                           ngram occurrence counts; activates the confusion rule if supported\n"
             + "  --word2vecmodel DIR      a directory with e.g. 'en' sub directory (i.e. a language code) that contains\n"
             + "                           final_embeddings.txt and dictionary.txt; activates neural network based rules\n"
+            + "  --neuralnetworkmodel DIR a base directory for various saved neural network models\n"
             + "  --fasttextmodel FILE     fasttext language detection model (optional), see https://fasttext.cc/docs/en/language-identification.html\n"
             + "  --fasttextbinary FILE    fasttext executable (optional), see https://fasttext.cc/docs/en/support.html\n"
             + "  --xmlfilter              remove XML/HTML elements from input before checking (deprecated)\n"

--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/Main.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/Main.java
@@ -80,6 +80,9 @@ class Main {
     if (options.getWord2VecModel() != null) {
       lt.activateWord2VecModelRules(options.getWord2VecModel());
     }
+    if (options.getNeuralNetworkModel() != null) {
+      lt.activateNeuralNetworkRules(options.getNeuralNetworkModel());
+    }
     Tools.selectRules(lt, options.getDisabledCategories(), options.getEnabledCategories(),
             new HashSet<>(options.getDisabledRules()), new HashSet<>(options.getEnabledRules()), options.isUseEnabledOnly());
   }

--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -413,6 +413,17 @@ public class JLanguageTool {
   }
 
   /**
+   * Activate rules that depend on pretrained neural network models.
+   * @param modelDir root dir of exported models
+   * @since 4.4
+   */
+  public void activateNeuralNetworkRules(File modelDir) throws IOException {
+    ResourceBundle messages = getMessageBundle(language);
+    List<Rule> rules = language.getRelevantNeuralNetworkModels(messages, modelDir);
+    userRules.addAll(rules);
+  }
+
+  /**
    * Activate rules that depend on a language model. The language model currently
    * consists of Lucene indexes with ngram occurrence counts.
    * @param indexDir directory with a '3grams' sub directory which contains a Lucene index with 3gram occurrence counts

--- a/languagetool-core/src/main/java/org/languagetool/Language.java
+++ b/languagetool-core/src/main/java/org/languagetool/Language.java
@@ -174,6 +174,15 @@ public abstract class Language {
   }
 
   /**
+   * Get a list of rules that load trained neural networks. Returns an empty list for
+   * languages that don't have such rules.
+   * @since 4.4
+   */
+  public List<Rule> getRelevantNeuralNetworkModels(ResourceBundle messages, File modelDir) {
+    return Collections.emptyList();
+  }
+
+  /**
    * Get this language's Java locale, not considering the country code.
    */
   public Locale getLocale() {

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -69,7 +69,7 @@ abstract class TextChecker {
   private static final String ENCODING = "UTF-8";
   private static final int CACHE_STATS_PRINT = 500; // print cache stats every n cache requests
   
-  private final Map<String,Integer> languageCheckCounts = new HashMap<>(); 
+  private final Map<String,Integer> languageCheckCounts = new HashMap<>();
   private Queue<Runnable> workQueue;
   private RequestCounter reqCounter;
   private final LanguageIdentifier identifier;
@@ -189,7 +189,7 @@ abstract class TextChecker {
       throw new IllegalArgumentException("You can specify 'noopLanguages' only when also using 'language=auto'");
     }
     List<String> noopLangs = parameters.get("noopLanguages") != null ?
-            Arrays.asList(parameters.get("noopLanguages").split(",")) : Collections.emptyList();        
+            Arrays.asList(parameters.get("noopLanguages").split(",")) : Collections.emptyList();
     DetectedLanguage detLang = getLanguage(aText.getPlainText(), parameters, preferredVariants, noopLangs);
     Language lang = detLang.getGivenLanguage();
     Integer count = languageCheckCounts.get(lang.getShortCodeWithCountryAndVariant());
@@ -231,7 +231,7 @@ abstract class TextChecker {
     boolean allowIncompleteResults = "true".equals(parameters.get("allowIncompleteResults"));
     boolean enableHiddenRules = "true".equals(parameters.get("enableHiddenRules"));
     JLanguageTool.Mode mode = ServerTools.getMode(parameters);
-    QueryParams params = new QueryParams(altLanguages, enabledRules, disabledRules, enabledCategories, disabledCategories, 
+    QueryParams params = new QueryParams(altLanguages, enabledRules, disabledRules, enabledCategories, disabledCategories,
             useEnabledOnly, useQuerySettings, allowIncompleteResults, enableHiddenRules, mode);
 
     Long textSessionId = null;

--- a/languagetool-wikipedia/src/main/java/org/languagetool/dev/dumpcheck/SentenceSourceChecker.java
+++ b/languagetool-wikipedia/src/main/java/org/languagetool/dev/dumpcheck/SentenceSourceChecker.java
@@ -79,8 +79,11 @@ public class SentenceSourceChecker {
                             new File(commandLine.getOptionValue("languagemodel")) : null;
     File word2vecModelDir = commandLine.hasOption("word2vecmodel") ?
             new File(commandLine.getOptionValue("word2vecmodel")) : null;
+    File neuralNetworkModelDir = commandLine.hasOption("neuralnetworkmodel") ?
+      new File(commandLine.getOptionValue("neuralnetworkmodel")) : null;
     Pattern filter = commandLine.hasOption("filter") ? Pattern.compile(commandLine.getOptionValue("filter")) : null;
-    prg.run(propFile, disabledRuleIds, languageCode, Arrays.asList(fileNames), ruleIds, categoryIds, maxArticles, maxErrors, languageModelDir, word2vecModelDir, filter);
+    prg.run(propFile, disabledRuleIds, languageCode, Arrays.asList(fileNames), ruleIds, categoryIds, maxArticles,
+      maxErrors, languageModelDir, word2vecModelDir, neuralNetworkModelDir, filter);
   }
 
   private static void addDisabledRules(String languageCode, Set<String> disabledRuleIds, Properties disabledRules) {
@@ -126,6 +129,9 @@ public class SentenceSourceChecker {
     options.addOption(OptionBuilder.withLongOpt("languagemodel").withArgName("indexDir").hasArg()
             .withDescription("directory with a '3grams' sub directory that contains an ngram index")
             .create());
+    options.addOption(OptionBuilder.withLongOpt("neuralnetworkmodel").withArgName("baseDir").hasArg()
+      .withDescription("base directory for saved neural network models")
+      .create());
     options.addOption(OptionBuilder.withLongOpt("filter").withArgName("regex").hasArg()
             .withDescription("Consider only sentences that contain this regular expression (for speed up)")
             .create());
@@ -144,7 +150,8 @@ public class SentenceSourceChecker {
   }
 
   private void run(File propFile, Set<String> disabledRules, String langCode, List<String> fileNames, String[] ruleIds,
-                   String[] additionalCategoryIds, int maxSentences, int maxErrors, File languageModelDir, File word2vecModelDir, Pattern filter) throws IOException {
+                   String[] additionalCategoryIds, int maxSentences, int maxErrors,
+                   File languageModelDir, File word2vecModelDir, File neuralNetworkModelDir, Pattern filter) throws IOException {
     Language lang = Languages.getLanguageForShortCode(langCode);
     MultiThreadedJLanguageTool languageTool = new MultiThreadedJLanguageTool(lang);
     languageTool.setCleanOverlappingMatches(false);
@@ -153,6 +160,9 @@ public class SentenceSourceChecker {
     }
     if (word2vecModelDir != null) {
       languageTool.activateWord2VecModelRules(word2vecModelDir);
+    }
+    if (neuralNetworkModelDir != null) {
+      languageTool.activateNeuralNetworkRules(neuralNetworkModelDir);
     }
     if (ruleIds != null) {
       enableOnlySpecifiedRules(ruleIds, languageTool);


### PR DESCRIPTION
Added option `neuralNetworkModel` allows providing a base directory of saved neural network models.
Rules listed by the new `Language.getRelevantNeuralNetworkModels` should expect any exported models they require to be found there.