### PR TITLE
Grazie migration: Make compounds rules lazy

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractDashRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractDashRule.java
@@ -33,12 +33,9 @@ import java.util.*;
  */
 public abstract class AbstractDashRule extends Rule {
 
-  private final AhoCorasickDoubleArrayTrie<String> trie;
-
-  public AbstractDashRule(AhoCorasickDoubleArrayTrie<String> trie, ResourceBundle messages) {
+  public AbstractDashRule(ResourceBundle messages) {
     super(messages);
     setCategory(Categories.TYPOGRAPHY.getCategory(messages));
-    this.trie = trie;
   }
 
   @Override
@@ -51,6 +48,8 @@ public abstract class AbstractDashRule extends Rule {
 
   public abstract String getMessage();
 
+  protected abstract AhoCorasickDoubleArrayTrie<String> getCompoundsData();
+
   @Override
   public int estimateContextForSureMatch() {
     return 2;
@@ -60,7 +59,7 @@ public abstract class AbstractDashRule extends Rule {
   public RuleMatch[] match(AnalyzedSentence sentence) throws IOException {
     List<RuleMatch> matches = new ArrayList<>();
     String text = sentence.getText();
-    List<AhoCorasickDoubleArrayTrie.Hit<String>> hits = trie.parseText(text);
+    List<AhoCorasickDoubleArrayTrie.Hit<String>> hits = getCompoundsData().parseText(text);
     Set<Integer> startPositions = new HashSet<>();
     Collections.reverse(hits);  // work on longest matches first
     for (AhoCorasickDoubleArrayTrie.Hit<String> hit : hits) {

--- a/languagetool-language-modules/br/src/main/java/org/languagetool/rules/br/BretonCompoundRule.java
+++ b/languagetool-language-modules/br/src/main/java/org/languagetool/rules/br/BretonCompoundRule.java
@@ -26,17 +26,10 @@
 
 package org.languagetool.rules.br;
 
-import org.languagetool.rules.AbstractCompoundRule;
-import org.languagetool.rules.CompoundRuleData;
-import org.languagetool.rules.Example;
-import org.languagetool.rules.Categories;
-import org.languagetool.rules.ITSIssueType;
-import org.languagetool.tools.Tools;
+import org.languagetool.rules.*;
 
 import java.io.IOException;
 import java.util.ResourceBundle;
-
-import java.net.URL;
 
 /**
  * Checks that compounds (if in the list) are not written as separate words.
@@ -44,7 +37,7 @@ import java.net.URL;
  */
 public class BretonCompoundRule extends AbstractCompoundRule {
 
-  private static final CompoundRuleData compoundData = new CompoundRuleData("/br/compounds.txt");
+  private static volatile CompoundRuleData compoundData;
 
   public BretonCompoundRule(ResourceBundle messages) throws IOException {    
     super(messages,
@@ -77,6 +70,16 @@ public class BretonCompoundRule extends AbstractCompoundRule {
 
   @Override
   protected CompoundRuleData getCompoundRuleData() {
-    return compoundData;
+    CompoundRuleData data = compoundData;
+    if (data == null) {
+      synchronized (BretonCompoundRule.class) {
+        data = compoundData;
+        if (data == null) {
+          compoundData = data = new CompoundRuleData("/br/compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 }

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanCompoundRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanCompoundRule.java
@@ -18,13 +18,10 @@
  */
 package org.languagetool.rules.de;
 
+import org.languagetool.rules.*;
+
 import java.io.IOException;
 import java.util.ResourceBundle;
-
-import org.languagetool.rules.AbstractCompoundRule;
-import org.languagetool.rules.Categories;
-import org.languagetool.rules.CompoundRuleData;
-import org.languagetool.rules.Example;
 
 /**
  * Checks that compounds are not written as separate words. The supported compounds are loaded
@@ -34,7 +31,7 @@ import org.languagetool.rules.Example;
  */
 public class GermanCompoundRule extends AbstractCompoundRule {
 
-  private static final CompoundRuleData compoundData = new CompoundRuleData("/de/compounds.txt", "/de/compound-cities.txt");
+  private static volatile CompoundRuleData compoundData;
  
   public GermanCompoundRule(ResourceBundle messages) throws IOException {
     super(messages,
@@ -59,6 +56,16 @@ public class GermanCompoundRule extends AbstractCompoundRule {
 
   @Override
   protected CompoundRuleData getCompoundRuleData() {
-    return compoundData;
+    CompoundRuleData data = compoundData;
+    if (data == null) {
+      synchronized (GermanCompoundRule.class) {
+        data = compoundData;
+        if (data == null) {
+          compoundData = data = new CompoundRuleData("/de/compounds.txt", "/de/compound-cities.txt");
+        }
+      }
+    }
+
+    return data;
   }
 }

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/SwissCompoundRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/SwissCompoundRule.java
@@ -18,20 +18,18 @@
  */
 package org.languagetool.rules.de;
 
+import org.languagetool.rules.CompoundRuleData;
 import org.languagetool.rules.LineExpander;
-import org.languagetool.rules.*;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.ResourceBundle;
+import java.util.*;
 
 /**
  * @since 4.9
  */
 public class SwissCompoundRule extends GermanCompoundRule {
 
-  private static final CompoundRuleData compoundData = new CompoundRuleData(new SwissExpander(), "/de/compounds.txt", "/de/compound-cities.txt");
+  private static volatile CompoundRuleData compoundData;
  
   public SwissCompoundRule(ResourceBundle messages) throws IOException {
     super(messages);
@@ -44,7 +42,17 @@ public class SwissCompoundRule extends GermanCompoundRule {
 
   @Override
   protected CompoundRuleData getCompoundRuleData() {
-    return compoundData;
+    CompoundRuleData data = compoundData;
+    if (data == null) {
+      synchronized (SwissCompoundRule.class) {
+        data = compoundData;
+        if (data == null) {
+          compoundData = data = new CompoundRuleData(new SwissExpander(), "/de/compounds.txt", "/de/compound-cities.txt");
+        }
+      }
+    }
+
+    return data;
   }
   
   static class SwissExpander implements LineExpander {

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/CompoundRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/CompoundRule.java
@@ -18,19 +18,15 @@
  */
 package org.languagetool.rules.en;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.ResourceBundle;
-
 import org.languagetool.Language;
-import org.languagetool.language.AmericanEnglish;
-import org.languagetool.rules.AbstractCompoundRule;
-import org.languagetool.rules.CompoundRuleData;
-import org.languagetool.rules.Example;
+import org.languagetool.Languages;
+import org.languagetool.rules.*;
 import org.languagetool.rules.patterns.PatternToken;
 import org.languagetool.rules.patterns.PatternTokenBuilder;
 import org.languagetool.tagging.disambiguation.rules.DisambiguationPatternRule;
+
+import java.io.IOException;
+import java.util.*;
 
 /**
  * Checks that compounds (if in the list) are not written as separate words.
@@ -38,8 +34,8 @@ import org.languagetool.tagging.disambiguation.rules.DisambiguationPatternRule;
 public class CompoundRule extends AbstractCompoundRule {
 
   // static to make sure this gets loaded only once:
-  private static final CompoundRuleData compoundData = new CompoundRuleData("/en/compounds.txt");
-  private static final Language AMERICAN_ENGLISH = new AmericanEnglish();
+  private static volatile CompoundRuleData compoundData;
+  private static final Language AMERICAN_ENGLISH = Languages.getLanguageForShortCode("en-US");
   private static List<DisambiguationPatternRule> antiDisambiguationPatterns = null;
   private static final List<List<PatternToken>> ANTI_PATTERNS = Arrays.asList(
       Arrays.asList(
@@ -74,7 +70,17 @@ public class CompoundRule extends AbstractCompoundRule {
 
   @Override
   protected CompoundRuleData getCompoundRuleData() {
-    return compoundData;
+    CompoundRuleData data = compoundData;
+    if (data == null) {
+      synchronized (CompoundRule.class) {
+        data = compoundData;
+        if (data == null) {
+          compoundData = data = new CompoundRuleData("/en/compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 
   @Override

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishDashRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishDashRule.java
@@ -31,10 +31,10 @@ import java.util.ResourceBundle;
  */
 public class EnglishDashRule extends AbstractDashRule {
 
-  private static final AhoCorasickDoubleArrayTrie<String> trie = loadCompoundFile("/en/compounds.txt");
+  private static volatile AhoCorasickDoubleArrayTrie<String> trie;
 
   public EnglishDashRule(ResourceBundle messages) {
-    super(trie, messages);
+    super(messages);
     addExamplePair(Example.wrong("I'll buy a new <marker>T—shirt</marker>."),
                    Example.fixed("I'll buy a new <marker>T-shirt</marker>."));
   }
@@ -54,4 +54,18 @@ public class EnglishDashRule extends AbstractDashRule {
     return "A dash was used instead of a hyphen.";
   }
 
+  @Override
+  protected AhoCorasickDoubleArrayTrie<String> getCompoundsData() {
+    AhoCorasickDoubleArrayTrie<String> data = trie;
+    if (data == null) {
+      synchronized (EnglishDashRule.class) {
+        data = trie;
+        if (data == null) {
+          trie = data = loadCompoundFile("/en/compounds.txt");
+        }
+      }
+    }
+
+    return data;
+  }
 }

--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/rules/fr/CompoundRule.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/rules/fr/CompoundRule.java
@@ -18,19 +18,17 @@
  */
 package org.languagetool.rules.fr;
 
+import org.languagetool.rules.*;
+
 import java.io.IOException;
 import java.util.ResourceBundle;
-
-import org.languagetool.rules.AbstractCompoundRule;
-import org.languagetool.rules.CompoundRuleData;
-import org.languagetool.rules.Example;
 
 /**
  * Checks that compounds (if in the list) are not written as separate words.
  */
 public class CompoundRule extends AbstractCompoundRule {
 
-  private static final CompoundRuleData compoundData = new CompoundRuleData("/fr/compounds.txt");
+  private static volatile CompoundRuleData compoundData;
 
   public CompoundRule(ResourceBundle messages) throws IOException {
     super(messages,
@@ -54,7 +52,17 @@ public class CompoundRule extends AbstractCompoundRule {
 
   @Override
   protected CompoundRuleData getCompoundRuleData() {
-    return compoundData;
+    CompoundRuleData data = compoundData;
+    if (data == null) {
+      synchronized (CompoundRule.class) {
+        data = compoundData;
+        if (data == null) {
+          compoundData = data = new CompoundRuleData("/fr/compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 
 }

--- a/languagetool-language-modules/ga/src/main/java/org/languagetool/rules/ga/CompoundRule.java
+++ b/languagetool-language-modules/ga/src/main/java/org/languagetool/rules/ga/CompoundRule.java
@@ -18,19 +18,17 @@
  */
 package org.languagetool.rules.ga;
 
+import org.languagetool.rules.*;
+
 import java.io.IOException;
 import java.util.ResourceBundle;
-
-import org.languagetool.rules.AbstractCompoundRule;
-import org.languagetool.rules.CompoundRuleData;
-import org.languagetool.rules.Example;
 
 /**
  * Checks that compounds (if in the list) are not written as separate words.
  */
 public final class CompoundRule extends AbstractCompoundRule {
 
-  private static final CompoundRuleData compoundData = new CompoundRuleData("/ga/compounds.txt");
+  private static volatile CompoundRuleData compoundData;
 
   public CompoundRule(ResourceBundle messages) throws IOException {
     super(messages,
@@ -54,7 +52,17 @@ public final class CompoundRule extends AbstractCompoundRule {
 
   @Override
   protected CompoundRuleData getCompoundRuleData() {
-    return compoundData;
+    CompoundRuleData data = compoundData;
+    if (data == null) {
+      synchronized (CompoundRule.class) {
+        data = compoundData;
+        if (data == null) {
+          compoundData = data = new CompoundRuleData("/ga/compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 
 }

--- a/languagetool-language-modules/nl/src/main/java/org/languagetool/rules/nl/CompoundRule.java
+++ b/languagetool-language-modules/nl/src/main/java/org/languagetool/rules/nl/CompoundRule.java
@@ -29,7 +29,7 @@ import java.util.ResourceBundle;
  */
 public class CompoundRule extends AbstractCompoundRule {
 
-  private static final CompoundRuleData compoundData = new CompoundRuleData("/nl/compounds.txt");
+  private static volatile CompoundRuleData compoundData;
 
   public CompoundRule(ResourceBundle messages) throws IOException {
     super(messages,
@@ -52,7 +52,17 @@ public class CompoundRule extends AbstractCompoundRule {
 
   @Override
   protected CompoundRuleData getCompoundRuleData() {
-    return compoundData;
+    CompoundRuleData data = compoundData;
+    if (data == null) {
+      synchronized (CompoundRule.class) {
+        data = compoundData;
+        if (data == null) {
+          compoundData = data = new CompoundRuleData("/nl/compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 
 }

--- a/languagetool-language-modules/pl/src/main/java/org/languagetool/rules/pl/CompoundRule.java
+++ b/languagetool-language-modules/pl/src/main/java/org/languagetool/rules/pl/CompoundRule.java
@@ -18,12 +18,10 @@
  */
 package org.languagetool.rules.pl;
 
+import org.languagetool.rules.*;
+
 import java.io.IOException;
 import java.util.ResourceBundle;
-
-import org.languagetool.rules.AbstractCompoundRule;
-import org.languagetool.rules.CompoundRuleData;
-import org.languagetool.rules.Example;
 
 /**
  * Checks that compounds (if in the list) are not written as separate words.
@@ -32,7 +30,7 @@ import org.languagetool.rules.Example;
  */
 public final class CompoundRule extends AbstractCompoundRule {
 
-  private static final CompoundRuleData compoundData = new CompoundRuleData("/pl/compounds.txt");
+  private static volatile CompoundRuleData compoundData;
 
   public CompoundRule(ResourceBundle messages) throws IOException {
     super(messages,
@@ -56,7 +54,17 @@ public final class CompoundRule extends AbstractCompoundRule {
 
   @Override
   protected CompoundRuleData getCompoundRuleData() {
-    return compoundData;
+    CompoundRuleData data = compoundData;
+    if (data == null) {
+      synchronized (CompoundRule.class) {
+        data = compoundData;
+        if (data == null) {
+          compoundData = data = new CompoundRuleData("/pl/compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 
 }

--- a/languagetool-language-modules/pl/src/main/java/org/languagetool/rules/pl/DashRule.java
+++ b/languagetool-language-modules/pl/src/main/java/org/languagetool/rules/pl/DashRule.java
@@ -30,10 +30,10 @@ import java.util.ResourceBundle;
  */
 public class DashRule extends AbstractDashRule {
 
-  private static final AhoCorasickDoubleArrayTrie<String> trie = loadCompoundFile("/pl/compounds.txt");
+  private static volatile AhoCorasickDoubleArrayTrie<String> trie;
 
   public DashRule(ResourceBundle messages) {
-    super(trie, messages);
+    super(messages);
   }
 
   @Override
@@ -44,6 +44,21 @@ public class DashRule extends AbstractDashRule {
   @Override
   public String getMessage() {
     return "Błędne użycie myślnika zamiast łącznika.";
+  }
+
+  @Override
+  protected AhoCorasickDoubleArrayTrie<String> getCompoundsData() {
+    AhoCorasickDoubleArrayTrie<String> data = trie;
+    if (data == null) {
+      synchronized (DashRule.class) {
+        data = trie;
+        if (data == null) {
+          trie = data = loadCompoundFile("/pl/compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 
 }

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PostReformPortugueseCompoundRule.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PostReformPortugueseCompoundRule.java
@@ -18,16 +18,12 @@
  */
 package org.languagetool.rules.pt;
 
-import org.languagetool.rules.AbstractCompoundRule;
-import org.languagetool.rules.CompoundRuleData;
-import org.languagetool.rules.Categories;
-import org.languagetool.rules.ITSIssueType;
+import org.languagetool.rules.*;
 import org.languagetool.tools.Tools;
 
 import java.io.IOException;
-import java.util.ResourceBundle;
-
 import java.net.URL;
+import java.util.ResourceBundle;
 
 /**
  * Checks that compounds (if in the list) are not written as separate words.
@@ -35,7 +31,7 @@ import java.net.URL;
  */
 public class PostReformPortugueseCompoundRule extends AbstractCompoundRule {
 
-  private static final CompoundRuleData compoundData = new CompoundRuleData("/pt/post-reform-compounds.txt");
+  private static volatile CompoundRuleData compoundData;
 
   public PostReformPortugueseCompoundRule(ResourceBundle messages) throws IOException {    
     super(messages,
@@ -64,6 +60,16 @@ public class PostReformPortugueseCompoundRule extends AbstractCompoundRule {
 
   @Override
   protected CompoundRuleData getCompoundRuleData() {
-    return compoundData;
+    CompoundRuleData data = compoundData;
+    if (data == null) {
+      synchronized (PostReformPortugueseCompoundRule.class) {
+        data = compoundData;
+        if (data == null) {
+          compoundData = data = new CompoundRuleData("/pt/post-reform-compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 }

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PostReformPortugueseDashRule.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PostReformPortugueseDashRule.java
@@ -30,10 +30,10 @@ import java.util.ResourceBundle;
  */
 public class PostReformPortugueseDashRule extends AbstractDashRule {
 
-  private static final AhoCorasickDoubleArrayTrie<String> trie = loadCompoundFile("/pt/post-reform-compounds.txt");
+  private static volatile AhoCorasickDoubleArrayTrie<String> trie;
   
   public PostReformPortugueseDashRule(ResourceBundle messages) {
-    super(trie, messages);
+    super(messages);
     setLocQualityIssueType(ITSIssueType.Typographical);
   }
 
@@ -55,6 +55,21 @@ public class PostReformPortugueseDashRule extends AbstractDashRule {
   @Override
   protected boolean isBoundary(String s) {
     return !s.matches("[a-zA-ZÂâÃãÇçÊêÓóÔôÕõü]");  // chars from http://unicode.e-workers.de/portugiesisch.php
+  }
+
+  @Override
+  protected AhoCorasickDoubleArrayTrie<String> getCompoundsData() {
+    AhoCorasickDoubleArrayTrie<String> data = trie;
+    if (data == null) {
+      synchronized (PostReformPortugueseDashRule.class) {
+        data = trie;
+        if (data == null) {
+          trie = data = loadCompoundFile("/pt/post-reform-compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 
 }

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PreReformPortugueseCompoundRule.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PreReformPortugueseCompoundRule.java
@@ -18,10 +18,7 @@
  */
 package org.languagetool.rules.pt;
 
-import org.languagetool.rules.AbstractCompoundRule;
-import org.languagetool.rules.CompoundRuleData;
-import org.languagetool.rules.Categories;
-import org.languagetool.rules.ITSIssueType;
+import org.languagetool.rules.*;
 
 import java.io.IOException;
 import java.util.ResourceBundle;
@@ -32,7 +29,7 @@ import java.util.ResourceBundle;
  */
 public class PreReformPortugueseCompoundRule extends AbstractCompoundRule {
 
-  private static final CompoundRuleData compoundData = new CompoundRuleData("/pt/pre-reform-compounds.txt");
+  private static volatile CompoundRuleData compoundData;
 
   public PreReformPortugueseCompoundRule(ResourceBundle messages) throws IOException {    
     super(messages,
@@ -56,7 +53,17 @@ public class PreReformPortugueseCompoundRule extends AbstractCompoundRule {
 
   @Override
   protected CompoundRuleData getCompoundRuleData() {
-    return compoundData;
+    CompoundRuleData data = compoundData;
+    if (data == null) {
+      synchronized (PreReformPortugueseCompoundRule.class) {
+        data = compoundData;
+        if (data == null) {
+          compoundData = data = new CompoundRuleData("/pt/pre-reform-compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 
 }

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PreReformPortugueseDashRule.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PreReformPortugueseDashRule.java
@@ -30,10 +30,10 @@ import java.util.ResourceBundle;
  */
 public class PreReformPortugueseDashRule extends AbstractDashRule {
 
-  private static final AhoCorasickDoubleArrayTrie<String> trie = loadCompoundFile("/pt/pre-reform-compounds.txt");
+  private static volatile AhoCorasickDoubleArrayTrie<String> trie;
   
   public PreReformPortugueseDashRule(ResourceBundle messages) {
-    super(trie, messages);
+    super(messages);
     setLocQualityIssueType(ITSIssueType.Typographical);
   }
 
@@ -55,6 +55,21 @@ public class PreReformPortugueseDashRule extends AbstractDashRule {
   @Override
   protected boolean isBoundary(String s) {
     return !s.matches("[a-zA-ZÂâÃãÇçÊêÓóÔôÕõü]");  // chars from http://unicode.e-workers.de/portugiesisch.php
+  }
+
+  @Override
+  protected AhoCorasickDoubleArrayTrie<String> getCompoundsData() {
+    AhoCorasickDoubleArrayTrie<String> data = trie;
+    if (data == null) {
+      synchronized (PreReformPortugueseDashRule.class) {
+        data = trie;
+        if (data == null) {
+          trie = data = loadCompoundFile("/pt/pre-reform-compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 
 }

--- a/languagetool-language-modules/ro/src/main/java/org/languagetool/rules/ro/CompoundRule.java
+++ b/languagetool-language-modules/ro/src/main/java/org/languagetool/rules/ro/CompoundRule.java
@@ -18,11 +18,11 @@
  */
 package org.languagetool.rules.ro;
 
-import java.io.IOException;
-import java.util.ResourceBundle;
-
 import org.languagetool.rules.AbstractCompoundRule;
 import org.languagetool.rules.CompoundRuleData;
+
+import java.io.IOException;
+import java.util.ResourceBundle;
 
 /**
  * Checks that compounds (if in the list) are not written as separate words.
@@ -31,7 +31,7 @@ import org.languagetool.rules.CompoundRuleData;
  */
 public class CompoundRule extends AbstractCompoundRule {
 
-  private static final CompoundRuleData compoundData = new CompoundRuleData("/ro/compounds.txt");
+  private static volatile CompoundRuleData compoundData;
 
   public CompoundRule(ResourceBundle messages) throws IOException {
     super(messages,
@@ -58,7 +58,17 @@ public class CompoundRule extends AbstractCompoundRule {
 
   @Override
   protected CompoundRuleData getCompoundRuleData() {
-    return compoundData;
+    CompoundRuleData data = compoundData;
+    if (data == null) {
+      synchronized (CompoundRule.class) {
+        data = compoundData;
+        if (data == null) {
+          compoundData = data = new CompoundRuleData("/ro/compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 
 }

--- a/languagetool-language-modules/ru/src/main/java/org/languagetool/rules/ru/RussianCompoundRule.java
+++ b/languagetool-language-modules/ru/src/main/java/org/languagetool/rules/ru/RussianCompoundRule.java
@@ -18,12 +18,10 @@
  */
 package org.languagetool.rules.ru;
 
+import org.languagetool.rules.*;
+
 import java.io.IOException;
 import java.util.ResourceBundle;
-
-import org.languagetool.rules.AbstractCompoundRule;
-import org.languagetool.rules.CompoundRuleData;
-import org.languagetool.rules.Example;
 
 
 /**
@@ -37,7 +35,7 @@ import org.languagetool.rules.Example;
  */
 public class RussianCompoundRule extends AbstractCompoundRule {
 
-  private static final CompoundRuleData compoundData = new CompoundRuleData("/ru/compounds.txt");
+  private static volatile CompoundRuleData compoundData;
 
   public RussianCompoundRule(ResourceBundle messages) throws IOException {
     super(messages,
@@ -62,7 +60,17 @@ public class RussianCompoundRule extends AbstractCompoundRule {
 
   @Override
   protected CompoundRuleData getCompoundRuleData() {
-    return compoundData;
+    CompoundRuleData data = compoundData;
+    if (data == null) {
+      synchronized (RussianCompoundRule.class) {
+        data = compoundData;
+        if (data == null) {
+          compoundData = data = new CompoundRuleData("/ru/compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 
 }

--- a/languagetool-language-modules/ru/src/main/java/org/languagetool/rules/ru/RussianDashRule.java
+++ b/languagetool-language-modules/ru/src/main/java/org/languagetool/rules/ru/RussianDashRule.java
@@ -30,10 +30,10 @@ import java.util.ResourceBundle;
  */
 public class RussianDashRule extends AbstractDashRule {
 
-  private static final AhoCorasickDoubleArrayTrie<String> trie = loadCompoundFile("/ru/compounds.txt");
+  private static volatile AhoCorasickDoubleArrayTrie<String> trie;
 
   public RussianDashRule(ResourceBundle messages) {
-    super(trie, messages);
+    super(messages);
   //  setDefaultTempOff(); // Slows down start up. See GitHub issue #1016.
   }
 
@@ -55,6 +55,21 @@ public class RussianDashRule extends AbstractDashRule {
   @Override
   protected boolean isBoundary(String s) {
     return !s.matches("[\u0400-\u04FF]");
+  }
+
+  @Override
+  protected AhoCorasickDoubleArrayTrie<String> getCompoundsData() {
+    AhoCorasickDoubleArrayTrie<String> data = trie;
+    if (data == null) {
+      synchronized (RussianDashRule.class) {
+        data = trie;
+        if (data == null) {
+          trie = data = loadCompoundFile("/ru/compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 
 }

--- a/languagetool-language-modules/sk/src/main/java/org/languagetool/rules/sk/CompoundRule.java
+++ b/languagetool-language-modules/sk/src/main/java/org/languagetool/rules/sk/CompoundRule.java
@@ -18,11 +18,11 @@
  */
 package org.languagetool.rules.sk;
 
-import java.io.IOException;
-import java.util.ResourceBundle;
-
 import org.languagetool.rules.AbstractCompoundRule;
 import org.languagetool.rules.CompoundRuleData;
+
+import java.io.IOException;
+import java.util.ResourceBundle;
 
 /**
  * Checks that compounds (if in the list) are not written as separate words.
@@ -31,7 +31,7 @@ import org.languagetool.rules.CompoundRuleData;
  */
 public final class CompoundRule extends AbstractCompoundRule {
 
-  private static final CompoundRuleData compoundData = new CompoundRuleData("/sk/compounds.txt");
+  private static volatile CompoundRuleData compoundData;
 
   public CompoundRule(ResourceBundle messages) throws IOException {
     super(messages,
@@ -53,7 +53,17 @@ public final class CompoundRule extends AbstractCompoundRule {
 
   @Override
   protected CompoundRuleData getCompoundRuleData() {
-    return compoundData;
+    CompoundRuleData data = compoundData;
+    if (data == null) {
+      synchronized (CompoundRule.class) {
+        data = compoundData;
+        if (data == null) {
+          compoundData = data = new CompoundRuleData("/sk/compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 
 }

--- a/languagetool-language-modules/sv/src/main/java/org/languagetool/rules/sv/CompoundRule.java
+++ b/languagetool-language-modules/sv/src/main/java/org/languagetool/rules/sv/CompoundRule.java
@@ -18,18 +18,18 @@
  */
 package org.languagetool.rules.sv;
 
-import java.io.IOException;
-import java.util.ResourceBundle;
-
 import org.languagetool.rules.AbstractCompoundRule;
 import org.languagetool.rules.CompoundRuleData;
+
+import java.io.IOException;
+import java.util.ResourceBundle;
 
 /**
  * Checks that compounds (if in the list) are not written as separate words.
  */
 public class CompoundRule extends AbstractCompoundRule {
 
-  private static final CompoundRuleData compoundData = new CompoundRuleData("/sv/compounds.txt");
+  private static volatile CompoundRuleData compoundData;
 
   public CompoundRule(ResourceBundle messages) throws IOException {
     super(messages,
@@ -50,7 +50,17 @@ public class CompoundRule extends AbstractCompoundRule {
 
   @Override
   protected CompoundRuleData getCompoundRuleData() {
-    return compoundData;
+    CompoundRuleData data = compoundData;
+    if (data == null) {
+      synchronized (CompoundRule.class) {
+        data = compoundData;
+        if (data == null) {
+          compoundData = data = new CompoundRuleData("/sv/compounds.txt");
+        }
+      }
+    }
+
+    return data;
   }
 
 }


### PR DESCRIPTION
Some rules use too much static memory, even if not used. I made them lazy, so if the user disables them, they will not waste memory.