### PR TITLE
Fixed uber-jar build in languagetool-dev

### DIFF
--- a/languagetool-dev/pom.xml
+++ b/languagetool-dev/pom.xml
@@ -28,12 +28,11 @@
         <plugins>
             <plugin>
                 <!-- call with: mvn clean compile assembly:single -->
+                <!-- may need to call `mvn install` in parent folder for this to work -->
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>${maven.assemby.plugin}</version>
                 <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
+                    <descriptor>src/main/assembly/zip.xml</descriptor>
                 </configuration>
             </plugin>
             <plugin>

--- a/languagetool-dev/src/main/assembly/zip.xml
+++ b/languagetool-dev/src/main/assembly/zip.xml
@@ -1,0 +1,55 @@
+<!--
+  ~ /* LanguageTool, a natural language style checker
+  ~  * Copyright (C) 2018 Fabian Richter
+  ~  *
+  ~  * This library is free software; you can redistribute it and/or
+  ~  * modify it under the terms of the GNU Lesser General Public
+  ~  * License as published by the Free Software Foundation; either
+  ~  * version 2.1 of the License, or (at your option) any later version.
+  ~  *
+  ~  * This library is distributed in the hope that it will be useful,
+  ~  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  ~  * Lesser General Public License for more details.
+  ~  *
+  ~  * You should have received a copy of the GNU Lesser General Public
+  ~  * License along with this library; if not, write to the Free Software
+  ~  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+  ~  * USA
+  ~  */
+  -->
+<!-- documentation can be found at http://maven.apache.org/plugins/maven-assembly-plugin/assembly.html -->
+
+<assembly>
+    <!-- copied from http://maven.apache.org/plugins/maven-assembly-plugin/descriptor-refs.html#jar-with-dependencies -->
+    <id>jar-with-dependencies</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+
+    <!-- as found in standalone's zip.xml -->
+
+    <containerDescriptorHandlers>
+        <!-- both of these handlers are needed so all language-module.properties get merged into one file: -->
+        <containerDescriptorHandler>
+            <handlerName>metaInf-services</handlerName>
+        </containerDescriptorHandler>
+        <containerDescriptorHandler>
+            <handlerName>file-aggregator</handlerName>
+            <configuration>
+                <filePattern>META-INF/org/languagetool/language-module.properties</filePattern>
+                <outputPath>META-INF/org/languagetool/language-module.properties</outputPath>
+            </configuration>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
+</assembly>
+


### PR DESCRIPTION
New assembly descriptor for langaugetool-dev:
- based on jar-with-dependencies (as used before)
- added aggregation of language-module.properties from languagetool-standalone