### PR TITLE
[de] improve DE_AGREEMENT by lowering its prio

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
@@ -292,6 +292,7 @@ public class German extends Language implements AutoCloseable {
       case "DIESEN_JAHRES": return 1;
       case "EBEN_FALLS": return 1;
       case "DASS_MIT_VERB": return 1; // prefer over SUBJUNKTION_KOMMA ("Dass wird Konsequenzen haben.")
+      case "DE_AGREEMENT": return -1;  // prefer RECHT_MACHEN, MONTAGS and other
       case "CONFUSION_RULE": return -1;  // probably less specific than the rules from grammar.xml
       case "MODALVERB_FLEKT_VERB": return -1;
       case "AKZENT_STATT_APOSTROPH": return -1;  // lower prio than PLURAL_APOSTROPH

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -16493,6 +16493,31 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example>Das <marker>letzte</marker> der drei Bücher</example>
         </rule>
         -->
+        <rule id="RECHT_MACHEN" name="Kleinschreibung 'recht' in 'es allen recht machen'" default="temp_off">
+            <antipattern>
+                <token regexp="yes">zum|mit</token>
+                <token>Recht</token>
+            </antipattern>
+            <antipattern>
+                <token>zu</token>
+                <token />
+                <token>Recht</token>
+            </antipattern>
+            <pattern>
+                <marker>
+                    <token case_sensitive="yes">Recht</token>
+                </marker>
+                <token min="0">zu</token>
+                <token inflected="yes">machen</token>
+            </pattern>
+            <message>Wenn die Phrase 'recht machen' (= jemandes Wunsch nachkommen) gemeint ist, wird 'recht' kleingeschrieben.</message>
+            <suggestion><match no="1" case_conversion="startlower"/></suggestion>
+            <url>https://www.duden.de/rechtschreibung/recht_machen</url>
+            <short>&prgk;.</short>
+            <example correction="recht">Sie will es allen <marker>Recht</marker> machen.</example>
+            <example>1929 warnte er, das Dritte Reich werde Massenmorde, Pogrome und Plünderungen zum Recht machen.</example>
+            <example>Sie wollen den Besitz von Waffen zu ihrem Recht machen.</example>
+        </rule>
         <rule id="TEILEN" name="zu beiden teilen (Teilen)">
             <pattern case_sensitive="yes">
                 <token postag="PRP:.+" postag_regexp="yes"/>


### PR DESCRIPTION
@danielnaber Ich habe die Regel "DE_AGREEMENT" etwas niedriger priorisiert, weil sie andere Regeln unterdrückt hat:

Hier wäre die Regel "MONTAGS" hilfreicher:
<img width="506" alt="Bildschirmfoto 2019-10-18 um 09 40 17" src="https://user-images.githubusercontent.com/37363/67075517-9b507400-f18b-11e9-8756-aa6a5c1d419f.png">

Hier gibt es anscheinend keine Regel für die Kleinschreibung von "recht machen" (habe ich hinzugefügt):
<img width="523" alt="Bildschirmfoto 2019-10-18 um 09 28 52" src="https://user-images.githubusercontent.com/37363/67075566-b7541580-f18b-11e9-9595-593c2212cd7e.png">

Macht das Sinn? Die "CONFUSION_RULE" hat jetzt dieselbe Prio wie "DE_AGREEMENT".
