### PR TITLE
[en] add POS for cancel

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/added.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/added.txt
@@ -952,6 +952,8 @@ Canadianized	Canadianize	VBD
 Canadianized	Canadianize	VBN
 Canadianizes	Canadianize	VBZ
 Canadianizing	Canadianize	VBG
+cancel	cancel	NN
+cancels	cancel	NNS
 cancellable	cancellable	JJ
 cancerisation	cancerisation	NN:U
 cancerization	cancerization	NN:U


### PR DESCRIPTION
Hey @MikeUnwalla,

I saw many false positives caused by "a/the cancel". 

Webster and Oxford lists it as a noun:
https://www.lexico.com/en/definition/cancel
https://www.merriam-webster.com/dictionary/cancel

Apparently there's no plural form of "cancel". Do I need to add the uncountable POS here?
What is the difference between `NN:U` and `NN:UN`?

