### PR TITLE
Remove redundant .toString()

### DIFF
--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/Main.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/Main.java
@@ -381,13 +381,13 @@ class Main {
       commandLineParser.printUsage();
       System.exit(1);
     } catch (IllegalArgumentException e) {
-      System.err.println(e.toString());
+      System.err.println(e);
       System.exit(1);
     } catch (UnknownParameterException e) {
       if (e.getMessage() != null) {
         System.err.println(e.getMessage());
       } else {
-        System.err.println(e.toString());
+        System.err.println(e);
       }
       commandLineParser.printUsage(System.err);
       System.exit(1);

--- a/languagetool-core/src/main/java/org/languagetool/AnalyzedTokenReadings.java
+++ b/languagetool-core/src/main/java/org/languagetool/AnalyzedTokenReadings.java
@@ -547,7 +547,7 @@ public final class AnalyzedTokenReadings implements Iterable<AnalyzedToken> {
   private void addHistoricalAnnotations(String oldValue, String ruleApplied) {
     if (!ruleApplied.isEmpty()) {
       this.historicalAnnotations = this.getHistoricalAnnotations() + "\n" + ruleApplied + ": " + oldValue + " -> "
-          + this.toString();
+          + this;
     }
   }
   

--- a/languagetool-core/src/main/java/org/languagetool/rules/neuralnetwork/NeuralNetworkRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/neuralnetwork/NeuralNetworkRule.java
@@ -65,7 +65,7 @@ public class NeuralNetworkRule extends Rule {
       }
       classifier = tmpClassifier;
     } catch (FileNotFoundException e) {
-      throw new IOException("Weights for confusion set " + confusionSet.toString() + " are missing", e);
+      throw new IOException("Weights for confusion set " + confusionSet + " are missing", e);
     }
 
     this.id = createId(language);

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/RegexPatternRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/RegexPatternRule.java
@@ -167,7 +167,7 @@ public class RegexPatternRule extends AbstractPatternRule implements RuleMatcher
   
   @Override
   public String toString() {
-    return pattern.toString() + "/flags:" + pattern.flags();
+    return pattern + "/flags:" + pattern.flags();
   }
 
   /* (non-Javadoc)

--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
@@ -375,7 +375,7 @@ public class PatternRuleTest extends AbstractPatternRuleTest {
           }
           String info = "";
           if (rule instanceof RegexPatternRule) {
-            info = "\nRegexp: " + ((RegexPatternRule) rule).getPattern().toString();
+            info = "\nRegexp: " + ((RegexPatternRule) rule).getPattern();
           }
           String failure = badSentence + "\"\n"
                   + "Errors expected: 1\n"

--- a/languagetool-dev/src/main/java/org/languagetool/dev/httpchecker/CheckCallable.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/httpchecker/CheckCallable.java
@@ -94,7 +94,7 @@ class CheckCallable implements Callable<File> {
               //System.out.println(threadName + " - answered by " + result.backendServer);
               JsonNode jsonNode = mapper.readTree(result.json);
               ((ObjectNode)jsonNode).put("title", pseudoFileName);  // needed for MatchKey to be specific enough
-              fw.write(jsonNode.toString() + "\n");
+              fw.write(jsonNode + "\n");
               tempLines.clear();
               startLine = i;
               break;
@@ -136,7 +136,7 @@ class CheckCallable implements Callable<File> {
     String json = new RuleMatchesAsJsonSerializer().ruleMatchesToJson(Collections.singletonList(ruleMatch), textToCheck, 100, detectedLang);
     JsonNode jsonNode = mapper.readTree(json);
     ((ObjectNode)jsonNode).put("title", pseudoFileName);  // needed for MatchKey to be specific enough
-    fw.write(jsonNode.toString() + "\n");
+    fw.write(jsonNode + "\n");
   }
 
   private CheckResult checkByPost(URL url, String postData) throws IOException, ApiErrorException {

--- a/languagetool-language-modules/ro/src/test/java/org/languagetool/tagging/ro/AbstractRomanianTaggerTest.java
+++ b/languagetool-language-modules/ro/src/test/java/org/languagetool/tagging/ro/AbstractRomanianTaggerTest.java
@@ -89,7 +89,7 @@ public abstract class AbstractRomanianTaggerTest {
     }
     assertTrue(String.format("Lemma and POS not found for word [%s]! "
             + "Expected [%s/%s]. Actual: %s", inflected, lemma, posTag,
-            allTags.toString()), found);
+            allTags), found);
   }
 
   public RomanianTagger getTagger() {

--- a/languagetool-language-modules/uk/src/test/java/org/languagetool/rules/uk/MorfologikUkrainianSpellerRuleTest.java
+++ b/languagetool-language-modules/uk/src/test/java/org/languagetool/rules/uk/MorfologikUkrainianSpellerRuleTest.java
@@ -193,7 +193,7 @@ public class MorfologikUkrainianSpellerRuleTest {
     match = rule.match(langTool.getAnalyzedSentence("авіабегемот"));
     assertEquals(1, match.length);
 
-    assertTrue("Should be empty: " + match[0].getSuggestedReplacements().toString(), match[0].getSuggestedReplacements().isEmpty());
+    assertTrue("Should be empty: " + match[0].getSuggestedReplacements(), match[0].getSuggestedReplacements().isEmpty());
 
     match = rule.match(langTool.getAnalyzedSentence("вело-маршрут"));
     assertEquals(1, match.length);
@@ -208,7 +208,7 @@ public class MorfologikUkrainianSpellerRuleTest {
     match = rule.match(langTool.getAnalyzedSentence("вело-бегемот"));
     assertEquals(1, match.length);
 
-    assertTrue("Unexpected suggestions: " + match[0].getSuggestedReplacements().toString(), match[0].getSuggestedReplacements().isEmpty());
+    assertTrue("Unexpected suggestions: " + match[0].getSuggestedReplacements(), match[0].getSuggestedReplacements().isEmpty());
 
     match = rule.match(langTool.getAnalyzedSentence("радіо- та відеоспостереження"));
     assertEquals(0, match.length);

--- a/languagetool-language-modules/uk/src/test/java/org/languagetool/tagging/disambiguation/uk/UkrainianDisambiguationRuleTest.java
+++ b/languagetool-language-modules/uk/src/test/java/org/languagetool/tagging/disambiguation/uk/UkrainianDisambiguationRuleTest.java
@@ -394,7 +394,7 @@ public class UkrainianDisambiguationRuleTest {
       AnalyzedTokenReadings taggedToken = tagged.get(0);
       TokenMatcher tokenMatcher = entry.getValue();
       
-      assertTrue(String.format("%s not found in dictionary, tags: %s", entry.toString(), tagged.toString()), matches(taggedToken, tokenMatcher));
+      assertTrue(String.format("%s not found in dictionary, tags: %s", entry, tagged), matches(taggedToken, tokenMatcher));
     }
   }
 

--- a/languagetool-office-extension/src/main/java/org/languagetool/openoffice/LanguageToolMenus.java
+++ b/languagetool-office-extension/src/main/java/org/languagetool/openoffice/LanguageToolMenus.java
@@ -426,10 +426,10 @@ public class LanguageToolMenus {
         MessageHandler.printToLogFile("Property: Name: " + property.Name + ", Type: " + property.Type);
       }
       if(props.getPropertySetInfo().hasPropertyByName("Text")) {
-        MessageHandler.printToLogFile("Property: Name: " + props.getPropertyValue("Text").toString());
+        MessageHandler.printToLogFile("Property: Name: " + props.getPropertyValue("Text"));
       }
       if(props.getPropertySetInfo().hasPropertyByName("CommandURL")) {
-        MessageHandler.printToLogFile("Property: CommandURL: " + props.getPropertyValue("CommandURL").toString());
+        MessageHandler.printToLogFile("Property: CommandURL: " + props.getPropertyValue("CommandURL"));
       }
     }
 

--- a/languagetool-office-extension/src/main/java/org/languagetool/openoffice/MessageHandler.java
+++ b/languagetool-office-extension/src/main/java/org/languagetool/openoffice/MessageHandler.java
@@ -55,7 +55,7 @@ class MessageHandler {
   private static void initLogFile() {
     try (BufferedWriter bw = new BufferedWriter(new FileWriter(getLogPath()))) {
       Date date = new Date();
-      bw.write("LT office integration log from " + date.toString() + logLineBreak);
+      bw.write("LT office integration log from " + date + logLineBreak);
     } catch (Throwable t) {
       showError(t);
     }
@@ -112,7 +112,7 @@ class MessageHandler {
       if(!parentDir.exists()) {
         boolean success = parentDir.mkdirs();
         if(!success) {
-          showMessage("Can't create directory: " + parentDir.toString());
+          showMessage("Can't create directory: " + parentDir);
         }
       }
     }

--- a/languagetool-wikipedia/src/main/java/org/languagetool/dev/index/Searcher.java
+++ b/languagetool-wikipedia/src/main/java/org/languagetool/dev/index/Searcher.java
@@ -151,7 +151,7 @@ public class Searcher {
         throw new NullPointerException("Cannot search on null query for rule: " + rule.getId());
       }
 
-      System.out.println("Running query: " + query.toString());
+      System.out.println("Running query: " + query);
       SearchRunnable runnable = new SearchRunnable(indexSearcher, query, language, rule);
       Thread searchThread = new Thread(runnable);
       searchThread.start();


### PR DESCRIPTION
There is no need to use `toString()` on string concatenation or in `.format()`, as it is automatically called by the compiler/implementation.