### PR TITLE
Fix for example of `Readability: Three nouns in a row` rule in English

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -55229,8 +55229,8 @@ The accident victim died from her injuries.
             </pattern>
             <message>You used three nouns one after another, and this might decrease readability. You might consider rewording the sentence.</message>
             <short>Possibly bad style</short>
-            <example correction="">The <marker>security protection software</marker> we offer is the state-of-the art achievement.</example>
-            <example>The security software we offer is the state-of-the art achievement.</example>
+            <example correction="">The <marker>security protection software</marker> we offer is the state-of-the-art achievement.</example>
+            <example>The security software we offer is the state-of-the-art achievement.</example>
         </rule>
         <rule id="POSSIBILTY_POSSIBLE" name="Style: 'possible' after 'possibility'"><!-- https://github.com/languagetool-org/languagetool/issues/540 -->
             <pattern>


### PR DESCRIPTION
Minor fix of spelling mistake in `Readability: Three nouns in a row` rule