### PR TITLE
[pl] Update broken links

### DIFF
--- a/languagetool-language-modules/pl/src/main/resources/org/languagetool/rules/pl/grammar.xml
+++ b/languagetool-language-modules/pl/src/main/resources/org/languagetool/rules/pl/grammar.xml
@@ -2602,7 +2602,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token regexp='yes'>jak|dlaczego|co</token>
                     </pattern>
                     <message>Prawdopodobnie zbędny przecinek. Poprawnie: <suggestion><match no="1"/> <match no="3"/></suggestion>.</message>
-                    <url>http://poradnia.pwn.pl/lista.php?id=14326</url>
+                    <url>https://sjp.pwn.pl/poradnia/haslo/;14326.html</url>
                     <short>Błąd interpunkcyjny</short>
                     <example correction="Oto jak"><marker>Oto, jak</marker> profesor robi naleśniki.</example>
                     <example>Oto jak profesor robi naleśniki.</example>
@@ -2615,7 +2615,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 </pattern>
                 <message>W tym stałym związku frazeologicznym zwykle nie stawia się przecinka.</message>
                     <suggestion>\1 \3</suggestion>
-                    <url>http://so.pwn.pl/zasady.php?id=629795</url>
+                    <url>https://sjp.pwn.pl/zasady/;629795.html</url>
                     <short>Zbędny przecinek</short>
                     <example correction="Wypisz wymaluj"><marker>Wypisz, wymaluj</marker>, sama pani Franciszka, czarnooka, czarnowłosa.</example>
                 </rule>
@@ -2629,7 +2629,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token postag="SENT_END"/>
                     </pattern>
                     <message>Prawdopodobnie zbędny przecinek. Poprawnie: <suggestion>\1 \3</suggestion>.</message>
-                    <url>http://poradnia.pwn.pl/lista.php?id=14974</url>
+                    <url>https://sjp.pwn.pl/poradnia/haslo/;14974.html</url>
                     <short>Zbędny przecinek</short>
                     <example>Nie mam pojęcia dlaczego.</example>
                     <example correction="pojęcia dlaczego">Nie mam <marker>pojęcia, dlaczego</marker>.</example>
@@ -3723,7 +3723,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token>trafił</token>
                     </pattern>
                     <message>W tym wyrażeniu nie kładzie się przecinka: <suggestion>\1 \2 \4</suggestion>.</message>
-                    <url>http://so.pwn.pl/zasady.php?id=629795</url>
+                    <url>https://sjp.pwn.pl/zasady/;629795.html</url>
                     <short>Zbędny przecinek</short>
                     <example>Szukali na chybił trafił.</example>
                     <example correction="na chybił trafił">Szukali czegoś <marker>na chybił, trafił</marker>.</example>
@@ -3736,7 +3736,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token>bądź</token>
                 </pattern>
                 <message>W tym związku frazeologicznym nie kładzie się przecinka: <suggestion>\1 \3 \4</suggestion>.</message>
-                <url>http://so.pwn.pl/zasady.php?id=629795</url>
+                <url>https://sjp.pwn.pl/zasady/;629795.html</url>
                 <short>Zbędny przecinek</short>
                 <example>Była to bądź co bądź prawda.</example>
                 <example correction="bądź co bądź">Była to <marker>bądź, co bądź</marker> prawda.</example>
@@ -3749,7 +3749,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token>ulał</token>
                 </pattern>
                 <message>Przed tym związkiem frazeologicznym nie kładzie się przecinka: <suggestion>\1 \3 \4</suggestion>.</message>
-                <url>http://so.pwn.pl/zasady.php?id=629774</url>
+                <url>https://sjp.pwn.pl/zasady/;629774.html</url>
                 <short>Zbędny przecinek</short>
                 <example>Pasowało jak ulał.</example>
                 <example correction="to jak ulał">Pasowało <marker>to, jak ulał</marker>.</example>
@@ -3764,7 +3764,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     </marker>
                   </pattern>
                   <message>Prawdopodobnie zbędny przecinek. Poprawnie: <suggestion> \3\4</suggestion>.</message>
-                  <url>http://poradnia.pwn.pl/lista.php?id=7774</url>
+                  <url>https://sjp.pwn.pl/poradnia/haslo/;7774.html</url>
                   <short>Błąd interpunkcyjny</short>                  
                   <example>To były garnki, talerze, łyżki itp., itd.</example>
                   <example correction=" itd.">To były garnki, talerze, łyżki<marker>, itd.</marker></example>
@@ -3959,7 +3959,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         <token>.</token>
       </pattern>
       <message>Brak spacji po dacie rocznej. Powinno być: <suggestion><match no="1" regexp_match="(\d+)(.*)" regexp_replace="$1 $2"/>.</suggestion>.</message>
-      <url>http://poradnia.pwn.pl/lista.php?id=6475</url>
+      <url>https://sjp.pwn.pl/poradnia/haslo/;6475.html</url>
       <short>Zły format liczby</short>
       <example>Zdarzyło się to w 2000 r.</example>
       <example correction="2000 r.">Zdarzyło się to w <marker>2000r.</marker></example>
@@ -3971,7 +3971,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         <token spacebefore="yes">%</token>
       </pattern>
       <message>Przed znakiem procenta nie stawia się spacji. Poprawnie: <suggestion>\1\2</suggestion>.</message>
-      <url>http://poradnia.pwn.pl/lista.php?id=2029</url>
+      <url>https://sjp.pwn.pl/poradnia/haslo/;2029.html</url>
       <short>Zbędna spacja</short>
       <example>10%</example>
       <example correction="10%"><marker>10 %</marker></example>
@@ -4672,7 +4672,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token regexp="yes">[,i]|lub|oraz</token>
                     </pattern>
                     <message>Myślnika ani półpauzy nie używa się do rozdzielania wielokrotnego wystąpienia przymiotnika złożonego. Poprawnie: <suggestion>\1-</suggestion>.</message>
