### PR TITLE
[de] prohibit „Ahoi-Brause“

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
@@ -8085,3 +8085,4 @@ Arttermin.*
 Ladenjustizkasse/N
 zimmer
 Standpunk/S
+Ahoi-Brause/N


### PR DESCRIPTION
Correct word would be „Ahoj-Brause“ (see https://de.wikipedia.org/wiki/Ahoj)