### PR TITLE
Log via slf4j instead of stdout / stderr

### DIFF
--- a/languagetool-server/src/main/java/org/languagetool/server/ServerTools.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/ServerTools.java
@@ -22,11 +22,12 @@ import com.sun.net.httpserver.HttpExchange;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.languagetool.JLanguageTool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -34,6 +35,8 @@ import java.util.TimeZone;
  * @since 3.4
  */
 final class ServerTools {
+  
+  private static final Logger LOG = LoggerFactory.getLogger(ServerTools.class);
 
   private ServerTools() {
   }
@@ -83,8 +86,8 @@ final class ServerTools {
     return dateFormat.format(date.getTime());
   }
 
-  static void print(String s) {
-    print(s, System.out);
+  static void print(final String s) {
+    LOG.info(s);
   }
 
   /* replace with structured logging:
@@ -105,11 +108,13 @@ final class ServerTools {
   various other exceptions
    */
 
-  static void print(String s, PrintStream outputStream) {
-    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss ZZ");
-    dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-    String now = dateFormat.format(new Date());
-    outputStream.println(now + " " + s);
+  static void print(final String s, final PrintStream outputStream) {
+    if (outputStream == System.err) {
+      LOG.error(s);
+    }
+    else {
+      LOG.info(s);
+    }
   }
 
   static void setCommonHeaders(HttpExchange httpExchange, String contentType, String allowOriginUrl) {


### PR DESCRIPTION
In the long run we should replace the calls (from outside ServerTools) with calls to the classes' own loggers (in order to get the correct class name in the output). This is rather a quick fix when you don't want LT to *"pollute"* your stdout/stderr. There might also be other places where `System.out` is used.

Also I had to drop `languagetool-server/src/main/resources/logback.xml` and rebuild in order to provide my own config via `-Dlogback.configurationFile`. But this might be a change with side-effects for some users so I won't propose this for now.