-                    <url>http://so.pwn.pl/zasady.php?id=629547</url>
+                    <url>https://sjp.pwn.pl/zasady/;629547.html</url>
                     <short>Błąd typograficzny</short>
                     <example>To jest przykład pierwszo-, drugo- i trzeciorzędowy.</example>
                     <example correction="pierwszo-">To jest przykład <marker>pierwszo–</marker>, drugo- i trzeciorzędowy.</example>
@@ -4755,7 +4755,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token regexp="yes">\d{2,4}</token>
                     </pattern>
                     <message>Prawdopodobnie błędny zapis daty. Powinno być bez kropek: <suggestion>\1 \3 \5</suggestion>.</message>
-                    <url>http://so.pwn.pl/zasady.php?id=629747</url>
+                    <url>https://sjp.pwn.pl/zasady/;629747.html</url>
                     <short>Błąd typograficzny</short>
                     <example>11 XI 1918</example>
                     <example correction="11 XI 1918"><marker>11.XI.1918</marker></example>
@@ -4769,7 +4769,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token regexp="yes">\d{2,4}</token>
                     </pattern>
                     <message>Prawdopodobnie błędny zapis daty. Powinno być bez dywizów: <suggestion>\1 \3 \5</suggestion>.</message>
-                    <url>http://so.pwn.pl/zasady.php?id=629747</url>
+                    <url>https://sjp.pwn.pl/zasady/;629747.html</url>
                     <short>Błąd typograficzny</short>
                     <example>11 XI 1918</example>
                     <example correction="11 XI 1918"><marker>11-XI-1918</marker></example>
@@ -4993,7 +4993,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 								</marker>
 						</pattern>
 						<message>Kropka kończąca zdanie powinna znajdować się za nawiasem (uwaga: dawniejsze reguły nakazywały stawiać kropkę przed nawiasem, jeśli w nawiasie znajdowało się całe zdanie; te reguły są dziś nieaktualne). Poprawnie: <suggestion>).</suggestion></message>
-						<url>http://so.pwn.pl/zasady.php?id=629865</url>
+						<url>https://sjp.pwn.pl/zasady/;629865.html</url>
 						<short>Błędne umiejscowienie kropki</short>
 						<example correction=").">(Całe zdanie jest w nawiasie<marker>.)</marker></example>
 						<example>Jest na to wiele przykładów (herbata, mleko, woda...).</example>
@@ -5058,7 +5058,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token>.</token>
                       </pattern>
                       <message>Ten skrót zapisuje się bez spacji: <suggestion>\1\2\3\4</suggestion>.</message>
-                      <url>http://poradnia.pwn.pl/lista.php?id=11869</url>
+                      <url>https://sjp.pwn.pl/poradnia/haslo/;11869.html</url>
                       <short>Zbędna spacja</short>                      
                       <example>To m.in. Jurek.</example>
                       <example correction="m.in.">To <marker>m. in.</marker> Jurek.</example>
@@ -5072,7 +5072,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token>.</token>
                       </pattern>
                       <message>Ten skrót zapisuje się bez spacji: <suggestion>\1 \2\3\4\5</suggestion>.</message>
-                      <url>http://poradnia.pwn.pl/lista.php?id=11869</url>
+                      <url>https://sjp.pwn.pl/poradnia/haslo/;11869.html</url>
                       <short>Zbędna spacja</short>                      
                       <example>Spółka z o.o.</example>
                       <example correction="z o.o.">Spółka <marker>z o. o.</marker> Jurek.</example>
@@ -5087,7 +5087,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token>e</token>
                       </pattern>
                       <message>Ten skrót zapisuje się bez spacji: <suggestion>\1\2\3\4\5</suggestion>.</message>
-                      <url>http://poradnia.pwn.pl/lista.php?id=11869</url>
+                      <url>https://sjp.pwn.pl/poradnia/haslo/;11869.html</url>
                       <short>Zbędna spacja</short>                                            
                       <example correction="p.n.e">To było w roku 241 <marker>p. n.e</marker>.</example>
                     </rule>
@@ -5101,7 +5101,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token spacebefore="yes">e</token>
                       </pattern>
                       <message>Ten skrót zapisuje się bez spacji: <suggestion>\1\2\3\4\5</suggestion>.</message>
-                      <url>http://poradnia.pwn.pl/lista.php?id=11869</url>
+                      <url>https://sjp.pwn.pl/poradnia/haslo/;11869.html</url>
                       <short>Zbędna spacja</short>                                            
                       <example correction="p.n.e">To było w roku 241 <marker>p.n. e</marker>.</example>
                     </rule>
@@ -5115,7 +5115,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         </marker>
                       </pattern>
                       <message>Ten skrót zapisuje się bez spacji: <suggestion>\2\3\4</suggestion>.</message>
-                      <url>http://poradnia.pwn.pl/lista.php?id=11869</url>
+                      <url>https://sjp.pwn.pl/poradnia/haslo/;11869.html</url>
                       <short>Zbędna spacja</short>                                            
                       <example correction="n.e">To było w roku 5 <marker>n. e</marker>.</example>
                     </rule>
@@ -5129,7 +5129,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token>.</token>
                       </pattern>
                       <message>Brak spacji w skrócie. Zapisujemy go tak: <suggestion>\1\2 \3\4</suggestion>.</message>
-                      <url>http://poradnia.pwn.pl/lista.php?id=10285</url>
+                      <url>https://sjp.pwn.pl/poradnia/haslo/;10285.html</url>
                       <short>Brak spacji</short>
                       <example>dz. cyt., s. 123</example>
                       <example correction="dz. cyt."><marker>dz.cyt.</marker></example>
@@ -5142,7 +5142,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token>.</token>
                       </pattern>
                       <message>Brak spacji w skrócie. Zapisujemy go tak: <suggestion>\1\2 \3\4</suggestion>.</message>
