### PR TITLE
Workaround for potential bug in morfologik

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/morfologik/MorfologikSpeller.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/morfologik/MorfologikSpeller.java
@@ -53,6 +53,7 @@ public class MorfologikSpeller {
 
   private final Dictionary dictionary;
   private final Speller speller;
+  private final int maxEditDistance;
 
   /**
    * Creates a speller with the given maximum edit distance.
@@ -76,6 +77,7 @@ public class MorfologikSpeller {
       throw new RuntimeException("maxEditDistance must be > 0: " + maxEditDistance);
     }
     this.dictionary = dictionary;
+    this.maxEditDistance = maxEditDistance;
     speller = new Speller(dictionary, maxEditDistance);
   }
 
@@ -88,6 +90,9 @@ public class MorfologikSpeller {
 
   public List<String> getSuggestions(String word) {
     List<String> suggestions = new ArrayList<>();
+    // needs to be reset every time, possible bug: HMatrix for distance computation is not reset;
+    // output changes when reused
+    Speller speller = new Speller(dictionary, maxEditDistance);
     suggestions.addAll(speller.findReplacements(word));
     suggestions.addAll(speller.replaceRunOnWords(word));
     // capitalize suggestions if necessary


### PR DESCRIPTION
Speller.findReplacements output changes when the same object is used multiple times
fix: create new Speller object every time in MorfologikSpeller.getSuggestions