### PR TITLE
Include another community-contributed Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ LanguageTool is freely available under the LGPL 2.1 or later.
 
 ## Docker
 
-Try https://github.com/silvio/docker-languagetool for a community-contributed Docker file.
+Try one of the following projects for a community-contributed Docker file:
+
+- https://github.com/silvio/docker-languagetool ([Docker Hub](https://hub.docker.com/r/silviof/docker-languagetool))
+- https://github.com/Erikvl87/docker-languagetool ([Docker Hub](https://hub.docker.com/r/erikvl87/languagetool))
 
 ## Contributions
 


### PR DESCRIPTION
In this PR I've added another community-contributed dockerfile for LanguageTool:
https://github.com/Erikvl87/docker-languagetool

The Docker Hub image can be found here: https://hub.docker.com/r/erikvl87/languagetool

In the past I've been using silvio's version, but for the following reasons I've created my own repository containing a LanguageTool Dockerfile. I wanted to:
- Push individual LanguageTool versions to Docker Hub so you are able to pin on a certain version
- [Run the LanguageTool unit tests using travis-ci](https://travis-ci.org/Erikvl87/docker-languagetool) for every container image before pushing an image to Docker Hub to guaranty a working image
- Be able to use the [HttpServerConfig](https://languagetool.org/development/api/org/languagetool/server/HTTPServerConfig.html) configuration variables
- Be able to adjust the Java heap sizes
- Create an image with a smaller footprint (currently 232 MB)

I think that this contribution would be a good addition to include in your README.