-                      <url>http://poradnia.pwn.pl/lista.php?id=10285</url>
+                      <url>https://sjp.pwn.pl/poradnia/haslo/;10285.html</url>
                       <short>Brak spacji</short>
                       <example>op. cit., s. 123</example>
                       <example correction="op. cit."><marker>op.cit.</marker></example>
@@ -5224,7 +5224,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token>aktyw</token>
                     </pattern>
                     <message>Błędna odmiana. Poprawnie: <suggestion><match no="1"/> aktywów</suggestion>.</message>
-                    <url>http://so.pwn.pl/lista.php?co=aktywa</url>
+                    <url>https://sjp.pwn.pl/slowniki/aktywa.html</url>
                     <short>Błędna odmiana</short>
                     <example correction="zablokowanych aktywów">Obiecano odmrożenie <marker>zablokowanych aktyw</marker> reżimu.</example>
                     <example>Obiecano odmrożenie zablokowanych aktywów reżimu.</example>
@@ -5247,7 +5247,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token postag='(:?subst|ger):sg:loc:[nm][1-3].*' postag_regexp='yes'></token>
                         </pattern>
                         <message>To błędna forma tego przymiotnika. Poprawnie: <suggestion>tylnym <match no="2"/></suggestion>.</message>
-                        <url>http://poradnia.pwn.pl/lista.php?id=9687</url>
+                        <url>https://sjp.pwn.pl/poradnia/haslo/;9687.html</url>
                         <short>Błędna odmiana</short>
                         <example correction="tylnym siedzeniu">Siedzę na <marker>tylnim siedzeniu</marker>.</example>
                         <example>Siedzę na tylnym siedzeniu.</example>
@@ -5429,7 +5429,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token postag="subst:pl:gen:m3">meczy</token>
                     </pattern>
                     <message>Wiele osób uznaje tę formę dopełniacza liczby mnogiej za niepoprawną. Lepiej: <suggestion>meczów</suggestion>.</message>
-                    <url>http://poradnia.pwn.pl/lista.php?id=3133</url>
+                    <url>https://sjp.pwn.pl/poradnia/haslo/;3133.html</url>
                     <short>Prawdopodobnie błędna odmiana</short>
                     <example>Rozegrałem wiele meczów.</example>
                     <example correction="meczów">Rozegrałem wiele <marker>meczy</marker>.</example>
@@ -10994,7 +10994,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 								</unify>
 						</pattern>
 						<message>To wyrażenie jest niepoprawną kalką z języka angielskiego. Poprawnie:<suggestion><match no="1"></match> <match no="2" postag="adj.*" postag_regexp="yes">poufny</match></suggestion> lub <suggestion><match no="1"></match> o szczególnym znaczeniu</suggestion>.</message>
-                        <url>http://poradnia.pwn.pl/lista.php?id=8332</url>
+                        <url>https://sjp.pwn.pl/poradnia/haslo/;8332.html</url>
 						<short>Błąd leksykalny</short>
 						<example correction="Informacje poufne|Informacje o szczególnym znaczeniu"><marker>Informacje wrażliwe</marker> odnoszące się do inspekcji należy traktować jako informacje niejawne.</example>
 						<example>Informacje poufne traktujemy ze szczególną ostrożnością.</example>
@@ -15042,7 +15042,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         </pattern>
                         <message>Tytuły czasopism pisze się wielkimi literami: <suggestion><match no="1" case_conversion="startupper"/> <match
                                 no="2" case_conversion="startupper"/></suggestion>.</message>
-                        <url>http://so.pwn.pl/zasady.php?id=629390</url>
+                        <url>https://sjp.pwn.pl/zasady/;629390.html</url>
                         <short>Błąd pisowni wielką i małą literą</short>
                         <example correction="Gazecie Wyborczej">Czytałem to w „<marker>Gazecie wyborczej</marker>”.</example>
                         <example>Czytałem to w „<marker>Gazecie Wyborczej</marker>”.</example>
@@ -15086,7 +15086,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         </pattern>
                         <message>Tytuły czasopism pisze się wielkimi literami: <suggestion><match no="1" case_conversion="startupper"/> <match
                                 no="2" case_conversion="startupper"/><match no="3"/><match no="4" case_conversion="startupper"/></suggestion>.</message>
-                        <url>http://so.pwn.pl/zasady.php?id=629390</url>
+                        <url>https://sjp.pwn.pl/zasady/;629390.html</url>
                         <short>Błąd pisowni wielką i małą literą</short>
                         <example correction="Przeglądzie Filozoficzno-Literackim">Czytałem to w „<marker>Przeglądzie filozoficzno-literackim</marker>”.</example>
                         <example>Czytałem to w „<marker>Przeglądzie Filozoficzno-Literackim</marker>”.</example>
@@ -15192,7 +15192,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 										<token postag="adj.*" postag_regexp="yes" regexp="yes"><exception regexp="yes">.*(go|ej)</exception>\p{Lu}\p{Ll}.*</token>
 								</pattern>
 								<message>W wypadku takich adresów pierwszy wyraz również piszemy wielką literą. Poprawnie: <suggestion><match case_conversion="startupper" no="1"></match>. <match no="3"></match></suggestion>.</message>
-                            <url>http://so.pwn.pl/zasady.php?id=629401</url>
+                            <url>https://sjp.pwn.pl/zasady/;629401.html</url>
 								<short>Błąd pisowni wielką i małą literą</short>
 								<example>Mieszkam przy al. Świerczewskiego.</example>
 								<example correction="Al. Ujazdowskie">Kancelaria mieści się w Warszawie, pod adresem <marker>al. Ujazdowskie</marker> 123412.</example>
@@ -15209,7 +15209,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 										</unify>
 								</pattern>
 								<message>W wypadku takich adresów pierwszy wyraz również piszemy wielką literą. Poprawnie: <suggestion><match case_conversion="startupper" no="1"></match> <match no="2"></match></suggestion>.</message>
