### PR TITLE
Grazie migration: Add exceptions for EnglishWordRepeatBeginningRule

### DIFF
--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishWordRepeatBeginningRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishWordRepeatBeginningRule.java
@@ -18,14 +18,12 @@
  */
 package org.languagetool.rules.en;
 
-import java.util.HashSet;
-import java.util.ResourceBundle;
-import java.util.Set;
-
 import org.languagetool.AnalyzedTokenReadings;
 import org.languagetool.Language;
 import org.languagetool.rules.Example;
 import org.languagetool.rules.WordRepeatBeginningRule;
+
+import java.util.*;
 
 /**
  * Adds a list English adverbs to {@link WordRepeatBeginningRule}.
@@ -52,7 +50,12 @@ public class EnglishWordRepeatBeginningRule extends WordRepeatBeginningRule {
     ADVERBS.add("Furthermore");
     ADVERBS.add("Moreover");
   }
-  
+
+  @Override
+  public boolean isException(String token) {
+    return super.isException(token) || token.equals("The") || token.equals("A") || token.equals("An");
+  }
+
   @Override
   protected boolean isAdverb(AnalyzedTokenReadings token) {
     return ADVERBS.contains(token.getToken());


### PR DESCRIPTION
If several sentences start with determiner - it is a correct case.