### PR TITLE
A/B Test for Suggestions ordering

### DIFF
--- a/languagetool-core/pom.xml
+++ b/languagetool-core/pom.xml
@@ -235,6 +235,12 @@
             <version>0.3.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.6</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/languagetool-core/src/main/java/org/languagetool/UserConfig.java
+++ b/languagetool-core/src/main/java/org/languagetool/UserConfig.java
@@ -40,6 +40,11 @@ public class UserConfig {
   private final Map<String, Integer> configurableRuleValues = new HashMap<>();
   private final LinguServices linguServices;
 
+  // indifferent for comparing UserConfigs (e.g. in PipelinePool)
+  // provided to rules only for A/B tests ->
+  private long textSessionId;
+  private String abTest;
+
   public UserConfig() {
     this(new ArrayList<>(), new HashMap<>());
   }
@@ -141,4 +146,19 @@ public class UserConfig {
       .toHashCode();
   }
 
+  public void setTextSessionId(Long textSessionId) {
+    this.textSessionId = textSessionId;
+  }
+
+  public Long getTextSessionId() {
+    return textSessionId;
+  }
+
+  public String getAbTest() {
+    return abTest;
+  }
+
+  public void setAbTest(String abTest) {
+    this.abTest = abTest;
+  }
 }

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/morfologik/MorfologikSpellerRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/morfologik/MorfologikSpellerRule.java
@@ -40,7 +40,7 @@ public abstract class MorfologikSpellerRule extends SpellingCheckRule {
   protected MorfologikMultiSpeller speller3;
   protected Locale conversionLocale;
 
-  private static SuggestionsOrderer suggestionsOrderer = null;
+  private final SuggestionsOrderer suggestionsOrderer;
   
   private boolean ignoreTaggedWords = false;
   private boolean checkCompound = false;

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/morfologik/suggestions_ordering/SuggestionsOrderer.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/morfologik/suggestions_ordering/SuggestionsOrderer.java
@@ -44,8 +44,8 @@ public class SuggestionsOrderer {
 
   private boolean mlAvailable = true;
 
-  private static NGramUtil nGramUtil = null;
-  private static Predictor predictor;
+  private NGramUtil nGramUtil = null;
+  private Predictor predictor;
 
   public boolean isMlAvailable() {
     return mlAvailable && SuggestionsOrdererConfig.isMLSuggestionsOrderingEnabled();
@@ -63,6 +63,7 @@ public class SuggestionsOrderer {
       } else {
         languageModelFileName = ngramBasedModelFilename;
       }
+      System.out.printf("Using suggestion ordering model '%s'.%n", languageModelFileName); // TODO: debugging only
 
       try (InputStream modelsPath = this.getClass().getClassLoader().getResourceAsStream(languageModelFileName)) {
         predictor = new Predictor(modelsPath);
@@ -82,7 +83,7 @@ public class SuggestionsOrderer {
     }
   }
 
-  private static float processRow(String sentence, String correctedSentence, String covered, String replacement,
+  private float processRow(String sentence, String correctedSentence, String covered, String replacement,
                                   Integer contextLength) {
 
     Pair<String, String> context = Pair.of("", "");
@@ -162,7 +163,7 @@ public class SuggestionsOrderer {
 
   private static class NGramUtil {
 
-    private Language language;
+    private final Language language;
     private LanguageModel languageModel;
     private boolean mockLanguageModel = false;
 

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/morfologik/suggestions_ordering/SuggestionsOrderer.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/morfologik/suggestions_ordering/SuggestionsOrderer.java
@@ -63,8 +63,6 @@ public class SuggestionsOrderer {
       } else {
         languageModelFileName = ngramBasedModelFilename;
       }
-      System.out.printf("Using suggestion ordering model '%s'.%n", languageModelFileName); // TODO: debugging only
-
       try (InputStream modelsPath = this.getClass().getClassLoader().getResourceAsStream(languageModelFileName)) {
         predictor = new Predictor(modelsPath);
       } catch (IOException | NullPointerException e) {

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/morfologik/suggestions_ordering/SuggestionsOrdererConfig.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/morfologik/suggestions_ordering/SuggestionsOrdererConfig.java
@@ -32,12 +32,12 @@ public class SuggestionsOrdererConfig {
     SuggestionsOrdererConfig.ngramsPath = ngramsPath;
   }
 
-  static boolean isMLSuggestionsOrderingEnabled() {
+  public static boolean isMLSuggestionsOrderingEnabled() {
     String enableMLSuggestionsOrderingProperty = System.getProperty(PROP_NAME, "false");
     return Boolean.parseBoolean(enableMLSuggestionsOrderingProperty);
   }
 
-  static void setMLSuggestionsOrderingEnabled(boolean MLSuggestionsOrderingEnabled) {
+  public static void setMLSuggestionsOrderingEnabled(boolean MLSuggestionsOrderingEnabled) {
     System.setProperty(PROP_NAME, String.valueOf(MLSuggestionsOrderingEnabled));
   }
 }

--- a/languagetool-core/src/test/java/org/languagetool/rules/spelling/morfologik/suggestions_ordering/SuggestionsOrdererTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/spelling/morfologik/suggestions_ordering/SuggestionsOrdererTest.java
@@ -18,18 +18,29 @@
  */
 package org.languagetool.rules.spelling.morfologik.suggestions_ordering;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.languagetool.AnalyzedSentence;
 import org.languagetool.JLanguageTool;
 import org.languagetool.Language;
+import org.languagetool.Languages;
 import org.languagetool.language.Demo;
+import org.languagetool.rules.Rule;
+import org.languagetool.rules.RuleMatch;
 
+import java.io.FileReader;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 public class SuggestionsOrdererTest {
   
@@ -90,6 +101,86 @@ public class SuggestionsOrdererTest {
     List<String> suggestionsOrdered = suggestionsOrderer.orderSuggestionsUsingModel(
             suggestions, word, languageTool.getAnalyzedSentence(sentence), startPos, wordLength);
     assertTrue(suggestionsOrdered.containsAll(suggestions));
+  }
+
+  public static void main(String[] args) throws IOException {
+    Map<String, JLanguageTool> ltMap = new HashMap<>();
+    Map<String, Rule> rules = new HashMap<>();
+    Map<String, SuggestionsOrderer> ordererMap = new HashMap<>();
+    final AtomicInteger numOriginalCorrect = new AtomicInteger(0),
+      numReorderedCorrect = new AtomicInteger(0),
+      numOtherCorrect = new AtomicInteger(0),
+      numBothCorrect = new AtomicInteger(0);
+    Runtime.getRuntime().addShutdownHook(new Thread(() ->
+      System.out.printf("%n**** Correct Suggestions ****%nBoth: %d / Original: %d / Reordered: %d / Other: %d%n",
+        numBothCorrect.intValue(), numOriginalCorrect.intValue(), numReorderedCorrect.intValue(), numOtherCorrect.intValue())));
+    SuggestionsOrdererConfig.setNgramsPath(args[1]);
+    try (CSVParser parser = new CSVParser(new FileReader(args[0]), CSVFormat.DEFAULT.withFirstRecordAsHeader())) {
+      for (CSVRecord record : parser) {
+        String lang = record.get("language");
+        String covered = record.get("covered");
+        String replacement = record.get("replacement");
+        String sentenceStr = record.get("sentence");
+        int suggestionPos = Integer.parseInt(record.get("suggestion_pos"));
+
+        if (lang.equals("auto") || !lang.equals("en-US")) { // TODO: debugging only
+          continue; // TODO do language detection?
+        }
+        Language language = Languages.getLanguageForShortCode(lang);
+        JLanguageTool lt = ltMap.computeIfAbsent(lang, langCode ->
+          new JLanguageTool(language));
+        Rule spellerRule = rules.computeIfAbsent(lang, langCode ->
+            lt.getAllRules().stream().filter(Rule::isDictionaryBasedSpellingRule)
+            .findFirst().orElse(null)
+        );
+        if (spellerRule == null) {
+          continue;
+        }
+        SuggestionsOrderer orderer = null;
+        try {
+          orderer = ordererMap.computeIfAbsent(lang, langCode -> new SuggestionsOrderer(language, spellerRule.getId()));
+        } catch (RuntimeException ignored) {
+        }
+        if (orderer == null) {
+          continue;
+        }
+        AnalyzedSentence sentence = lt.getAnalyzedSentence(sentenceStr);
+        RuleMatch[] matches = spellerRule.match(sentence);
+        for (RuleMatch match : matches) {
+          String matchedWord = sentence.getText().substring(match.getFromPos(), match.getToPos());
+          if (!matchedWord.equals(covered)) {
+            //System.out.println("Other spelling error detected, ignoring: " + matchedWord + " / " + covered);
+            continue;
+          }
+          List<String> original = match.getSuggestedReplacements();
+          SuggestionsOrdererConfig.setMLSuggestionsOrderingEnabled(true);
+          List<String> reordered = orderer.orderSuggestionsUsingModel(original, matchedWord, sentence, match.getFromPos(), matchedWord.length());
+          SuggestionsOrdererConfig.setMLSuggestionsOrderingEnabled(false);
+          if (original.size() == 0 || reordered.size() == 0) {
+            continue;
+          }
+          String firstOriginal = original.get(0);
+          String firstReordered = reordered.get(0);
+          if (firstOriginal.equals(firstReordered)) {
+            if (firstOriginal.equals(replacement)) {
+              numBothCorrect.incrementAndGet();
+            } else {
+              numOtherCorrect.incrementAndGet();
+            }
+            //System.out.println("No change for match: " + matchedWord);
+          } else {
+            System.out.println("Ordering changed for match " + matchedWord + ", before: " + firstOriginal + ", after: " + firstReordered + ", choosen: " + replacement);
+            if (firstOriginal.equals(replacement)) {
+              numOriginalCorrect.incrementAndGet();
+            } else if (firstReordered.equals(replacement)) {
+              numReorderedCorrect.incrementAndGet();
+            } else {
+              numOtherCorrect.incrementAndGet();
+            }
+          }
+        }
+      }
+    }
   }
 
 }

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
@@ -92,6 +92,7 @@ public class HTTPServerConfig {
   protected String dbPassword = null;
   protected boolean dbLogging;
 
+  protected String abTest = null;
   /**
    * Create a server configuration for the default port ({@link #DEFAULT_PORT}).
    */
@@ -261,6 +262,8 @@ public class HTTPServerConfig {
         if (dbLogging && (dbDriver == null || dbUrl == null || dbUsername == null || dbPassword == null)) {
           throw new IllegalArgumentException("dbLogging can only be true if dbDriver, dbUrl, dbUsername, and dbPassword are all set");
         }
+
+        setAbTest(getOptionalProperty(props, "abTest", null));
       }
     } catch (IOException e) {
       throw new RuntimeException("Could not load properties from '" + file + "'", e);
@@ -774,6 +777,31 @@ public class HTTPServerConfig {
   boolean getDatabaseLogging() {
     return this.dbLogging;
   }
+
+
+  /**
+   * @since 4.4
+   * See if a specific A/B-Test is to be run
+   */
+  @Experimental
+  @Nullable
+  public String getAbTest() {
+    return abTest;
+  }
+
+  /**
+   * @since 4.4
+   * Enable a specific A/B-Test to be run (or null to disable all tests)
+   */
+  @Experimental
+  public void setAbTest(@Nullable String abTest) {
+    List<String> values = Arrays.asList("SuggestionsOrderer");
+    if (abTest != null && !values.contains(abTest)) {
+        throw new IllegalConfigurationException("Unknown value for 'abTest' property: Must be one of: " + values);
+    }
+    this.abTest = abTest;
+  }
+
 
   /**
    * @throws IllegalConfigurationException if property is not set 


### PR DESCRIPTION
 Implemented simple A/B-Testing scheme, first test: SuggestionsOrderer

Assignment via textSessionId: even/odd -> A/B
Results implicitly found in existing check_log / corrections tables
Added abTest option to HTTPServerConfig, disables / specifies a test to run
Added textSessionId, abTest property to UserConfig as additional information,
but explicitly ignored in .equals/.hashCode -> invariant to e.g. PipelinePool