### PR TITLE
[ar] Fix rules after #9a4f1e3 

### DIFF
--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
@@ -348,7 +348,7 @@ public class PatternRuleTest extends AbstractPatternRuleTest {
       // necessary for XML Pattern rules containing <or>
       List<RuleMatch> matches = new ArrayList<>();
       for (Rule auxRule : rules) {
-        if (lang.getShortCode().matches("gl|eo|ar|br|ca|zh")) {
+        if (lang.getShortCode().matches("gl|eo|br|ca|zh")) {
           // this is less strict, getMatchesForText() should be used. Language maintainers
           // should make sure their tests work even when in the strict mode:
           matches.addAll(getMatchesForSingleSentence(auxRule, badSentence, lt));

--- a/languagetool-language-modules/ar/src/main/resources/org/languagetool/rules/ar/grammar.xml
+++ b/languagetool-language-modules/ar/src/main/resources/org/languagetool/rules/ar/grammar.xml
@@ -501,8 +501,8 @@ USA
       <message>يفضل أن يقال:
         <suggestion>حدّ بعيد</suggestion>
       </message>
-      <example correction='حدّ بعيد' type='incorrect'> يختلف البحث إلى <marker>حد كبير</marker> عن... </example>
-      <example type='correct'> يختلف البحث إلى حدّ بعيد عن... </example>
+      <example correction='حدّ بعيد' type='incorrect'> يختلف البحث إلى <marker>حد كبير</marker> عن...</example>
+      <example type='correct'> يختلف البحث إلى حدّ بعيد عن...</example>
     </rule>
 
     <rule id ='unsorted2044' name='rule_إلى عند_2044'>
@@ -526,8 +526,8 @@ USA
       <message>يفضل أن يقال:
         <suggestion>أما</suggestion>
       </message>
-      <example correction='أما' type='incorrect'> <marker>أما بالنسبة إلى</marker> بناء الكلية فيجب... </example>
-      <example type='correct'> أما بناء الكلية فيجب... </example>
+      <example correction='أما' type='incorrect'> <marker>أما بالنسبة إلى</marker> بناء الكلية فيجب...</example>
+      <example type='correct'> أما بناء الكلية فيجب...</example>
     </rule>
 
     <rule id ='unsorted2046' name='rule_انعكاس ل_2046'>
@@ -539,8 +539,8 @@ USA
         <suggestion>نتيجة <match no="2"/></suggestion>
         <suggestion>تعبير عن <match no="2" regexp_match="^ل" regexp_replace=""/></suggestion>
       </message>
-      <example correction='نتيجة لشعور|تعبير عن شعور' type='incorrect'> هل هو <marker>انعكاس لشعور</marker> عام.. </example>
-      <example type='correct'> هل هو نتيجة لشعور عام../هل هو تعبير عن شعور عام.. </example>
+      <example correction='نتيجة لشعور|تعبير عن شعور' type='incorrect'> هل هو <marker>انعكاس لشعور</marker> عام..</example>
+      <example type='correct'> هل هو نتيجة لشعور عام../هل هو تعبير عن شعور عام..</example>
     </rule>
 
     <rule id ='unsorted2047' name='rule_بالإضافة إلى ذلك_2047'>
@@ -554,8 +554,8 @@ USA
         <suggestion>زيادة على ذلك</suggestion>
         <suggestion>فضلاً على ذلك</suggestion>
       </message>
-      <example correction='إضافة إلى ذلك|زيادة على ذلك|فضلاً على ذلك' type='incorrect'> <marker>بالإضافة إلى ذلك</marker>، يمكن أن نفعل... </example>
-      <example type='correct'> إضافة إلى ذلك، يمكن أن نفعل... </example>
+      <example correction='إضافة إلى ذلك|زيادة على ذلك|فضلاً على ذلك' type='incorrect'> <marker>بالإضافة إلى ذلك</marker>، يمكن أن نفعل...</example>
+      <example type='correct'> إضافة إلى ذلك، يمكن أن نفعل...</example>
     </rule>
 
     <rule id ='unsorted2048' name='rule_بالرفاه والبنين_2048'>
@@ -582,9 +582,9 @@ USA
         <suggestion>أما ما يخصّ</suggestion>
       </message>
 
-      <example correction='ما يتعلق|أما ما يخصّ' type='incorrect'><marker>أما بالنسبة إلى</marker> المقررات العملية... </example>
+      <example correction='ما يتعلق|أما ما يخصّ' type='incorrect'><marker>أما بالنسبة إلى</marker> المقررات العملية...</example>
 
-      <example type='correct'> ...هذا ما يتعلق بالمقررات النظرية، أما ما يخصّ المقررات العملية... </example>
+      <example type='correct'> ...هذا ما يتعلق بالمقررات النظرية، أما ما يخصّ المقررات العملية...</example>
     </rule>
     <rule id ='unsorted2049b' name='rule_بالنسبة إلى 2049b'>
       <pattern>
@@ -595,9 +595,9 @@ USA
         <suggestion>ما يتعلق</suggestion>
         <suggestion>أما ما يخصّ</suggestion>
       </message>
-      <example correction='ما يتعلق|أما ما يخصّ' type='incorrect'> ...هذا <marker>بالنسبة إلى</marker> المقررات النظرية، ... </example>
+      <example correction='ما يتعلق|أما ما يخصّ' type='incorrect'> ...هذا <marker>بالنسبة إلى</marker> المقررات النظرية، ...</example>
 
-      <example type='correct'> ...هذا ما يتعلق بالمقررات النظرية، أما ما يخصّ المقررات العملية... </example>
+      <example type='correct'> ...هذا ما يتعلق بالمقررات النظرية، أما ما يخصّ المقررات العملية...</example>
     </rule>
 
     <rule id ='unsorted2050' name='rule_بالنسبة لنا|بالنسبة له|بالنسبة لي|بالنسبة لها_2050'>
@@ -674,8 +674,8 @@ USA
       <message>بما أنّ ... تركيب دخيل على العربية
         <suggestion>لما كان</suggestion>
       </message>
-      <example correction='لما كان' type='incorrect'> <marker>بما أن</marker>... فإن ... </example>
-      <example type='correct'> لمّا كان ... فإنّ ... </example>
+      <example correction='لما كان' type='incorrect'> <marker>بما أن</marker>... فإن ...</example>
+      <example type='correct'> لمّا كان ... فإنّ ...</example>
     </rule>
 
     <rule id ='unsorted2056' name='rule_بما فيها_2056'>
@@ -701,7 +701,7 @@ USA
       <message>يفضل أن يقال:
         <suggestion>حين كان</suggestion>
       </message>
-      <example correction='حين كان' type='incorrect'> رأيته... <marker>بينما كان</marker> يهم بالخروج </example>
+      <example correction='حين كان' type='incorrect'> رأيته...<marker>بينما كان</marker> يهم بالخروج </example>
       <example type='correct'> رأيتُه... حين كان يهمّ بالخروج </example>
     </rule>
 
@@ -739,8 +739,8 @@ USA
       <message>يفضل أن يقال:
         <suggestion>تُعدُّ هذه</suggestion>
       </message>
-      <example correction='تُعدُّ هذه' type='incorrect'> <marker>تشكل هذه</marker> الطريقة إنجازا ... </example>
-      <example type='correct'> تُعدُّ هذه الطريقة إنجازاً ... </example>
+      <example correction='تُعدُّ هذه' type='incorrect'> <marker>تشكل هذه</marker> الطريقة إنجازا ...</example>
+      <example type='correct'> تُعدُّ هذه الطريقة إنجازاً ...</example>
     </rule>
 
     <rule id ='unsorted2062' name='rule_حتى أنه لم_2062'>
@@ -765,8 +765,8 @@ USA
       <message>يفضل أن يقال:
         <suggestion>حتى لو كان</suggestion>
       </message>
-      <example correction='حتى لو كان' type='incorrect'> <marker>حتى ولو كان</marker>... </example>
-      <example type='correct'> حتى لو كان... </example>
+      <example correction='حتى لو كان' type='incorrect'> <marker>حتى ولو كان</marker>...</example>
+      <example type='correct'> حتى لو كان...</example>
     </rule>
 
     <rule id ='unsorted2064' name='rule_ذكي للغاية_2064'>
@@ -829,8 +829,8 @@ USA
       <message>يفضل أن يقال:
         <suggestion>سبق أن ذكرنا</suggestion>
       </message>
-      <example correction='سبق أن ذكرنا' type='incorrect'> <marker>سبق وذكرنا</marker>... </example>
-      <example type='correct'> سبق أن ذكرنا... </example>
+      <example correction='سبق أن ذكرنا' type='incorrect'> <marker>سبق وذكرنا</marker>...</example>
+      <example type='correct'> سبق أن ذكرنا...</example>
     </rule>
 
     <rule id ='unsorted2069' name='rule_سوف لن |سوف لا_2069'>
@@ -969,8 +969,8 @@ USA
         <suggestion>غيري</suggestion>
         <suggestion>غيرنا</suggestion>
       </message>
-      <example correction='غيري|غيرنا' type='incorrect'> لم يحضر <marker>غير نحن</marker> ... </example>
-      <example type='correct'> لم يحضرْ غيري / غيرنا ... </example>
+      <example correction='غيري|غيرنا' type='incorrect'> لم يحضر <marker>غير نحن</marker> ...</example>
+      <example type='correct'> لم يحضرْ غيري / غيرنا ...</example>
     </rule>
 
     <rule id ='unsorted2080' name='rule_غير بالله_2080'>
@@ -1049,8 +1049,8 @@ USA
       <message>كما = (ك) التشبيه+ (ما) المصدرية. ولا تستعمل (كما) للعطف والاستئناف
         <suggestion>ثم أن</suggestion>
       </message>
-      <example correction='ثم أن' type='incorrect'> كان للجهاز أثر كبير ...، <marker>كما أن</marker> استخدامه سيزداد ... </example>
-      <example type='correct'> كان للجهاز أثر كبير ...، ثم إن استخدامه سيزداد ... </example>
+      <example correction='ثم أن' type='incorrect'> كان للجهاز أثر كبير ...، <marker>كما أن</marker> استخدامه سيزداد ...</example>
+      <example type='correct'> كان للجهاز أثر كبير ...، ثم إن استخدامه سيزداد ...</example>
     </rule>
 
     <rule id ='unsorted2087' name='rule_كما أن_2087'>
@@ -1062,8 +1062,8 @@ USA
         <suggestion>وهو إلى ذلك</suggestion>
         <suggestion>وهي إلى ذلك</suggestion>
       </message>
-      <example correction='وهو إلى ذلك|وهي إلى ذلك' type='incorrect'> الخدمة مجانية..، <marker>كما أنها</marker> تعطي .. </example>
-      <example type='correct'> الخدمة مجانية..، وهي إلى ذلك تعطي.. </example>
+      <example correction='وهو إلى ذلك|وهي إلى ذلك' type='incorrect'> الخدمة مجانية..، <marker>كما أنها</marker> تعطي .</example>
+      <example type='correct'> الخدمة مجانية..، وهي إلى ذلك تعطي..</example>
     </rule>
 
     <rule id ='unsorted2088' name='rule_كما يمكن أن_2088'>
@@ -1075,8 +1075,8 @@ USA
       <message>يفضل أن يقال:
         <suggestion>ويمكن أن</suggestion>
       </message>
-      <example correction='ويمكن أن' type='incorrect'> يعمل الحاسوب في ...، <marker>كما يمكن أن</marker> تحتاج تجهيزاته إلى... </example>
-      <example type='correct'> يعمل الحاسوب في ...، ويمكن أن تحتاج تجهيزاته إلى... </example>
+      <example correction='ويمكن أن' type='incorrect'> يعمل الحاسوب في ...، <marker>كما يمكن أن</marker> تحتاج تجهيزاته إلى...</example>
+      <example type='correct'> يعمل الحاسوب في ...، ويمكن أن تحتاج تجهيزاته إلى...</example>
     </rule>
 
     <rule id ='unsorted2089' name='rule_لا بد وأن_2089'>
@@ -1176,8 +1176,8 @@ USA
       <message>يفضل أن يقال:
         <suggestion>وهذا دعا إلى</suggestion>
       </message>
-      <example correction='وهذا دعا إلى' type='incorrect'> كلفني وألح علي، مما <marker>دعاني إلى </marker>... </example>
-      <example type='correct'> كلّفني وألحّ عليّ، وهذا ما دعاني إلى.. </example>
+      <example correction='وهذا دعا إلى' type='incorrect'> كلفني وألح علي، مما <marker>دعاني إلى </marker>...</example>
+      <example type='correct'> كلّفني وألحّ عليّ، وهذا ما دعاني إلى..</example>
     </rule>
     -->
     <rule id ='unsorted2097' name='rule_ناهيك عن_2097'>
@@ -1321,8 +1321,8 @@ USA
         <suggestion>وأدهى من ذلك</suggestion>
       </message>
       <example correction='والأدهى|وأدهى من ذلك' type='incorrect'>
-        <marker>والأدهى من ذلك</marker> أن ... </example>
-      <example type='correct'> والأدهى أن .. / وأدهى من ذلك أن .. </example>
+        <marker>والأدهى من ذلك</marker> أن ...</example>
+      <example type='correct'> والأدهى أن .. / وأدهى من ذلك أن .</example>
     </rule>
 
     <rule id ='unsorted2110' name='rule_والأعجب من ذلك_2110'>
@@ -1335,8 +1335,8 @@ USA
         <suggestion>والأعجب</suggestion>
         <suggestion>وأعجب من ذلك</suggestion>
       </message>
-      <example correction='والأعجب|وأعجب من ذلك' type='incorrect'> <marker>والأعجب من ذلك</marker> قوله... </example>
-      <example type='correct'> والأعجب قولُه.../وأعجب من ذلك قولُه... </example>
+      <example correction='والأعجب|وأعجب من ذلك' type='incorrect'> <marker>والأعجب من ذلك</marker> قوله...</example>
+      <example type='correct'> والأعجب قولُه.../وأعجب من ذلك قولُه...</example>
     </rule>
 
     <rule id ='unsorted2111' name='rule_وبالتالي فإن_2111'>
@@ -1347,8 +1347,8 @@ USA
       <message>يفضل أن يقال:
         <suggestion>لذا فإن</suggestion>
       </message>
-      <example correction='لذا فإن' type='incorrect'> <marker>وبالتالي فإن</marker> حساسية القياس ... </example>
-      <example type='correct'> لذا فإن حساسية القياس ... </example>
+      <example correction='لذا فإن' type='incorrect'> <marker>وبالتالي فإن</marker> حساسية القياس ...</example>
+      <example type='correct'> لذا فإن حساسية القياس ...</example>
     </rule>
 
 
@@ -1688,8 +1688,8 @@ USA
         <suggestion>ذات صلة</suggestion>
         <suggestion>تتعلق ب</suggestion>
       </message>
-      <example correction='ذات صلة|تتعلق ب' type='incorrect'> إرشادات <marker>حول</marker> كذا ... </example>
-      <example type='correct'> إرشادات ذات صلة / تتعلق بكذا... </example>
+      <example correction='ذات صلة|تتعلق ب' type='incorrect'> إرشادات <marker>حول</marker> كذا ...</example>
+      <example type='correct'> إرشادات ذات صلة / تتعلق بكذا...</example>
     </rule>
 
     <rule id ='unsorted3119' name='rule_ل_3119'>
@@ -1739,8 +1739,8 @@ USA
         <suggestion/>
         <suggestion>ل</suggestion>
       </message>
-      <example correction='|ل' type='incorrect'> توضيح <marker>حول</marker> فتوى ... </example>
-      <example type='correct'> توضيحُ فتوى ... / توضيحٌ لفتوى ... </example>
+      <example correction='|ل' type='incorrect'> توضيح <marker>حول</marker> فتوى ...</example>
+      <example type='correct'> توضيحُ فتوى ... / توضيحٌ لفتوى ...</example>
     </rule>
 
     <rule id ='unsorted3123' name='rule_حول_3123'>
@@ -1841,8 +1841,8 @@ USA
       <message>يفضل أن يقال:
         <suggestion>على</suggestion>
       </message>
-      <example correction='على' type='incorrect'> ملاحظات <marker>حول</marker> الأسباب ... </example>
-      <example type='correct'> ملاحظات على الأسباب ... </example>
+      <example correction='على' type='incorrect'> ملاحظات <marker>حول</marker> الأسباب ...</example>
+      <example type='correct'> ملاحظات على الأسباب ...</example>
     </rule>
 
     <rule id ='unsorted3132' name='rule_حول_3132'>
@@ -1853,8 +1853,8 @@ USA
       <message>يفضل أن يقال:
         <suggestion>يتعلق ب</suggestion>
       </message>
-      <example correction='يتعلق ب' type='incorrect'> تعقيب <marker>حول</marker> الأسباب ... </example>
-      <example type='correct'> تعقيب يتعلق بالأسباب ... </example>
+      <example correction='يتعلق ب' type='incorrect'> تعقيب <marker>حول</marker> الأسباب ...</example>
+      <example type='correct'> تعقيب يتعلق بالأسباب ...</example>
     </rule>
 
     <rule id ='unsorted3133' name='rule_حول_3133'>
@@ -1865,8 +1865,8 @@ USA
       <message>يفضل أن يقال:
         <suggestion>على</suggestion>
       </message>
-      <example correction='على' type='incorrect'> استدراك <marker>حول</marker> الأسباب ... </example>
-      <example type='correct'> استدراك على الأسباب... </example>
+      <example correction='على' type='incorrect'> استدراك <marker>حول</marker> الأسباب ...</example>
+      <example type='correct'> استدراك على الأسباب...</example>
     </rule>
 
     <rule id ='unsorted3134' name='rule_ضد_3134'>
@@ -2206,8 +2206,8 @@ USA
         هذا الكلام عبارة عن كذا ≈ تعبير عن كذا ≈ معناه كذا ≈ ذو دَلالة على كذا
       </message>
       <url>http://www.reefnet.gov.sy/Arabic_Proficiency/72.htm</url>
-      <example correction=''> أشعة غاما هي  فوتونات. <marker>عبارة عن</marker> فوتونات</example>
-      <example correction=''> هذا الجهاز. <marker>عبارة عن</marker> صندوق فيه</example>
+      <example correction=''> أشعة غاما هي  فوتونات.<marker>عبارة عن</marker> فوتونات</example>
+      <example correction=''> هذا الجهاز.<marker>عبارة عن</marker> صندوق فيه</example>
     </rule>
 
 
@@ -2225,7 +2225,7 @@ USA
         لأن العِلاوة: أعلى الرأس، أو ما يُحمل على البعير وغيره. وهي ليست مصدرًا.
       </message>
       <url>http://www.reefnet.gov.sy/Arabic_Proficiency/77.htm</url>
-      <example correction="إضافةً إلى|زيادةً على|فضلًا على"> أشعة غاما هي  فوتونات. <marker>علاوة على</marker> ذلك</example>
+      <example correction="إضافةً إلى|زيادةً على|فضلًا على"> أشعة غاما هي  فوتونات.<marker>علاوة على</marker> ذلك</example>
     </rule>
 
     <rule id="لأول_مرة">
@@ -2239,7 +2239,7 @@ USA
         <suggestion>أول</suggestion>
         مرة
       </message>
-      <example correction='أول'> ‎يقام في دمشق معرض المخطوطات . <marker>لأول</marker> مرة</example>
+      <example correction='أول'> ‎يقام في دمشق معرض المخطوطات .<marker>لأول</marker> مرة</example>
     </rule>
     <rule id="من_كثب">
       <pattern>
@@ -2252,7 +2252,7 @@ USA
         <suggestion>من</suggestion> كثب
         لأن الكثب هو القرب
       </message>
-      <example correction='من'> ‎نتابع الأمر  . <marker>عن</marker> كثب</example>
+      <example correction='من'> ‎نتابع الأمر <marker>عن</marker> كثب</example>
     </rule>
 
 
@@ -2268,7 +2268,7 @@ USA
         <suggestion>خلال</suggestion>
         لأن "أثناء" ليست ظرفًا ولا مضافة إلى ما تكسب منه الظرفية، ولهذا يجب أن تقترن بحرف الجر، أما خلال فهي ظرفية. جاء في القرآن ﴿فجاسوا خلال الديار﴾[17:5].
       </message>
-      <example correction='في أثناء|خلال'> الزيارة  . <marker>أثناء</marker> العمل، تحرج الموظف</example>
+      <example correction='في أثناء|خلال'> الزيارة  .<marker>أثناء</marker> العمل، تحرج الموظف</example>
     </rule>
 
 
@@ -2547,7 +2547,7 @@ USA
         <suggestion>أوان</suggestion>
         لأن الآونة جمع أوان، مثل أزمنة وزمان.
       </message>
-      <example correction='أوان'> بين. <marker>آونة</marker> وأخرى</example>
+      <example correction='أوان'> بين.<marker>آونة</marker> وأخرى</example>
     </rule>
 
     <rule id="بواسل">
@@ -2577,7 +2577,7 @@ USA
         بالقانون أو بالعادات،
         لأن الاستهتار غاية الولع بالشيء فيقال فلان مستهتر بالقراءة إذا أولع بها بلا حد.
       </message>
-      <example correction='مستهين|مستخفّ'> ‎فلان  . <marker>مستهتر</marker> بالقانون</example>
+      <example correction='مستهين|مستخفّ'> ‎فلان  .<marker>مستهتر</marker> بالقانون</example>
     </rule>
 
 
@@ -2591,7 +2591,7 @@ USA
         ويفضل أن يقال:
         <suggestion>سيّاح</suggestion>
       </message>
-      <example correction='سيّاح'> ‎هؤلاء  . <marker>سواح</marker> أجانب</example>
+      <example correction='سيّاح'> ‎هؤلاء  .<marker>سواح</marker> أجانب</example>
     </rule>
 
     <rule id="ككل">
@@ -3570,7 +3570,7 @@ USA
         <suggestion>لا سيّما</suggestion>
       </message>
       <example correction='لا سيّما' type='incorrect'>سأحقق ما تريد <marker>سيما</marker> الراتب</example>
-      <example type='correct'> سأحقِّقُ ما تريد ولا سيّما../سأحقِّقُ ما تريد لا سيّما.. </example>
+      <example type='correct'> سأحقِّقُ ما تريد ولا سيّما../سأحقِّقُ ما تريد لا سيّما..</example>
     </rule>
 -->
 
@@ -3603,8 +3603,8 @@ USA
       <message>يفضل أن يقال:
         <suggestion>تركت</suggestion>
       </message>
-      <example correction='تركت' type='incorrect'> <marker>عكست</marker> الرحلة آثارا طيبة على... </example>
-      <example type='correct'> تركت الرحلة آثاراً طيبة على... </example>
+      <example correction='تركت' type='incorrect'> <marker>عكست</marker> الرحلة آثارا طيبة على...</example>
+      <example type='correct'> تركت الرحلة آثاراً طيبة على...</example>
     </rule>
 
     <rule id ='unsorted361' name='rule_فحوصات_361'>
@@ -3763,8 +3763,8 @@ USA
       <message>يفضل أن يقال:
         <suggestion>التي</suggestion>
       </message>
-      <example correction='التي' type='incorrect'> سنتبع سياسة الترغيب <marker>والتي</marker> ستكون.. </example>
-      <example type='correct'> سنتبع سياسة الترغيب التي ستكون.. </example>
+      <example correction='التي' type='incorrect'> سنتبع سياسة الترغيب <marker>والتي</marker> ستكون..</example>
+      <example type='correct'> سنتبع سياسة الترغيب التي ستكون..</example>
     </rule>
 
     <rule id ='unsorted376' name='rule_والذي_376'>


### PR DESCRIPTION
Fix rules after https://github.com/languagetool-org/languagetool/commit/9a4f1e36c5d9a15056d656ddfe102da7fc84159c  and https://github.com/languagetool-org/languagetool/issues/2511#issuecomment-592162654