### PR TITLE
Added confidence value to detected language field

### DIFF
--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineTools.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineTools.java
@@ -19,6 +19,7 @@
 package org.languagetool.commandline;
 
 import org.languagetool.AnalyzedSentence;
+import org.languagetool.DetectedLanguage;
 import org.languagetool.JLanguageTool;
 import org.languagetool.bitext.BitextReader;
 import org.languagetool.bitext.StringPair;
@@ -119,7 +120,8 @@ public final class CommandLineTools {
       out.print(xml);
     } else if (isJsonFormat) {
       RuleMatchesAsJsonSerializer serializer = new RuleMatchesAsJsonSerializer();
-      String json = serializer.ruleMatchesToJson(ruleMatches, contents, contextSize, lt.getLanguage(), null);      
+      String json = serializer.ruleMatchesToJson(ruleMatches, contents, contextSize,
+        new DetectedLanguage(lt.getLanguage(), lt.getLanguage()));
       PrintStream out = new PrintStream(System.out, true, "UTF-8");
       out.print(json);
     } else {

--- a/languagetool-core/src/main/java/org/languagetool/DetectedLanguage.java
+++ b/languagetool-core/src/main/java/org/languagetool/DetectedLanguage.java
@@ -15,8 +15,9 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
  * USA
+ *
  */
-package org.languagetool.server;
+package org.languagetool;
 
 import org.languagetool.Language;
 
@@ -29,10 +30,19 @@ public class DetectedLanguage {
 
   private final Language givenLanguage;
   private final Language detectedLanguage;
+  private final float detectionConfidence;
 
   public DetectedLanguage(Language givenLanguage, Language detectedLanguage) {
-    this.givenLanguage = Objects.requireNonNull(givenLanguage);
+    this(givenLanguage, detectedLanguage, 1.0f);
+  }
+
+  /**
+   * @since 4.4
+   */
+  public DetectedLanguage(Language givenLanguage, Language detectedLanguage, float detectionConfidence) {
+    this.givenLanguage = givenLanguage;
     this.detectedLanguage = detectedLanguage;
+    this.detectionConfidence = detectionConfidence;
   }
 
   public Language getGivenLanguage() {
@@ -42,6 +52,14 @@ public class DetectedLanguage {
   public Language getDetectedLanguage() {
     return detectedLanguage;
   }
+
+  /**
+   * @since 4.4
+   */
+  public float getDetectionConfidence() {
+    return detectionConfidence;
+  }
+
 
   @Override
   public String toString() {

--- a/languagetool-core/src/test/java/org/languagetool/tools/RuleMatchesAsJsonSerializerTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/tools/RuleMatchesAsJsonSerializerTest.java
@@ -20,6 +20,7 @@ package org.languagetool.tools;
 
 import org.junit.Test;
 import org.languagetool.AnalyzedSentence;
+import org.languagetool.DetectedLanguage;
 import org.languagetool.JLanguageTool;
 import org.languagetool.Languages;
 import org.languagetool.rules.ITSIssueType;
@@ -47,7 +48,8 @@ public class RuleMatchesAsJsonSerializerTest {
 
   @Test
   public void testJson() {
-    String json = serializer.ruleMatchesToJson(matches, "This is an text.", 5, Languages.getLanguageForShortCode("xx-XX"), null);
+    DetectedLanguage lang = new DetectedLanguage(Languages.getLanguageForShortCode("xx-XX"), Languages.getLanguageForShortCode("xx-XX")) ;
+    String json = serializer.ruleMatchesToJson(matches, "This is an text.", 5, lang);
     // Software:
     assertContains("\"LanguageTool\"", json);
     assertContains(JLanguageTool.VERSION, json);
@@ -71,13 +73,15 @@ public class RuleMatchesAsJsonSerializerTest {
 
   @Test
   public void testJsonWithUnixLinebreak() {
-    String json = serializer.ruleMatchesToJson(matches, "This\nis an text.", 5, Languages.getLanguageForShortCode("xx-XX"), null);
+    DetectedLanguage lang = new DetectedLanguage(Languages.getLanguageForShortCode("xx-XX"), Languages.getLanguageForShortCode("xx-XX")) ;
+    String json = serializer.ruleMatchesToJson(matches, "This\nis an text.", 5, lang);
     assertTrue(json.contains("This is ..."));  // got filtered out by ContextTools
   }
   
   @Test
   public void testJsonWithWindowsLinebreak() {
-    String json = serializer.ruleMatchesToJson(matches, "This\ris an text.", 5, Languages.getLanguageForShortCode("xx-XX"), null);
+    DetectedLanguage lang = new DetectedLanguage(Languages.getLanguageForShortCode("xx-XX"), Languages.getLanguageForShortCode("xx-XX")) ;
+    String json = serializer.ruleMatchesToJson(matches, "This\ris an text.", 5, lang);
     assertTrue(json.contains("This\\ris ..."));
   }
   

--- a/languagetool-http-client/src/test/java/org/languagetool/remote/RemoteLanguageToolIntegrationTest.java
+++ b/languagetool-http-client/src/test/java/org/languagetool/remote/RemoteLanguageToolIntegrationTest.java
@@ -94,11 +94,6 @@ public class RemoteLanguageToolIntegrationTest {
       assertThat(result5.getLanguage(), is("German (Germany)"));
       assertThat(result5.getLanguageCode(), is("de-DE"));
 
-      CheckConfiguration config2 = new CheckConfigurationBuilder().build();
-      RemoteResult result6 = lt.check("x", config2);  // too short, fallback will be used
-      assertThat(result6.getLanguage(), is("English (US)"));
-      assertThat(result6.getLanguageCode(), is("en-US"));
-
       RemoteResult result7 = lt.check("Das Häuser ist schön.", "de");
       assertThat(result7.getMatches().size(), is(1));
       assertThat(result7.getMatches().get(0).getRuleId(), is("DE_AGREEMENT"));

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -443,10 +443,13 @@ abstract class TextChecker {
     return result;
   }
 
-  Language detectLanguageOfString(String text, String fallbackLanguage, List<String> preferredVariants, List<String> noopLangs) {
-    Language lang = identifier.detectLanguage(text, noopLangs);
-    if (lang == null) {
+  DetectedLanguage detectLanguageOfString(String text, String fallbackLanguage, List<String> preferredVariants, List<String> noopLangs) {
+    DetectedLanguage detected = identifier.detectLanguage(text, noopLangs);
+    Language lang;
+    if (detected == null) {
       lang = Languages.getLanguageForShortCode(fallbackLanguage != null ? fallbackLanguage : "en");
+    } else {
+      lang = detected.getDetectedLanguage();
     }
     if (preferredVariants.size() > 0) {
       for (String preferredVariant : preferredVariants) {
@@ -466,7 +469,7 @@ abstract class TextChecker {
         lang = lang.getDefaultLanguageVariant();
       }
     }
-    return lang;
+    return new DetectedLanguage(null, lang, detected != null ? detected.getDetectionConfidence() : 0f);
   }
 
   static class QueryParams {

--- a/languagetool-server/src/main/java/org/languagetool/server/V2TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/V2TextChecker.java
@@ -20,6 +20,7 @@ package org.languagetool.server;
 
 import com.sun.net.httpserver.HttpExchange;
 import org.jetbrains.annotations.NotNull;
+import org.languagetool.DetectedLanguage;
 import org.languagetool.Language;
 import org.languagetool.Languages;
 import org.languagetool.markup.AnnotatedText;
@@ -52,8 +53,7 @@ class V2TextChecker extends TextChecker {
   protected String getResponse(AnnotatedText text, DetectedLanguage lang, Language motherTongue, List<RuleMatch> matches,
                                List<RuleMatch> hiddenMatches, String incompleteResultsReason) {
     RuleMatchesAsJsonSerializer serializer = new RuleMatchesAsJsonSerializer();
-    return serializer.ruleMatchesToJson(matches, hiddenMatches, text, CONTEXT_SIZE,
-            lang.getGivenLanguage(), lang.getDetectedLanguage(), incompleteResultsReason);
+    return serializer.ruleMatchesToJson(matches, hiddenMatches, text, CONTEXT_SIZE, lang, incompleteResultsReason);
   }
 
   @NotNull
@@ -103,14 +103,14 @@ class V2TextChecker extends TextChecker {
   protected DetectedLanguage getLanguage(String text, Map<String, String> parameters, List<String> preferredVariants,
                                          List<String> noopLangs) {
     String langParam = parameters.get("language");
-    Language detectedLang = detectLanguageOfString(text, null, preferredVariants, noopLangs);
+    DetectedLanguage detectedLang = detectLanguageOfString(text, null, preferredVariants, noopLangs);
     Language givenLang;
     if (getLanguageAutoDetect(parameters)) {
-      givenLang = detectedLang;
+      givenLang = detectedLang.getDetectedLanguage();
     } else {
       givenLang = Languages.getLanguageForShortCode(langParam);
     }
-    return new DetectedLanguage(givenLang, detectedLang);
+    return new DetectedLanguage(givenLang, detectedLang.getDetectedLanguage(), detectedLang.getDetectionConfidence());
   }
 
   @Override

--- a/languagetool-server/src/test/java/org/languagetool/server/HTTPServerTest.java
+++ b/languagetool-server/src/test/java/org/languagetool/server/HTTPServerTest.java
@@ -156,8 +156,9 @@ public class HTTPServerTest {
     String result6 = checkV2(null, "This is a test of the language detection.", "&preferredVariants=de-DE,en-GB");
     assertTrue("Result: " + result6, result6.contains("\"en-GB\""));
 
-    String result7 = checkV2(null, "x");  // too short for auto-fallback, will use fallback
-    assertTrue("Result: " + result7, result7.contains("\"en-US\""));
+    // fallback not working anymore, now giving confidence rating; tested in TextCheckerTest
+    //String result7 = checkV2(null, "x");  // too short for auto-fallback, will use fallback
+    //assertTrue("Result: " + result7, result7.contains("\"en-US\""));
 
     String res = check("text", "/v2/check", english, null, "A text.", "&sourceLanguage=de-DE&sourceText=Text");
     assertTrue(res.contains("DIFFERENT_PUNCTUATION"));   // bitext rule actually active

--- a/languagetool-server/src/test/java/org/languagetool/server/TextCheckerTest.java
+++ b/languagetool-server/src/test/java/org/languagetool/server/TextCheckerTest.java
@@ -127,18 +127,34 @@ public class TextCheckerTest {
   @Test
   public void testDetectLanguageOfString() {
     List<String> e = Collections.emptyList();
-    assertThat(checker.detectLanguageOfString("", "en", Arrays.asList("en-GB"), e).getShortCodeWithCountryAndVariant(), is("en-GB"));
-    assertThat(checker.detectLanguageOfString("X", "en", Arrays.asList("en-GB"), e).getShortCodeWithCountryAndVariant(), is("en-GB"));
-    assertThat(checker.detectLanguageOfString("X", "en", Arrays.asList("en-ZA"), e).getShortCodeWithCountryAndVariant(), is("en-ZA"));
-    assertThat(checker.detectLanguageOfString(english, "de", Arrays.asList("en-GB", "de-AT"), e).getShortCodeWithCountryAndVariant(), is("en-GB"));
-    assertThat(checker.detectLanguageOfString(english, "de", Arrays.asList(), e).getShortCodeWithCountryAndVariant(), is("en-US"));
-    assertThat(checker.detectLanguageOfString(english, "de", Arrays.asList("de-AT", "en-ZA"), e).getShortCodeWithCountryAndVariant(), is("en-ZA"));
+    assertThat(checker.detectLanguageOfString("", "en", Arrays.asList("en-GB"), e)
+      .getDetectedLanguage().getShortCodeWithCountryAndVariant(), is("en-GB"));
+
+    // fallback language does not work anymore, now detected as ca-ES, ensure that at least the probability is low
+    //assertThat(checker.detectLanguageOfString("X", "en", Arrays.asList("en-GB"), e)
+    //  .getDetectedLanguage().getShortCodeWithCountryAndVariant(), is("en-GB"));
+    //assertThat(checker.detectLanguageOfString("X", "en", Arrays.asList("en-ZA"), e)
+    //  .getDetectedLanguage().getShortCodeWithCountryAndVariant(), is("en-ZA"));
+    assertThat(checker.detectLanguageOfString("X", "en", Arrays.asList("en-GB"), e)
+      .getDetectedLanguage().getShortCodeWithCountryAndVariant(), is("ca-ES"));
+    assertTrue(checker.detectLanguageOfString("X", "en", Arrays.asList("en-GB"), e)
+      .getDetectionConfidence() < 0.5);
+
+    assertThat(checker.detectLanguageOfString(english, "de", Arrays.asList("en-GB", "de-AT"), e)
+      .getDetectedLanguage().getShortCodeWithCountryAndVariant(), is("en-GB"));
+    assertThat(checker.detectLanguageOfString(english, "de", Arrays.asList(), e)
+      .getDetectedLanguage().getShortCodeWithCountryAndVariant(), is("en-US"));
+    assertThat(checker.detectLanguageOfString(english, "de", Arrays.asList("de-AT", "en-ZA"), e)
+      .getDetectedLanguage().getShortCodeWithCountryAndVariant(), is("en-ZA"));
     String german = "Das hier ist klar ein deutscher Text, sollte gut zu erkennen sein.";
-    assertThat(checker.detectLanguageOfString(german, "fr", Arrays.asList("de-AT", "en-ZA"), e).getShortCodeWithCountryAndVariant(), is("de-AT"));
-    assertThat(checker.detectLanguageOfString(german, "fr", Arrays.asList("de-at", "en-ZA"), e).getShortCodeWithCountryAndVariant(), is("de-AT"));
-    assertThat(checker.detectLanguageOfString(german, "fr", Arrays.asList(), e).getShortCodeWithCountryAndVariant(), is("de-DE"));
-    assertThat(checker.detectLanguageOfString(unsupportedCzech, "en", Arrays.asList(), e).
-            getShortCodeWithCountryAndVariant(), is("sk-SK"));  // misdetected because it's not supported
+    assertThat(checker.detectLanguageOfString(german, "fr", Arrays.asList("de-AT", "en-ZA"), e)
+      .getDetectedLanguage().getShortCodeWithCountryAndVariant(), is("de-AT"));
+    assertThat(checker.detectLanguageOfString(german, "fr", Arrays.asList("de-at", "en-ZA"), e)
+      .getDetectedLanguage().getShortCodeWithCountryAndVariant(), is("de-AT"));
+    assertThat(checker.detectLanguageOfString(german, "fr", Arrays.asList(), e)
+      .getDetectedLanguage().getShortCodeWithCountryAndVariant(), is("de-DE"));
+    assertThat(checker.detectLanguageOfString(unsupportedCzech, "en", Arrays.asList(), e)
+      .getDetectedLanguage().getShortCodeWithCountryAndVariant(), is("sk-SK"));  // misdetected because it's not supported
   }
 
   @Test
@@ -147,9 +163,11 @@ public class TextCheckerTest {
     HTTPServerConfig config = new HTTPServerConfig();
     config.setFasttextBinary(new File("/prg/fastText-0.1.0/fasttext"));
     config.setFasttextModel(new File("/prg/fastText-0.1.0/data/lid.176.bin"));
+    config.setFasttextBinary(new File("/home/fabian/Documents/fastText/fasttext"));
+    config.setFasttextModel(new File("/home/fabian/Documents/fastText/lid.176.bin"));
     TextChecker checker = new V2TextChecker(config, false, null, new RequestCounter());
     assertThat(checker.detectLanguageOfString(unsupportedCzech, "en", Arrays.asList(), Arrays.asList("foo", "cs")).
-            getShortCodeWithCountryAndVariant(), is("zz"));  // cs not supported but mapped to noop language 
+            getDetectedLanguage().getShortCodeWithCountryAndVariant(), is("zz"));  // cs not supported but mapped to noop language
   }
 
   @Test(expected = RuntimeException.class)

--- a/languagetool-standalone/CHANGES.md
+++ b/languagetool-standalone/CHANGES.md
@@ -21,7 +21,10 @@
     mapped to a no-op language without rules. Useful for clients that rely on
     language auto-detection and whose users might use languages not supported by LT.
     NOTE 1: only works with fastText configured
-    NOTE 2: setting languages here will worsen language detection quality on average 
+    NOTE 2: setting languages here will worsen language detection quality on average
+  * Change to language detection behavior: Removed fallback to English when confidence of detection algorithm is low,
+    instead now always returning highest scoring detected language. Added a field `confidence` to `detectedLanguage`
+    object in the JSON response that contains the probability score for the detected language as computed by the detection algorithm.
 
 
 

--- a/languagetool-standalone/src/test/java/org/languagetool/language/LanguageIdentifierTest.java
+++ b/languagetool-standalone/src/test/java/org/languagetool/language/LanguageIdentifierTest.java
@@ -20,6 +20,7 @@ package org.languagetool.language;
 
 import org.junit.Ignore;
 import org.junit.Test;
+import org.languagetool.DetectedLanguage;
 import org.languagetool.Language;
 
 import java.io.File;
@@ -39,11 +40,6 @@ public class LanguageIdentifierTest {
 
   @Test
   public void testDetection() {
-    //identifier.enableFasttext(new File(fastTextBinary), new File(fastTextModel));
-    // fasttext just assumes english, ignore / comment out
-    langAssert(null, "");
-    langAssert(null, "X");
-
     langAssert("de", "Das ist ein deutscher Text");
     langAssert("en", "This is an English text");
     langAssert("fr", "Le mont Revard est un sommet du département français ...");
@@ -78,6 +74,7 @@ public class LanguageIdentifierTest {
   }
 
   @Test
+  @Ignore("disabled minimum length, instead now providing confidence score")
   public void testShortAndLongText() {
     LanguageIdentifier id10 = new LanguageIdentifier(10);
     langAssert(null, "Das ist so ein Text, mit dem man testen kann", id10);  // too short when max length is applied
@@ -93,9 +90,15 @@ public class LanguageIdentifierTest {
   
   @Test
   public void testKnownLimitations() {
+    // wrong, but low probabilities
+    //identifier.enableFasttext(new File(fastTextBinary), new File(fastTextModel));
+    // fasttext just assumes english, ignore / comment out
+    langAssert(null, "");
+    langAssert("ca", "X");
+
     // not activated because it impairs detection of Spanish, so ast and gl may be mis-detected:
     langAssert("es", "L'Iberorrománicu o Iberromance ye un subgrupu de llingües romances que posiblemente ...");  // ast
-    langAssert(null, "Dodro é un concello da provincia da Coruña pertencente á comarca do Sar ...");  // gl
+    langAssert("es", "Dodro é un concello da provincia da Coruña pertencente á comarca do Sar ...");  // gl
     // Somali, known by language-detector, but not by LT, so we get back something else:
     langAssert("tl", "Dhammaan garoomada caalamka ayaa loo isticmaalaa. Ururku waxa uu qabtaa ama uu ku shaqaleeyahay " +
             "isusocodka diyaaradaha aduunka ee iskaga gooshaya xuduudaha iyo ka hortagga wixii qalad ah iyo baaritaanka " +
@@ -136,8 +139,10 @@ public class LanguageIdentifierTest {
   }
   
   private void langAssert(String expectedLangCode, String text, LanguageIdentifier id, List<String> noopLangCodes) {
-    Language detectedLang = id.detectLanguage(text, noopLangCodes);
-    String detectedLangCode = detectedLang != null ? detectedLang.getShortCode() : null;
+    DetectedLanguage detectedLang = id.detectLanguage(text, noopLangCodes);
+    String detectedLangCode = detectedLang != null ?
+      detectedLang.getDetectedLanguage() != null ? detectedLang.getDetectedLanguage().getShortCode() : null
+      : null;
     if (expectedLangCode == null) {
       if (detectedLangCode != null) {
         fail("Got '" + detectedLangCode + "', expected null for '" + text + "'");


### PR DESCRIPTION
Not falling back to English anymore when confidence of language detection is low;
instead, including confidence of language detection model in response, so that
clients can decide if corrections should be ignored / marked as speculative