-                                <url>http://so.pwn.pl/zasady.php?id=629401</url>
+                                <url>https://sjp.pwn.pl/zasady/;629401.html</url>
 								<short>Błąd pisowni wielką i małą literą</short>
 								<example correction="Aleje Jerozolimskie">Jedną z piękniejszych ulic w Warszawie są <marker>aleje Jerozolimskie</marker>.</example>
 								<example>Mieszkam przy Alejach Świerczewskiego.</example>
@@ -15223,7 +15223,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             </pattern>
                             <message>W takich adresach pierwszy człon piszemy małą literą: <suggestion><match no="1" case_conversion="alllower"/><match no="2"/> <match
                                     no="3"/></suggestion>.</message>
-                            <url>http://so.pwn.pl/zasady.php?id=629401</url>
+                            <url>https://sjp.pwn.pl/zasady/;629401.html</url>
                             <short>Błąd pisowni wielką i małą literą</short>
                             <example>Mieszkał wraz z rodziną w Sopocie przy al. Niepodległości.</example>
                             <example correction="al. Niepodległości">Mieszkał wraz z rodziną w Sopocie przy <marker>Al. Niepodległości</marker>.</example>
@@ -15871,7 +15871,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token regexp="yes">bądź|boć</token>
                 </pattern>
                 <message>Błąd ortograficzny. Poprawnie: <suggestion>bądź co bądź</suggestion>.</message>
-                <url>http://so.pwn.pl/zasady.php?id=629494</url>
+                <url>https://sjp.pwn.pl/zasady/;629494.html</url>
                 <short>Błąd ortograficzny</short>
                 <example>Bądź co bądź to prawda.</example>
                 <example correction="bądź co bądź">Ale <marker>boć, co boć</marker> był najlepszym bratem na świecie.</example>
@@ -15884,7 +15884,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 <message>Te wyrazy należy napisać łącznie (jeśli cząstka „że” funkcjonuje jako wzmocnienie rozkazu) lub z przecinkiem, jeśli wprowadza zdanie podrzędne.</message>
                 <suggestion>\1\2</suggestion>
                 <suggestion>\1, \2</suggestion>
-                <url>http://so.pwn.pl/zasady.php?id=629496</url>
+                <url>https://sjp.pwn.pl/zasady/;629496.html</url>
                 <short>Błąd ortograficzny lub brak przecinka</short>
                 <example>Dajże mi spokój!</example>
                 <example correction="Dajże|Daj, że"><marker>Daj że</marker> mi spokój!</example>
@@ -15916,7 +15916,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token inflected="yes">naukowy</token>
                 </pattern>
                 <message>Ten przymiotnik piszemy łącznie: <suggestion>\1\3</suggestion>.</message>
-                <url>http://poradnia.pwn.pl/lista.php?id=11919</url>
+                <url>https://sjp.pwn.pl/poradnia/haslo/;11919.html</url>
                 <short>Niepotrzebny dywiz</short>
                 <example>To jest pismo popularnonaukowe.</example>
                 <example correction="popularnonaukowe">To jest pismo <marker>popularno-naukowe</marker>.</example>
@@ -16191,7 +16191,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                                 <token>piwa</token>
                             </pattern>
                             <message>Powinno być <suggestion><match no="1" regexp_match="ż" regexp_replace="rz"/> <match no="2"/></suggestion>.</message>
-                            <url>http://so.pwn.pl/lista.php?co=warzenie</url>
+                            <url>https://sjp.pwn.pl/slowniki/warzenie.html</url>
                             <short>Błąd ortograficzny</short>
                             <example correction="warzenie piwa">Uwielbiam <marker>ważenie piwa</marker>.</example>
                             <example>Uwielbiam warzenie piwa.</example>
@@ -16204,7 +16204,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 								<token>Eiffela</token>
 						</pattern>
 						<message>Nieprawidłowa pisownia. Poprawnie: <suggestion>\1 Eiffla</suggestion> (wymowa: Ajfla).</message>
-                        <url>http://so.pwn.pl/lista.php?co=Eiffel</url>
+                        <url>https://sjp.pwn.pl/slowniki/Eiffel.html</url>
 						<short>Błąd ortograficzny</short>
 						<example correction="wieżą Eiffla">Spędźmy dziką noc pod <marker>wieżą Eiffela</marker>!</example>
 						<example>W Warszawie nie ma nic, co przypominałoby wieżę Eiffla.</example>
@@ -16218,7 +16218,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             </marker>
                         </pattern>
                         <message>Nieprawidłowa pisownia. Poprawnie: <suggestion><match no="2" case_conversion="alllower"/> Eiffla</suggestion>.</message>
-                        <url>http://poradnia.pwn.pl/lista.php?id=14712</url>
+                        <url>https://sjp.pwn.pl/poradnia/haslo/;14712.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="wieży Eiffla">W związku z remontem części wind na <marker>Wieży Eiffla</marker> bilety dostępne są na zapytanie.</example>
                     </rule>
@@ -16947,7 +16947,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token regexp="yes">[aeu]|owi|[oe]m|ach|ami|owie|ów</token>
                         </pattern>
                         <message>Ten wyraz odmienia się prawdopodobnie bez apostrofów: <suggestion>\1\3</suggestion>.</message>
-                        <url>http://so.pwn.pl/lista.php?co=Ramsay</url>
+                        <url>https://sjp.pwn.pl/slowniki/Ramsay.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Bentleyu">Porozmawiajmy o <marker>Bentley'u</marker>.</example>
                         <example>Porozmawiajmy o <marker>Bentleyu</marker> Lennonie.</example>
@@ -16960,7 +16960,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token regexp="yes">em|owi|a</token>
                         </pattern>
                         <message>To imię jest nieodmienne. Poprawnie: <suggestion>\1</suggestion>.</message>
