### PR TITLE
[en] partially address #1812

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/added.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/added.txt
@@ -3558,6 +3558,8 @@ focalizes	focalize	VBZ
 focalizing	focalize	VBG
 FOCs	FOC	NN
 fo'c'sle	fo'c'sle	NN
+follow	follow	NN
+follows	follow	NNS
 fondue	fondue	NN:U
 FontoXML	FontoXML	NNP
 food	food	NN
@@ -8364,6 +8366,8 @@ recategorized	recategorize	VBD
 recategorized	recategorize	VBN
 recategorizes	recategorize	VBZ
 recategorizing	recategorize	VBG
+recharge	recharge	NN
+recharges	recharge	NNS
 reclothe	reclothe	VB
 reclothe	reclothe	VBP
 reclothed	reclothe	VBD

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -8999,10 +8999,18 @@ USA
                 <token>download</token>
                 <token>manager</token>
             </antipattern>
+            <antipattern><!-- "I got a write up at work." -->
+                <token>write</token>
+                <token>up</token>
+            </antipattern>
             <antipattern>
                 <token postag="VB|VBP" postag_regexp="yes" />
                 <token>a</token>
                 <token>listen</token>
+            </antipattern>
+            <antipattern> <!-- "Please click the unsubscribe link at the end of the mail" (TODO: we should probably have a rule that suggests putting the verb in quotes) -->
+                <token postag="VB|VBP" postag_regexp="yes" />
+                <token regexp="yes">buttons?|links?|teasers?|icons?|keys?</token>
             </antipattern>
             <antipattern> <!-- this is better covered by rule ALTER_BOY -->
                 <token regexp="yes">at|to|worship(s|ped)?|around</token>
@@ -9024,7 +9032,7 @@ USA
             <pattern>
                 <token regexp='yes'>an?|the</token>
                 <token postag='VB|VBP' postag_regexp='yes'>
-                    <exception regexp="yes">commit|remix|long-running</exception>
+                    <exception regexp="yes">commit|remix|long-running|merge|google|thank</exception>
                     <exception postag='VBP?|(SENT|PARA)_END' postag_regexp='yes' negate_pos='yes'/>
                 </token>
             </pattern>
@@ -9032,13 +9040,44 @@ USA
             <short>Grammatical mistake</short>
             <example correction="">This is <marker>a compete</marker> catastrophe.</example>
             <example correction=""><marker>a compete</marker></example>
-            <example correction="">Missing hyphen: Here's <marker>a follow</marker> up task.</example>
             <example correction="">Not a noun in standard English. Only <marker>a reload</marker> of the page will fix this. [https://github.com/languagetool-org/languagetool/issues/1379]</example>
             <example>This is <marker>a complete</marker> catastrophe</example>
             <example>Let's have a listen to what he wants to say</example>
             <example>a show</example>
             <example>Sections 4.a and 5.<marker>a are</marker> not correct.</example>
             <example>For the <marker>merge processes</marker> to be faster, we must...</example>
+        </rule>
+        <rule id="A_GOOGLE" name="a/the + google">
+            <pattern>
+                <token regexp='yes'>an?|the|that|this|those|my|his|her|their|our</token>
+                <token postag="JJ|RB" postag_regexp="yes" min="0" />
+                <marker>
+                    <token case_sensitive="yes">google</token>
+                </marker>
+                <token postag_regexp="yes" postag="NN(S|:UN?)?"/>
+            </pattern>
+            <message>'Google' is a proper noun and needs to be capitalized.</message>
+            <suggestion>Google</suggestion>
+            <example correction="Google">Have you seen the simplified <marker>google</marker> doc?</example>
+            <example correction="Google">My <marker>google</marker> skills are outstanding!</example>
+            <example>He wanted to <marker>google</marker> for the medicine.</example>
+        </rule>
+        <rule id="A_THANK_YOU" name="a/the + thank you">
+            <pattern>
+                <token regexp='yes'>an?|the|that|this|those|my|his|her|their|our</token>
+                <token postag="JJ|RB" postag_regexp="yes" min="0" />
+                <marker>
+                    <token>thank</token>
+                    <token>you</token>
+                </marker>
+                <token postag_regexp="yes" postag="SENT_END|NN(S|:UN?)?"/>
+            </pattern>
+            <message>It appears that 'thank you' is missing a hyphen or needs to be quoted.</message>
+            <suggestion>thank-you</suggestion>
+            <suggestion>“Thank You”</suggestion>
+            <example correction='thank-you|“Thank You”'>Have you seen my <marker>thank you</marker> letter?</example>
+            <example correction='thank-you|“Thank You”'>Did you receive our little <marker>thank you</marker>?</example>
+            <example>He was surprised by the <marker>thank-you</marker> message.</example>
         </rule>
         <rule id="BE_FINED_WITH" name="be fined with (be fine with)">
             <pattern>


### PR DESCRIPTION
What's in this PR:
1. Add NN as POS for "follow" (see https://en.wiktionary.org/wiki/follow and https://www.merriam-webster.com/dictionary/follow) "a follow up" is now caught by `CA_FOLLOW_UP` which also offers a suggestion. (this would close https://github.com/languagetool-org/languagetool/issues/1468)
2. Add NN as POS for "recharge" (see https://en.wiktionary.org/wiki/recharge and https://en.wiktionary.org/wiki/recharge)
3. Improve A_INFINITIVE by adding antipatterns
4. In those antipatterns are now "thank" and "google" for which I created special rules
5. Added "merge" as an antipattern to `A_INFINITIVE` to prevent some false alarms in common tech speak: "Can you have a look at the merge request?"

@MikeUnwalla let me know what you think. Thanks!