### PR TITLE
added trimming for varchar fields to database logging code

### DIFF
--- a/languagetool-server/src/main/java/org/languagetool/server/DatabaseAccessLimitLogEntry.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/DatabaseAccessLimitLogEntry.java
@@ -21,6 +21,8 @@
 
 package org.languagetool.server;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
@@ -49,14 +51,14 @@ public class DatabaseAccessLimitLogEntry extends DatabaseLogEntry {
   @Override
   public Map<Object, Object> getMapping() {
     HashMap<Object, Object> parameters = new HashMap<>();
-    parameters.put("type", type);
+    parameters.put("type", StringUtils.abbreviate(type, 64));
     parameters.put("date", ServerTools.getSQLDatetimeString(date));
     parameters.put("server", server);
     parameters.put("client", client);
     parameters.put("user", user);
-    parameters.put("referrer", referrer);
-    parameters.put("user_agent", userAgent);
-    parameters.put("reason", reason);
+    parameters.put("referrer", StringUtils.abbreviate(referrer, 128));
+    parameters.put("user_agent", StringUtils.abbreviate(userAgent,  512));
+    parameters.put("reason", StringUtils.abbreviate(reason,  512));
     return parameters;
   }
 

--- a/languagetool-server/src/main/java/org/languagetool/server/DatabaseCheckErrorLogEntry.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/DatabaseCheckErrorLogEntry.java
@@ -21,6 +21,7 @@
 
 package org.languagetool.server;
 
+import org.apache.commons.lang3.StringUtils;
 import org.languagetool.Language;
 
 import java.util.Calendar;
@@ -53,15 +54,15 @@ public class DatabaseCheckErrorLogEntry extends DatabaseLogEntry {
   @Override
   public Map<Object, Object> getMapping() {
     HashMap<Object, Object> parameters = new HashMap<>();
-    parameters.put("type", type);
+    parameters.put("type", StringUtils.abbreviate(type, 64));
     parameters.put("date", ServerTools.getSQLDatetimeString(date));
     parameters.put("server", server);
     parameters.put("client", client);
     parameters.put("user", user);
-    parameters.put("language", languageSet.getShortCodeWithCountryAndVariant());
-    parameters.put("language_detected", languageDetected.getShortCodeWithCountryAndVariant());
+    parameters.put("language", StringUtils.abbreviate(languageSet.getShortCodeWithCountryAndVariant(), 30));
+    parameters.put("language_detected", StringUtils.abbreviate(languageDetected.getShortCodeWithCountryAndVariant(), 30));
     parameters.put("text_length", textLength);
-    parameters.put("extra", extra);
+    parameters.put("extra", StringUtils.abbreviate(extra, 256));
     return parameters;
   }
 

--- a/languagetool-server/src/main/java/org/languagetool/server/DatabaseCheckLogEntry.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/DatabaseCheckLogEntry.java
@@ -21,6 +21,7 @@
 
 package org.languagetool.server;
 
+import org.apache.commons.lang3.StringUtils;
 import org.languagetool.Language;
 
 import java.text.SimpleDateFormat;
@@ -70,11 +71,11 @@ class DatabaseCheckLogEntry extends DatabaseLogEntry {
     map.put("user_id", userId);
     map.put("textsize", textSize);
     map.put("matches", matches);
-    map.put("language", lang.getShortCodeWithCountryAndVariant());
-    map.put("language_detected", langDetected.getShortCodeWithCountryAndVariant());
+    map.put("language", StringUtils.abbreviate(lang.getShortCodeWithCountryAndVariant(), 30));
+    map.put("language_detected", StringUtils.abbreviate(langDetected.getShortCodeWithCountryAndVariant(), 30));
     map.put("computation_time", computationTime);
     map.put("text_session_id", textSessionId);
-    map.put("check_mode", checkMode);
+    map.put("check_mode", StringUtils.abbreviate(checkMode, 32));
     map.put("server", server);
     map.put("client", client);
     return map;

--- a/languagetool-server/src/main/java/org/languagetool/server/DatabaseMiscLogEntry.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/DatabaseMiscLogEntry.java
@@ -21,6 +21,8 @@
 
 package org.languagetool.server;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +49,7 @@ public class DatabaseMiscLogEntry extends DatabaseLogEntry {
     parameters.put("server", server);
     parameters.put("client", client);
     parameters.put("user", user);
-    parameters.put("message", message);
+    parameters.put("message", StringUtils.abbreviate(message, 1024));
     return parameters;
   }
 

--- a/languagetool-server/src/main/java/org/languagetool/server/DatabaseRuleMatchLogEntry.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/DatabaseRuleMatchLogEntry.java
@@ -21,6 +21,9 @@
 
 package org.languagetool.server;
 
+import org.apache.commons.lang3.StringUtils;
+import org.languagetool.tools.StringTools;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -57,7 +60,7 @@ class DatabaseRuleMatchLogEntry extends DatabaseLogEntry {
     int matchCount;
 
     RuleMatchInfo(String rule_id, int match_count) {
-      this.ruleId = rule_id;
+      this.ruleId = StringUtils.abbreviate(rule_id, 128);
       this.matchCount = match_count;
     }
   }


### PR DESCRIPTION
fixes errors when SQL strict mode is enabled and a field value exceeds the maximum configured length