-                        <url>http://poradnia.pwn.pl/lista.php?id=10494</url>
+                        <url>https://sjp.pwn.pl/poradnia/haslo/;10494.html</url>
                         <short>Błąd ortograficzny</short>
                         <example>Wywiad z Andrew Jacksonem</example>
                         <example correction="Andrew">Wywiad z <marker>Andrew'em</marker> Jacksonem</example>
@@ -16972,7 +16972,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token>m</token>
                         </pattern>
                         <message>Ten wyraz odmienia się prawdopodobnie bez apostrofów: <suggestion><match no="1"/><match no="3"/></suggestion>.</message>
-                        <url>http://so.pwn.pl/zasady.php?id=629610</url>
+                        <url>https://sjp.pwn.pl/zasady/;629610.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Andym">Porozmawiajmy o <marker>Andy'm</marker>.</example>
                         <example>Porozmawiajmy o Andym.</example>
@@ -16984,7 +16984,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token>m</token>
                         </pattern>
                         <message>Ten wyraz odmienia się prawdopodobnie tak: <suggestion><match no="1"/>’em</suggestion>.</message>
-                        <url>http://so.pwn.pl/zasady.php?id=629610</url>
+                        <url>https://sjp.pwn.pl/zasady/;629610.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Joyce’em">Zajmijmy się wreszcie <marker>Joyce'm</marker>.</example>
                         <example>Zajmijmy się wreszcie Joyce'em.</example>
@@ -16997,7 +16997,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token regexp="yes">(?:i?e)?m</token>
                         </pattern>
                         <message>Ten wyraz odmienia się prawdopodobnie tak: <suggestion><match no="1" regexp_match="(.*)(?:c?ke|que)" regexp_replace="$1kiem"/></suggestion>.</message>
-                        <url>http://so.pwn.pl/zasady.php?id=629610</url>
+                        <url>https://sjp.pwn.pl/zasady/;629610.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Lockiem">Zajmuję się <marker>Locke'm</marker>.</example>
                         <example correction="Brakiem">Zajmuję się <marker>Braque'm</marker>.</example>
@@ -17010,7 +17010,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token regexp='yes'>e?(?:go|mu|i?m)</token>
                         </pattern>
                         <message>Ten wyraz odmienia się prawdopodobnie tak: <suggestion><match no="1"/><match no="3" regexp_match=".*(go|mu|i?m)" regexp_replace="$1"/></suggestion>.</message>
-                        <url>http://so.pwn.pl/lista.php?co=Chaplin</url>
+                        <url>https://sjp.pwn.pl/slowniki/Chaplin.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Charliego">Zaprośmy <marker>Charlie'go</marker>.</example>
                         <example>Zaprośmy Charliego.</example>
@@ -17023,7 +17023,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token>im</token>
                         </pattern>
                         <message>Ten wyraz odmienia się prawdopodobnie bez apostrofów: <suggestion><match no="1"/>ym</suggestion>.</message>
-                        <url>http://so.pwn.pl/zasady.php?id=629610</url>
+                        <url>https://sjp.pwn.pl/zasady/;629610.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Billym">Porozmawiajmy o <marker>Bill'im</marker>.</example>
                         <example>Porozmawiajmy o Billym.</example>
@@ -17035,7 +17035,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token>ie</token>
                         </pattern>
                         <message>Ten wyraz odmienia się prawdopodobnie tak: <suggestion><match no="1" regexp_match="(.*)e" regexp_replace="$1ie"/></suggestion>.</message>
-                        <url>http://poradnia.pwn.pl/lista.php?id=8782</url>
+                        <url>https://sjp.pwn.pl/poradnia/haslo/;8782.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Stevie">Porozmawiajmy o <marker>Steve'ie</marker>.</example>
                         <example>Porozmawiajmy o Stevie.</example>
@@ -17047,7 +17047,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token regexp='yes'>i?em</token>
                         </pattern>
                         <message>Ten wyraz odmienia się tak: <suggestion>Erikiem</suggestion>.</message>
-                        <url>http://so.pwn.pl/lista.php?co=Clapton</url>
+                        <url>https://sjp.pwn.pl/slowniki/Clapton.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Erikiem">Zajmij się <marker>Eric'iem</marker>.</example>
                         <example>Zajmij się Erikiem.</example>
@@ -17072,7 +17072,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token regexp='yes'>a|go</token>
                         </pattern>
                         <message>To imię odmienia się bez apostrofów: <suggestion><match no="1"/>go</suggestion>.</message>
-                        <url>http://poradnia.pwn.pl/lista.php?id=3727</url>
+                        <url>https://sjp.pwn.pl/poradnia/haslo/;3727.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Joego">Widzę <marker>Joe'a</marker>.</example>
                         <example>Widzę Joego.</example>
@@ -17084,7 +17084,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token>owi</token>
                         </pattern>
                         <message>To imię odmienia się inaczej: <suggestion><match no="1"/>mu</suggestion>.</message>
-                        <url>http://poradnia.pwn.pl/lista.php?id=3727</url>
+                        <url>https://sjp.pwn.pl/poradnia/haslo/;3727.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Joemu">Dowal <marker>Joe'owi</marker>.</example>
                         <example>Dowal Joemu.</example>
@@ -17096,7 +17096,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token regexp='yes'>e?mu?</token>
                         </pattern>
                         <message>To imię odmienia się inaczej: <suggestion><match no="1"/><match no="3" regexp_match="e?(mu?)" regexp_replace="$1"/></suggestion>.</message>
-                        <url>http://poradnia.pwn.pl/lista.php?id=3727</url>
+                        <url>https://sjp.pwn.pl/poradnia/haslo/;3727.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Joemu">Dowal <marker>Joe'emu</marker>.</example>
                         <example correction="Joem">Porozmawiajmy o <marker>Joe'em</marker>.</example>
