### PR TITLE
Added Language.getRemoteEnhancedRules

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/Language.java
+++ b/languagetool-core/src/main/java/org/languagetool/Language.java
@@ -43,6 +43,7 @@ import org.languagetool.tokenizers.WordTokenizer;
 
 import java.io.*;
 import java.util.*;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 /**
@@ -195,12 +196,25 @@ public abstract class Language {
 
 
   /**
+   * For rules that depend on a remote server; based on {@link org.languagetool.rules.RemoteRule}
+   * will be executed asynchronously, with timeout, retries, etc.  as configured
    * Can return non-remote rules (e.g. if configuration missing, or for A/B tests), will be executed normally
    */
   public List<Rule> getRelevantRemoteRules(ResourceBundle messageBundle, List<RemoteRuleConfig> configs,
                                            UserConfig userConfig, Language motherTongue, List<Language> altLanguages)
     throws IOException {
     return Collections.emptyList();
+  }
+
+  /**
+   * For rules whose results are extended using some remote service, e.g. {@link org.languagetool.rules.BERTSuggestionRanking}
+   * @return function that transforms old rule into remote-enhanced rule
+   */
+  @Experimental
+  public Function<Rule, Rule> getRemoteEnhancedRules(
+    ResourceBundle messageBundle, List<RemoteRuleConfig> configs, UserConfig userConfig,
+    Language motherTongue, List<Language> altLanguages) throws IOException {
+    return Function.identity();
   }
 
   /**

--- a/languagetool-core/src/main/java/org/languagetool/rules/BERTSuggestionRanking.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/BERTSuggestionRanking.java
@@ -113,6 +113,7 @@ public class BERTSuggestionRanking extends RemoteRule {
       }
       return new MatchesForReordering(matches, requests);
     } catch (IOException e) {
+      logger.error("Error while executing rule " + wrappedRule.getId(), e);
       return new MatchesForReordering(Collections.emptyList(), Collections.emptyList());
     }
   }

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/AmericanEnglish.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/AmericanEnglish.java
@@ -23,8 +23,6 @@ import org.jetbrains.annotations.Nullable;
 import org.languagetool.Language;
 import org.languagetool.UserConfig;
 import org.languagetool.languagemodel.LanguageModel;
-import org.languagetool.rules.BERTSuggestionRanking;
-import org.languagetool.rules.RemoteRuleConfig;
 import org.languagetool.rules.Rule;
 import org.languagetool.rules.en.MorfologikAmericanSpellerRule;
 import org.languagetool.rules.en.UnitConversionRuleUS;
@@ -61,27 +59,7 @@ public class AmericanEnglish extends English {
     if (SuggestionsChanges.isRunningExperiment("SymSpell") || SuggestionsChanges.isRunningExperiment("SymSpell+NewSuggestionsOrderer")) {
       rules.add(new SymSpellRule(messages, this, userConfig, altLanguages, languageModel));
     } else {
-      // A/B test of BERTSuggestionRanking for speller rule, added as remote rule; tests/command line etc. still need this one
-      if (!UserConfig.hasABTestsEnabled()) {
-        rules.add(new MorfologikAmericanSpellerRule(messages, this, userConfig, altLanguages, languageModel));
-      }
-    }
-    return rules;
-  }
-
-  @Override
-  public List<Rule> getRelevantRemoteRules(ResourceBundle messageBundle, List<RemoteRuleConfig> configs,
-                                           UserConfig userConfig, Language motherTongue, List<Language> altLanguages)
-    throws IOException {
-    List<Rule> rules = new ArrayList<>(super.getRelevantRemoteRules(messageBundle, configs, userConfig, motherTongue, altLanguages));
-    RemoteRuleConfig bert = RemoteRuleConfig.getRelevantConfig(BERTSuggestionRanking.RULE_ID, configs);
-    if (UserConfig.hasABTestsEnabled()) {
-      Rule speller = new MorfologikAmericanSpellerRule(messageBundle, this, userConfig, altLanguages);
-      if (bert != null) {
-        rules.add(new BERTSuggestionRanking(speller, bert, userConfig));
-      } else { // not added above, add plain rule here
-        rules.add(speller);
-      }
+      rules.add(new MorfologikAmericanSpellerRule(messages, this, userConfig, altLanguages, languageModel));
     }
     return rules;
   }


### PR DESCRIPTION
Introduced for BERTSuggestionRanking
Allows existing rules to be replaced by a RemoteRule that wraps them
Fixes issues with altLanguages
BERTSuggestionRanking now activated for MORFOLOGIK_RULE_EN_* (i.e. all
variants of English)