### PR TITLE
[en] improve dictionary and suggestions

### DIFF
--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/AbstractEnglishSpellerRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/AbstractEnglishSpellerRule.java
@@ -231,11 +231,15 @@ public abstract class AbstractEnglishSpellerRule extends MorfologikSpellerRule {
       return Arrays.asList("e-commerce");
     } else if ("Ecommerce".equals(word)) {
       return Arrays.asList("E-Commerce");
+    } else if ("eCommerce".equals(word)) {
+      return Arrays.asList("e-commerce");
     } else if ("elearning".equals(word)) {
       return Arrays.asList("e-learning");
     } else if ("eLearning".equals(word)) {
       return Arrays.asList("e-learning");
     } else if ("ebook".equals(word)) {
+      return Arrays.asList("e-book");
+    } else if ("eBook".equals(word)) {
       return Arrays.asList("e-book");
     } else if ("Ebook".equals(word)) {
       return Arrays.asList("E-Book");

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/added.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/added.txt
@@ -5045,6 +5045,7 @@ maderized	maderize	VBD
 maderized	maderize	VBN
 maderizes	maderize	VBZ
 maderizing	maderize	VBG
+Magento	Magento	NNP
 magnetisability	magnetisability	NN:UN
 magnetisable	magnetisable	JJ
 magnetizable	magnetizable	JJ
@@ -7573,6 +7574,20 @@ premiumized	premiumize	VBD
 premiumized	premiumize	VBN
 premiumizes	premiumize	VBZ
 premiumizing	premiumize	VBG
+pre-order	pre-order	NN
+pre-orders	pre-order	NNS
+preorder	preorder	VB
+pre-order	pre-order	VB
+preorder	preorder	VBP
+pre-order	pre-order	VBP
+preordering	preorder	VBG
+pre-ordering	pre-order	VBG
+preorder	preorder	VBD
+pre-order	pre-order	VBD
+preordered	preorder	VBN
+pre-ordered	pre-order	VBN
+preorders	preorder	VBZ
+pre-orders	pre-order	VBZ
 preowned	preowned	JJ
 prequalified	prequalify	VBD
 pre-qualified	pre-qualify	VBD
@@ -10601,6 +10616,7 @@ willed	will	VBD
 willed	will	VBN
 willing	will	VBG
 wills	will	VBZ
+Wix	Wix	NNP
 wood	wood	NN
 woodcarving	woodcarving	NN:U
 word	word	NN

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
@@ -958,6 +958,7 @@ Luca
 Lyft
 Maddie
 maderization
+Magento
 magna opera
 Mailchimp
 majuscule
@@ -970,6 +971,8 @@ marsupializing
 McAfee
 McAllister
 mea culpa
+mechatronic
+mechatronics
 megaampere
 megaamperes
 megabecquerel
@@ -1477,6 +1480,10 @@ pragmatized
 pragmatizes
 pragmatizing
 Praveen
+pre-order
+pre-orders
+pre-ordering
+pre-ordered
 preconize
 preconized
 preconizes
@@ -2589,6 +2596,7 @@ Weight Watchers
 WeMakeItSafer
 Wheaton World Wide Moving
 Whitby Group
+Wix
 Wolfram Research
 Wolters Kluwer
 Workhands

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling_en-US.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling_en-US.txt
@@ -1763,6 +1763,10 @@ predations
 pre-eclampsia
 preformants
 pre-format
+preorder
+preorders
+preordering
+preordered
 preindustrial
 problematize
 problematized


### PR DESCRIPTION
* POS-tagged `pre-order` and `preorder` as verb and noun
* added `pre-order` to the dictionary of all English variants
* added `preorder` only to the AmE
* generate a better suggestion for `eCommerce` (currently only "commerce" is suggested)
* added two popular software products (`Magento` and `Wix`) to the dictionary
* added `mechatronic(s)` to the dictionary, after receiving user feedback (POS was already there)

@MikeUnwalla what do you think?