### PR TITLE
Remove redundant usage

### DIFF
--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineTools.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineTools.java
@@ -69,17 +69,17 @@ public final class CommandLineTools {
   }
 
   public static int checkText(String contents, JLanguageTool lt) throws IOException {
-    return checkText(contents, lt, false, false, -1, 0, 0, StringTools.ApiPrintMode.NORMAL_API, false, Collections.<String>emptyList());
+    return checkText(contents, lt, false, false, -1, 0, 0, StringTools.ApiPrintMode.NORMAL_API, false, Collections.emptyList());
   }
 
   public static int checkText(String contents, JLanguageTool lt,
                               boolean isXmlFormat, boolean isJsonFormat, int lineOffset) throws IOException {
-    return checkText(contents, lt, isXmlFormat, isJsonFormat, -1, lineOffset, 0, StringTools.ApiPrintMode.NORMAL_API, false, Collections.<String>emptyList());
+    return checkText(contents, lt, isXmlFormat, isJsonFormat, -1, lineOffset, 0, StringTools.ApiPrintMode.NORMAL_API, false, Collections.emptyList());
   }
   
   public static int checkText(String contents, JLanguageTool lt,
           boolean isXmlFormat, boolean isJsonFormat, int lineOffset, boolean listUnknownWords) throws IOException {
-    return checkText(contents, lt, isXmlFormat, isJsonFormat, -1, lineOffset, 0, StringTools.ApiPrintMode.NORMAL_API, listUnknownWords, Collections.<String>emptyList());
+    return checkText(contents, lt, isXmlFormat, isJsonFormat, -1, lineOffset, 0, StringTools.ApiPrintMode.NORMAL_API, listUnknownWords, Collections.emptyList());
 }
 
   /**

--- a/languagetool-core/src/main/java/org/languagetool/rules/RuleMatch.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RuleMatch.java
@@ -436,7 +436,7 @@ public class RuleMatch implements Comparable<RuleMatch> {
     if (rule instanceof PatternRule) {
       //String covered = getSentence().getText().substring(getFromPos(), getToPos());
       //return ((PatternRule) rule).getFullId() + ":" + offsetPosition + ":" + message + ":" + covered + " -> " + getSuggestedReplacements();
-      return ((PatternRule) rule).getFullId() + ":" + offsetPosition + ":" + message;
+      return rule.getFullId() + ":" + offsetPosition + ":" + message;
     } else {
       //String covered = getSentence().getText().substring(getFromPos(), getToPos());
       //return rule.getId() + ":" + offsetPosition + ":" + message + ":" + covered + " -> " + getSuggestedReplacements();

--- a/languagetool-core/src/main/java/org/languagetool/rules/TestHackHelper.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/TestHackHelper.java
@@ -18,9 +18,6 @@
  */
 package org.languagetool.rules;
 