@@ -17109,7 +17109,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token>ie</token>
                         </pattern>
                         <message>Ten wyraz odmienia się prawdopodobnie tak: <suggestion><match no="1" regexp_match="(.*)ce" regexp_replace="$1sie"/></suggestion>.</message>
-                        <url>http://so.pwn.pl/lista.php?co=Olivier</url>
+                        <url>https://sjp.pwn.pl/slowniki/Olivier.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Laurensie">Porozmawiajmy o <marker>Laurence'ie</marker>.</example>
                         <example>Porozmawiajmy o Laurensie.</example>
@@ -17121,7 +17121,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token>ie</token>
                         </pattern>
                         <message>To imię odmienia się inaczej: <suggestion>Smicie</suggestion> (lub <suggestion>Smisie</suggestion>).</message>
-                        <url>http://so.pwn.pl/lista.php?co=Smith</url>
+                        <url>https://sjp.pwn.pl/szukaj/Smith.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Smicie|Smisie">Porozmawiajmy o <marker>Smith'ie</marker>.</example>
                         <example>Porozmawiajmy o Smicie.</example>
@@ -17133,7 +17133,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token>ie</token>
                         </pattern>
                         <message>To nazwisko odmienia się inaczej: <suggestion>Stonie</suggestion>.</message>
-                        <url>http://so.pwn.pl/lista.php?co=Stone</url>
+                        <url>https://sjp.pwn.pl/slowniki/Stone.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Stonie">Porozmawiajmy o <marker>Stone'ie</marker>.</example>
                         <example>Porozmawiajmy o Stonie.</example>
@@ -17145,7 +17145,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token regexp="yes">c?ie</token>
                         </pattern>
                         <message>To nazwisko odmienia się inaczej: <suggestion>Wrighcie</suggestion>.</message>
-                        <url>http://so.pwn.pl/lista.php?co=Wright</url>
+                        <url>https://sjp.pwn.pl/slowniki/Wright.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="Wrighcie">Porozmawiajmy o <marker>Wright'cie</marker>.</example>
                         <example>Porozmawiajmy o Wrighcie.</example>
@@ -17670,7 +17670,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 										<token regexp="yes">\d+-?(?:[mt]*y|[w]*sz[ey]|[w]*szym[i]*|[w]*si|tym|tymi|c[ihe]|a|ci[eam]|ciej|cioletnią|ego|ej|g[ao]|gi|gi[em]|im|ki|stokrotnie|które.*|m[ae]|miu|stoletniego|stu|sza|[tm]*a|[tm]*ego|[mt]*ej|to|[mt]*[i]*oletni.*|[mt]*[uąe]|[mt]*ych)</token>
 								</pattern>
 								<message>Liczebniki porządkowe zapisujemy nie z końcówkami przypadków, tylko z kropką: <suggestion><match no="1" regexp_match="(\d+)-?(.*)" regexp_replace="$1"></match>.</suggestion>.</message>
-                                <url>http://poradnia.pwn.pl/lista.php?id=11203</url>
+                                <url>https://sjp.pwn.pl/poradnia/haslo/;11203.html</url>
 								<short>Błąd ortograficzny</short>
 								<example>Ten system jest 32-bitowy.</example>
 								<example correction="5.">To już <marker>5-ty</marker> raz!</example>
@@ -17708,7 +17708,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token regexp="yes">(?:[mt]*y|[w]*sz[ey]|[w]*szym[i]*|[w]*si|tym|tymi|c[ihe]|a|ci[eamu]|ciej|cioletnią|ego|ej|g[ao]|gi|gi[em]|im|ki|stokrotnie|które.*|m[ae]|miu|stoletniego|stu|sza|[tm]*a|[tm]*ego|[mt]*ej|to|[mt]*[i]*oletni.*|[mt]*[uąe]|[mt]*ych)</token>
                         </pattern>
                         <message>Liczebniki porządkowe zapisujemy nie z końcówkami przypadków, tylko z kropką: <suggestion><match no="1"/>.</suggestion>.</message>
-                        <url>http://poradnia.pwn.pl/lista.php?id=11203</url>
+                        <url>https://sjp.pwn.pl/poradnia/haslo/;11203.html</url>
                         <short>Błąd ortograficzny</short>
                         <example>Ten system jest 32-bitowy.</example>
                         <example correction="5.">To już <marker>5—ty</marker> raz!</example>
@@ -17727,7 +17727,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token regexp="yes">stycznia|lutego|marca|kwietnia|maja|czerwca|lipca|sierpnia|września|października|listopada|grudnia|(?-iu)I{1,3}|I?V|VI{1,3}|I?X|XI{1,2}</token>
                         </pattern>
                         <message>W datach nie używamy końcówek przypadków:: <suggestion><match no="1"/> <match no="4"/></suggestion>.</message>
-                        <url>http://poradnia.pwn.pl/lista.php?id=11203</url>
+                        <url>https://sjp.pwn.pl/poradnia/haslo/;11203.html</url>
                         <short>Błąd ortograficzny</short>
                         <example>Ten system jest 32-bitowy.</example>
                         <example correction="21 maja">To było <marker>21—go maja</marker>.</example>
@@ -17753,7 +17753,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 										<token postag="conj"></token>
 								</pattern>
 								<message>W wypadku rozdzielenia przymiotników zawierających liczby pierwszy piszemy tylko z łącznikiem: <suggestion><match no="1" regexp_match="(\d+)-?(.*)" regexp_replace="$1"></match>-</suggestion>.</message>
-                                <url>http://poradnia.pwn.pl/lista.php?id=10793</url>
+                                <url>https://sjp.pwn.pl/poradnia/haslo/;10793.html</url>
 								<short>Błąd ortograficzny</short>
 								<example>Ten system jest 32-bitowy.</example>
 								<example correction="32-">W tym czasie istniały maszyny <marker>32-u</marker> i 64-bitowe.</example>
