### PR TITLE
pull request that addresses the issue #2191

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/CommaWhitespaceRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/CommaWhitespaceRule.java
@@ -1,6 +1,6 @@
 /* LanguageTool, a natural language style checker
  * Copyright (C) 2005 Daniel Naber (http://www.danielnaber.de)
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -28,15 +28,14 @@ import org.languagetool.tools.StringTools;
 
 import static org.languagetool.tools.StringTools.isEmpty;
 
+
 /**
  * A rule that matches periods, commas and closing parenthesis preceded by whitespace and
  * opening parenthesis followed by whitespace.
- * 
+ *
  * @author Daniel Naber
  */
 public class CommaWhitespaceRule extends Rule {
-
-	private boolean quotesWhitespaceCheck;
 
   /** @since 3.3 */
   public CommaWhitespaceRule(ResourceBundle messages, IncorrectExample incorrectExample, CorrectExample correctExample) {
@@ -46,12 +45,7 @@ public class CommaWhitespaceRule extends Rule {
     if (incorrectExample != null && correctExample != null) {
       addExamplePair(incorrectExample, correctExample);
     }
-    this.quotesWhitespaceCheck = true;
-  }
 
-  public CommaWhitespaceRule(ResourceBundle messages, boolean quotesWhitespace) {
-	  this(messages, null, null);
-	  this.quotesWhitespaceCheck = quotesWhitespace;
   }
 
   /**
@@ -59,7 +53,6 @@ public class CommaWhitespaceRule extends Rule {
    */
   public CommaWhitespaceRule(ResourceBundle messages) {
     this(messages, null, null);
-    this.quotesWhitespaceCheck = true;
   }
 
 
@@ -72,7 +65,7 @@ public class CommaWhitespaceRule extends Rule {
   public final String getDescription() {
     return messages.getString("desc_comma_whitespace");
   }
-  
+
   public String getCommaCharacter() {
     return ",";
   }
@@ -95,11 +88,7 @@ public class CommaWhitespaceRule extends Rule {
           msg = messages.getString("no_space_after");
           suggestionText = prevToken;
         }
-      } else if (isWhitespace && isQuote(prevToken) && this.quotesWhitespaceCheck && prevPrevToken.equals(" ")) {
-      	  msg = messages.getString("no_space_around_quotes");
-          suggestionText = "";
       } else if (!isWhitespace && prevToken.equals(getCommaCharacter())
-          && !isQuote(token)
           && !isHyphenOrComma(token)
           && !containsDigit(prevPrevToken)
           && !containsDigit(token)
@@ -150,18 +139,6 @@ public class CommaWhitespaceRule extends Rule {
 	  return (   token.isWhitespace()
 			  || StringTools.isNonBreakingWhitespace(token.getToken())
 			  || token.isFieldCode()) && !token.equals("\u200B");
-  }
-
-  private static boolean isQuote(String str) {
-	    if (str.length() == 1) {
-	      char c = str.charAt(0);
-	      if (c =='\'' || c == '"' || c =='’'
-	          || c == '”' || c == '“'
-	          || c == '«'|| c == '»') {
-	        return true;
-	      }
-	    }
-	    return false;
   }
 
   private static boolean isHyphenOrComma(String str) {

--- a/languagetool-core/src/main/java/org/languagetool/rules/QuotesWhitespaceRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/QuotesWhitespaceRule.java
@@ -1,0 +1,115 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2019 Nataliia Stulova (s0nata.github.io)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ResourceBundle;
+
+import org.languagetool.AnalyzedSentence;
+import org.languagetool.AnalyzedTokenReadings;
+import org.languagetool.tools.StringTools;
+
+/**
+ * A rule that matches quotation marks surrounded by whitespace.
+ *
+ * @author Nataliia Stulova
+ * @since 4.8
+ */
+public class QuotesWhitespaceRule extends Rule {
+
+
+  /** @since 4.8 */
+  public QuotesWhitespaceRule(ResourceBundle messages, IncorrectExample incorrectExample, CorrectExample correctExample) {
+    super(messages);
+    super.setCategory(Categories.TYPOGRAPHY.getCategory(messages));
+    setLocQualityIssueType(ITSIssueType.Whitespace);
+    if (incorrectExample != null && correctExample != null) {
+      addExamplePair(incorrectExample, correctExample);
+    }
+  }
+
+  @Override
+  public String getId() {
+    return "QUOTES_WHITESPACE";
+  }
+
+  @Override
+  public final String getDescription() {
+    return messages.getString("desc_quotes_whitespace");
+  }
+
+  public String getCommaCharacter() {
+    return ",";
+  }
+
+  @Override
+  public final RuleMatch[] match(AnalyzedSentence sentence) {
+
+    List<RuleMatch> ruleMatches = new ArrayList<>();
+    AnalyzedTokenReadings[] tokens = sentence.getTokens();
+
+    String prevToken = "";
+    String prevPrevToken = "";
+    for (int i = 0; i < tokens.length; i++) {
+      String token = tokens[i].getToken();
+      boolean isWhitespace = isWhitespaceToken(tokens[i]);
+      String msg = null;
+      String suggestionText = null;
+
+      if (isWhitespace && isQuote(prevToken) && prevPrevToken.equals(" ")) {
+      	  msg = messages.getString("no_space_around_quotes");
+          suggestionText = "";
+
+      }
+
+      if (msg != null) {
+        int fromPos = tokens[i - 1].getStartPos();
+        int toPos = tokens[i].getEndPos();
+        RuleMatch ruleMatch = new RuleMatch(this, sentence, fromPos, toPos, msg);
+        ruleMatch.setSuggestedReplacement(suggestionText);
+        ruleMatches.add(ruleMatch);
+      }
+
+      prevPrevToken = prevToken;
+      prevToken = token;
+    }
+
+    return toRuleMatchArray(ruleMatches);
+  }
+
+  private static boolean isWhitespaceToken(AnalyzedTokenReadings token) {
+	  return (   token.isWhitespace()
+			  || StringTools.isNonBreakingWhitespace(token.getToken())
+			  || token.isFieldCode()) && !token.equals("\u200B");
+  }
+
+  public static boolean isQuote(String str) {
+	    if (str.length() == 1) {
+	      char c = str.charAt(0);
+	      if (c =='\'' || c == '"' || c =='’'
+	          || c == '”' || c == '“'
+	          || c == '«'|| c == '»') {
+	        return true;
+	      }
+	    }
+	    return false;
+  }
+
+}

--- a/languagetool-core/src/main/resources/org/languagetool/MessagesBundle.properties
+++ b/languagetool-core/src/main/resources/org/languagetool/MessagesBundle.properties
@@ -308,6 +308,8 @@ no_space_before = Don't put a space before the closing parenthesis
 
 no_space_before_dot = Don't put a space before the full stop
 
+no_space_around_quotes = Don't put a space on both sides of a quote symbol
+
 # 3607406 +
 
 no_space_before_colon = Don't put a space before the colon

--- a/languagetool-core/src/main/resources/org/languagetool/MessagesBundle.properties
+++ b/languagetool-core/src/main/resources/org/languagetool/MessagesBundle.properties
@@ -89,6 +89,8 @@ deactivatedRulesText = <br>Deactivated rules - click to activate again:
 
 desc_comma_whitespace = Use of whitespace before comma and before/after parentheses
 
+desc_quotes_whitespace = Use of whitespace before/after quotes
+
 desc_double_punct = Use of two consecutive dots or commas
 
 desc_repetition = Word repetition (e.g. 'will will')

--- a/languagetool-core/src/main/resources/org/languagetool/MessagesBundle_en.properties
+++ b/languagetool-core/src/main/resources/org/languagetool/MessagesBundle_en.properties
@@ -89,6 +89,8 @@ deactivatedRulesText = <br>Deactivated rules - click to activate again:
 
 desc_comma_whitespace = Use of whitespace before comma and before/after parentheses
 
+desc_quotes_whitespace = Use of whitespace before/after quotes
+
 desc_double_punct = Use of two consecutive dots or commas
 
 desc_repetition = Word repetition (e.g. 'will will')

--- a/languagetool-core/src/test/java/org/languagetool/rules/CommaWhitespaceRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/CommaWhitespaceRuleTest.java
@@ -55,6 +55,7 @@ public class CommaWhitespaceRuleTest {
     assertMatches("In his book,\u0002 Einstein proved this to be true.", 0);
     assertMatches("- [ ] A checkbox at GitHub", 0);
     assertMatches("- [x] A checked checkbox at GitHub", 0);
+    assertMatches("A sentence 'with' ten \"correct\" examples of ’using’ quotation “marks” at «once» in it.", 0);
 
     // errors:
     assertMatches("This,is a test sentence.", 1);
@@ -69,6 +70,7 @@ public class CommaWhitespaceRuleTest {
     assertMatches("This (foo bar } is a test!.", 1);
     assertMatches("This is a sentence with an orphaned full stop .", 1);
     assertMatches("This is a test with a OOo footnote\u0002, which is denoted by 0x2 in the text.", 0);
+    assertMatches("A sentence ' with ' ten \" incorrect \" examples of ’ using ’ quotation “ marks ” at « once » in it.", 10);
 
     RuleMatch[] matches = rule.match(langTool.getAnalyzedSentence("ABB (  z.B. )"));
     assertEquals(2, matches.length);

--- a/languagetool-core/src/test/java/org/languagetool/rules/CommaWhitespaceRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/CommaWhitespaceRuleTest.java
@@ -34,7 +34,7 @@ public class CommaWhitespaceRuleTest {
   
   @Before
   public void setUp() {
-    rule = new CommaWhitespaceRule(TestTools.getEnglishMessages());
+    rule = new CommaWhitespaceRule(TestTools.getEnglishMessages(), null, null);
     langTool = new JLanguageTool(TestTools.getDemoLanguage());
   }
 
@@ -55,7 +55,6 @@ public class CommaWhitespaceRuleTest {
     assertMatches("In his book,\u0002 Einstein proved this to be true.", 0);
     assertMatches("- [ ] A checkbox at GitHub", 0);
     assertMatches("- [x] A checked checkbox at GitHub", 0);
-    assertMatches("A sentence 'with' ten \"correct\" examples of ’using’ quotation “marks” at «once» in it.", 0);
 
     // errors:
     assertMatches("This,is a test sentence.", 1);
@@ -70,7 +69,6 @@ public class CommaWhitespaceRuleTest {
     assertMatches("This (foo bar } is a test!.", 1);
     assertMatches("This is a sentence with an orphaned full stop .", 1);
     assertMatches("This is a test with a OOo footnote\u0002, which is denoted by 0x2 in the text.", 0);
-    assertMatches("A sentence ' with ' ten \" incorrect \" examples of ’ using ’ quotation “ marks ” at « once » in it.", 10);
 
     RuleMatch[] matches = rule.match(langTool.getAnalyzedSentence("ABB (  z.B. )"));
     assertEquals(2, matches.length);

--- a/languagetool-core/src/test/java/org/languagetool/rules/QuotesWhitespaceRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/QuotesWhitespaceRuleTest.java
@@ -1,0 +1,55 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2019 Nataliia Stulova (s0nata.github.io)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.languagetool.JLanguageTool;
+import org.languagetool.TestTools;
+
+public class QuotesWhitespaceRuleTest {
+
+  private QuotesWhitespaceRule rule;
+  private JLanguageTool langTool;
+
+  @Before
+  public void setUp() {
+    rule = new QuotesWhitespaceRule(TestTools.getEnglishMessages(), null, null);
+    langTool = new JLanguageTool(TestTools.getDemoLanguage());
+  }
+
+  @Test
+  public void testRule() throws IOException {
+	// correct examples:
+    assertMatches("A sentence 'with' ten \"correct\" examples of ’using’ quotation “marks” at «once» in it.", 0);
+
+    // erroneous examples:
+    assertMatches("A sentence ' with ' ten \" incorrect \" examples of ’ using ’ quotation “ marks ” at « once » in it.", 10);
+
+  }
+
+  private void assertMatches(String text, int expectedMatches) throws IOException {
+    assertEquals(expectedMatches, rule.match(langTool.getAnalyzedSentence(text)).length);
+  }
+
+}

--- a/languagetool-language-modules/ast/src/main/java/org/languagetool/language/Asturian.java
+++ b/languagetool-language-modules/ast/src/main/java/org/languagetool/language/Asturian.java
@@ -64,7 +64,8 @@ public class Asturian extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages),
             new MorfologikAsturianSpellerRule(messages, this, userConfig, altLanguages),

--- a/languagetool-language-modules/be/src/main/java/org/languagetool/language/Belarusian.java
+++ b/languagetool-language-modules/be/src/main/java/org/languagetool/language/Belarusian.java
@@ -83,7 +83,8 @@ public class Belarusian extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new MorfologikBelarusianSpellerRule(messages, this, userConfig, altLanguages),
             new UppercaseSentenceStartRule(messages, this),

--- a/languagetool-language-modules/br/src/main/java/org/languagetool/language/Breton.java
+++ b/languagetool-language-modules/br/src/main/java/org/languagetool/language/Breton.java
@@ -106,7 +106,8 @@ public class Breton extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new MorfologikBretonSpellerRule(messages, this, userConfig, altLanguages),
             new UppercaseSentenceStartRule(messages, this),

--- a/languagetool-language-modules/ca/src/main/java/org/languagetool/language/Catalan.java
+++ b/languagetool-language-modules/ca/src/main/java/org/languagetool/language/Catalan.java
@@ -96,6 +96,7 @@ public class Catalan extends Language {
             new CommaWhitespaceRule(messages, 
             		Example.wrong("A parer seu<marker> ,</marker> no era veritat."),
             		Example.fixed("A parer seu<marker>,</marker> no era veritat.")),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new CatalanUnpairedBracketsRule(messages, this),
             new UppercaseSentenceStartRule(messages, this,

--- a/languagetool-language-modules/ca/src/main/java/org/languagetool/language/ValencianCatalan.java
+++ b/languagetool-language-modules/ca/src/main/java/org/languagetool/language/ValencianCatalan.java
@@ -27,6 +27,7 @@ import java.util.ResourceBundle;
 import org.languagetool.Language;
 import org.languagetool.UserConfig;
 import org.languagetool.rules.CommaWhitespaceRule;
+import org.languagetool.rules.QuotesWhitespaceRule;
 import org.languagetool.rules.DoublePunctuationRule;
 import org.languagetool.rules.Example;
 import org.languagetool.rules.LongSentenceRule;
@@ -76,6 +77,7 @@ public class ValencianCatalan extends Catalan {
             new CommaWhitespaceRule(messages, 
                 Example.wrong("A parer seu<marker> ,</marker> no era veritat."),
                 Example.fixed("A parer seu<marker>,</marker> no era veritat.")),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new CatalanUnpairedBracketsRule(messages, this),
             new UppercaseSentenceStartRule(messages, this,

--- a/languagetool-language-modules/da/src/main/java/org/languagetool/language/Danish.java
+++ b/languagetool-language-modules/da/src/main/java/org/languagetool/language/Danish.java
@@ -90,7 +90,8 @@ public class Danish extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages,
                     Arrays.asList("[", "(", "{", "\"", "”"),

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
@@ -160,6 +160,7 @@ public class German extends Language implements AutoCloseable {
             new CommaWhitespaceRule(messages,
                     Example.wrong("Die Partei<marker> ,</marker> die die letzte Wahl gewann."),
                     Example.fixed("Die Partei<marker>,</marker> die die letzte Wahl gewann.")),
+            new QuotesWhitespaceRule(messages, null, null),
             new GenericUnpairedBracketsRule(messages,
                     Arrays.asList("[", "(", "{", "„", "»", "«", "\""),
                     Arrays.asList("]", ")", "}", "“", "«", "»", "\"")),

--- a/languagetool-language-modules/el/src/main/java/org/languagetool/language/Greek.java
+++ b/languagetool-language-modules/el/src/main/java/org/languagetool/language/Greek.java
@@ -79,6 +79,7 @@ public class Greek extends Language {
             new CommaWhitespaceRule(messages, 
                     Example.wrong("Το κόμμα χωρίζει προτάσεις<marker> ,</marker> όρους προτάσεων και φράσεις."),
                     Example.fixed("Το κόμμα χωρίζει προτάσεις<marker>,</marker> όρους προτάσεων και φράσεις.")),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule("EL_UNPAIRED_BRACKETS", messages,
                     Arrays.asList("[", "(", "{", "“", "\"", "«"),

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/English.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/English.java
@@ -196,6 +196,7 @@ public class English extends Language implements AutoCloseable {
         new CommaWhitespaceRule(messages,
                 Example.wrong("We had coffee<marker> ,</marker> cheese and crackers and grapes."),
                 Example.fixed("We had coffee<marker>,</marker> cheese and crackers and grapes.")),
+        new QuotesWhitespaceRule(messages, null, null),
         new DoublePunctuationRule(messages),
         new UppercaseSentenceStartRule(messages, this,
                 Example.wrong("This house is old. <marker>it</marker> was built in 1950."),

--- a/languagetool-language-modules/eo/src/main/java/org/languagetool/language/Esperanto.java
+++ b/languagetool-language-modules/eo/src/main/java/org/languagetool/language/Esperanto.java
@@ -94,7 +94,8 @@ public class Esperanto extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages),
             new HunspellRule(messages, this, userConfig, altLanguages),

--- a/languagetool-language-modules/es/src/main/java/org/languagetool/language/Spanish.java
+++ b/languagetool-language-modules/es/src/main/java/org/languagetool/language/Spanish.java
@@ -119,7 +119,8 @@ public class Spanish extends Language implements AutoCloseable{
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages,
                     Arrays.asList("[", "(", "{", "“", "«", "»"),

--- a/languagetool-language-modules/fa/src/main/java/org/languagetool/language/Persian.java
+++ b/languagetool-language-modules/fa/src/main/java/org/languagetool/language/Persian.java
@@ -84,7 +84,8 @@ public class Persian extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-        new CommaWhitespaceRule(messages),
+        new CommaWhitespaceRule(messages, null, null), // TODO: PersianCommaWhitespaceRule.java?
+        new QuotesWhitespaceRule(messages, null, null),
         new DoublePunctuationRule(messages),
         new MultipleWhitespaceRule(messages, this),
         new LongSentenceRule(messages, userConfig),

--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
@@ -107,7 +107,7 @@ public class French extends Language implements AutoCloseable {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, false),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages,
                     Arrays.asList("[", "(", "{" /*"«", "‘"*/),

--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
@@ -107,7 +107,7 @@ public class French extends Language implements AutoCloseable {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages, false),
+            new CommaWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages,
                     Arrays.asList("[", "(", "{" /*"«", "‘"*/),

--- a/languagetool-language-modules/gl/src/main/java/org/languagetool/language/Galician.java
+++ b/languagetool-language-modules/gl/src/main/java/org/languagetool/language/Galician.java
@@ -122,6 +122,7 @@ public class Galician extends Language {
             new CommaWhitespaceRule(messages,
                 Example.wrong("Tomamos café<marker> ,</marker> queixo, bolachas e uvas."),
                 Example.fixed("Tomamos café<marker>,</marker> queixo, bolachas e uvas.")),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages,
                     Arrays.asList("[", "(", "{", "“", "«", "»", "‘", "\"", "'"),

--- a/languagetool-language-modules/is/src/main/java/org/languagetool/language/Icelandic.java
+++ b/languagetool-language-modules/is/src/main/java/org/languagetool/language/Icelandic.java
@@ -81,7 +81,8 @@ public class Icelandic extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages),
             new HunspellNoSuggestionRule(messages, this, userConfig, altLanguages),

--- a/languagetool-language-modules/it/src/main/java/org/languagetool/language/Italian.java
+++ b/languagetool-language-modules/it/src/main/java/org/languagetool/language/Italian.java
@@ -89,7 +89,8 @@ public class Italian extends Language implements AutoCloseable {
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
             new WhitespaceBeforePunctuationRule(messages),
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages,
                     Arrays.asList("[", "(", "{", "»", "«" /*"‘"*/),

--- a/languagetool-language-modules/lt/src/main/java/org/languagetool/language/Lithuanian.java
+++ b/languagetool-language-modules/lt/src/main/java/org/languagetool/language/Lithuanian.java
@@ -80,7 +80,8 @@ public class Lithuanian extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages),
             new MorfologikLithuanianSpellerRule(messages, this, userConfig, altLanguages),

--- a/languagetool-language-modules/ml/src/main/java/org/languagetool/language/Malayalam.java
+++ b/languagetool-language-modules/ml/src/main/java/org/languagetool/language/Malayalam.java
@@ -91,7 +91,8 @@ public class Malayalam extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages),
             new MorfologikMalayalamSpellerRule(messages, this, userConfig, altLanguages),

--- a/languagetool-language-modules/nl/src/main/java/org/languagetool/language/Dutch.java
+++ b/languagetool-language-modules/nl/src/main/java/org/languagetool/language/Dutch.java
@@ -122,7 +122,8 @@ public class Dutch extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages,
                     Arrays.asList("[", "(", "{", "“", "‹", "“", "„", "\""),

--- a/languagetool-language-modules/pl/src/main/java/org/languagetool/language/Polish.java
+++ b/languagetool-language-modules/pl/src/main/java/org/languagetool/language/Polish.java
@@ -112,7 +112,8 @@ public class Polish extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-        new CommaWhitespaceRule(messages),
+        new CommaWhitespaceRule(messages, null, null),
+        new QuotesWhitespaceRule(messages, null, null),
         new UppercaseSentenceStartRule(messages, this),
         new WordRepeatRule(messages, this),
         new MultipleWhitespaceRule(messages, this),

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
@@ -139,6 +139,7 @@ public class Portuguese extends Language implements AutoCloseable {
             new CommaWhitespaceRule(messages,
                 Example.wrong("Tomamos café<marker> ,</marker> queijo, bolachas e uvas."),
                 Example.fixed("Tomamos café<marker>,</marker> queijo, bolachas e uvas.")),
+            new QuotesWhitespaceRule(messages, null, null),
             new GenericUnpairedBracketsRule(messages,
                     Arrays.asList("[", "(", "{", "\"", "“" /*, "«", "'", "‘" */),
                     Arrays.asList("]", ")", "}", "\"", "”" /*, "»", "'", "’" */)),

--- a/languagetool-language-modules/ro/src/main/java/org/languagetool/language/Romanian.java
+++ b/languagetool-language-modules/ro/src/main/java/org/languagetool/language/Romanian.java
@@ -87,7 +87,8 @@ public class Romanian extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new UppercaseSentenceStartRule(messages, this),
             new MultipleWhitespaceRule(messages, this),

--- a/languagetool-language-modules/ru/src/main/java/org/languagetool/language/Russian.java
+++ b/languagetool-language-modules/ru/src/main/java/org/languagetool/language/Russian.java
@@ -114,6 +114,7 @@ public class Russian extends Language implements AutoCloseable {
             new CommaWhitespaceRule(messages,
                     Example.wrong("Не род<marker> ,</marker> а ум поставлю в воеводы."),
                     Example.fixed("Не род<marker>,</marker> а ум поставлю в воеводы.")),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new UppercaseSentenceStartRule(messages, this,
                     Example.wrong("Закончилось лето. <marker>дети</marker> снова сели за школьные парты."),

--- a/languagetool-language-modules/sk/src/main/java/org/languagetool/language/Slovak.java
+++ b/languagetool-language-modules/sk/src/main/java/org/languagetool/language/Slovak.java
@@ -96,7 +96,8 @@ public class Slovak extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages,
                     Arrays.asList("[", "(", "{", "„", "»", "«", "\""),

--- a/languagetool-language-modules/sl/src/main/java/org/languagetool/language/Slovenian.java
+++ b/languagetool-language-modules/sl/src/main/java/org/languagetool/language/Slovenian.java
@@ -69,7 +69,8 @@ public class Slovenian extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages,
                     Arrays.asList("[", "(", "{", "„", "»", "«", "\""),

--- a/languagetool-language-modules/sr/src/main/java/org/languagetool/language/Serbian.java
+++ b/languagetool-language-modules/sr/src/main/java/org/languagetool/language/Serbian.java
@@ -144,6 +144,7 @@ public class Serbian extends Language {
       new CommaWhitespaceRule(messages,
         Example.wrong("Није шија<marker> ,</marker> него врат."),
         Example.fixed("Није шија<marker>,</marker> него врат.")),
+      new QuotesWhitespaceRule(messages, null, null),
       new DoublePunctuationRule(messages),
       new GenericUnpairedBracketsRule(messages,
         Arrays.asList("[", "(", "{", "„", "„", "\""),

--- a/languagetool-language-modules/sv/src/main/java/org/languagetool/language/Swedish.java
+++ b/languagetool-language-modules/sv/src/main/java/org/languagetool/language/Swedish.java
@@ -81,7 +81,8 @@ public class Swedish extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages),
             new HunspellRule(messages, this, userConfig, altLanguages),

--- a/languagetool-language-modules/ta/src/main/java/org/languagetool/language/Tamil.java
+++ b/languagetool-language-modules/ta/src/main/java/org/languagetool/language/Tamil.java
@@ -74,7 +74,8 @@ public class Tamil extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) {
     return Arrays.asList(
-        new CommaWhitespaceRule(messages),
+        new CommaWhitespaceRule(messages, null, null),
+        new QuotesWhitespaceRule(messages, null, null),
         new DoublePunctuationRule(messages),
         new MultipleWhitespaceRule(messages, this),
         new LongSentenceRule(messages, userConfig),

--- a/languagetool-language-modules/tl/src/main/java/org/languagetool/language/Tagalog.java
+++ b/languagetool-language-modules/tl/src/main/java/org/languagetool/language/Tagalog.java
@@ -96,7 +96,8 @@ public class Tagalog extends Language {
   @Override
   public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Arrays.asList(
-            new CommaWhitespaceRule(messages),
+            new CommaWhitespaceRule(messages, null, null),
+            new QuotesWhitespaceRule(messages, null, null),
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages),
             new UppercaseSentenceStartRule(messages, this),

--- a/languagetool-language-modules/uk/src/main/java/org/languagetool/language/Ukrainian.java
+++ b/languagetool-language-modules/uk/src/main/java/org/languagetool/language/Ukrainian.java
@@ -31,6 +31,7 @@ import org.languagetool.LanguageMaintainedState;
 import org.languagetool.UserConfig;
 import org.languagetool.databroker.ResourceDataBroker;
 import org.languagetool.rules.CommaWhitespaceRule;
+import org.languagetool.rules.QuotesWhitespaceRule;
 import org.languagetool.rules.Example;
 import org.languagetool.rules.MultipleWhitespaceRule;
 import org.languagetool.rules.Rule;
@@ -168,7 +169,7 @@ public class Ukrainian extends Language {
         new CommaWhitespaceRule(messages,
             Example.wrong("Ми обідали борщем<marker> ,</marker> пловом і салатом."),
             Example.fixed("Ми обідали борщем<marker>,</marker> пловом і салатом")),
-
+        new QuotesWhitespaceRule(messages, null, null),
         // TODO: does not handle dot in abbreviations in the middle of the sentence, and also !.., ?..
         new UppercaseSentenceStartRule(messages, this,
             Example.wrong("<marker>речення</marker> має починатися з великої."),


### PR DESCRIPTION
Separated the code that treats extra whitespace around quotes and around commas.

All tests run without regression.

@danielnaber @ebraminio I have noticed that there is special `PersianCommaWhitespaceRule` rule class, that is used along with the general `CommaWhitespaceRule` rule class for Farsi, but I still have not understood if it adds any special treatment.