-import java.util.Arrays;
-import java.util.List;
-
 final class TestHackHelper {
 
   private TestHackHelper() {
@@ -28,8 +25,7 @@ final class TestHackHelper {
 
   static boolean isJUnitTest() {
     StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-    List<StackTraceElement> list = Arrays.asList(stackTrace);
-    for (StackTraceElement element : list) {
+    for (StackTraceElement element : stackTrace) {
       if (element.getClassName().startsWith("org.junit.") ||
               element.getClassName().equals("org.languagetool.rules.patterns.PatternRuleTest")) {
         return true;

--- a/languagetool-core/src/main/java/org/languagetool/rules/bitext/IncorrectBitextExample.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/bitext/IncorrectBitextExample.java
@@ -34,7 +34,7 @@ public class IncorrectBitextExample {
   private final List<String> corrections;
 
   public IncorrectBitextExample(StringPair example) {
-    this(example, Collections.<String>emptyList());
+    this(example, Collections.emptyList());
   }
 
   /**

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/symspell/implementation/SymSpell.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/symspell/implementation/SymSpell.java
@@ -715,7 +715,7 @@ public class SymSpell implements Serializable {
     }
 
     hash &= this.compactMask;
-    hash |= (long) lenMask;
+    hash |= lenMask;
     return (int) hash;
   }
 

--- a/languagetool-core/src/main/java/org/languagetool/tools/ContextTools.java
+++ b/languagetool-core/src/main/java/org/languagetool/tools/ContextTools.java
@@ -53,7 +53,7 @@ public class ContextTools {
     // now build context string plus marker:
     StringBuilder sb = new StringBuilder();
     sb.append(prefix);
-    sb.append(text.substring(startContent, endContent));
+    sb.append(text, startContent, endContent);
     String markerStr = markerPrefix
         + marker.substring(startContent, endContent);
     sb.append(postfix);

--- a/languagetool-core/src/test/java/org/languagetool/languagemodel/BaseLanguageModelTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/languagemodel/BaseLanguageModelTest.java
@@ -51,7 +51,7 @@ public class BaseLanguageModelTest {
   @Test(expected = IndexOutOfBoundsException.class)
   public void testPseudoProbabilityFail1() throws IOException {
     try (FakeLanguageModel lm = new FakeLanguageModel()) {
-      lm.getPseudoProbability(Collections.<String>emptyList());
+      lm.getPseudoProbability(Collections.emptyList());
     }
   }
 

--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/DemoPatternRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/DemoPatternRuleTest.java
@@ -43,7 +43,7 @@ public class DemoPatternRuleTest extends PatternRuleTest {
 
   @Test
   public void testGrammarRulesFromXML2() throws IOException {
-    new PatternRule("-1", language, Collections.<PatternToken>emptyList(), "", "", "");
+    new PatternRule("-1", language, Collections.emptyList(), "", "", "");
   }
 
   @Test

--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleMatcherTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleMatcherTest.java
@@ -469,7 +469,7 @@ public class PatternRuleMatcherTest {
   @Test
   public void testEquals() throws Exception {
     PatternRule patternRule1 = new PatternRule("id1", Languages.getLanguageForShortCode("xx"),
-            Collections.<PatternToken>emptyList(), "desc1", "msg1", "short1");
+            Collections.emptyList(), "desc1", "msg1", "short1");
     RuleMatch ruleMatch1 = new RuleMatch(patternRule1, null, 0, 1, "message");
     RuleMatch ruleMatch2 = new RuleMatch(patternRule1, null, 0, 1, "message");
     assertTrue(ruleMatch1.equals(ruleMatch2));

--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
@@ -82,12 +82,12 @@ public class PatternRuleTest extends AbstractPatternRuleTest {
   public void testSupportsLanguage() {
     FakeLanguage fakeLanguage1 = new FakeLanguage("yy");
     FakeLanguage fakeLanguage2 = new FakeLanguage("zz");
-    PatternRule patternRule1 = new PatternRule("ID", fakeLanguage1, Collections.<PatternToken>emptyList(), "", "", "");
+    PatternRule patternRule1 = new PatternRule("ID", fakeLanguage1, Collections.emptyList(), "", "", "");
     assertTrue(patternRule1.supportsLanguage(fakeLanguage1)); 
     assertFalse(patternRule1.supportsLanguage(fakeLanguage2));
     FakeLanguage fakeLanguage1WithVariant1 = new FakeLanguage("zz", "VAR1");
     FakeLanguage fakeLanguage1WithVariant2 = new FakeLanguage("zz", "VAR2");
-    PatternRule patternRuleVariant1 = new PatternRule("ID", fakeLanguage1WithVariant1, Collections.<PatternToken>emptyList(), "", "", "");
+    PatternRule patternRuleVariant1 = new PatternRule("ID", fakeLanguage1WithVariant1, Collections.emptyList(), "", "", "");
     assertTrue(patternRuleVariant1.supportsLanguage(fakeLanguage1WithVariant1));    
     assertFalse(patternRuleVariant1.supportsLanguage(fakeLanguage1));
     assertFalse(patternRuleVariant1.supportsLanguage(fakeLanguage2));
@@ -223,7 +223,7 @@ public class PatternRuleTest extends AbstractPatternRuleTest {
           boolean hasExplicitMarker = patternTokens.stream().anyMatch(PatternToken::isInsideMarker);
           for (PatternToken patternToken : patternTokens) {
             if ((patternToken.isInsideMarker() || !hasExplicitMarker) && patternToken.isSentenceStart()) {
-              System.err.println("WARNING: Sentence start in <marker>: " + ((AbstractPatternRule) rule).getFullId() +
+              System.err.println("WARNING: Sentence start in <marker>: " + rule.getFullId() +
                       " (hasExplicitMarker: " + hasExplicitMarker + ") - please move the <marker> so the SENT_START is not covered");
             }
           }

--- a/languagetool-dev/src/main/java/org/languagetool/dev/archive/MissingGenitiveFinder.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/archive/MissingGenitiveFinder.java
@@ -51,7 +51,7 @@ public class MissingGenitiveFinder {
   private Map<String, Integer> loadOccurrences(String filename) throws IOException {
     System.err.println("Loading " + filename);
     Map<String, Integer> map = new HashMap<>();
-    List<String> lines = (List<String>)FileUtils.readLines(new File(filename));
+    List<String> lines = FileUtils.readLines(new File(filename));
     for (String line : lines) {
       String[] parts = line.split(" ");
       map.put(parts[0], Integer.valueOf(parts[1]));

--- a/languagetool-dev/src/main/java/org/languagetool/dev/eval/RealWordCorpusEvaluator.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/eval/RealWordCorpusEvaluator.java
@@ -123,7 +123,7 @@ class RealWordCorpusEvaluator {
     System.out.println("    [+ ] = this is an expected error");
     System.out.println("    [++] = this is an expected error and the first suggestion is correct");
     System.out.println("    [//]  = not counted because already matches by a different rule");
-    System.out.println("");
+    System.out.println();
     ErrorCorpus corpus = getCorpus(dir);
     checkLines(corpus);
     printResults();
@@ -179,7 +179,7 @@ class RealWordCorpusEvaluator {
   }
 
   private void printResults() {
-    System.out.println("");
+    System.out.println();
     System.out.println(sentenceCount + " lines checked with " + errorsInCorpusCount + " errors.");
     System.out.println("Confusion rule matches: " + perfectConfusionMatches+ " perfect, "
             + goodConfusionMatches + " good, " + badConfusionMatches + " bad (" + badConfusionMatchWords + ")");

--- a/languagetool-dev/src/main/java/org/languagetool/dev/eval/SimpleCorpusEvaluator.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/eval/SimpleCorpusEvaluator.java
@@ -127,7 +127,7 @@ public class SimpleCorpusEvaluator {
   }
 
   private PrecisionRecall printAndResetResults() {
-    System.out.println("");
+    System.out.println();
     System.out.println(sentenceCount + " lines checked with " + errorsInCorpusCount + " errors.");
 
     System.out.println("\nCounting matches, no matter whether the first suggestion is correct:");

--- a/languagetool-gui-commons/src/main/java/org/languagetool/gui/Configuration.java
+++ b/languagetool-gui-commons/src/main/java/org/languagetool/gui/Configuration.java
@@ -801,9 +801,7 @@ public class Configuration {
               || rule.getLocQualityIssueType().toString().equalsIgnoreCase("REGISTER")
               || rule.getCategory().getId().toString().equals("STYLE")
               || rule.getCategory().getId().toString().equals("TYPOGRAPHY")) {
-        if (!styleLikeCategories.contains(rule.getCategory().getName())) {
-          styleLikeCategories.add(rule.getCategory().getName());
-        }
+        styleLikeCategories.add(rule.getCategory().getName());
       }
     }
   }
@@ -834,9 +832,7 @@ public class Configuration {
   public String[] getSpecialTabNames() {
     Set<String> tabNames = new HashSet<>();
     for (Map.Entry<String, String> entry : specialTabCategories.entrySet()) {
-      if (!tabNames.contains(entry.getValue())) {
-        tabNames.add(entry.getValue());
-      }
+      tabNames.add(entry.getValue());
     }
     return tabNames.toArray(new String[tabNames.size()]);
   }
@@ -1010,9 +1006,9 @@ public class Configuration {
       
       String prefix;
       if(currentProfile == null) {
-        prefix = new String("");
+        prefix = "";
       } else {
-        prefix = new String(currentProfile);
+        prefix = currentProfile;
       }
       if(!prefix.isEmpty()) {
         prefix = prefix.replaceAll(BLANK, BLANK_REPLACE);
@@ -1269,14 +1265,14 @@ public class Configuration {
     List<String> prefixes = new ArrayList<String>();
     prefixes.add("");
     for(String profile : definedProfiles) {
-      String prefix = new String(profile);
+      String prefix = profile;
       prefixes.add(prefix.replaceAll(BLANK, BLANK_REPLACE) + PROFILE_DELIMITER);
     }
     String currentPrefix;
     if (currentProfile == null) {
-      currentPrefix = new String("");
+      currentPrefix = "";
     } else {
-      currentPrefix = new String(currentProfile);
+      currentPrefix = currentProfile;
     }
     if(!currentPrefix.isEmpty()) {
       currentPrefix = currentPrefix.replaceAll(BLANK, BLANK_REPLACE);
@@ -1366,7 +1362,7 @@ public class Configuration {
           StringBuilder sb = new StringBuilder();
           for (Map.Entry<ITSIssueType, Color> entry : errorColors.entrySet()) {
             String rgb = Integer.toHexString(entry.getValue().getRGB());
-            rgb = rgb.substring(2, rgb.length());
+            rgb = rgb.substring(2);
             sb.append(entry.getKey()).append(":#").append(rgb).append(", ");
           }
           props.setProperty(prefix + ERROR_COLORS_KEY, sb.toString());
@@ -1375,7 +1371,7 @@ public class Configuration {
           StringBuilder sbUC = new StringBuilder();
           for (Map.Entry<String, Color> entry : underlineColors.entrySet()) {
             String rgb = Integer.toHexString(entry.getValue().getRGB());
-            rgb = rgb.substring(2, rgb.length());
+            rgb = rgb.substring(2);
             sbUC.append(entry.getKey()).append(":#").append(rgb).append(", ");
           }
           props.setProperty(prefix + UNDERLINE_COLORS_KEY, sbUC.toString());
@@ -1454,7 +1450,7 @@ public class Configuration {
     List<String> prefix = new ArrayList<String>();
     prefix.add("");
     for(String profile : definedProfiles) {
-      String sPrefix = new String(profile);
+      String sPrefix = profile;
       prefix.add(sPrefix.replaceAll(BLANK, BLANK_REPLACE) + PROFILE_DELIMITER);
     }
     for(String sPrefix : prefix) {

--- a/languagetool-gui-commons/src/main/java/org/languagetool/gui/ConfigurationDialog.java
+++ b/languagetool-gui-commons/src/main/java/org/languagetool/gui/ConfigurationDialog.java
@@ -980,7 +980,7 @@ public class ConfigurationDialog implements ActionListener {
     defaultButton.addActionListener(e -> {
       List<String> saveProfiles = new ArrayList<String>(); 
       saveProfiles.addAll(config.getDefinedProfiles());
-      String saveCurrent = config.getCurrentProfile() == null ? null : new String(config.getCurrentProfile());
+      String saveCurrent = config.getCurrentProfile() == null ? null : config.getCurrentProfile();
       config.initOptions();
       config.addProfiles(saveProfiles);
       config.setCurrentProfile(saveCurrent);
@@ -1365,10 +1365,10 @@ public class ConfigurationDialog implements ActionListener {
   
   private String[] getUnderlineTypes() {
     String[] types = {
-        new String(messages.getString("guiUTypeWave")),
-        new String(messages.getString("guiUTypeBoldWave")),
-        new String(messages.getString("guiUTypeBold")),
-        new String(messages.getString("guiUTypeDash")) };
+      messages.getString("guiUTypeWave"),
+      messages.getString("guiUTypeBoldWave"),
+      messages.getString("guiUTypeBold"),
+      messages.getString("guiUTypeDash")};
     return types;
   }
 

--- a/languagetool-language-modules/ca/src/main/java/org/languagetool/rules/ca/SimpleReplaceVerbsRule.java
+++ b/languagetool-language-modules/ca/src/main/java/org/languagetool/rules/ca/SimpleReplaceVerbsRule.java
@@ -134,7 +134,7 @@ public class SimpleReplaceVerbsRule extends AbstractSimpleReplaceRule {
             }
           }
           if (desinence.startsWith("ï")) {
-            desinence = "i" + desinence.substring(1, desinence.length());
+            desinence = "i" + desinence.substring(1);
           }
           infinitive = lexeme.concat("ar");
           if (wrongWords.containsKey(infinitive)) {

--- a/languagetool-language-modules/de/src/test/java/org/languagetool/tagging/de/GermanTaggerTest.java
+++ b/languagetool-language-modules/de/src/test/java/org/languagetool/tagging/de/GermanTaggerTest.java
@@ -285,9 +285,7 @@ public class GermanTaggerTest {
     Set<String> elements = new TreeSet<>();
     sb.append('[');
     for (AnalyzedToken reading : tokenReadings) {
-      if (!elements.contains(reading.toString())) {
-        elements.add(reading.toString());
-      }
+      elements.add(reading.toString());
     }
     sb.append(String.join(", ", elements));
     sb.append(']');

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishWordRepeatRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishWordRepeatRule.java
@@ -52,7 +52,7 @@ public class EnglishWordRepeatRule extends WordRepeatRule {
     // but you you're my best friend ...
     // I'm so so happy
     // I'm very very happy
-    String word = tokens[position].getToken().toString();
+    String word = tokens[position].getToken();
 
     if (wordRepetitionOf("had", tokens, position) && posIsIn(tokens, position - 2, "PRP", "NN")) {
       return true;   // "If I had had time, I would have gone to see him."

--- a/languagetool-language-modules/eo/src/main/java/org/languagetool/rules/eo/DateCheckFilter.java
+++ b/languagetool-language-modules/eo/src/main/java/org/languagetool/rules/eo/DateCheckFilter.java
@@ -45,17 +45,17 @@ public class DateCheckFilter extends AbstractDateCheckFilter {
     int n = 0;
     if (day.startsWith("dek")) {
       n = 10;
-      day = day.substring(3, day.length());
+      day = day.substring(3);
     } else if (day.startsWith("dudek")) {
       n = 20;
-      day = day.substring(5, day.length());
+      day = day.substring(5);
     } else if (day.startsWith("tridek")) {
       n = 30;
-      day = day.substring(6, day.length());
+      day = day.substring(6);
     }
     if (n > 0 && day.startsWith("-")) {
       // Remove hyphen as in "dudek-trian".
-      day = day.substring(1, day.length());
+      day = day.substring(1);
     }
     if (day.equals("unua"))  n += 1;
     if (day.equals("dua"))   n += 2;

--- a/languagetool-language-modules/ga/src/main/java/org/languagetool/tagging/ga/Utils.java
+++ b/languagetool-language-modules/ga/src/main/java/org/languagetool/tagging/ga/Utils.java
@@ -653,95 +653,95 @@ public class Utils {
     return sb.toString();
   }
 
-  private static final int MATHEMATICAL_BOLD_CAPITAL_A = (int) '\uDC00';
-  private static final int MATHEMATICAL_BOLD_CAPITAL_Z = (int) '\uDC19';
-  private static final int MATHEMATICAL_BOLD_SMALL_A = (int) '\uDC1A';
-  private static final int MATHEMATICAL_BOLD_SMALL_Z = (int) '\uDC33';
-  private static final int MATHEMATICAL_ITALIC_CAPITAL_A = (int) '\uDC34';
-  private static final int MATHEMATICAL_ITALIC_CAPITAL_Z = (int) '\uDC4D';
-  private static final int MATHEMATICAL_ITALIC_SMALL_A = (int) '\uDC4E';
-  private static final int MATHEMATICAL_ITALIC_SMALL_Z = (int) '\uDC67';
-  private static final int MATHEMATICAL_BOLD_ITALIC_CAPITAL_A = (int) '\uDC68';
-  private static final int MATHEMATICAL_BOLD_ITALIC_CAPITAL_Z = (int) '\uDC81';
-  private static final int MATHEMATICAL_BOLD_ITALIC_SMALL_A = (int) '\uDC82';
-  private static final int MATHEMATICAL_BOLD_ITALIC_SMALL_Z = (int) '\uDC9B';
-  private static final int MATHEMATICAL_SCRIPT_CAPITAL_A = (int) '\uDC9C';
-  private static final int MATHEMATICAL_SCRIPT_CAPITAL_Z = (int) '\uDCB5';
-  private static final int MATHEMATICAL_SCRIPT_SMALL_A = (int) '\uDCB6';
-  private static final int MATHEMATICAL_SCRIPT_SMALL_Z = (int) '\uDCCF';
-  private static final int MATHEMATICAL_BOLD_SCRIPT_CAPITAL_A = (int) '\uDCD0';
-  private static final int MATHEMATICAL_BOLD_SCRIPT_CAPITAL_Z = (int) '\uDCE9';
-  private static final int MATHEMATICAL_BOLD_SCRIPT_SMALL_A = (int) '\uDCEA';
-  private static final int MATHEMATICAL_BOLD_SCRIPT_SMALL_Z = (int) '\uDD03';
-  private static final int MATHEMATICAL_FRAKTUR_CAPITAL_A = (int) '\uDD04';
-  private static final int MATHEMATICAL_FRAKTUR_CAPITAL_Z = (int) '\uDD1D';
-  private static final int MATHEMATICAL_FRAKTUR_SMALL_A = (int) '\uDD1E';
-  private static final int MATHEMATICAL_FRAKTUR_SMALL_Z = (int) '\uDD37';
-  private static final int MATHEMATICAL_DOUBLESTRUCK_CAPITAL_A = (int) '\uDD38';
-  private static final int MATHEMATICAL_DOUBLESTRUCK_CAPITAL_Z = (int) '\uDD51';
-  private static final int MATHEMATICAL_DOUBLESTRUCK_SMALL_A = (int) '\uDD52';
-  private static final int MATHEMATICAL_DOUBLESTRUCK_SMALL_Z = (int) '\uDD6B';
-  private static final int MATHEMATICAL_BOLD_FRAKTUR_CAPITAL_A = (int) '\uDD6C';
-  private static final int MATHEMATICAL_BOLD_FRAKTUR_CAPITAL_Z = (int) '\uDD85';
-  private static final int MATHEMATICAL_BOLD_FRAKTUR_SMALL_A = (int) '\uDD86';
-  private static final int MATHEMATICAL_BOLD_FRAKTUR_SMALL_Z = (int) '\uDD9F';
-  private static final int MATHEMATICAL_SANSSERIF_CAPITAL_A = (int) '\uDDA0';
-  private static final int MATHEMATICAL_SANSSERIF_CAPITAL_Z = (int) '\uDDB9';
-  private static final int MATHEMATICAL_SANSSERIF_SMALL_A = (int) '\uDDBA';
-  private static final int MATHEMATICAL_SANSSERIF_SMALL_Z = (int) '\uDDD3';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_CAPITAL_A = (int) '\uDDD4';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_CAPITAL_Z = (int) '\uDDED';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_SMALL_A = (int) '\uDDEE';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_SMALL_Z = (int) '\uDE07';
-  private static final int MATHEMATICAL_SANSSERIF_ITALIC_CAPITAL_A = (int) '\uDE08';
-  private static final int MATHEMATICAL_SANSSERIF_ITALIC_CAPITAL_Z = (int) '\uDE21';
-  private static final int MATHEMATICAL_SANSSERIF_ITALIC_SMALL_A = (int) '\uDE22';
-  private static final int MATHEMATICAL_SANSSERIF_ITALIC_SMALL_Z = (int) '\uDE3B';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_CAPITAL_A = (int) '\uDE3C';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_CAPITAL_Z = (int) '\uDE55';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_SMALL_A = (int) '\uDE56';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_SMALL_Z = (int) '\uDE6F';
-  private static final int MATHEMATICAL_MONOSPACE_CAPITAL_A = (int) '\uDE70';
-  private static final int MATHEMATICAL_MONOSPACE_CAPITAL_Z = (int) '\uDE89';
-  private static final int MATHEMATICAL_MONOSPACE_SMALL_A = (int) '\uDE8A';
-  private static final int MATHEMATICAL_MONOSPACE_SMALL_Z = (int) '\uDEA3';
-  private static final int MATHEMATICAL_ITALIC_SMALL_DOTLESS_I = (int) '\uDEA4';
-  private static final int MATHEMATICAL_ITALIC_SMALL_DOTLESS_J = (int) '\uDEA5';
-  private static final int MATHEMATICAL_BOLD_CAPITAL_ALPHA = (int) '\uDEA8';
-  private static final int MATHEMATICAL_BOLD_CAPITAL_OMEGA = (int) '\uDEC0';
-  private static final int MATHEMATICAL_BOLD_SMALL_ALPHA = (int) '\uDEC2';
-  private static final int MATHEMATICAL_BOLD_SMALL_OMEGA = (int) '\uDEDA';
-  private static final int MATHEMATICAL_ITALIC_CAPITAL_ALPHA = (int) '\uDEE2';
-  private static final int MATHEMATICAL_ITALIC_CAPITAL_OMEGA = (int) '\uDEFA';
-  private static final int MATHEMATICAL_ITALIC_SMALL_ALPHA = (int) '\uDEFC';
-  private static final int MATHEMATICAL_ITALIC_SMALL_OMEGA = (int) '\uDF14';
-  private static final int MATHEMATICAL_BOLD_ITALIC_CAPITAL_ALPHA = (int) '\uDF1C';
-  private static final int MATHEMATICAL_BOLD_ITALIC_CAPITAL_OMEGA = (int) '\uDF34';
-  private static final int MATHEMATICAL_BOLD_ITALIC_SMALL_ALPHA = (int) '\uDF36';
-  private static final int MATHEMATICAL_BOLD_ITALIC_SMALL_OMEGA = (int) '\uDF4E';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_CAPITAL_ALPHA = (int) '\uDF56';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_CAPITAL_OMEGA = (int) '\uDF6E';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_SMALL_ALPHA = (int) '\uDF70';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_SMALL_OMEGA = (int) '\uDF88';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_CAPITAL_ALPHA = (int) '\uDF90';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_CAPITAL_OMEGA = (int) '\uDFA8';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_SMALL_ALPHA = (int) '\uDFAA';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_SMALL_OMEGA = (int) '\uDFC2';
-  private static final int MATHEMATICAL_BOLD_DIGIT_ZERO = (int) '\uDFCE';
-  private static final int MATHEMATICAL_BOLD_DIGIT_NINE = (int) '\uDFD7';
-  private static final int MATHEMATICAL_DOUBLESTRUCK_DIGIT_ZERO = (int) '\uDFD8';
-  private static final int MATHEMATICAL_DOUBLESTRUCK_DIGIT_NINE = (int) '\uDFE1';
-  private static final int MATHEMATICAL_SANSSERIF_DIGIT_ZERO = (int) '\uDFE2';
-  private static final int MATHEMATICAL_SANSSERIF_DIGIT_NINE = (int) '\uDFEB';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_DIGIT_ZERO = (int) '\uDFEC';
-  private static final int MATHEMATICAL_SANSSERIF_BOLD_DIGIT_NINE = (int) '\uDFF5';
-  private static final int MATHEMATICAL_MONOSPACE_DIGIT_ZERO = (int) '\uDFF6';
-  private static final int MATHEMATICAL_MONOSPACE_DIGIT_NINE = (int) '\uDFFF';
-  private static final int CAPITAL_A = (int) 'A';
-  private static final int SMALL_A = (int) 'a';
-  private static final int CAPITAL_ALPHA = (int) 'Α';
-  private static final int SMALL_ALPHA = (int) 'α';
-  private static final int DIGIT_ZERO = (int) '0';
+  private static final int MATHEMATICAL_BOLD_CAPITAL_A = '\uDC00';
+  private static final int MATHEMATICAL_BOLD_CAPITAL_Z = '\uDC19';
+  private static final int MATHEMATICAL_BOLD_SMALL_A = '\uDC1A';
+  private static final int MATHEMATICAL_BOLD_SMALL_Z = '\uDC33';
+  private static final int MATHEMATICAL_ITALIC_CAPITAL_A = '\uDC34';
+  private static final int MATHEMATICAL_ITALIC_CAPITAL_Z = '\uDC4D';
+  private static final int MATHEMATICAL_ITALIC_SMALL_A = '\uDC4E';
+  private static final int MATHEMATICAL_ITALIC_SMALL_Z = '\uDC67';
+  private static final int MATHEMATICAL_BOLD_ITALIC_CAPITAL_A = '\uDC68';
+  private static final int MATHEMATICAL_BOLD_ITALIC_CAPITAL_Z = '\uDC81';
+  private static final int MATHEMATICAL_BOLD_ITALIC_SMALL_A = '\uDC82';
+  private static final int MATHEMATICAL_BOLD_ITALIC_SMALL_Z = '\uDC9B';
+  private static final int MATHEMATICAL_SCRIPT_CAPITAL_A = '\uDC9C';
+  private static final int MATHEMATICAL_SCRIPT_CAPITAL_Z = '\uDCB5';
+  private static final int MATHEMATICAL_SCRIPT_SMALL_A = '\uDCB6';
+  private static final int MATHEMATICAL_SCRIPT_SMALL_Z = '\uDCCF';
+  private static final int MATHEMATICAL_BOLD_SCRIPT_CAPITAL_A = '\uDCD0';
+  private static final int MATHEMATICAL_BOLD_SCRIPT_CAPITAL_Z = '\uDCE9';
+  private static final int MATHEMATICAL_BOLD_SCRIPT_SMALL_A = '\uDCEA';
+  private static final int MATHEMATICAL_BOLD_SCRIPT_SMALL_Z = '\uDD03';
+  private static final int MATHEMATICAL_FRAKTUR_CAPITAL_A = '\uDD04';
+  private static final int MATHEMATICAL_FRAKTUR_CAPITAL_Z = '\uDD1D';
+  private static final int MATHEMATICAL_FRAKTUR_SMALL_A = '\uDD1E';
+  private static final int MATHEMATICAL_FRAKTUR_SMALL_Z = '\uDD37';
+  private static final int MATHEMATICAL_DOUBLESTRUCK_CAPITAL_A = '\uDD38';
+  private static final int MATHEMATICAL_DOUBLESTRUCK_CAPITAL_Z = '\uDD51';
+  private static final int MATHEMATICAL_DOUBLESTRUCK_SMALL_A = '\uDD52';
+  private static final int MATHEMATICAL_DOUBLESTRUCK_SMALL_Z = '\uDD6B';
+  private static final int MATHEMATICAL_BOLD_FRAKTUR_CAPITAL_A = '\uDD6C';
+  private static final int MATHEMATICAL_BOLD_FRAKTUR_CAPITAL_Z = '\uDD85';
+  private static final int MATHEMATICAL_BOLD_FRAKTUR_SMALL_A = '\uDD86';
+  private static final int MATHEMATICAL_BOLD_FRAKTUR_SMALL_Z = '\uDD9F';
+  private static final int MATHEMATICAL_SANSSERIF_CAPITAL_A = '\uDDA0';
+  private static final int MATHEMATICAL_SANSSERIF_CAPITAL_Z = '\uDDB9';
+  private static final int MATHEMATICAL_SANSSERIF_SMALL_A = '\uDDBA';
+  private static final int MATHEMATICAL_SANSSERIF_SMALL_Z = '\uDDD3';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_CAPITAL_A = '\uDDD4';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_CAPITAL_Z = '\uDDED';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_SMALL_A = '\uDDEE';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_SMALL_Z = '\uDE07';
+  private static final int MATHEMATICAL_SANSSERIF_ITALIC_CAPITAL_A = '\uDE08';
+  private static final int MATHEMATICAL_SANSSERIF_ITALIC_CAPITAL_Z = '\uDE21';
+  private static final int MATHEMATICAL_SANSSERIF_ITALIC_SMALL_A = '\uDE22';
+  private static final int MATHEMATICAL_SANSSERIF_ITALIC_SMALL_Z = '\uDE3B';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_CAPITAL_A = '\uDE3C';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_CAPITAL_Z = '\uDE55';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_SMALL_A = '\uDE56';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_SMALL_Z = '\uDE6F';
+  private static final int MATHEMATICAL_MONOSPACE_CAPITAL_A = '\uDE70';
+  private static final int MATHEMATICAL_MONOSPACE_CAPITAL_Z = '\uDE89';
+  private static final int MATHEMATICAL_MONOSPACE_SMALL_A = '\uDE8A';
+  private static final int MATHEMATICAL_MONOSPACE_SMALL_Z = '\uDEA3';
+  private static final int MATHEMATICAL_ITALIC_SMALL_DOTLESS_I = '\uDEA4';
+  private static final int MATHEMATICAL_ITALIC_SMALL_DOTLESS_J = '\uDEA5';
+  private static final int MATHEMATICAL_BOLD_CAPITAL_ALPHA = '\uDEA8';
+  private static final int MATHEMATICAL_BOLD_CAPITAL_OMEGA = '\uDEC0';
+  private static final int MATHEMATICAL_BOLD_SMALL_ALPHA = '\uDEC2';
+  private static final int MATHEMATICAL_BOLD_SMALL_OMEGA = '\uDEDA';
+  private static final int MATHEMATICAL_ITALIC_CAPITAL_ALPHA = '\uDEE2';
+  private static final int MATHEMATICAL_ITALIC_CAPITAL_OMEGA = '\uDEFA';
+  private static final int MATHEMATICAL_ITALIC_SMALL_ALPHA = '\uDEFC';
+  private static final int MATHEMATICAL_ITALIC_SMALL_OMEGA = '\uDF14';
+  private static final int MATHEMATICAL_BOLD_ITALIC_CAPITAL_ALPHA = '\uDF1C';
+  private static final int MATHEMATICAL_BOLD_ITALIC_CAPITAL_OMEGA = '\uDF34';
+  private static final int MATHEMATICAL_BOLD_ITALIC_SMALL_ALPHA = '\uDF36';
+  private static final int MATHEMATICAL_BOLD_ITALIC_SMALL_OMEGA = '\uDF4E';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_CAPITAL_ALPHA = '\uDF56';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_CAPITAL_OMEGA = '\uDF6E';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_SMALL_ALPHA = '\uDF70';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_SMALL_OMEGA = '\uDF88';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_CAPITAL_ALPHA = '\uDF90';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_CAPITAL_OMEGA = '\uDFA8';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_SMALL_ALPHA = '\uDFAA';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_ITALIC_SMALL_OMEGA = '\uDFC2';
+  private static final int MATHEMATICAL_BOLD_DIGIT_ZERO = '\uDFCE';
+  private static final int MATHEMATICAL_BOLD_DIGIT_NINE = '\uDFD7';
+  private static final int MATHEMATICAL_DOUBLESTRUCK_DIGIT_ZERO = '\uDFD8';
+  private static final int MATHEMATICAL_DOUBLESTRUCK_DIGIT_NINE = '\uDFE1';
+  private static final int MATHEMATICAL_SANSSERIF_DIGIT_ZERO = '\uDFE2';
+  private static final int MATHEMATICAL_SANSSERIF_DIGIT_NINE = '\uDFEB';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_DIGIT_ZERO = '\uDFEC';
+  private static final int MATHEMATICAL_SANSSERIF_BOLD_DIGIT_NINE = '\uDFF5';
+  private static final int MATHEMATICAL_MONOSPACE_DIGIT_ZERO = '\uDFF6';
+  private static final int MATHEMATICAL_MONOSPACE_DIGIT_NINE = '\uDFFF';
+  private static final int CAPITAL_A = 'A';
+  private static final int SMALL_A = 'a';
+  private static final int CAPITAL_ALPHA = 'Α';
+  private static final int SMALL_ALPHA = 'α';
+  private static final int DIGIT_ZERO = '0';
 
   public static boolean isAllMathsChars(String s) {
     if(s.length() % 2 != 0) {
@@ -753,7 +753,7 @@ public class Utils {
           return false;
         }
       } else {
-        int numValue = (int) s.charAt(i);
+        int numValue = s.charAt(i);
         if (numValue < MATHEMATICAL_BOLD_CAPITAL_A || numValue > MATHEMATICAL_MONOSPACE_DIGIT_NINE) {
           return false;
         }
@@ -764,7 +764,7 @@ public class Utils {
 
   public static boolean isAllHalfWidthChars(String s) {
     for (char c : s.toCharArray()) {
-      int charValue = (int) c;
+      int charValue = c;
       if (charValue < (int) 'Ａ') {
         return false;
       } else if (charValue > (int) 'Ｚ' && charValue < (int) 'ａ') {
@@ -778,13 +778,13 @@ public class Utils {
 
   public static String halfwidthLatinToLatin(String s) {
     StringBuilder sb = new StringBuilder();
-    int HALFWIDTH_LATIN_CAPITAL_A = (int) 'Ａ';
-    int HALFWIDTH_LATIN_CAPITAL_Z = (int) 'Ｚ';
-    int HALFWIDTH_LATIN_SMALL_A = (int) 'ａ';
-    int HALFWIDTH_LATIN_SMALL_Z = (int) 'ｚ';
+    int HALFWIDTH_LATIN_CAPITAL_A = 'Ａ';
+    int HALFWIDTH_LATIN_CAPITAL_Z = 'Ｚ';
+    int HALFWIDTH_LATIN_SMALL_A = 'ａ';
+    int HALFWIDTH_LATIN_SMALL_Z = 'ｚ';
 
     for (char c : s.toCharArray()) {
-      int charValue = (int) c;
+      int charValue = c;
       if (charValue >= HALFWIDTH_LATIN_CAPITAL_A && charValue <= HALFWIDTH_LATIN_CAPITAL_Z) {
         sb.append((char) (charValue - HALFWIDTH_LATIN_CAPITAL_A + CAPITAL_A));
       } else if (charValue >= HALFWIDTH_LATIN_SMALL_A && charValue <= HALFWIDTH_LATIN_SMALL_Z) {
@@ -801,7 +801,7 @@ public class Utils {
   }
 
   private static char getMathsChar(char c, boolean normaliseGreek, boolean normaliseDigits) {
-    int numeric = (int) c;
+    int numeric = c;
     if (numeric < 0) {
       throw new RuntimeException("Failed to read character " + c);
     }

--- a/languagetool-language-modules/nl/src/main/java/org/languagetool/tokenizers/nl/DutchWordTokenizer.java
+++ b/languagetool-language-modules/nl/src/main/java/org/languagetool/tokenizers/nl/DutchWordTokenizer.java
@@ -59,7 +59,7 @@ public class DutchWordTokenizer extends WordTokenizer {
         if (startsWithQuote(token) && endsWithQuote(token) && token.length() > 2) {
           l.add(token.substring(0, 1));
           l.add(token.substring(1, token.length()-1));
-          l.add(token.substring(token.length()-1, token.length()));
+          l.add(token.substring(token.length()-1));
         } else if (endsWithQuote(token)) {
           int cnt = 0;
           while (endsWithQuote(token)) {
@@ -73,7 +73,7 @@ public class DutchWordTokenizer extends WordTokenizer {
         } else if (startsWithQuote(token)) {
           while (startsWithQuote(token)) {
             l.add(token.substring(0, 1));
-            token = token.substring(1, token.length());
+            token = token.substring(1);
           }
           l.add(token);
         } else {

--- a/languagetool-language-modules/pl/src/main/java/org/languagetool/tokenizers/pl/PolishWordTokenizer.java
+++ b/languagetool-language-modules/pl/src/main/java/org/languagetool/tokenizers/pl/PolishWordTokenizer.java
@@ -98,7 +98,7 @@ public class PolishWordTokenizer extends WordTokenizer {
           l.add("-");
         } else if (token.charAt(0) == '-') {
           l.add("-");
-          l.addAll(tokenize(token.substring(1, token.length())));
+          l.addAll(tokenize(token.substring(1)));
         } else if (token.contains("-")) {
           String[] tokenParts = token.split("-");
           if (prefixes.contains(tokenParts[0])

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
@@ -164,7 +164,7 @@ public class Portuguese extends Language implements AutoCloseable {
   /** @since 3.6 */
   @Override
   public List<Rule> getRelevantLanguageModelRules(ResourceBundle messages, LanguageModel languageModel, UserConfig userConfig) throws IOException {
-    return Arrays.<Rule>asList(
+    return Arrays.asList(
             new PortugueseConfusionProbabilityRule(messages, languageModel, this)
     );
   }

--- a/languagetool-language-modules/ru/src/main/java/org/languagetool/language/Russian.java
+++ b/languagetool-language-modules/ru/src/main/java/org/languagetool/language/Russian.java
@@ -126,7 +126,7 @@ public class Russian extends Language implements AutoCloseable {
   /** @since 3.1 */
   @Override
   public List<Rule> getRelevantLanguageModelRules(ResourceBundle messages, LanguageModel languageModel, UserConfig userConfig) throws IOException {
-    return Arrays.<Rule>asList(
+    return Arrays.asList(
             new RussianConfusionProbabilityRule(messages, languageModel, this)
     );
   }

--- a/languagetool-language-modules/uk/src/main/java/org/languagetool/rules/uk/MixedAlphabetsRule.java
+++ b/languagetool-language-modules/uk/src/main/java/org/languagetool/rules/uk/MixedAlphabetsRule.java
@@ -147,7 +147,7 @@ public class MixedAlphabetsRule extends Rule {
       else if( tokenString.endsWith("°С") ) {  // cyrillic С
         List<String> replacements = new ArrayList<>();
         int length = tokenString.length();
-        replacements.add( tokenString.substring(0,  length-1) + toLatin(tokenString.substring(length-1, tokenString.length())) );
+        replacements.add( tokenString.substring(0,  length-1) + toLatin(tokenString.substring(length-1)) );
 
         String msg = "Вжито кириличну літеру замість латинської";
         RuleMatch potentialRuleMatch = createRuleMatch(tokenReadings, replacements, msg, sentence);

--- a/languagetool-language-modules/uk/src/main/java/org/languagetool/tagging/uk/CompoundTagger.java
+++ b/languagetool-language-modules/uk/src/main/java/org/languagetool/tagging/uk/CompoundTagger.java
@@ -1295,7 +1295,7 @@ class CompoundTagger {
 
 
   private String capitalize(String word) {
-    return word.substring(0, 1).toUpperCase(conversionLocale) + word.substring(1, word.length());
+    return word.substring(0, 1).toUpperCase(conversionLocale) + word.substring(1);
   }
 
   private List<TaggedWord> tagBothCases(String leftWord, Pattern posTagMatcher) {

--- a/languagetool-language-modules/zh/src/main/java/org/languagetool/language/Chinese.java
+++ b/languagetool-language-modules/zh/src/main/java/org/languagetool/language/Chinese.java
@@ -93,7 +93,7 @@ public class Chinese extends Language implements AutoCloseable {
   /** @since 3.1 */
   @Override
   public List<Rule> getRelevantLanguageModelRules(ResourceBundle messages, LanguageModel languageModel, UserConfig userConfig) throws IOException {
-    return Arrays.<Rule>asList(
+    return Arrays.asList(
             new ChineseConfusionProbabilityRule(messages, languageModel, this)
     );
   }

--- a/languagetool-office-extension/src/main/java/org/languagetool/openoffice/FlatParagraphTools.java
+++ b/languagetool-office-extension/src/main/java/org/languagetool/openoffice/FlatParagraphTools.java
@@ -500,7 +500,7 @@ public class FlatParagraphTools {
     }
     if(override) {
       flatPara.getMarkupInfoContainer();
-      flatPara.commitStringMarkup(TextMarkupType.SENTENCE, new String ("Sentence"), 0, flatPara.getText().length(), props);
+      flatPara.commitStringMarkup(TextMarkupType.SENTENCE, "Sentence", 0, flatPara.getText().length(), props);
     }
   }
 

--- a/languagetool-office-extension/src/main/java/org/languagetool/openoffice/MessageHandler.java
+++ b/languagetool-office-extension/src/main/java/org/languagetool/openoffice/MessageHandler.java
@@ -35,7 +35,7 @@ import org.languagetool.tools.Tools;
  */
 class MessageHandler {
   
-  private static final String logLineBreak = System.getProperty("line.separator");  //  LineBreak in Log-File (MS-Windows compatible)
+  private static final String logLineBreak = System.lineSeparator();  //  LineBreak in Log-File (MS-Windows compatible)
   
   private static String homeDir;
   private static String logFileName;

--- a/languagetool-office-extension/src/main/java/org/languagetool/openoffice/OfficeTools.java
+++ b/languagetool-office-extension/src/main/java/org/languagetool/openoffice/OfficeTools.java
@@ -52,7 +52,7 @@ class OfficeTools {
   public static final String SINGLE_END_OF_PARAGRAPH = "\n";
   public static final String MANUAL_LINEBREAK = "\r";  //  to distinguish from paragraph separator
   public static final String ZERO_WIDTH_SPACE = "\u200B";  // Used to mark footnotes
-  public static final String LOG_LINE_BREAK = System.getProperty("line.separator");  //  LineBreak in Log-File (MS-Windows compatible)
+  public static final String LOG_LINE_BREAK = System.lineSeparator();  //  LineBreak in Log-File (MS-Windows compatible)
   
   public static int DEBUG_MODE_SD = 0;
   public static boolean DEBUG_MODE_MD = false;

--- a/languagetool-office-extension/src/main/java/org/languagetool/openoffice/SingleDocument.java
+++ b/languagetool-office-extension/src/main/java/org/languagetool/openoffice/SingleDocument.java
@@ -989,7 +989,7 @@ class SingleDocument {
           pErrors = singleParaCache.getFromPara(0, startSentencePos, endSentencePos);
           return pErrors;
         } else if(startSentencePos == 0) {
-          lastSinglePara = new String(paraText);
+          lastSinglePara = paraText;
         }
       }
       // return Cache result if available / for right mouse click or Dialog only use cache

--- a/languagetool-office-extension/src/main/java/org/languagetool/openoffice/TextLevelCheckQueue.java
+++ b/languagetool-office-extension/src/main/java/org/languagetool/openoffice/TextLevelCheckQueue.java
@@ -315,7 +315,7 @@ public class TextLevelCheckQueue {
       this.nEnd = nEnd;
       this.nCache = nCache;
       this.nCheck = nCheck;
-      this.docId = new String(docId);
+      this.docId = docId;
       this.overrideRunning = overrideRunning;
     }
     
@@ -434,7 +434,7 @@ public class TextLevelCheckQueue {
                 MessageHandler.printToLogFile("run queue entry: docId = " + queueEntry.docId + ", nStart = " 
                     + queueEntry.nStart + ", nEnd = " + queueEntry.nEnd + ", nCheck = " + queueEntry.nCheck + ", overrideRunning = " + queueEntry.overrideRunning);
               }
-              lastDocId = new String(queueEntry.docId);
+              lastDocId = queueEntry.docId;
               Language entryLanguage = getLanguage(lastDocId);
               if(lastLanguage == null || !lastLanguage.equals(entryLanguage)) {
                 lastLanguage = entryLanguage;

--- a/languagetool-standalone/src/main/java/org/languagetool/gui/Main.java
+++ b/languagetool-standalone/src/main/java/org/languagetool/gui/Main.java
@@ -230,9 +230,7 @@ public final class Main {
       textArea.setText(fileContents);
       currentFile = file;
       updateTitle();
-      if(recentFiles.contains(file.getAbsolutePath())) {
-        recentFiles.remove(file.getAbsolutePath());
-      }
+      recentFiles.remove(file.getAbsolutePath());
       recentFiles.add(file.getAbsolutePath());
       localStorage.saveProperty("recentFiles", recentFiles);
       updateRecentFilesMenu();

--- a/languagetool-tools/src/test/java/org/languagetool/tools/POSDictionaryBuilderTest.java
+++ b/languagetool-tools/src/test/java/org/languagetool/tools/POSDictionaryBuilderTest.java
@@ -57,7 +57,7 @@ public class POSDictionaryBuilderTest extends DictionaryBuilderTestHelper {
       if (!b) {
         throw new RuntimeException("Could not rename" + newBinaryFile.getAbsolutePath() + " to " + oldBinaryFile.getCanonicalPath());
       }*/
-      System.out.println("");
+      System.out.println();
     }
   }
   

--- a/languagetool-tools/src/test/java/org/languagetool/tools/SynthDictionaryBuilderTest.java
+++ b/languagetool-tools/src/test/java/org/languagetool/tools/SynthDictionaryBuilderTest.java
@@ -67,7 +67,7 @@ public class SynthDictionaryBuilderTest extends DictionaryBuilderTestHelper {
       if (!b) {
         throw new RuntimeException("Could not rename " + newBinarySynthFile.getAbsolutePath() + " to " + oldBinarySynthFile.getCanonicalPath());
       }*/
-      System.out.println("");
+      System.out.println();
     }
   }
   

--- a/languagetool-wikipedia/src/main/java/org/languagetool/dev/index/AnyCharTokenizer.java
+++ b/languagetool-wikipedia/src/main/java/org/languagetool/dev/index/AnyCharTokenizer.java
@@ -37,8 +37,8 @@ public final class AnyCharTokenizer extends Tokenizer {
 
   private final CharacterUtils.CharacterBuffer ioBuffer = CharacterUtils.newCharacterBuffer(4096);
   private final CharacterUtils charUtils = CharacterUtils.getInstance();
-  private final CharTermAttribute termAtt = (CharTermAttribute)this.addAttribute(CharTermAttribute.class);
-  private final OffsetAttribute offsetAtt = (OffsetAttribute)this.addAttribute(OffsetAttribute.class);
+  private final CharTermAttribute termAtt = this.addAttribute(CharTermAttribute.class);
+  private final OffsetAttribute offsetAtt = this.addAttribute(OffsetAttribute.class);
 
   private int bufferIndex = 0;
   private int dataLen = 0;

--- a/languagetool-wikipedia/src/main/java/org/languagetool/dev/wikipedia/LocationHelper.java
+++ b/languagetool-wikipedia/src/main/java/org/languagetool/dev/wikipedia/LocationHelper.java
@@ -83,23 +83,23 @@ public class LocationHelper {
   }
 
   private static boolean isReferenceStart(String text, int i) {
-    return i < text.length() - 4 && text.substring(i, i + 4).equals("<ref");
+    return text.startsWith("<ref", i);
   }
 
   private static boolean isFullReferenceEndTag(String text, int i) {
-    return i < text.length() - 6 && text.substring(i, i + 6).equals("</ref>");
+    return text.startsWith("</ref>", i);
   }
 
   private static boolean isShortReferenceEndTag(String text, int i) {
-    return i < text.length() - 2 && text.substring(i, i + 2).equals("/>");
+    return text.startsWith("/>", i);
   }
 
   private static boolean isHtmlCommentStart(String text, int i) {
-    return i < text.length() - 4 && text.substring(i, i + 4).equals("<!--");
+    return text.startsWith("<!--", i);
   }
 
   private static boolean isHtmlCommentEnd(String text, int i) {
-    return i < text.length() - 3 && text.substring(i, i + 3).equals("-->");
+    return text.startsWith("-->", i);
   }
 
 }

--- a/languagetool-wikipedia/src/main/java/org/languagetool/dev/wikipedia/Main.java
+++ b/languagetool-wikipedia/src/main/java/org/languagetool/dev/wikipedia/Main.java
@@ -78,9 +78,9 @@ public class Main {
     System.out.println("   index      - index a plain text file, putting the analysis in a Lucene index for faster rule match search");
     System.out.println("   search     - search for rule matches in an index created with 'index' or 'wiki-index'");
     System.out.println("   version    - print LanguageTool version number and build date");
-    System.out.println("");
+    System.out.println();
     System.out.println("All commands have different usages. Call them without arguments to get help.");
-    System.out.println("");
+    System.out.println();
     System.out.println("Example for a call with valid arguments:");
     System.out.println("   java -jar languagetool-wikipedia.jar wiki-check http://de.wikipedia.org/wiki/Bielefeld");
     System.exit(1);

--- a/languagetool-wikipedia/src/main/java/org/languagetool/dev/wikipedia/WikipediaQuickCheck.java
+++ b/languagetool-wikipedia/src/main/java/org/languagetool/dev/wikipedia/WikipediaQuickCheck.java
@@ -300,12 +300,12 @@ public class WikipediaQuickCheck {
       RuleMatchApplication matchApplication = match.getRuleMatchApplications().get(0);
       RuleMatch ruleMatch = match.getRuleMatch();
       Rule rule = ruleMatch.getRule();
-      System.out.println("");
+      System.out.println();
       String message = ruleMatch.getMessage().replace("<suggestion>", "'").replace("</suggestion>", "'");
       errorCount++;
       System.out.print(errorCount + ". " + message);
       if (rule instanceof AbstractPatternRule) {
-        System.out.println(" (" + ((AbstractPatternRule) rule).getFullId() + ")");
+        System.out.println(" (" + rule.getFullId() + ")");
       } else {
         System.out.println(" (" + rule.getId() + ")");
       }


### PR DESCRIPTION
This PR removes:
- Redundant types
- Redundant cast
- Redundant string construction
- Unnecessary escaped character
- No need to check for existence of an object before adding into a `Set`

Which where mostly detected by IntelliJ cleanup.

Also, `System.lineSeparator()` should better be used.