@@ -17768,7 +17768,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 										<token negate_pos="yes" postag="conj|comp|adj.*" postag_regexp="yes"></token>
 								</pattern>
 								<message>Nigdy nie dodaje się końcówek do odmienianych liczb; piszemy je po prostu: <suggestion><match no="1" regexp_match="(\d+)-?(.*)" regexp_replace="$1"></match></suggestion> lub <suggestion><match no="1" regexp_match="(\d+)-(.*)" regexp_replace="$1"></match>.</suggestion> (w wypadku liczebników porządkowych).</message>
-                                <url>http://poradnia.pwn.pl/lista.php?id=11203</url>
+                                <url>https://sjp.pwn.pl/poradnia/haslo/;11203.html</url>
 								<short>Błąd ortograficzny</short>
 								<example>Ten system jest 32-bitowy.</example>
 								<example correction="10|10.">Odnotowano <marker>10-cio</marker> proc. wzrost.</example>
@@ -17778,7 +17778,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 										<token postag="UNKNOWN" regexp="yes"><exception regexp="yes">^\p{Ll}.*|^-.*|Ice|Isi|Ite|Lo</exception><exception regexp="yes">X-.*</exception><exception>V-ce</exception>((XC|XL|L?X{0,3})(IX|IV|V?I{0,3}))-?([mt]*y|[w]*sz[ey]|[w]*szym[i]*|[w]*si|tymi?|a|c[ieh]|ci[aemou]|ciej|cioletnią|ego|ej|g[aio]|gi[em]|[yi]m|ki|któregoś|m[aeo]|miu|o|[tr]o|stoletniego|stu|sza|[tm]*a|[tm]*ego|[mt]*ej|tk[ai]|[mt]*[i]*oletni.*|[mt]*[ueą]|[mt]*ych)</token>
 								</pattern>
 								<message>Liczebniki porządkowe pisane liczbami rzymskimi zapisujemy bez żadnych końcówek przypadków. Poprawnie: <suggestion><match no="1" regexp_match="((XC|XL|L?X{0,3})(IX|IV|V?I{0,3}))-?.*" regexp_replace="$1"></match></suggestion></message>
-                                <url>http://poradnia.pwn.pl/lista.php?id=13046</url>
+                                <url>https://sjp.pwn.pl/poradnia/haslo/;13046.html</url>
 								<short>Błąd ortograficzny</short>
 								<example correction="XIX">To poglądy rodem z <marker>XIX-go</marker> wieku.</example>
 								<example>To poglądy rodem z XIX wieku.</example>
@@ -17797,7 +17797,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token regexp="yes">(:?[mt]*y|[w]*sz[ey]|[w]*szym[i]*|[w]*si|tymi?|a|c[ieh]|ci[aemou]|ciej|cioletnią|ego|ej|g[aio]|gi[em]|[yi]m|ki|któregoś|m[aeo]|miu|o|[tr]o|stoletniego|stu|sza|[tm]*a|[tm]*ego|[mt]*ej|tk[ai]|[mt]*[i]*oletni.*|[mt]*[ueą]|[mt]*ych)</token>
                         </pattern>
                         <message>Liczebniki porządkowe pisane liczbami rzymskimi zapisujemy bez żadnych końcówek przypadków. Poprawnie: <suggestion><match no="1" regexp_match="((XC|XL|L?X{0,3})(IX|IV|V?I{0,3}))-" regexp_replace="$1"></match></suggestion>.</message>
-                        <url>http://poradnia.pwn.pl/lista.php?id=13046</url>
+                        <url>https://sjp.pwn.pl/poradnia/haslo/;13046.html</url>
                         <short>Błąd ortograficzny</short>
                         <example correction="XIX">To poglądy rodem z <marker>XIX- go</marker> wieku.</example>
                         <example>To poglądy rodem z XIX wieku.</example>
@@ -17828,7 +17828,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                         <token regexp="yes">\p{L}+</token>
                     </pattern>
                     <message>Nie stawiamy kropki po cyfrach arabskich, jeśli oznaczają godzinę: <suggestion>\1 \2</suggestion>.</message>
-                    <url>http://poradnia.pwn.pl/lista.php?id=6141</url>
+                    <url>https://sjp.pwn.pl/poradnia/haslo/;6141.html</url>
                     <short>Błąd ortograficzny</short>
                     <example>Poszedłem tam o godzinie 10.</example>
                     <example>Poszedłem tam o 22.00.</example>
@@ -20822,7 +20822,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token>hoc</token>
                 </pattern>
                 <message>Czy chodziło o <suggestion>ad hoc</suggestion> (z łaciny)?</message>
-                <url>http://so.pwn.pl/lista.php?co=ad+hoc</url>
+                <url>https://sjp.pwn.pl/slowniki/ad+hoc.html</url>
                 <short>Literówka</short>
                 <example correction="ad hoc">To było <marker>at hoc</marker>.</example>
                 <example>To było ad hoc.</example>
@@ -20925,7 +20925,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token>młodu<exception regexp='yes' scope='previous'>za?</exception></token>
                 </pattern>
                 <message>Ten wyraz nie występuje samodzielnie. Czy chodziło o <suggestion>za <match no="1"/></suggestion>?</message>
-                <url>http://so.pwn.pl/lista.php?co=m%B3odu</url>
+                <url>https://sjp.pwn.pl/slowniki/m%C5%82odu.html</url>
                 <short>Prawdopodobna literówka</short>
                 <example correction="za młodu">Kupiłem to <marker>młodu</marker>.</example>
                 <example>Kupiłem to za młodu.</example>
@@ -20935,7 +20935,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token>bezcen<exception scope='previous'>za</exception></token>
                 </pattern>
                 <message>Ten wyraz nie występuje samodzielnie. Czy chodziło o <suggestion>za bezcen</suggestion>? A może o <suggestion>bez cen</suggestion>?</message>
