### PR TITLE
treat zero-width-space also as white space 

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/tools/StringTools.java
+++ b/languagetool-core/src/main/java/org/languagetool/tools/StringTools.java
@@ -399,6 +399,10 @@ public final class StringTools {
         || "\u0001".equals(str)) { // breakable field in OOo
       return false;
     }
+
+    if ("\uFEFF".equals(str)) {
+      return true;
+    }
     String trimStr = str.trim();
     if (isEmpty(trimStr)) {
       return true;

--- a/languagetool-core/src/test/java/org/languagetool/tools/StringToolsTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/tools/StringToolsTest.java
@@ -198,6 +198,7 @@ public class StringToolsTest {
 
   @Test
   public void testIsWhitespace() {
+    assertEquals(true, StringTools.isWhitespace("\uFEFF"));
     assertEquals(true, StringTools.isWhitespace("  "));
     assertEquals(true, StringTools.isWhitespace("\t"));
     assertEquals(true, StringTools.isWhitespace("\u2002"));


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Zero-width_space

Currently, every zero-width-space is creating an UNKNOWN token.
The LT browser add-on and many rich text editor libraries make heavy use of ZWS characters to work around certain issues.
Technically ZWS is a space. Other languages like JavaScript are already treating it as one.

Here's an example showing that the rule `LETS_LET` gets confused by ZWS (second sentence contains a ZWS before "do"):

<img width="347" alt="Bildschirmfoto 2019-10-01 um 17 15 39" src="https://user-images.githubusercontent.com/37363/65975713-529c7980-e46f-11e9-9440-b405acfc0fd2.png">
