### PR TITLE
Added textSessionId to fingerprint used by RequestLimiter

### DIFF
--- a/languagetool-server/src/main/java/org/languagetool/server/ErrorRequestLimiter.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/ErrorRequestLimiter.java
@@ -52,12 +52,13 @@ class ErrorRequestLimiter extends RequestLimiter {
   
   /**
    * @param ipAddress the client's IP address
+   * @param params the request's query parameters
    */
-  void logAccess(String ipAddress, Map<String, List<String>> httpHeader) {
+  void logAccess(String ipAddress, Map<String, List<String>> httpHeader, Map<String, String> params) {
     while (requestEvents.size() > REQUEST_QUEUE_SIZE) {
       requestEvents.remove(0);
     }
-    requestEvents.add(new RequestEvent(ipAddress, new Date(), 0, computeFingerprint(httpHeader), JLanguageTool.Mode.ALL));
+    requestEvents.add(new RequestEvent(ipAddress, new Date(), 0, computeFingerprint(httpHeader, params), JLanguageTool.Mode.ALL));
   }
   
 }

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -314,7 +314,7 @@ abstract class TextChecker {
       Path loadFile = Paths.get("/proc/loadavg");  // works in Linux only(?)
       String loadInfo = loadFile.toFile().exists() ? Files.readAllLines(loadFile).toString() : "(unknown)";
       if (errorRequestLimiter != null) {
-        errorRequestLimiter.logAccess(remoteAddress, httpExchange.getRequestHeaders());
+        errorRequestLimiter.logAccess(remoteAddress, httpExchange.getRequestHeaders(), parameters);
       }
       String message = "Text checking took longer than allowed maximum of " + limits.getMaxCheckTimeMillis() +
                        " milliseconds (cancelled: " + cancelled +

--- a/languagetool-server/src/test/java/org/languagetool/server/ErrorRequestLimiterTest.java
+++ b/languagetool-server/src/test/java/org/languagetool/server/ErrorRequestLimiterTest.java
@@ -37,10 +37,10 @@ public class ErrorRequestLimiterTest {
     String ip2 = "192.168.0.2";
     assertTrue(limiter.wouldAccessBeOkay(ip1, params, header));
     assertTrue(limiter.wouldAccessBeOkay(ip2, params, header));
-    limiter.logAccess(ip1, header);
-    limiter.logAccess(ip1, header);
-    limiter.logAccess(ip1, header);
-    limiter.logAccess(ip1, header);
+    limiter.logAccess(ip1, header, params);
+    limiter.logAccess(ip1, header, params);
+    limiter.logAccess(ip1, header, params);
+    limiter.logAccess(ip1, header, params);
     assertFalse(limiter.wouldAccessBeOkay(ip1, params, header));
     assertTrue(limiter.wouldAccessBeOkay(ip2, params, header));
     Thread.sleep(1050);


### PR DESCRIPTION
Fix limits being imposed on users in e.g. a classroom environment where multiple users are behind identical browsers / IP addresses. 