### PR TITLE
Fixed exception caused by concurrent modification of list in CommonWords

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/language/CommonWords.java
+++ b/languagetool-core/src/main/java/org/languagetool/language/CommonWords.java
@@ -56,7 +56,8 @@ public class CommonWords {
               String key = line.toLowerCase();
               List<Language> languages = word2langs.get(key);
               if (languages == null) {
-                ArrayList<Language> l = new ArrayList<>();
+                // word2langs is static, so this can be accessed from multiple threads concurrently -> prevent exceptions
+                List<Language> l = Collections.synchronizedList(new LinkedList<>());
                 l.add(lang);
                 word2langs.put(key, l);
               } else {


### PR DESCRIPTION
Should fix this:

```
2018-12-20 23:11:33 +0100 ERROR o.l.l.LanguageIdentifier Disabling fasttext language identification, got error for text: Thank you for su
java.lang.ArrayIndexOutOfBoundsException: 11
       at java.base/java.util.ArrayList.add(ArrayList.java:468)
       at java.base/java.util.ArrayList.add(ArrayList.java:480)
       at org.languagetool.language.CommonWords.<init>(CommonWords.java:63)
       at org.languagetool.language.LanguageIdentifier.detectLanguage(LanguageIdentifier.java:182)
       at org.languagetool.server.TextChecker.detectLanguageOfString(TextChecker.java:458)
       at org.languagetool.server.V2TextChecker.getLanguage(V2TextChecker.java:106)
       at org.languagetool.server.TextChecker.checkText(TextChecker.java:204)
       at org.languagetool.server.ApiV2.handleCheckRequest(ApiV2.java:113)
       at org.languagetool.server.ApiV2.handleRequest(ApiV2.java:65)
       at org.languagetool.server.LanguageToolHttpHandler.handle(LanguageToolHttpHandler.java:146)
       at jdk.httpserver/com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:77)
       at jdk.httpserver/sun.net.httpserver.AuthFilter.doFilter(AuthFilter.java:82)
       at jdk.httpserver/com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:80)
       at jdk.httpserver/sun.net.httpserver.ServerImpl$Exchange$LinkHandler.handle(ServerImpl.java:691)
       at jdk.httpserver/com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:77)
       at jdk.httpserver/sun.net.httpserver.ServerImpl$Exchange.run(ServerImpl.java:663)
       at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1135)
       at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
       at java.base/java.lang.Thread.run(Thread.java:844)
```