-                <url>http://so.pwn.pl/lista.php?co=bezcen</url>
+                <url>https://sjp.pwn.pl/slowniki/bezcen.html</url>
                 <short>Prawdopodobna literówka</short>
                 <example correction="za bezcen|bez cen">Kupiłem to <marker>bezcen</marker>.</example>
                 <example>Kupiłem to za bezcen.</example>
@@ -21037,7 +21037,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                      <marker><token>propos</token></marker>
                  </pattern>
                  <message>To wyrażenie nie jest samodzielne. Poprawnie: <suggestion>à propos</suggestion>.</message>
-                 <url>http://so.pwn.pl/lista.php?co=a+propos</url>
+                 <url>https://sjp.pwn.pl/slowniki/a+propos.html</url>
                  <short>Literówka</short>
                  <example>A to à propos czego?</example>
                  <example correction="à propos">A to <marker>propos</marker> czego?</example>
@@ -21050,7 +21050,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                      </marker>
                  </pattern>
                  <message>W tym wyrażeniu „a” musi być z akcentem w lewą stronę. Poprawnie: <suggestion>à propos</suggestion>.</message>
-                 <url>http://so.pwn.pl/lista.php?co=a+propos</url>
+                 <url>https://sjp.pwn.pl/slowniki/a+propos.html</url>
                  <short>Literówka</short>
                  <example>A to à propos czego?</example>
                  <example correction="à propos">A to <marker>a propos</marker> czego?</example>
@@ -21065,7 +21065,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                      </marker>
                  </pattern>
                  <message>W tym wyrażeniu „a” musi być z akcentem w lewą stronę. Poprawnie: <suggestion>à propos</suggestion>.</message>
-                 <url>http://so.pwn.pl/lista.php?co=a+propos</url>
+                 <url>https://sjp.pwn.pl/slowniki/a+propos.html</url>
                  <short>Literówka</short>
                  <example>A to à propos czego?</example>
                  <example correction="à propos">A to <marker>a` propos</marker> czego?</example>

--- a/languagetool-language-modules/pl/src/main/resources/org/languagetool/rules/pl/grammar.xml
+++ b/languagetool-language-modules/pl/src/main/resources/org/languagetool/rules/pl/grammar.xml
@@ -4725,7 +4725,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token>.</token>
                         </pattern>
                         <message>Zbędny apostrof. Poprawnie: <suggestion>\3</suggestion></message>
-                        <url>http://www.ekorekta24.pl/porady-jezykowe/19-interpunkcja/188-lata-90-te-lata-90-czy-lata-90-jak-zapisac-liczebniki-porzadkowe</url>
+                        <url>https://www.ekorekta24.pl/lata-90-te-lata-90-czy-lata-90-jak-zapisac-liczebniki-porzadkowe/</url>
                         <short>Błąd typograficzny</short>
                         <example correction="90">Piekne lata <marker>'90</marker>.</example>
                         <example>To były lata 90.</example>
@@ -4740,7 +4740,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                             <token><exception>.</exception></token>
                         </pattern>
                         <message>Zbędny apostrof. Poprawnie: <suggestion>\3.</suggestion></message>
-                        <url>http://www.ekorekta24.pl/porady-jezykowe/19-interpunkcja/188-lata-90-te-lata-90-czy-lata-90-jak-zapisac-liczebniki-porzadkowe</url>
+                        <url>https://www.ekorekta24.pl/lata-90-te-lata-90-czy-lata-90-jak-zapisac-liczebniki-porzadkowe/</url>
                         <short>Błąd typograficzny</short>
                         <example correction="90.">Piekne lata <marker>'90</marker> były za nami</example>
                         <example>To były lata 90., ale co tu dużo mówić.</example>

--- a/languagetool-language-modules/pl/src/main/resources/org/languagetool/rules/pl/grammar.xml
+++ b/languagetool-language-modules/pl/src/main/resources/org/languagetool/rules/pl/grammar.xml
@@ -5819,7 +5819,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 										<token inflected="yes">Schulz<exception postag="subst:sg:nom:m1"></exception></token>
 								</pattern>
 								<message>Imię Bruno jest odmienne: <suggestion><match no="2" postag="(subst.*)(:m1)" postag_regexp="yes" postag_replace="$1:m[1-3]*">Brunon</match></suggestion>.</message>
-								<url>http://nasze-imiona.pl/2011/07/14/bruno-i-gramatyka/</url>
+								<url>http://filologpolski.blogspot.com/2014/11/odmiana-imion-hugo-i-bruno-przez.html</url>
 								<short>Błąd odmiany</short>
 								<example>Uwielbiam prozę Brunona Schulza.</example>
 								<example correction="Brunona">Uwielbiam prozę <marker>Bruno</marker> Schulza.</example>
@@ -5832,7 +5832,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 										<token inflected="yes">Kołłątaj<exception postag="subst:sg:nom:m1"></exception></token>
 								</pattern>
 								<message>Imię „Hugo” jest odmienne: <suggestion><match no="2" postag="subst.*" postag_regexp="yes">Hugon</match></suggestion>.</message>
-								<url>http://nasze-imiona.pl/2011/07/14/bruno-i-gramatyka/</url>
+								<url>http://filologpolski.blogspot.com/2014/11/odmiana-imion-hugo-i-bruno-przez.html</url>
 								<short>Błąd odmiany</short>
 								<example>Uwielbiam pisma Hugona Kołłątaja.</example>
 								<example correction="Hugonowi">Polacy zamierzają ufundować pomnik <marker>Hugo</marker> Kołłątajowi.</example>


### PR DESCRIPTION
This patch fixes broken links detected in #2729 (except of 2)

Links are updated to the same page with new URL schema or to another page describe the same rule. Every link was manually reviewed.

For following two links I cannot find an equivalent:
```
FOUND BROKEN URL [http://slowniki.gazeta.pl/pl/kondycja]
FOUND BROKEN URL [http://sjp.pwn.pl/haslo.php?id=63498]
```

I want to ask @dpelle to run his script again and check if I didn't leave any broken link more :) 