### PR TITLE
Improve newest QUESTION_MARK rule to cover more test cases

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/grammar.xml
@@ -42874,31 +42874,29 @@ The accident victim died from her injuries.
                 <example>Who does not love wine, women and song; remains a fool his whole life long.</example>
                 <example>"What did the professor talk about?" the student asked.</example>
             </rule>
-            <rule default="temp_off">
+            <rule>
+                <antipattern> <!-- inversion of the conditional clause -->
+                    <token postag="SENT_START"/>
+                    <token inflected="yes" regexp="yes">Should|Be|Have</token>
+                    <token regexp="yes" skip="-1">I|you|we|they|s?he|it|(any|some)(body|one)</token>
+                    <token min="1" postag="," />
+                    <token postag="DT" min="0" />
+                    <token postag_regexp="yes" postag="PRP.*|NN.*" skip="-1" />
+                </antipattern>
                 <pattern>
                     <token postag="SENT_START"/>
-                    <token inflected="yes" regexp="yes">Can|(Wi|Sha)ll|Should|Do|Be|Have</token>
+                    <token inflected="yes" regexp="yes">Can|(Wi|Sha)ll|Should|Do|Be|Have
+                        <exception>Don</exception> <!-- imperative -->
+                    </token>
                     <token spacebefore="no" regexp="yes" min="0">&apostrophe;</token>
                     <token spacebefore="no" min="0">t</token>
                     <token regexp="yes" skip="-1">I|you|we|they|he|she</token>
-                    <marker>
-                        <token postag="SENT_END" spacebefore="no">
-                            .
-                            <exception scope="next">.</exception>
-                            <exception scope="previous">.</exception>
-                        </token>
-                    </marker>
+                    <marker><token postag="SENT_END" spacebefore="no">.<exception scope="next">.</exception></token></marker>
                 </pattern>
                 <message>This looks like a question. Did you mean <suggestion>?</suggestion>?</message>
                 <example correction="?">Can you help me<marker>.</marker></example>
                 <example type="correct">Can you help me make dinner?</example>
-                <example type="correct">Won't you help me fix this sentence?</example>
-                <example type="correct">Shall she help with the horses?</example>
-                <example type="correct">Should we help them find the location?</example>
-                <example type="correct">Does she need our help at the store today?</example>
-                <example type="correct">Are they going to need our help with the research report?</example>
-                <example type="correct">Haven't I helped you already this week?</example>
-                <example>Have you checked ...</example>
+                <example type="correct">Were I a bird, I would fly to you.</example>
             </rule>
         </rulegroup>
         <rule id="NN_CD_NN_CD_COMMA" name="Comma in 'act 2 scene 5'">


### PR DESCRIPTION
This covers the majority of the test cases that didn't pass the first time (especially the large chunk of sentences with inverted conditional clauses), and there were only a handful of unavoidable false negatives in the language tool checker.
Do you in general prefer false negatives or false positives, in cases in which one or the other is necessary? (e.g., "Don't you run." and "Don't you run?" can both be correct.)
