### PR TITLE
fix match offset positions in PattenRuleTest

### DIFF
--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
@@ -574,8 +574,15 @@ public class PatternRuleTest extends AbstractPatternRuleTest {
   private List<RuleMatch> getMatchesForText(Rule rule, String sentence, JLanguageTool lt) throws IOException {
     List<AnalyzedSentence> analyzedSentences = lt.analyzeText(sentence);
     List<RuleMatch> matches = new ArrayList<>();
+    int matchOffset = 0;
+    // fix offset calculation for testCorrectSentences / testBadSentences (e.g. position of marker)
     for (AnalyzedSentence analyzedSentence : analyzedSentences) {
-      matches.addAll(Arrays.asList(rule.match(analyzedSentence)));
+      List<RuleMatch> sentenceMatches = Arrays.asList(rule.match(analyzedSentence));
+      for (RuleMatch match : sentenceMatches) {
+        match.setOffsetPosition(match.getFromPos() + matchOffset, match.getToPos() + matchOffset);
+      }
+      matches.addAll(sentenceMatches);
+      matchOffset += analyzedSentence.getText().length();
     }
     return matches;
   }


### PR DESCRIPTION
PatternRuleTest now (as of 9a4f1e36c5) separately checks each sentence,
but computes expected position from <marker> on the whole text
Need to adjust offsets of RuleMatch objects accordingly (relative to whole text),
else examples with multiple sentences will fail