### PR TITLE
Added simple Prometheus monitoring

### DIFF
--- a/languagetool-server/pom.xml
+++ b/languagetool-server/pom.xml
@@ -105,7 +105,27 @@
             <artifactId>mariadb-java-client</artifactId>
             <version>2.2.3</version>
         </dependency>
-        
+
+        <!-- monitoring via prometheusMonitoring -->
+        <!-- The client -->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.6.0</version>
+        </dependency>
+        <!-- Hotspot JVM metrics-->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_hotspot</artifactId>
+            <version>0.6.0</version>
+        </dependency>
+        <!-- Exposition HTTPServer-->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+            <version>0.6.0</version>
+        </dependency>
+
         <dependency>
             <!-- see http://stackoverflow.com/questions/174560/sharing-test-code-in-maven#174670 -->
             <groupId>org.languagetool</groupId>

--- a/languagetool-server/src/main/java/org/languagetool/server/ApiV2.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/ApiV2.java
@@ -85,6 +85,7 @@ class ApiV2 {
     ServerTools.setCommonHeaders(httpExchange, JSON_CONTENT_TYPE, allowOriginUrl);
     httpExchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.getBytes(ENCODING).length);
     httpExchange.getResponseBody().write(response.getBytes(ENCODING));
+    ServerMetricsCollector.getInstance().logResponse(HttpURLConnection.HTTP_OK);
   }
 
   private void handleCheckRequest(HttpExchange httpExchange, Map<String, String> parameters, ErrorRequestLimiter errorRequestLimiter, String remoteAddress) throws Exception {
@@ -245,6 +246,7 @@ class ApiV2 {
     ServerTools.setCommonHeaders(httpExchange, JSON_CONTENT_TYPE, allowOriginUrl);
     httpExchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.getBytes(ENCODING).length);
     httpExchange.getResponseBody().write(response.getBytes(ENCODING));
+    ServerMetricsCollector.getInstance().logResponse(HttpURLConnection.HTTP_OK);
   }
 
   private void handleLogRequest(HttpExchange httpExchange, Map<String, String> parameters) throws IOException {
@@ -257,6 +259,7 @@ class ApiV2 {
     String response = "OK";
     httpExchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.getBytes(ENCODING).length);
     httpExchange.getResponseBody().write(response.getBytes(ENCODING));
+    ServerMetricsCollector.getInstance().logResponse(HttpURLConnection.HTTP_OK);
   }
 
   private AnnotatedText getAnnotatedTextFromString(JsonNode data, String text) {

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServer.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServer.java
@@ -112,7 +112,7 @@ public class HTTPServer extends Server {
       server.setExecutor(executorService);
 
       if (config.isPrometheusMonitoring()) {
-        ServerMetricsCollector.init();
+        ServerMetricsCollector.init(config.getPrometheusPort());
       }
     } catch (Exception e) {
       ResourceBundle messages = JLanguageTool.getMessageBundle();

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServer.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServer.java
@@ -110,6 +110,10 @@ public class HTTPServer extends Server {
       server.createContext("/", httpHandler);
       executorService = getExecutorService(workQueue, config);
       server.setExecutor(executorService);
+
+      if (config.isPrometheusMonitoring()) {
+        ServerMetricsCollector.init();
+      }
     } catch (Exception e) {
       ResourceBundle messages = JLanguageTool.getMessageBundle();
       String message = Tools.i18n(messages, "http_server_start_failed", host, Integer.toString(port));

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
@@ -91,6 +91,7 @@ public class HTTPServerConfig {
   protected String dbUsername = null;
   protected String dbPassword = null;
   protected boolean dbLogging;
+  protected boolean prometheusMonitoring = false;
   protected boolean skipLoggingRuleMatches = false;
 
   protected int slowRuleLoggingThreshold = -1; // threshold in milliseconds, used by SlowRuleLogger; < 0 - disabled
@@ -255,6 +256,7 @@ public class HTTPServerConfig {
         dbUsername = getOptionalProperty(props, "dbUsername", null);
         dbPassword = getOptionalProperty(props, "dbPassword", null);
         dbLogging = Boolean.valueOf(getOptionalProperty(props, "dbLogging", "false"));
+        prometheusMonitoring = Boolean.valueOf(getOptionalProperty(props, "prometheusMonitoring", "false"));
         skipLoggingRuleMatches = Boolean.valueOf(getOptionalProperty(props, "skipLoggingRuleMatches", "false"));
         if (dbLogging && (dbDriver == null || dbUrl == null || dbUsername == null || dbPassword == null)) {
           throw new IllegalArgumentException("dbLogging can only be true if dbDriver, dbUrl, dbUsername, and dbPassword are all set");
@@ -812,6 +814,16 @@ public class HTTPServerConfig {
   boolean getDatabaseLogging() {
     return this.dbLogging;
   }
+
+
+  /**
+   * @since 4.6
+   * @return
+   */
+  public boolean isPrometheusMonitoring() {
+    return prometheusMonitoring;
+  }
+
 
   /**
    * @since 4.5

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
@@ -92,6 +92,8 @@ public class HTTPServerConfig {
   protected String dbPassword = null;
   protected boolean dbLogging;
   protected boolean prometheusMonitoring = false;
+  protected int prometheusPort = 9301;
+
   protected boolean skipLoggingRuleMatches = false;
 
   protected int slowRuleLoggingThreshold = -1; // threshold in milliseconds, used by SlowRuleLogger; < 0 - disabled
@@ -257,6 +259,7 @@ public class HTTPServerConfig {
         dbPassword = getOptionalProperty(props, "dbPassword", null);
         dbLogging = Boolean.valueOf(getOptionalProperty(props, "dbLogging", "false"));
         prometheusMonitoring = Boolean.valueOf(getOptionalProperty(props, "prometheusMonitoring", "false"));
+        prometheusPort = Integer.parseInt(getOptionalProperty(props, "prometheusPort", "9301"));
         skipLoggingRuleMatches = Boolean.valueOf(getOptionalProperty(props, "skipLoggingRuleMatches", "false"));
         if (dbLogging && (dbDriver == null || dbUrl == null || dbUsername == null || dbPassword == null)) {
           throw new IllegalArgumentException("dbLogging can only be true if dbDriver, dbUrl, dbUsername, and dbPassword are all set");
@@ -824,6 +827,13 @@ public class HTTPServerConfig {
     return prometheusMonitoring;
   }
 
+  /**
+   * @since 4.6
+   * @return
+   */
+  public int getPrometheusPort() {
+    return prometheusPort;
+  }
 
   /**
    * @since 4.5

--- a/languagetool-server/src/main/java/org/languagetool/server/ServerMetricsCollector.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/ServerMetricsCollector.java
@@ -1,0 +1,82 @@
+package org.languagetool.server;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.exporter.HTTPServer;
+import io.prometheus.client.hotspot.DefaultExports;
+
+import java.io.IOException;
+
+public class ServerMetricsCollector {
+
+  public enum RequestErrorType {
+    QUEUE_FULL,
+    TOO_MANY_ERRORS,
+    MAX_CHECK_TIME,
+    MAX_TEXT_SIZE,
+    INVALID_REQUEST
+  }
+
+
+  private static final ServerMetricsCollector collector = new ServerMetricsCollector();
+  private static HTTPServer server;
+
+
+  private final Counter checkCounter = Counter
+    .build("languagetool_checks_total", "Total text checks").register();
+  private final Counter charactersCounter = Counter
+    .build("languagetool_characters_total", "Total processed characters").register();
+  private final Counter computationTimeCounter = Counter
+    .build("languagetool_computation_time_seconds_total", "Total computation time, in seconds").register();
+
+  private final Counter requestErrorCounter = Counter
+    .build("languagetool_request_errors_total", "Various request errors")
+    .labelNames("reason").register();
+
+  // TODO add label for route, method, ...?
+  private final Counter httpRequestCounter = Counter
+    .build("languagetool_http_requests_total", "Received HTTP requests").register();
+
+  private final Counter httpResponseCounter = Counter
+    .build("languagetool_http_responses_total", "HTTP responses by code")
+    .labelNames("code").register();
+
+  private final Counter failedHealthcheckCounter = Counter
+    .build("languagetool_failed_healthchecks_total", "Failed healthchecks").register();
+
+
+  public static void init() throws IOException {
+    DefaultExports.initialize();
+    server = new HTTPServer(9300, true);
+  }
+
+  public static void stop() {
+    server.stop();
+  }
+
+  public static ServerMetricsCollector getInstance() {
+    return collector;
+  }
+
+  public void logCheck(long milliseconds, int textSize) {
+    checkCounter.inc();
+    charactersCounter.inc(textSize);
+    computationTimeCounter.inc((double) milliseconds / 1000.0);
+  }
+
+  public void logRequestError(RequestErrorType type) {
+    requestErrorCounter.labels(type.name().toLowerCase()).inc();
+  }
+
+  public void logRequest() {
+    httpRequestCounter.inc();
+  }
+
+  public void logResponse(int httpCode) {
+    httpResponseCounter.labels(String.valueOf(httpCode)).inc();
+  }
+
+  public void logFailedHealthcheck() {
+    failedHealthcheckCounter.inc();
+  }
+
+}

--- a/languagetool-server/src/main/java/org/languagetool/server/ServerMetricsCollector.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/ServerMetricsCollector.java
@@ -44,9 +44,9 @@ public class ServerMetricsCollector {
     .build("languagetool_failed_healthchecks_total", "Failed healthchecks").register();
 
 
-  public static void init() throws IOException {
+  public static void init(int port) throws IOException {
     DefaultExports.initialize();
-    server = new HTTPServer(9300, true);
+    server = new HTTPServer(port, true);
   }
 
   public static void stop() {


### PR DESCRIPTION
Enable via `prometheusMonitoring=true` in configuration file
Configure port via `prometheusPort`, defaults to 9301.
For now, counts HTTP requests & responses (by code), some errors and check statistics (total, time, size).
Also exposes some JVM metrics.