### PR TITLE
[en] rework ATD_VERBS_TO_COLLOCATION

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -23422,14 +23422,14 @@ The accident victim died from her injuries.
 
   <rulegroup id='ATD_VERBS_TO_COLLOCATION' name='Collocation: Word + to + PRP|NNP|DT'>
      <!-- Based on AtD by Tiago F. Santos, 2019-09-13 -->
-     <rule>
+     <rule default="off"><!-- See examples, why turned off, new less aggressive rule: MISSING_PREPOSITION  -->
       <antipattern>
           <token regexp="yes">adds?|adding|prepares?|refuse|regard|tendenc(y|ies)</token>
           <token postag='PRP'/>
       </antipattern>
       <antipattern>
           <token regexp="yes">adds?|adding|dedicated|prepares?|refuse|regards?|relates?</token>
-          <token regexp="yes">an?|the|some</token>
+          <token regexp="yes">an?|the|some|any</token>
       </antipattern>
       <antipattern>
           <token postag_regexp="yes" postag='PRP|NNP|DT'/>
@@ -23452,7 +23452,7 @@ The accident victim died from her injuries.
       <antipattern>
           <token>thanks</token>
           <token>a</token>
-          <token regexp="yes">lot|bunch</token>
+          <token regexp="yes">lot|bunch|ton|mill</token>
       </antipattern>
       <antipattern>
           <token inflected='yes'>go</token>
@@ -23548,6 +23548,7 @@ The accident victim died from her injuries.
       <example type='triggers_error'>Though we cannot perfect the endeavour we should strive for it: the will-to-live constantly...</example><!-- XXX missing comma -->
       <example type='triggers_error'>In addition the races can last several hours, with heartrates com...</example><!-- XXX missing comma -->
       <example>Thanks a lot!</example>
+      <example>Thanks a ton!</example>
       <example>He couldn't go any further.</example>
       <example>...sing is possible by "blowing" the product: namely reacting it with oxygen.</example>
       <example>The Sealab 2021 character Jodene Sparks references A Modest Proposal when trying to convince Debbie Du...</example>
@@ -23581,6 +23582,35 @@ The accident victim died from her injuries.
       <example>The five enterprises which passed to 100 percent Russian state ownership are:</example>
       <example>...e has a fictional daughter named Jody Crowley who continues her father's search for the Scarlet Woman.</example>
       <example>While listening the radio, I fell asleep.</example>
+      <!-- False positives/negatives collected by user feedback and regression test
+      <example correction="According to his"><marker>According his</marker> friend, they were outside playing basketball.</example>
+      <example>I didn't know if I was coming or going the week before I got married.</example>
+      <example>I have not asked for help, nor do I desire it.</example>
+      <example>It'll serve him right if he fails the exam; he doesn't study at all.</example>
+      <example>The desire he has had for years has been fulfilled.</example>
+      <example>He also "gallantly stepped forward" to contribute a quarter of the costs of dramatising.</example>
+      <example>They were able to add another $3 credit.</example>
+      <example>He's currently owing them a total of 10 USD.</example>
+      <example>As far as going the traditional way, ...</example>
+      <example>Click the button to add another line.</example>
+      <example>I'm going to add those finishing touches.</example>
+      <example>I would want to add each SKU as param.</example>
+      <example>He had a strong opinion regarding letters.</example>
+      <example>Please show how able you are and what qualifies you.</example>
+      <example>He's your dedicated Shopify Guru.</example>
+      <example>I think he's going a bit loopy.</example>
+      <example>He might be adding those employees sooner.</example>
+      <example>Learn more about adding HTML content.</example>
+      <example>Most references do not follow.</example>
+      <example>You have to subscribe every week.</example>
+      <example>He thanks me again.</example>
+      <example>We try to respond a.s.a.p.</example>
+      <example>Life Is Going On</example>
+      <example>Is it possible to add Google Maps API features?</example>
+      <example>The Commitment Fee must be paid.</example>
+      <example>Add these search fields.</example>
+      <example>Welcome home.</example>
+      <example>Refer a friend.</example> -->
     </rule>
      <rule>
       <antipattern>
@@ -23656,6 +23686,40 @@ The accident victim died from her injuries.
     <!-- XXX Beware/couple OF rules have too many obvious exceptions -->
   </rulegroup>
 
+  <rule id="MISSING_PREPOSITION" name='Missing preposition' default="off"><!-- off to see regression test results first -->
+        <antipattern>
+            <token>thanks</token>
+            <token>a</token>
+            <token regexp="yes">lot|bunch|ton|mill?</token>
+        </antipattern>
+        <antipattern>
+            <token>Prior</token>
+            <token>General</token>
+        </antipattern>
+        <antipattern>
+            <token>due</token>
+            <token regexp="yes">east|west</token>
+        </antipattern>
+        <pattern>
+            <token postag="SENT_START|CC" postag_regexp="yes" />
+            <marker>
+                <token regexp="yes">thanks|according|due|prior</token>
+                <token postag_regexp="yes" postag='PRP\$?|NNP|DT' />
+            </marker>
+        </pattern>
+        <message>It appears that a preposition is missing after '\2'.</message>
+        <suggestion>\2 to \3</suggestion>
+        <example correction='According to Angela'><marker>According Angela</marker>, they are dating.</example>
+        <example correction='According to his'><marker>According his</marker> friend, they are dating.</example>
+        <example correction='According to him'><marker>According him</marker>, they are dating.</example>
+        <example correction="According to a"><marker>According a</marker> TV forecast, it will rain tomorrow.</example>
+        <example correction="Prior to the"><marker>Prior the</marker> storm everything was calm.</example>
+        <example correction="Due to the"><marker>Due the</marker> unique climate in Azerbaijan , the flora is much richer in the number of species.</example>
+        <example correction="Thanks to the"><marker>Thanks the</marker> friend of Mike.</example>
+        <example>Thanks a lot.</example>
+        <example>The arc connecting the points on the horizon due East and due West.</example>
+        <example>His term as Prior General of the Camaldolese.</example>
+  </rule>
 
   <rulegroup id='GOOD_IN_AT' name='Collocation: Good in/at'>
     <!-- Created by Nicholas Walker (Bokomaru), 2017-11-14 -->


### PR DESCRIPTION
My suggestion for #1944 
* Collected false alarms reported by users and regression test and added them to the rule (btw: none of those false alarms is happening on the ATD website)
* Added a false positive where "According to his friend" is not detected
* Disabled the affected sub rule which got too complex (at least for me)
* Started a new rule that is less aggressive (it will find fewer errors, but still the most common ones)

@TiagoSantos81 My goal is not to disrespect your work. I'm just trying to find a good compromise. 