### PR TITLE
Possible fix for ConcurrentModificationException

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/SpellingCheckRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/SpellingCheckRule.java
@@ -346,7 +346,7 @@ public abstract class SpellingCheckRule extends Rule {
     }
   }
 
-  protected void init() throws IOException {
+  protected synchronized void init() throws IOException {
     for (String ignoreWord : wordListLoader.loadWords(getIgnoreFileName())) {
       addIgnoreWords(ignoreWord);
     }

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
@@ -359,7 +359,7 @@ public class HunspellRule extends SpellingCheckRule {
   }
 
   @Override
-  protected void init() throws IOException {
+  protected synchronized void init() throws IOException {
     super.init();
     String langCountry = language.getShortCode();
     if (language.getCountries().length > 0) {


### PR DESCRIPTION
ConcurrentModificationException in
SpellingCheckRule.updateIgnoredWordDictionary
probably caused by multiple calls to init()