### PR TITLE
[es] add 'mami' and 'papi'

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/resource/es/hunspell/spelling.txt
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/resource/es/hunspell/spelling.txt
@@ -5,9 +5,7 @@
 # derrepente
 # desabasto
 # Hey
-# mami
 # New
-# papi
 # religionista
 # religionistas
 # River
@@ -282,6 +280,7 @@ Mac
 MacBook
 MacBook Air
 mail
+mami
 marcación
 Marcelo
 Mari
@@ -336,6 +335,7 @@ Osorio
 Osvaldo
 Outlook
 Paco
+papi
 Paola
 Paris
 Parker


### PR DESCRIPTION
Adding "mami" and "papi" to the Spanish dictionary since they are officially listed in the "Diccionario de la lengua española"

https://dle.rae.es/?id=O6KVLaO
https://dle.rae.es/?id=RnOaO3e