### PR TITLE
Make RegexPatternRule class public

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/RegexPatternRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/RegexPatternRule.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
  *
  * @since 3.2
  */
-class RegexPatternRule extends AbstractPatternRule implements RuleMatcher {
+public class RegexPatternRule extends AbstractPatternRule implements RuleMatcher {
 
   private static final Pattern suggestionPattern = Pattern.compile("<suggestion>(.*?)</suggestion>");  // TODO: this needs to be cleaned up, there should be no need to parse this?
   private static final Pattern matchPattern = Pattern.compile("\\\\\\d");


### PR DESCRIPTION
It would be useful if the `RegexPatternRule` class was public.

Our project adds rules to a `LanguageTool` instance programmatically. The `PatternRule` class is public and its tokens can use regular expressions, but we have a large library of regexes that cover multiple words and don't work as tokens, and we'd have to rewrite these expressions to use them in this model.

Using a `RegexPatternRule` solves this problem nicely, and it would be useful to import it directly rather than duplicating it, which raises licensing concerns, or resorting to reflection to gain access.