### PR TITLE
fixed messages for test failures in PatternRuleTest

### DIFF
--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
@@ -57,10 +57,11 @@ public class PatternRuleTest extends AbstractPatternRuleTest {
     }
 
     @Override
-    public String toString() {
+    public String getMessage() {
       return String.format("Test failure for rule %s in file %s: %s",
         rule.getFullId(), rule.getSourceFile(), message);
     }
+
   }
 
   public void testFake() {


### PR DESCRIPTION
See https://forum.languagetool.org/t/testrules-ignore-there-were-10-errors/5433