### PR TITLE
PR for Issue #2341

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -1274,12 +1274,13 @@ public class JLanguageTool {
             newMatch.setOffsetPosition(newFromPos, newToPos, newMatch);
             newMatch.setLine(range.from.line);
             newMatch.setEndLine(range.to.line);
-            if (match.getLine() == 0) {
+            if (newMatch.getLine() == 0) {
               newMatch.setColumn(range.from.column + 1);
+              newMatch.setEndColumn(range.to.column + 1);
             } else {
               newMatch.setColumn(range.from.column);
+              newMatch.setEndColumn(range.to.column);
             }
-            newMatch.setEndColumn(range.to.column);
             adaptedMatches.add(newMatch);
           }
           ruleMatches.addAll(adaptedMatches);

--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -1276,9 +1276,12 @@ public class JLanguageTool {
             newMatch.setEndLine(range.to.line);
             if (newMatch.getLine() == 0) {
               newMatch.setColumn(range.from.column + 1);
-              newMatch.setEndColumn(range.to.column + 1);
             } else {
               newMatch.setColumn(range.from.column);
+            }
+            if (newMatch.getEndLine() == 0) {
+              newMatch.setEndColumn(range.to.column + 1);
+            } else {
               newMatch.setEndColumn(range.to.column);
             }
             adaptedMatches.add(newMatch);

--- a/languagetool-core/src/test/java/org/languagetool/rules/GenericUnpairedBracketsRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/GenericUnpairedBracketsRuleTest.java
@@ -85,8 +85,8 @@ public class GenericUnpairedBracketsRuleTest {
     assertThat(match1.getToPos(), is(6));
     assertThat(match1.getLine(), is(0));
     assertThat(match1.getEndLine(), is(0));
-    assertThat(match1.getColumn(), is(5));
-    assertThat(match1.getEndColumn(), is(6));
+    assertThat(match1.getColumn(), is(6));
+    assertThat(match1.getEndColumn(), is(7));
 
     RuleMatch match2 = lt.check("This.\nSome stuff.\nIt »is a test.").get(0);
     assertThat(match2.getFromPos(), is(21));


### PR DESCRIPTION
Related to issue #2341:
- fix for `JLanguageTool.java`:
  match column number now is 1-based for first input text line, too
- fix for `GenericUnpairedBracketsRuleTest.java`:
  `mvn clean test` does run successfully

Matthias

EDIT: revised fix for `JLanguageTool.java`