### PR TITLE
Use Files.newInputStream instead of FileInputStream

### DIFF
--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/Main.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/Main.java
@@ -40,6 +40,8 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -90,7 +92,7 @@ class Main {
 
   private void addExternalRules(String filename) throws IOException {
     PatternRuleLoader ruleLoader = new PatternRuleLoader();
-    try (InputStream is = new FileInputStream(filename)) {
+    try (InputStream is = Files.newInputStream(Paths.get(filename))) {
       List<AbstractPatternRule> externalRules = ruleLoader.getRules(is, filename);
       for (AbstractPatternRule externalRule : externalRules) {
         lt.addRule(externalRule);
@@ -297,7 +299,7 @@ class Main {
     String charsetName = encoding != null ? encoding : Charset.defaultCharset().name();
     InputStream is = System.in;
     if (!isStdIn(filename)) {
-      is = new FileInputStream(new File(filename));
+      is = Files.newInputStream(Paths.get(filename));
       BOMInputStream bomIn = new BOMInputStream(is, true, ByteOrderMark.UTF_8,
         ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_16LE,
         ByteOrderMark.UTF_32BE,ByteOrderMark.UTF_32LE);

--- a/languagetool-commandline/src/test/java/org/languagetool/commandline/MainTest.java
+++ b/languagetool-commandline/src/test/java/org/languagetool/commandline/MainTest.java
@@ -23,16 +23,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.PrintStream;
-import java.io.PrintWriter;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
@@ -282,38 +276,42 @@ public class MainTest extends AbstractSecurityTestCase {
 
   @Test
   public void testEnglishStdIn4() throws Exception {
-    System.setIn(new FileInputStream(enTestFile));
-    String[] args = {"-l", "en", "--api", "-"};
+    try (InputStream is = Files.newInputStream(enTestFile.toPath())) {
+      System.setIn(is);
+      String[] args = {"-l", "en", "--api", "-"};
 
-    Main.main(args);
-    String output = new String(this.out.toByteArray());
-    assertTrue("Got: " + output, output.contains("<error fromy=\"4\" fromx=\"5\" toy=\"4\" " +
+      Main.main(args);
+      String output = new String(this.out.toByteArray());
+      assertTrue("Got: " + output, output.contains("<error fromy=\"4\" fromx=\"5\" toy=\"4\" " +
         "tox=\"10\" ruleId=\"ENGLISH_WORD_REPEAT_RULE\" msg=\"Possible typo: you repeated a word\" shortmsg=\"Word repetition\" " +
         "replacements=\"is\" context=\"....  This is a test of of language tool.  This is is a test of language tool. \"" +
         " contextoffset=\"48\" offset=\"60\" errorlength=\"5\" category=\"Miscellaneous\" categoryid=\"MISC\" locqualityissuetype=\"duplication\"/>"));
+    }
   }
   
   @Test
   public void testEnglishStdInJsonOutput() throws Exception {
-    System.setIn(new FileInputStream(enTestFile));
-    String[] args = {"-l", "en", "--json", "-"};
-    Main.main(args);
-    String output = new String(this.out.toByteArray());
-    assertTrue("Got: " + output, output.contains("\"matches\":[{\"message\":\"Use \\\"a\\\" instead of 'an'"));
-    assertTrue("Got: " + output, output.contains("\"shortMessage\":\"Wrong article\""));
-    assertTrue("Got: " + output, output.contains("\"replacements\":[{\"value\":\"a\"}]"));
-    assertTrue("Got: " + output, output.contains("\"offset\":8"));
-    assertTrue("Got: " + output, output.contains("\"length\":2"));
-    assertTrue("Got: " + output, output.contains("\"context\":{\"text\":\"This is an test.  This is a test of of language tool.  ...\""));
-    assertTrue("Got: " + output, output.contains("\"id\":\"EN_A_VS_AN\""));
-    assertTrue("Got: " + output, output.contains("\"description\":\"Use of"));
-    assertTrue("Got: " + output, output.contains("\"issueType\":\"misspelling\""));
-    assertTrue("Got: " + output, output.contains("\"category\":{\"id\":\"MISC\",\"name\":\"Miscellaneous\"}"));
-    assertTrue("Got: " + output, output.contains("\"message\":\"Possible typo: you repeated a word\""));
-    assertTrue("Got: " + output, output.contains("\"sentence\":\"This is an test.\""));
-    assertTrue("Doesn't display Time", !output.contains("Time: "));
-    assertTrue("Json start check",output.startsWith("{\"software\":{\"name\":\"LanguageTool\",\"version\":"));
-    assertTrue("Json end check",output.endsWith("}]}"));
+    try (InputStream is = Files.newInputStream(enTestFile.toPath())) {
+      System.setIn(is);
+      String[] args = {"-l", "en", "--json", "-"};
+      Main.main(args);
+      String output = new String(this.out.toByteArray());
+      assertTrue("Got: " + output, output.contains("\"matches\":[{\"message\":\"Use \\\"a\\\" instead of 'an'"));
+      assertTrue("Got: " + output, output.contains("\"shortMessage\":\"Wrong article\""));
+      assertTrue("Got: " + output, output.contains("\"replacements\":[{\"value\":\"a\"}]"));
+      assertTrue("Got: " + output, output.contains("\"offset\":8"));
+      assertTrue("Got: " + output, output.contains("\"length\":2"));
+      assertTrue("Got: " + output, output.contains("\"context\":{\"text\":\"This is an test.  This is a test of of language tool.  ...\""));
+      assertTrue("Got: " + output, output.contains("\"id\":\"EN_A_VS_AN\""));
+      assertTrue("Got: " + output, output.contains("\"description\":\"Use of"));
+      assertTrue("Got: " + output, output.contains("\"issueType\":\"misspelling\""));
+      assertTrue("Got: " + output, output.contains("\"category\":{\"id\":\"MISC\",\"name\":\"Miscellaneous\"}"));
+      assertTrue("Got: " + output, output.contains("\"message\":\"Possible typo: you repeated a word\""));
+      assertTrue("Got: " + output, output.contains("\"sentence\":\"This is an test.\""));
+      assertTrue("Doesn't display Time", !output.contains("Time: "));
+      assertTrue("Json start check", output.startsWith("{\"software\":{\"name\":\"LanguageTool\",\"version\":"));
+      assertTrue("Json end check", output.endsWith("}]}"));
+    }
   }
 
   //test line mode vs. para mode

--- a/languagetool-core/src/main/java/org/languagetool/Language.java
+++ b/languagetool-core/src/main/java/org/languagetool/Language.java
@@ -37,6 +37,9 @@ import org.languagetool.tagging.xx.DemoTagger;
 import org.languagetool.tokenizers.*;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -585,8 +588,8 @@ public abstract class Language {
           boolean ignore = false;
           if (is == null) {                     // files loaded via the dialog
             try {
-              is = new FileInputStream(fileName);
-            } catch (FileNotFoundException e) {
+              is = Files.newInputStream(Paths.get(fileName));
+            } catch (NoSuchFileException e) {
               if (fileName.contains("-test-")) {
                 // ignore, used for testing
                 ignore = true;

--- a/languagetool-core/src/main/java/org/languagetool/bitext/TabBitextReader.java
+++ b/languagetool-core/src/main/java/org/languagetool/bitext/TabBitextReader.java
@@ -22,9 +22,10 @@ package org.languagetool.bitext;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Iterator;
 
 /**
@@ -48,9 +49,9 @@ public class TabBitextReader implements BitextReader {
   public TabBitextReader(String filename, String encoding) {
     try {     
       if (encoding == null) {
-        in = new BufferedReader(new InputStreamReader(new FileInputStream(filename)));
+        in = Files.newBufferedReader(Paths.get(filename));
       } else {
-        in = new BufferedReader(new InputStreamReader(new FileInputStream(filename), encoding));
+        in = Files.newBufferedReader(Paths.get(filename), Charset.forName(encoding));
       }
       nextLine = in.readLine();
       prevLine = "";

--- a/languagetool-core/src/main/java/org/languagetool/language/CommonWords.java
+++ b/languagetool-core/src/main/java/org/languagetool/language/CommonWords.java
@@ -22,6 +22,8 @@ import org.languagetool.*;
 import org.languagetool.broker.ResourceDataBroker;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -49,8 +51,8 @@ public class CommonWords {
             if (path != null) {
               if (dataBroker.resourceExists(path)) {
                 stream = dataBroker.getFromResourceDirAsStream(path);
-              } else if (new File(path).exists()) {
-                stream = new FileInputStream(path);
+              } else if (Files.exists(Paths.get(path))) {
+                stream = Files.newInputStream(Paths.get(path));
               } else {
                 throw new IOException("Common words file not found for " + lang + ": " + path);
               }

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleConfig.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleConfig.java
@@ -35,9 +35,9 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -56,8 +56,8 @@ public class RemoteRuleConfig {
     .expireAfterWrite(15, TimeUnit.MINUTES)
     .build(new CacheLoader<File, List<RemoteRuleConfig>>() {
       @Override
-      public List<RemoteRuleConfig> load(File path) throws Exception {
-        try (FileInputStream in = new FileInputStream(path)) {
+      public List<RemoteRuleConfig> load(File file) throws Exception {
+        try (InputStream in = Files.newInputStream(file.toPath())) {
           return parse(in);
         }
       }

--- a/languagetool-core/src/main/java/org/languagetool/rules/neuralnetwork/NeuralNetworkRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/neuralnetwork/NeuralNetworkRule.java
@@ -29,6 +29,7 @@ import org.languagetool.rules.ScoredConfusionSet;
 import org.languagetool.tools.Tools;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.*;
 
 public class NeuralNetworkRule extends Rule {
@@ -86,9 +87,9 @@ public class NeuralNetworkRule extends Rule {
     return language.getShortCode().toUpperCase() + "_" + subjects.get(0) + "_VS_" + subjects.get(1) + "_NEURALNETWORK";
   }
 
-  private InputStream streamFor(File path, String filename) throws FileNotFoundException {
+  private InputStream streamFor(File path, String filename) throws IOException {
     String folderName = String.join("_", subjects);
-    return new FileInputStream(path.getPath() + File.separator + "neuralnetwork" + File.separator + folderName + File.separator + filename);
+    return Files.newInputStream(path.toPath().resolve("neuralnetwork").resolve(folderName).resolve(filename));
   }
 
   public List<String> getSubjects() {

--- a/languagetool-core/src/main/java/org/languagetool/rules/neuralnetwork/NeuralNetworkRuleCreator.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/neuralnetwork/NeuralNetworkRuleCreator.java
@@ -24,6 +24,7 @@ import org.languagetool.rules.ScoredConfusionSet;
 import org.languagetool.rules.ScoredConfusionSetLoader;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -36,7 +37,7 @@ public abstract class NeuralNetworkRuleCreator {
 
   public static List<Rule> createRules(ResourceBundle messages, Language language, Word2VecModel word2vecModel) throws IOException {
     List<ScoredConfusionSet> confusionSets;
-    try(InputStream confusionSetsStream = new FileInputStream(word2vecModel.getPath() + File.separator + CONFUSION_SET_FILENAME)) {
+    try(InputStream confusionSetsStream = Files.newInputStream(word2vecModel.getPath().toPath().resolve(CONFUSION_SET_FILENAME))) {
       confusionSets = ScoredConfusionSetLoader.loadConfusionSet(confusionSetsStream);
     } catch (FileNotFoundException e) {
       System.err.println("Warning: " + CONFUSION_SET_FILENAME + " not found for " + language.getShortCode());

--- a/languagetool-core/src/main/java/org/languagetool/rules/neuralnetwork/Word2VecModel.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/neuralnetwork/Word2VecModel.java
@@ -19,17 +19,18 @@
 package org.languagetool.rules.neuralnetwork;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 public class Word2VecModel {
 
   private final Embedding embedding;
   private final File path;
 
-  public Word2VecModel(String path) throws FileNotFoundException {
-    Dictionary dictionary = new org.languagetool.rules.neuralnetwork.Dictionary(new FileInputStream(path + File.separator + "dictionary.txt"));
-    Matrix embedding = new Matrix(new FileInputStream(path + File.separator + "final_embeddings.txt"));
+  public Word2VecModel(String path) throws IOException {
+    Dictionary dictionary = new Dictionary(Files.newInputStream(Paths.get(path, "dictionary.txt")));
+    Matrix embedding = new Matrix(Files.newInputStream(Paths.get(path, "final_embeddings.txt")));
     this.embedding = new Embedding(dictionary, embedding);
     this.path = new File(path);
   }

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/FalseFriendRuleLoader.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/FalseFriendRuleLoader.java
@@ -25,6 +25,7 @@ import org.xml.sax.helpers.DefaultHandler;
 
 import javax.xml.parsers.*;
 import java.io.*;
+import java.nio.file.Files;
 import java.text.MessageFormat;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -55,7 +56,7 @@ public class FalseFriendRuleLoader extends DefaultHandler {
    * @since 2.3
    */
   public final List<AbstractPatternRule> getRules(File file, Language language, Language motherTongue) throws IOException {
-    try (InputStream inputStream = new FileInputStream(file)) {
+    try (InputStream inputStream = Files.newInputStream(file.toPath())) {
       return getRules(inputStream, language, motherTongue);
     } catch (ParserConfigurationException | SAXException e) {
       throw new IOException("Could not load false friend rules from " + file, e);

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleLoader.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleLoader.java
@@ -19,9 +19,9 @@
 package org.languagetool.rules.patterns;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.List;
 
 import javax.xml.parsers.SAXParser;
@@ -43,7 +43,7 @@ public class PatternRuleLoader extends DefaultHandler {
    * @param file XML file with pattern rules
    */
   public final List<AbstractPatternRule> getRules(File file) throws IOException {
-    try (InputStream inputStream = new FileInputStream(file)) {
+    try (InputStream inputStream = Files.newInputStream(file.toPath())) {
       PatternRuleLoader ruleLoader = new PatternRuleLoader();
       return ruleLoader.getRules(inputStream, file.getAbsolutePath());
     }

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/morfologik/MorfologikMultiSpeller.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/morfologik/MorfologikMultiSpeller.java
@@ -22,13 +22,15 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.languagetool.JLanguageTool.*;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.languagetool.Experimental;
 import org.languagetool.UserConfig;
 import org.languagetool.rules.spelling.SpellingCheckRule;
 
@@ -40,7 +42,6 @@ import morfologik.fsa.FSA;
 import morfologik.fsa.builders.CFSA2Serializer;
 import morfologik.fsa.builders.FSABuilder;
 import morfologik.stemming.Dictionary;
-import org.languagetool.tools.StringTools;
 
 /**
  * Morfologik speller that merges results from binary (.dict) and plain text (.txt) dictionaries.
@@ -203,10 +204,11 @@ public class MorfologikMultiSpeller {
       FSA fsa = FSABuilder.build(linesCopy);
       ByteArrayOutputStream fsaOutStream = new CFSA2Serializer().serialize(fsa, new ByteArrayOutputStream());
       ByteArrayInputStream fsaInStream = new ByteArrayInputStream(fsaOutStream.toByteArray());
+      Path path = Paths.get(infoPath);
       Dictionary dict;
-      if (new File(infoPath).exists()) {
+      if (Files.exists(path)) {
         // e.g. when loading dynamic languages from outside the class path
-        dict = Dictionary.read(fsaInStream, new FileInputStream(infoPath));
+        dict = Dictionary.read(fsaInStream, Files.newInputStream(path));
       } else {
         dict = Dictionary.read(fsaInStream, getDataBroker().getFromResourceDirAsStream(infoPath));
       }

--- a/languagetool-core/src/main/java/org/languagetool/tools/StringTools.java
+++ b/languagetool-core/src/main/java/org/languagetool/tools/StringTools.java
@@ -88,24 +88,13 @@ public final class StringTools {
    * @since 2.3
    */
   public static String readStream(InputStream stream, String encoding) throws IOException {
-    InputStreamReader isr = null;
     StringBuilder sb = new StringBuilder();
-    try {
-      if (encoding == null) {
-        isr = new InputStreamReader(stream);
-      } else {
-        isr = new InputStreamReader(stream, encoding);
-      }
-      try (BufferedReader br = new BufferedReader(isr)) {
-        String line;
-        while ((line = br.readLine()) != null) {
-          sb.append(line);
-          sb.append('\n');
-        }
-      }
-    } finally {
-      if (isr != null) {
-        isr.close();
+    try (Reader r = encoding == null ? new InputStreamReader(stream) : new InputStreamReader(stream, encoding);
+      BufferedReader br = new BufferedReader(r)) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        sb.append(line);
+        sb.append('\n');
       }
     }
     return sb.toString();

--- a/languagetool-core/src/main/java/org/languagetool/tools/Tools.java
+++ b/languagetool-core/src/main/java/org/languagetool/tools/Tools.java
@@ -29,6 +29,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
 import java.lang.reflect.Constructor;
 import java.net.*;
+import java.nio.file.Files;
 import java.text.MessageFormat;
 import java.util.*;
 
@@ -122,7 +123,9 @@ public final class Tools {
       }
     }
     if (externalBitextRuleFile != null) {
-      bRules.addAll(ruleLoader.getRules(new FileInputStream(externalBitextRuleFile), externalBitextRuleFile.getAbsolutePath()));
+      try (InputStream is = Files.newInputStream(externalBitextRuleFile.toPath())) {
+        bRules.addAll(ruleLoader.getRules(is, externalBitextRuleFile.getAbsolutePath()));
+      }
     }
     
     //load the false friend rules in the bitext mode:

--- a/languagetool-core/src/test/java/org/languagetool/languagemodel/LanguageModelTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/languagemodel/LanguageModelTest.java
@@ -21,7 +21,9 @@ package org.languagetool.languagemodel;
 import org.languagetool.tokenizers.WordTokenizer;
 import org.languagetool.tools.StringTools;
 
-import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
@@ -31,7 +33,7 @@ public class LanguageModelTest {
   private static final String FILE = "/lt/performance-test/en.txt";
 
   protected void testPerformance(LuceneLanguageModel model, int ngramLength) throws Exception {
-    try (FileInputStream fis = new FileInputStream(FILE)) {
+    try (InputStream fis = Files.newInputStream(Paths.get(FILE))) {
       String content = StringTools.readStream(fis, "UTF-8");
       WordTokenizer wordTokenizer = new WordTokenizer();
       List<String> words = wordTokenizer.tokenize(content);

--- a/languagetool-core/src/test/java/org/languagetool/rules/neuralnetwork/MatrixTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/neuralnetwork/MatrixTest.java
@@ -36,10 +36,10 @@ public class MatrixTest {
 
 //    @Test
 //    public void bigtest() throws IOException {
-//      FileInputStream fileInputStream = new FileInputStream("/tmp/m");
+//      InputStream inputStream = Files.newInputStream(Paths.get("/tmp/m"));
 //      long start = System.currentTimeMillis();
 //      float m[][] = new float[52520][64];
-//      Matrix matrix = new Matrix(fileInputStream);
+//      Matrix matrix = new Matrix(inputStream);
 //      long end = System.currentTimeMillis();
 //      System.out.println((end - start)/1000.0);
 //    }

--- a/languagetool-core/src/test/java/org/languagetool/tools/StringToolsTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/tools/StringToolsTest.java
@@ -23,9 +23,11 @@ import org.languagetool.FakeLanguage;
 import org.languagetool.Language;
 import org.languagetool.TestTools;
 
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,8 +57,10 @@ public class StringToolsTest {
 
   @Test
   public void testReadStream() throws IOException {
-    String content = StringTools.readStream(new FileInputStream("src/test/resources/testinput.txt"), "utf-8");
-    assertEquals("one\ntwo\nöäüß\nșțîâăȘȚÎÂĂ\n", content);
+    try (InputStream is = Files.newInputStream(Paths.get("src/test/resources/testinput.txt"))) {
+      String content = StringTools.readStream(is, "utf-8");
+      assertEquals("one\ntwo\nöäüß\nșțîâăȘȚÎÂĂ\n", content);
+    }
   }
 
   @Test

--- a/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/AutomaticConfusionRuleEvaluator.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/AutomaticConfusionRuleEvaluator.java
@@ -18,7 +18,8 @@
  */
 package org.languagetool.dev.bigdata;
 
-import org.apache.commons.io.IOUtils;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.*;
@@ -32,6 +33,8 @@ import org.languagetool.rules.ConfusionPair;
 import org.languagetool.rules.ConfusionSetLoader;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -250,7 +253,7 @@ class AutomaticConfusionRuleEvaluator {
       System.exit(1);
     }
     Language lang = Languages.getLanguageForShortCode(args[0]);
-    List<String> lines = IOUtils.readLines(new FileInputStream(args[1]), "utf-8");
+    List<String> lines = Files.readAllLines(Paths.get(args[1]), UTF_8);
     boolean caseInsensitive = args[5].equalsIgnoreCase("true");
     AutomaticConfusionRuleEvaluator eval = new AutomaticConfusionRuleEvaluator(new File(args[2]), args[4], caseInsensitive, lang);
     eval.run(lines, new File(args[3]));

--- a/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/AutomaticProhibitedCompoundRuleEvaluator.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/AutomaticProhibitedCompoundRuleEvaluator.java
@@ -20,7 +20,8 @@
  */
 package org.languagetool.dev.bigdata;
 
-import org.apache.commons.io.IOUtils;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.Term;
@@ -35,6 +36,8 @@ import org.languagetool.rules.ConfusionPair;
 import org.languagetool.rules.ConfusionSetLoader;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -199,7 +202,7 @@ class AutomaticProhibitedCompoundRuleEvaluator {
       System.out.println("   <exampleSentenceIndexDir> is a Lucene index created by TextIndexCreator");
       System.exit(1);
     }
-    List<String> lines = IOUtils.readLines(new FileInputStream(args[0]), "utf-8");
+    List<String> lines = Files.readAllLines(Paths.get(args[0]), UTF_8);
     AutomaticProhibitedCompoundRuleEvaluator eval = new AutomaticProhibitedCompoundRuleEvaluator(new File(args[1]));
     eval.run(lines, new File(args[2]));
   }

--- a/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/CommonCrawlToNgram.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/CommonCrawlToNgram.java
@@ -38,6 +38,7 @@ import org.languagetool.tokenizers.Tokenizer;
 import org.tukaani.xz.XZInputStream;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -92,7 +93,7 @@ class CommonCrawlToNgram implements AutoCloseable {
   
   void indexInputFile() throws IOException {
     writeAndEvaluate();  // run now so we have a baseline
-    FileInputStream fin = new FileInputStream(input);
+    InputStream fin = Files.newInputStream(input.toPath());
     BufferedInputStream in = new BufferedInputStream(fin);
     try (XZInputStream xzIn = new XZInputStream(in)) {
       final byte[] buffer = new byte[8192];

--- a/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/CommonCrawlToNgram3.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/CommonCrawlToNgram3.java
@@ -29,6 +29,7 @@ import org.languagetool.tokenizers.SentenceTokenizer;
 import org.languagetool.tokenizers.Tokenizer;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -74,7 +75,7 @@ class CommonCrawlToNgram3 implements AutoCloseable {
   }
 
   private void indexInputFile() throws IOException, CompressorException {
-    FileInputStream fin = new FileInputStream(input);
+    InputStream fin = Files.newInputStream(input.toPath());
     BufferedInputStream in = new BufferedInputStream(fin);
     try (CompressorInputStream input = new CompressorStreamFactory().createCompressorInputStream(in)) {
       final byte[] buffer = new byte[8192];

--- a/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/ConfusionRuleEvaluator.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/ConfusionRuleEvaluator.java
@@ -34,6 +34,9 @@ import org.languagetool.tagging.xx.DemoTagger;
 import org.languagetool.tools.StringTools;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -203,12 +206,12 @@ class ConfusionRuleEvaluator {
   private List<Sentence> getRelevantSentences(List<String> inputs, String token, int maxSentences) throws IOException {
     List<Sentence> sentences = new ArrayList<>();
     for (String input : inputs) {
-      if (new File(input).isDirectory()) {
-        File file = new File(input, token + ".txt");
-        if (!file.exists()) {
-          throw new RuntimeException("File with example sentences not found: " + file);
+      if (Files.isDirectory(Paths.get(input))) {
+        Path path = Paths.get(input, token + ".txt");
+        if (!Files.exists(path)) {
+          throw new RuntimeException("File with example sentences not found: " + path);
         }
-        try (FileInputStream fis = new FileInputStream(file)) {
+        try (InputStream fis = Files.newInputStream(path)) {
           SentenceSource sentenceSource = new PlainTextSentenceSource(fis, language);
           sentences = getSentencesFromSource(inputs, token, maxSentences, sentenceSource);
         }

--- a/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/FrequencyIndexCreator.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/FrequencyIndexCreator.java
@@ -30,6 +30,7 @@ import org.languagetool.languagemodel.LanguageModel;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.text.NumberFormat;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
@@ -175,7 +176,7 @@ public class FrequencyIndexCreator {
     float progress = (float)bytesProcessed.get() / totalBytes * 100;
     System.out.printf("==== Working on " + inputFile + " (%.2f%%) ====\n", progress);
     try (
-      InputStream fileStream = new FileInputStream(inputFile);
+      InputStream fileStream = Files.newInputStream(inputFile.toPath());
       InputStream gzipStream = new GZIPInputStream(fileStream, BUFFER_SIZE);
       Reader decoder = new InputStreamReader(gzipStream, StandardCharsets.UTF_8);
       BufferedReader buffered = new BufferedReader(decoder, BUFFER_SIZE)

--- a/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/OccurrenceAdder.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/OccurrenceAdder.java
@@ -18,9 +18,11 @@
  */
 package org.languagetool.dev.bigdata;
 
-import org.apache.commons.io.IOUtils;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,9 +45,9 @@ public class OccurrenceAdder {
   private void runOnFile(Map<String, Integer> map, File file) throws IOException {
     System.out.println("Working on " + file);
     try (
-      InputStream fileStream = new FileInputStream(file);
+      InputStream fileStream = Files.newInputStream(file.toPath());
       InputStream gzipStream = new GZIPInputStream(fileStream, BUFFER_SIZE);
-      Reader decoder = new InputStreamReader(gzipStream, "utf-8");
+      Reader decoder = new InputStreamReader(gzipStream, UTF_8);
       BufferedReader buffered = new BufferedReader(decoder, BUFFER_SIZE)
     ) {
       String line;
@@ -68,7 +70,7 @@ public class OccurrenceAdder {
     }
     OccurrenceAdder occurrenceAdder = new OccurrenceAdder();
     Map<String, Integer> map = new HashMap<>();
-    List<String> words = IOUtils.readLines(new FileInputStream(args[0]));
+    List<String> words = Files.readAllLines(Paths.get(args[0]));
     for (String word : words) {
       map.put(word, 0);
     }

--- a/languagetool-dev/src/main/java/org/languagetool/dev/errorcorpus/PedlerCorpus.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/errorcorpus/PedlerCorpus.java
@@ -18,13 +18,12 @@
  */
 package org.languagetool.dev.errorcorpus;
 
-import org.apache.commons.io.IOUtils;
 import org.languagetool.markup.AnnotatedText;
 import org.languagetool.markup.AnnotatedTextBuilder;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -53,9 +52,7 @@ public class PedlerCorpus implements ErrorCorpus {
         System.out.println("Ignoring " + file + ", does not match *.txt");
         continue;
       }
-      try (FileInputStream fis = new FileInputStream(file)) {
-        lines.addAll(IOUtils.readLines(fis));
-      }
+      lines.addAll(Files.readAllLines(file.toPath()));
     }
   }
 

--- a/languagetool-dev/src/main/java/org/languagetool/dev/errorcorpus/SimpleCorpus.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/errorcorpus/SimpleCorpus.java
@@ -18,13 +18,12 @@
  */
 package org.languagetool.dev.errorcorpus;
 
-import org.apache.commons.io.IOUtils;
 import org.languagetool.markup.AnnotatedText;
 import org.languagetool.markup.AnnotatedTextBuilder;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -46,9 +45,7 @@ public class SimpleCorpus implements ErrorCorpus {
   private int pos;
   
   public SimpleCorpus(File simpleTextFile) throws IOException {
-    try (FileInputStream fis = new FileInputStream(simpleTextFile)) {
-      lines.addAll(IOUtils.readLines(fis).stream().filter(line -> line.matches("\\d+\\..*")).collect(Collectors.toList()));
-    }
+    lines.addAll(Files.readAllLines(simpleTextFile.toPath()).stream().filter(line -> line.matches("\\d+\\..*")).collect(Collectors.toList()));
     System.out.println("Loaded " + lines.size() + " example sentences");
   }
 

--- a/languagetool-dev/src/main/java/org/languagetool/dev/eval/CheckBNC.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/eval/CheckBNC.java
@@ -20,8 +20,9 @@
 package org.languagetool.dev.eval;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.List;
 
 import org.languagetool.JLanguageTool;
@@ -70,16 +71,18 @@ public final class CheckBNC {
       }
     } else {
       System.out.println("Checking " + file.getAbsolutePath());
-      String text = StringTools.readStream(new FileInputStream(file.getAbsolutePath()), "utf-8");
-      text = textFilter.filter(text);
-      if (CHECK_BY_SENTENCE) {
-        final Tokenizer sentenceTokenizer = langTool.getLanguage().getSentenceTokenizer();
-        final List<String> sentences = sentenceTokenizer.tokenize(text);
-        for (String sentence : sentences) {
-          CommandLineTools.checkText(sentence, langTool, false, false, 1000);
+      try (InputStream is = Files.newInputStream(file.toPath())) {
+        String text = StringTools.readStream(is, "utf-8");
+        text = textFilter.filter(text);
+        if (CHECK_BY_SENTENCE) {
+          final Tokenizer sentenceTokenizer = langTool.getLanguage().getSentenceTokenizer();
+          final List<String> sentences = sentenceTokenizer.tokenize(text);
+          for (String sentence : sentences) {
+            CommandLineTools.checkText(sentence, langTool, false, false, 1000);
+          }
+        } else {
+          CommandLineTools.checkText(text, langTool);
         }
-      } else {
-        CommandLineTools.checkText(text, langTool);
       }
     }
   }

--- a/languagetool-dev/src/main/java/org/languagetool/dev/eval/RealWordFalseAlarmEvaluator.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/eval/RealWordFalseAlarmEvaluator.java
@@ -18,12 +18,10 @@
  */
 package org.languagetool.dev.eval;
 
-import org.apache.commons.io.IOUtils;
 import org.languagetool.JLanguageTool;
 import org.languagetool.Language;
 import org.languagetool.language.AmericanEnglish;
 import org.languagetool.language.BritishEnglish;
-import org.languagetool.language.English;
 import org.languagetool.languagemodel.LanguageModel;
 import org.languagetool.languagemodel.LuceneLanguageModel;
 import org.languagetool.rules.*;
@@ -31,9 +29,9 @@ import org.languagetool.rules.en.EnglishConfusionProbabilityRule;
 import org.languagetool.rules.ngrams.ConfusionProbabilityRule;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.*;
 
 /**
@@ -95,11 +93,9 @@ class RealWordFalseAlarmEvaluator {
         System.out.println("Ignoring " + file + ", does not match *.txt");
         continue;
       }
-      try (FileInputStream fis = new FileInputStream(file)) {
-        System.out.println("===== Working on " + file.getName() + " (" + fileCount + "/" + files.length + ") =====");
-        checkLines(IOUtils.readLines(fis), file.getName().replace(".txt", ""));
-        fileCount++;
-      }
+      System.out.println("===== Working on " + file.getName() + " (" + fileCount + "/" + files.length + ") =====");
+      checkLines(Files.readAllLines(file.toPath()), file.getName().replace(".txt", ""));
+      fileCount++;
     }
     System.out.println("==============================");
     System.out.println(globalSentenceCount + " sentences checked");

--- a/languagetool-dev/src/main/java/org/languagetool/dev/eval/SpellCheckEvaluation.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/eval/SpellCheckEvaluation.java
@@ -18,6 +18,8 @@
  */
 package org.languagetool.dev.eval;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import org.languagetool.JLanguageTool;
 import org.languagetool.Language;
 import org.languagetool.Languages;
@@ -25,6 +27,7 @@ import org.languagetool.rules.Rule;
 import org.languagetool.rules.RuleMatch;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.List;
 
 /**
@@ -53,11 +56,7 @@ public class SpellCheckEvaluation {
   }
 
   private void checkFile(File file, JLanguageTool lt) throws IOException {
-    try (
-      FileInputStream fis = new FileInputStream(file);
-      InputStreamReader reader = new InputStreamReader(fis, "utf-8");
-      BufferedReader br = new BufferedReader(reader)
-    ) {
+    try (BufferedReader br = Files.newBufferedReader(file.toPath(), UTF_8)) {
       String line;
       while ((line = br.readLine()) != null) {
         List<RuleMatch> matches = lt.check(line);

--- a/languagetool-gui-commons/src/main/java/org/languagetool/gui/Configuration.java
+++ b/languagetool-gui-commons/src/main/java/org/languagetool/gui/Configuration.java
@@ -20,11 +20,9 @@ package org.languagetool.gui;
 
 import java.awt.Color;
 import java.awt.Font;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -985,7 +983,7 @@ public class Configuration {
       cfgFile = oldConfigFile;
     }
 
-    try (FileInputStream fis = new FileInputStream(cfgFile)) {
+    try (InputStream fis = Files.newInputStream(cfgFile.toPath())) {
 
       Properties props = new Properties();
       props.load(fis);
@@ -1145,7 +1143,7 @@ public class Configuration {
       //store config for other languages
       loadConfigForOtherLanguages(lang, props, prefix);
 
-    } catch (FileNotFoundException e) {
+    } catch (NoSuchFileException e) {
       // file not found: okay, leave disabledRuleIds empty
     }
 

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPSServer.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPSServer.java
@@ -29,9 +29,10 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.File;
-import java.io.FileInputStream;
+import java.io.InputStream;
 import java.net.BindException;
 import java.net.InetSocketAddress;
+import java.nio.file.Files;
 import java.security.KeyStore;
 import java.util.ResourceBundle;
 import java.util.Set;
@@ -87,7 +88,7 @@ public class HTTPSServer extends Server {
   }
 
   private SSLContext getSslContext(File keyStoreFile, String passPhrase) {
-    try (FileInputStream keyStoreStream = new FileInputStream(keyStoreFile)) {
+    try (InputStream keyStoreStream = Files.newInputStream(keyStoreFile.toPath())) {
       KeyStore keystore = KeyStore.getInstance("JKS");
       keystore.load(keyStoreStream, passPhrase.toCharArray());
       KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPSServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPSServerConfig.java
@@ -19,8 +19,11 @@
 package org.languagetool.server;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Properties;
 
 /**
@@ -73,10 +76,10 @@ public class HTTPSServerConfig extends HTTPServerConfig {
    */
   HTTPSServerConfig(String[] args) {
     super(args);
-    File config = null;
+    Path config = null;
     for (int i = 0; i < args.length; i++) {
       if ("--config".equals(args[i])) {
-        config = new File(args[++i]);
+        config = Paths.get(args[++i]);
       }
     }
     if (config == null) {
@@ -84,10 +87,10 @@ public class HTTPSServerConfig extends HTTPServerConfig {
     }
     try {
       Properties props = new Properties();
-      try (FileInputStream fis = new FileInputStream(config)) {
-        props.load(fis);
-        keystore = new File(getProperty(props, "keystore", config));
-        keyStorePassword = getProperty(props, "password", config);
+      try (InputStream is = Files.newInputStream(config)) {
+        props.load(is);
+        keystore = new File(getProperty(props, "keystore", config.toFile()));
+        keyStorePassword = getProperty(props, "password", config.toFile());
       }
     } catch (IOException e) {
       throw new RuntimeException("Could not load properties from '" + config + "'", e);

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
@@ -25,10 +25,11 @@ import org.languagetool.*;
 import org.languagetool.rules.spelling.morfologik.suggestions_ordering.SuggestionsOrdererConfig;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -207,7 +208,7 @@ public class HTTPServerConfig {
   private void parseConfigFile(File file, boolean loadLangModel, boolean loadWord2VecModel, boolean loadNeuralNetworkModel) {
     try {
       Properties props = new Properties();
-      try (FileInputStream fis = new FileInputStream(file)) {
+      try (InputStream fis = Files.newInputStream(file.toPath())) {
         props.load(fis);
         maxTextLength = Integer.parseInt(getOptionalProperty(props, "maxTextLength", Integer.toString(Integer.MAX_VALUE)));
         maxTextLengthWithApiKey = Integer.parseInt(getOptionalProperty(props, "maxTextLengthWithApiKey", Integer.toString(Integer.MAX_VALUE)));

--- a/languagetool-server/src/test/java/org/languagetool/rules/DictionaryMatchFilterTest.java
+++ b/languagetool-server/src/test/java/org/languagetool/rules/DictionaryMatchFilterTest.java
@@ -51,7 +51,7 @@ public class DictionaryMatchFilterTest {
     }
 
     @Override
-    public RuleMatch[] match(AnalyzedSentence sentence) throws IOException {
+    public RuleMatch[] match(AnalyzedSentence sentence) {
       List<RuleMatch> matches = new LinkedList<>();
       for (AnalyzedTokenReadings token : sentence.getTokensWithoutWhitespace()) {
         String word = token.getToken();

--- a/languagetool-standalone/src/main/java/org/languagetool/gui/LocalStorage.java
+++ b/languagetool-standalone/src/main/java/org/languagetool/gui/LocalStorage.java
@@ -20,12 +20,9 @@ package org.languagetool.gui;
 
 import java.beans.XMLDecoder;
 import java.beans.XMLEncoder;
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
+import java.io.*;
+import java.nio.file.Files;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 
@@ -121,7 +118,7 @@ class LocalStorage {
     }
     synchronized(directory) {
       try (XMLDecoder decoder = new XMLDecoder(new BufferedInputStream(
-            new FileInputStream(new File(directory, name))))) {
+            Files.newInputStream(directory.toPath().resolve(name))))) {
         try {
           return clazz.cast(decoder.readObject());
         } catch (ClassCastException ex) {
@@ -132,7 +129,7 @@ class LocalStorage {
           Tools.showError(ex);
           return null;
         }
-      } catch (FileNotFoundException ex) {
+      } catch (IOException ex) {
         //ignore, we have not saved yet a property with this name
       }
     }

--- a/languagetool-standalone/src/main/java/org/languagetool/gui/Main.java
+++ b/languagetool-standalone/src/main/java/org/languagetool/gui/Main.java
@@ -58,12 +58,10 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.Reader;
+import java.io.*;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -213,7 +211,7 @@ public final class Main {
   }
 
   private void loadFile(File file) {
-    try (FileInputStream inputStream = new FileInputStream(file)) {
+    try (InputStream inputStream = Files.newInputStream(file.toPath())) {
       BOMInputStream bomIn = new BOMInputStream(inputStream, false,
               ByteOrderMark.UTF_8, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_16LE,
               ByteOrderMark.UTF_32BE, ByteOrderMark.UTF_32LE);
@@ -283,7 +281,7 @@ public final class Main {
     List<Rule> rules = langTool.getAllRules();
     ConfigurationDialog configDialog = getCurrentConfigDialog();
     boolean configChanged = configDialog.show(rules); // this blocks until OK/Cancel is clicked in the dialog
-    if(configChanged) {
+    if (configChanged) {
       Configuration config = ltSupport.getConfig();
       try { //save config - needed for the server
         config.saveConfiguration(langTool.getLanguage());

--- a/languagetool-standalone/src/test/java/org/languagetool/TranslationTest.java
+++ b/languagetool-standalone/src/test/java/org/languagetool/TranslationTest.java
@@ -22,8 +22,8 @@ import org.junit.Test;
 import org.languagetool.tools.StringTools;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.*;
 
@@ -37,23 +37,25 @@ public class TranslationTest {
     // use English version as the reference:
     File englishFile = getEnglishTranslationFile();
     Properties enProps = new Properties();
-    enProps.load(new FileInputStream(englishFile));
-    Set<Object> englishKeys = enProps.keySet();
-    for (Language lang : Languages.get()) {
-      if (lang.getShortCode().equals("en")) {
-        continue;
-      }
-      Properties langProps = new Properties();
-      File langFile = getTranslationFile(lang);
-      if (!langFile.exists()) {
-        continue;
-      }
-      try (FileInputStream stream = new FileInputStream(langFile)) {
-        langProps.load(stream);
-        Set<Object> langKeys = langProps.keySet();
-        for (Object englishKey : englishKeys) {
-          if (!langKeys.contains(englishKey)) {
-            System.err.println("***** No key '" + englishKey + "' in file " + langFile);
+    try (InputStream is = Files.newInputStream(englishFile.toPath())) {
+      enProps.load(is);
+      Set<Object> englishKeys = enProps.keySet();
+      for (Language lang : Languages.get()) {
+        if (lang.getShortCode().equals("en")) {
+          continue;
+        }
+        Properties langProps = new Properties();
+        File langFile = getTranslationFile(lang);
+        if (!langFile.exists()) {
+          continue;
+        }
+        try (InputStream stream = Files.newInputStream(langFile.toPath())) {
+          langProps.load(stream);
+          Set<Object> langKeys = langProps.keySet();
+          for (Object englishKey : englishKeys) {
+            if (!langKeys.contains(englishKey)) {
+              System.err.println("***** No key '" + englishKey + "' in file " + langFile);
+            }
           }
         }
       }

--- a/languagetool-tools/src/main/java/org/languagetool/tools/DictionaryBuilder.java
+++ b/languagetool-tools/src/main/java/org/languagetool/tools/DictionaryBuilder.java
@@ -18,15 +18,8 @@
  */
 package org.languagetool.tools;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
+import java.io.*;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
@@ -64,7 +57,9 @@ class DictionaryBuilder {
   private String outputFilename;
 
   protected DictionaryBuilder(File infoFile) throws IOException {
-    props.load(new FileInputStream(infoFile));
+    try (InputStream is = Files.newInputStream(infoFile.toPath())) {
+      props.load(is);
+    }
   }
   
   protected void setOutputFilename(String outputFilename) {
@@ -125,7 +120,7 @@ class DictionaryBuilder {
   
   protected void readFreqList(File freqListFile) {
     try (
-      FileInputStream fis = new FileInputStream(freqListFile.getAbsoluteFile());
+      InputStream fis = Files.newInputStream(freqListFile.toPath());
       InputStreamReader reader = new InputStreamReader(fis, "utf-8");
       BufferedReader br = new BufferedReader(reader)
     ) {
@@ -154,8 +149,8 @@ class DictionaryBuilder {
     String encoding = getOption("fsa.dict.encoding");
     int freqValuesApplied = 0;
 
-    try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(tempFile.getAbsoluteFile()), encoding));
-         BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(dictFile.getAbsoluteFile()), encoding))) {
+    try (BufferedWriter bw = Files.newBufferedWriter(tempFile.toPath(), Charset.forName(encoding));
+         BufferedReader br = Files.newBufferedReader(dictFile.toPath(), Charset.forName(encoding))) {
       String line;
       int maxFreq = Collections.max(freqList.values());
       double maxFreqLog = Math.log(maxFreq);

--- a/languagetool-wikipedia/src/main/java/org/languagetool/dev/dumpcheck/DatabaseHandler.java
+++ b/languagetool-wikipedia/src/main/java/org/languagetool/dev/dumpcheck/DatabaseHandler.java
@@ -26,8 +26,9 @@ import org.languagetool.rules.patterns.AbstractPatternRule;
 import org.languagetool.tools.ContextTools;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.sql.*;
 import java.util.Date;
 import java.util.List;
@@ -60,7 +61,7 @@ class DatabaseHandler extends ResultHandler {
             "VALUES (0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)";
 
     Properties dbProperties = new Properties();
-    try (FileInputStream inStream = new FileInputStream(propertiesFile)) {
+    try (InputStream inStream = Files.newInputStream(propertiesFile.toPath())) {
       dbProperties.load(inStream);
       String dbUrl = getProperty(dbProperties, "dbUrl");
       String dbUser = getProperty(dbProperties, "dbUser");

--- a/languagetool-wikipedia/src/main/java/org/languagetool/dev/dumpcheck/MixingSentenceSource.java
+++ b/languagetool-wikipedia/src/main/java/org/languagetool/dev/dumpcheck/MixingSentenceSource.java
@@ -21,9 +21,10 @@ package org.languagetool.dev.dumpcheck;
 import org.apache.commons.lang3.StringUtils;
 import org.languagetool.Language;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -45,15 +46,15 @@ public class MixingSentenceSource extends SentenceSource {
   public static MixingSentenceSource create(List<String> dumpFileNames, Language language, Pattern filter) throws IOException {
     List<SentenceSource> sources = new ArrayList<>();
     for (String dumpFileName : dumpFileNames) {
-      File file = new File(dumpFileName);
-      if (file.getName().endsWith(".xml")) {
-        sources.add(new WikipediaSentenceSource(new FileInputStream(dumpFileName), language, filter));
-      } else if (file.getName().startsWith("tatoeba-")) {
-        sources.add(new TatoebaSentenceSource(new FileInputStream(dumpFileName), language, filter));
-      } else if (file.getName().endsWith(".txt")) {
-        sources.add(new PlainTextSentenceSource(new FileInputStream(dumpFileName), language, filter));
-      } else if (file.getName().endsWith(".xz")) {
-        sources.add(new CommonCrawlSentenceSource(new FileInputStream(dumpFileName), language, filter));
+      Path path = Paths.get(dumpFileName);
+      if (path.toString().endsWith(".xml")) {
+        sources.add(new WikipediaSentenceSource(Files.newInputStream(path), language, filter));
+      } else if (path.toString().startsWith("tatoeba-")) {
+        sources.add(new TatoebaSentenceSource(Files.newInputStream(path), language, filter));
+      } else if (path.toString().endsWith(".txt")) {
+        sources.add(new PlainTextSentenceSource(Files.newInputStream(path), language, filter));
+      } else if (path.toString().endsWith(".xz")) {
+        sources.add(new CommonCrawlSentenceSource(Files.newInputStream(path), language, filter));
       } else {
         throw new RuntimeException("Could not find a source handler for " + dumpFileName +
                 " - Wikipedia files must be named '*.xml', Tatoeba files must be named 'tatoeba-*', CommonCrawl files '*.xz', plain text files '*.txt'");

--- a/languagetool-wikipedia/src/main/java/org/languagetool/dev/dumpcheck/SentenceSourceChecker.java
+++ b/languagetool-wikipedia/src/main/java/org/languagetool/dev/dumpcheck/SentenceSourceChecker.java
@@ -30,8 +30,11 @@ import org.languagetool.rules.RuleMatch;
 import org.languagetool.rules.patterns.AbstractPatternRule;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.NumberFormat;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -59,12 +62,12 @@ public class SentenceSourceChecker {
     String languageCode = commandLine.getOptionValue('l');
     Set<String> disabledRuleIds = new HashSet<>();
     if (commandLine.hasOption("rule-properties")) {
-      File disabledRulesPropFile = new File(commandLine.getOptionValue("rule-properties"));
-      if (!disabledRulesPropFile.exists() || disabledRulesPropFile.isDirectory()) {
-        throw new IOException("File not found or isn't a file: " + disabledRulesPropFile.getAbsolutePath());
+      Path disabledRulesPropPath = Paths.get(commandLine.getOptionValue("rule-properties"));
+      if (!Files.exists(disabledRulesPropPath) || Files.isDirectory(disabledRulesPropPath)) {
+        throw new IOException("File not found or isn't a file: " + disabledRulesPropPath.toAbsolutePath());
       }
       Properties disabledRules = new Properties();
-      try (FileInputStream stream = new FileInputStream(disabledRulesPropFile)) {
+      try (InputStream stream = Files.newInputStream(disabledRulesPropPath)) {
         disabledRules.load(stream);
         addDisabledRules("all", disabledRuleIds, disabledRules);
         addDisabledRules(languageCode, disabledRuleIds, disabledRules);

--- a/languagetool-wikipedia/src/main/java/org/languagetool/dev/dumpcheck/WikipediaSentenceExtractor.java
+++ b/languagetool-wikipedia/src/main/java/org/languagetool/dev/dumpcheck/WikipediaSentenceExtractor.java
@@ -26,9 +26,10 @@ import org.languagetool.Language;
 import org.languagetool.Languages;
 
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 /**
  * Command line tool to extract sentences from a (optionally bz2-compressed) Wikipedia XML dump.
@@ -37,9 +38,8 @@ import java.io.InputStream;
 class WikipediaSentenceExtractor {
 
   private void extract(Language language, String xmlDumpPath, String outputFile) throws IOException, CompressorException {
-    try (FileInputStream fis = new FileInputStream(xmlDumpPath);
-         BufferedInputStream bis = new BufferedInputStream(fis);
-         FileWriter fw = new FileWriter(outputFile)) {
+    try (BufferedInputStream bis = new BufferedInputStream(Files.newInputStream(Paths.get(xmlDumpPath)));
+         BufferedWriter w = Files.newBufferedWriter(Paths.get(outputFile))) {
       InputStream input;
       if (xmlDumpPath.endsWith(".bz2")) {
         input = new CompressorStreamFactory().createCompressorInputStream(bis);
@@ -56,8 +56,8 @@ class WikipediaSentenceExtractor {
           continue;
         }
         //System.out.println(sentence);
-        fw.write(sentence);
-        fw.write('\n');
+        w.write(sentence);
+        w.write("\n");
         sentenceCount++;
         if (sentenceCount % 1000 == 0) {
           System.err.println("Exporting sentence #" + sentenceCount + "...");

--- a/languagetool-wikipedia/src/main/java/org/languagetool/dev/wikipedia/IpaExtractor.java
+++ b/languagetool-wikipedia/src/main/java/org/languagetool/dev/wikipedia/IpaExtractor.java
@@ -23,8 +23,11 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -45,23 +48,24 @@ class IpaExtractor {
   private int articleCount = 0;
   private int ipaCount = 0;
 
-  public static void main(String[] args) throws XMLStreamException, FileNotFoundException {
+  public static void main(String[] args) throws XMLStreamException, FileNotFoundException, IOException {
     if (args.length == 0) {
       System.out.println("Usage: " + IpaExtractor.class.getSimpleName() + " <xml-dump...>");
       System.exit(1);
     }
     IpaExtractor extractor = new IpaExtractor();
     for (String filename : args) {
-      FileInputStream fis = new FileInputStream(filename);
-      extractor.run(fis);
+      try (InputStream is = Files.newInputStream(Paths.get(filename))) {
+        extractor.run(is);
+      }
     }
     System.err.println("articleCount: " + extractor.articleCount);
     System.err.println("IPA count: " + extractor.ipaCount);
   }
 
-  private void run(FileInputStream fis) throws XMLStreamException {
+  private void run(InputStream is) throws XMLStreamException {
     XMLInputFactory factory = XMLInputFactory.newInstance();
-    XMLEventReader reader = factory.createXMLEventReader(fis);
+    XMLEventReader reader = factory.createXMLEventReader(is);
     String title = null;
     while (reader.hasNext()) {
       XMLEvent event = reader.nextEvent();


### PR DESCRIPTION
As hinted in a [PMD suggestion](https://pmd.github.io/latest/pmd_rules_java_performance.html#avoidfilestream):

>The FileInputStream and FileOutputStream classes contains a finalizer method which will cause garbage collection pauses. See [JDK-8080225](https://bugs.openjdk.java.net/browse/JDK-8080225) for details.

This PR resolves that, also it adds `try-with-resource` in some missing places.

Also, `File` could be moved to `Path`, but I don't know the deprecation policy in place.

Some places may lack the stream `.close()`, e.g. `Word2VecModel`, but I would check that in a separate PR.