### PR TITLE
[en] NNP for lowercased 'google'

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/added.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/added.txt
@@ -3916,6 +3916,7 @@ Gomal	Gomal	NNP
 gonadectomised	gonadectomised	JJ
 gonadectomized	gonadectomized	JJ
 Google	Google	NNP
+google	google	NNP
 google	google	VB
 google	google	VBP
 googled	google	VBD


### PR DESCRIPTION
Hi Mike, I noticed that many users were using the noun "google" in lowercase:
> Have you checked the **google**  search?
> It's a **google** plugin, that checks your spelling.

This triggers a false alarm:
![Bildschirmfoto 2019-08-12 um 08 43 40](https://user-images.githubusercontent.com/37363/62848782-4f8dd400-bcdd-11e9-8ffe-36379922cf3f.png)
