### PR TITLE
fixed NPE in PipelinePool.returnPipeline

### DIFF
--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -442,7 +442,9 @@ abstract class TextChecker {
         lt = pipelinePool.getPipeline(settings);
         return lt.check(aText, true, JLanguageTool.ParagraphHandling.NORMAL, listener, params.mode);
       } finally {
-        pipelinePool.returnPipeline(settings, lt);
+        if (lt != null) {
+          pipelinePool.returnPipeline(settings, lt);
+        }
       }
     }
   }


### PR DESCRIPTION
Came up when e.g. ngrams were missing / PipelinePool.createPipeline failed with an exception