### PR TITLE
[en] add 'Rebecca'

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
@@ -384,3 +384,4 @@ WhatsApp
 Wi-Fi
 Xbox
 Xiaomi
+Rebecca


### PR DESCRIPTION
Common name marked as error in American, Canadian and Australian English.
@MikeUnwalla ok for you?