### PR TITLE
New option skipLoggingRuleMatches in server config

### DIFF
--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
@@ -92,6 +92,7 @@ public class HTTPServerConfig {
   protected String dbUsername = null;
   protected String dbPassword = null;
   protected boolean dbLogging;
+  protected boolean skipLoggingRuleMatches = false;
 
   protected String abTest = null;
   /**
@@ -261,6 +262,7 @@ public class HTTPServerConfig {
         dbUsername = getOptionalProperty(props, "dbUsername", null);
         dbPassword = getOptionalProperty(props, "dbPassword", null);
         dbLogging = Boolean.valueOf(getOptionalProperty(props, "dbLogging", "false"));
+        skipLoggingRuleMatches = Boolean.valueOf(getOptionalProperty(props, "skipLoggingRuleMatches", "false"));
         if (dbLogging && (dbDriver == null || dbUrl == null || dbUsername == null || dbPassword == null)) {
           throw new IllegalArgumentException("dbLogging can only be true if dbDriver, dbUrl, dbUsername, and dbPassword are all set");
         }
@@ -787,6 +789,14 @@ public class HTTPServerConfig {
   @Experimental
   boolean getDatabaseLogging() {
     return this.dbLogging;
+  }
+
+  /**
+   * @since 4.5
+   */
+  @Experimental
+  boolean isSkipLoggingRuleMatches() {
+    return this.skipLoggingRuleMatches;
   }
 
 

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -393,9 +393,11 @@ abstract class TextChecker {
     DatabaseCheckLogEntry logEntry = new DatabaseCheckLogEntry(userId, agentId, logServerId, textSize, matchCount,
       lang, detLang.getDetectedLanguage(), computationTime, textSessionId, mode.toString());
     Map<String, Integer> ruleMatchCount = new HashMap<>();
-    for (RuleMatch match : matches) {
-      String ruleId = match.getRule().getId();
-      ruleMatchCount.put(ruleId, ruleMatchCount.getOrDefault(ruleId, 0) + 1);
+    if (!config.isSkipLoggingRuleMatches()) {
+      for (RuleMatch match : matches) {
+        String ruleId = match.getRule().getId();
+        ruleMatchCount.put(ruleId, ruleMatchCount.getOrDefault(ruleId, 0) + 1);
+      }
     }
     logEntry.setRuleMatches(new DatabaseRuleMatchLogEntry(ruleMatchCount));
     logger.log(logEntry);


### PR DESCRIPTION
Made logging of rule matches to database configurable,
since enabling it creates heavy write load for database