### PR TITLE
[en] add words to english dictionary

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
@@ -384,3 +384,15 @@ WhatsApp
 Wi-Fi
 Xbox
 Xiaomi
+Jira
+Christy
+deliverable
+deliverables
+Deloitte
+UX
+flyers
+Liam
+KPIs
+Vijay
+summative
+fintech


### PR DESCRIPTION
@MikeUnwalla I added a few words that our addon users often add to their personal dictionary.

Jira = popular task management software by Atlassian
Christy = name
deliverable = https://en.wikipedia.org/wiki/Deliverable
Deloitte = name of big consulting company
UX = common abbreviation of "User Experience"
dev = common abbreviation of "Developer" or "Development" ("He is a good web dev")
flyers = for some reason not in the american english dict
Liam = common person name
KPIs = plural of KPI (key performance indicator)
Vijay = common person name
summative = https://dictionary.cambridge.org/dictionary/english/summative
fintech = like biotech but for the finance industry (https://en.wikipedia.org/wiki/Financial_technology)

Let me know what you think. Thanks!