### PR TITLE
New server setting: serverURL

### DIFF
--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
@@ -27,6 +27,8 @@ import org.languagetool.rules.spelling.morfologik.suggestions_ordering.Suggestio
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.*;
 
 /**
@@ -49,6 +51,8 @@ public class HTTPServerConfig {
   protected boolean publicAccess = false;
   protected int port = DEFAULT_PORT;
   protected String allowOriginUrl = null;
+
+  protected URI serverURL = null;
   protected int maxTextLength = Integer.MAX_VALUE;
   protected int maxTextHardLength = Integer.MAX_VALUE;
   protected int maxTextLengthWithApiKey = Integer.MAX_VALUE;
@@ -203,6 +207,8 @@ public class HTTPServerConfig {
         if (maxWorkQueueSize < 0) {
           throw new IllegalArgumentException("maxWorkQueueSize must be >= 0: " + maxWorkQueueSize);
         }
+        String url = getOptionalProperty(props, "serverURL", null);
+        setServerURL(url);
         String langModel = getOptionalProperty(props, "languageModel", null);
         if (langModel != null && loadLangModel) {
           setLanguageModelDirectory(langModel);
@@ -380,6 +386,34 @@ public class HTTPServerConfig {
   public void setAllowOriginUrl(String allowOriginUrl) {
     this.allowOriginUrl = allowOriginUrl;
   }
+
+
+  /**
+   * @since 4.8
+   * @return prefix / base URL for API requests
+   */
+  @Nullable
+  public URI getServerURL() {
+    return serverURL;
+  }
+
+  /**
+   * @since 4.8
+   * @param url prefix / base URL for API requests
+   */
+  public void setServerURL(@Nullable String url) {
+    if (url != null) {
+      try {
+        // ignore different protocols, ports,... just use path for relative requests
+        serverURL = new URI(new URI(url).getPath());
+      } catch (URISyntaxException e) {
+        throw new IllegalArgumentException("Could not parse provided serverURL: '" + url + "'", e);
+      }
+    } else {
+      serverURL = null;
+    }
+  }
+
 
   /**
    * @param len the maximum text length allowed (in number of characters), texts that are longer

--- a/languagetool-server/src/test/java/org/languagetool/server/HTTPServerTest.java
+++ b/languagetool-server/src/test/java/org/languagetool/server/HTTPServerTest.java
@@ -18,33 +18,23 @@
  */
 package org.languagetool.server;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.languagetool.Language;
+import org.languagetool.language.*;
+import org.languagetool.tools.StringTools;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.HashSet;
 
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.apache.commons.lang3.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.languagetool.Language;
-import org.languagetool.language.AmericanEnglish;
-import org.languagetool.language.English;
-import org.languagetool.language.German;
-import org.languagetool.language.GermanyGerman;
-import org.languagetool.language.Polish;
-import org.languagetool.language.Romanian;
-import org.languagetool.tools.StringTools;
-import org.xml.sax.SAXException;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
 
 public class HTTPServerTest {
 
@@ -338,6 +328,20 @@ public class HTTPServerTest {
           fail("Expected exception with error 400, got: " + expected);
         }
       }
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testServerUrlSetting() throws Exception {
+    HTTPServerConfig config = new HTTPServerConfig(HTTPTools.getDefaultPort());
+    String prefix = "/languagetool-api/";
+    config.setServerURL(prefix);
+    HTTPServer server = new HTTPServer(config, false);
+    try {
+      server.run();
+      HTTPTools.checkAtUrl(new URL("http://localhost:" + HTTPTools.getDefaultPort() + prefix + "v2/check?text=Test&language=en"));
     } finally {
       server.stop();
     }


### PR DESCRIPTION
allow processing of requests with different base locations, e.g
`serverURL=/languagetool-api/` or `serverURL=http://localhost/languagetool-api/`
 allows requests like `GET http://localhost:8081/languagetool-api/v2/languages`

only path is considered, all other URI components are ignored