### PR TITLE
[en] improve antipattern for PROFANITY

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -31721,9 +31721,13 @@ The accident victim died from her injuries.
     </rule>
         <rule>
             <antipattern>
-                <token regexp="yes">Magna|Summa|Egregia|Maxima</token>
                 <token>cum</token>
                 <token>laude</token>
+            </antipattern>
+            <antipattern>
+                <token>cum</token>
+                <token min="0">/</token>
+                <token>ex</token>
             </antipattern>
             <pattern>
                 <token regexp='yes'>cums?</token>


### PR DESCRIPTION
"Cum Laude" can be used without "Summa" etc.

See https://en.wikipedia.org/wiki/Latin_honors

> cum laude, meaning "with praise". This honor is typically awarded to graduates in the top 20%, top 25%, or top 30% of their class, depending on the institution.[2][3]