### PR TITLE
Hauptakttaktion statt Hauptattraktionen

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
@@ -6341,3 +6341,6 @@ nestle
 .*schreibwaise
 .*schreibwaisen
 Profikamp
+Zeugenau
+Hauptakttaktion
+Hauptakttaktionen


### PR DESCRIPTION
Hauptakttaktion statt Hauptattraktionen; + Zeugenau
Zeugenau ergibt kein Sinn.
Zeu + genau: vlt die Kombination **genau** verbieten?