### PR TITLE
Fix HunspellRuleTest on Windows

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
@@ -28,12 +28,12 @@ import org.languagetool.rules.Categories;
 import org.languagetool.rules.RuleMatch;
 import org.languagetool.rules.SuggestedReplacement;
 import org.languagetool.rules.spelling.SpellingCheckRule;
-import org.languagetool.tools.Tools;
 
 import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -345,9 +345,7 @@ public class HunspellRule extends SpellingCheckRule {
       hunspell = Hunspell.getInstance(Paths.get(shortDicPath + ".dic"), affPath);
     }
     if (affPath != null) {
-      Scanner sc = new Scanner(affPath);
-      while (sc.hasNextLine()) {
-        String line = sc.nextLine();
+      for (String line : Files.readAllLines(affPath)) {
         if (line.startsWith("WORDCHARS ")) {
           String wordCharsFromAff = line.substring("WORDCHARS ".length());
           //System.out.println("#" + wordCharsFromAff+ "#");

--- a/languagetool-dev/src/main/java/org/languagetool/dev/SentenceChecker.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/SentenceChecker.java
@@ -22,9 +22,10 @@ import org.languagetool.JLanguageTool;
 import org.languagetool.Language;
 import org.languagetool.Languages;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.Scanner;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Run LT on a large file with one sentence per line.
@@ -35,19 +36,16 @@ class SentenceChecker {
   
   private static final int BATCH_SIZE = 1000;
 
-  private void run(Language language, File file) throws IOException {
+  private void run(Language language, Path path) throws IOException {
     JLanguageTool lt = new JLanguageTool(language);
-    try (Scanner scanner = new Scanner(file)) {
-      int count = 0;
-      long startTime = System.currentTimeMillis();
-      while (scanner.hasNextLine()) {
-        String line = scanner.nextLine();
-        lt.check(line);
-        if (++count % BATCH_SIZE == 0) {
-          long time = System.currentTimeMillis() - startTime;
-          System.out.println(count + ". " + time + "ms per " + BATCH_SIZE + " sentences");
-          startTime = System.currentTimeMillis();
-        }
+    int count = 0;
+    long startTime = System.currentTimeMillis();
+    for (String line : Files.readAllLines(path)) {
+      lt.check(line);
+      if (++count % BATCH_SIZE == 0) {
+        long time = System.currentTimeMillis() - startTime;
+        System.out.println(count + ". " + time + "ms per " + BATCH_SIZE + " sentences");
+        startTime = System.currentTimeMillis();
       }
     }
   }
@@ -58,6 +56,6 @@ class SentenceChecker {
       System.exit(1);
     }
     SentenceChecker checker = new SentenceChecker();
-    checker.run(Languages.getLanguageForShortCode(args[0]), new File(args[1]));
+    checker.run(Languages.getLanguageForShortCode(args[0]), Paths.get(args[1]));
   }
 }

--- a/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/AggregatedNgramToLucene.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/AggregatedNgramToLucene.java
@@ -28,6 +28,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 
 /**
@@ -54,13 +56,10 @@ class AggregatedNgramToLucene implements AutoCloseable {
     }
   }
 
-  void indexInputFile(File file) throws IOException {
-    System.out.println("=== Indexing " + file + " ===");
-    try (Scanner scanner = new Scanner(file)) {
-      while (scanner.hasNextLine()) {
-        String line = scanner.nextLine();
-        indexLine(line);
-      }
+  void indexInputFile(Path path) throws IOException {
+    System.out.println("=== Indexing " + path + " ===");
+    for (String line : Files.readAllLines(path)) {
+      indexLine(line);
     }
   }
 
@@ -127,7 +126,7 @@ class AggregatedNgramToLucene implements AutoCloseable {
     try (AggregatedNgramToLucene prg = new AggregatedNgramToLucene(outputDir)) {
       for (File file : inputDir.listFiles()) {
         if (file.isFile()) {
-          prg.indexInputFile(file);
+          prg.indexInputFile(file.toPath());
         }
       }
       prg.addTotalTokenCountDoc(prg.totalTokenCount, prg.indexes.get(1).indexWriter);

--- a/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/ConfusionSetOccurrenceLookup.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/ConfusionSetOccurrenceLookup.java
@@ -22,6 +22,8 @@ import org.languagetool.languagemodel.LuceneLanguageModel;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 
 /**
@@ -39,11 +41,8 @@ final class ConfusionSetOccurrenceLookup {
       System.out.println("Usage: " + ConfusionSetOccurrenceLookup.class.getName() + " <confusion-file> <ngram-data-dir>");
       System.exit(1);
     }
-    try (Scanner sc = new Scanner(new File(args[0]));
-         LuceneLanguageModel lm = new LuceneLanguageModel(new File(args[1]))
-    ) {
-      while (sc.hasNextLine()) {
-        String line = sc.nextLine();
+    try (LuceneLanguageModel lm = new LuceneLanguageModel(new File(args[1]))) {
+      for (String line : Files.readAllLines(Paths.get(args[0]))) {
         String[] words = line.split(";\\s*");
         long total = 0;
         List<Long> counts = new ArrayList<>();

--- a/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/TextIndexCreator.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/bigdata/TextIndexCreator.java
@@ -29,10 +29,12 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.FSDirectory;
 import org.languagetool.dev.index.Lucene;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Scanner;
 
 /**
  * Index sentences with Lucene from a plain text file, one sentence per line.
@@ -56,9 +58,9 @@ class TextIndexCreator {
   private void indexFile(IndexWriter indexWriter, String inputFile) throws IOException {
     System.out.println("Indexing " + inputFile);
     int lineCount = 0;
-    try (Scanner scanner = new Scanner(new File(inputFile))) {
-      while (scanner.hasNextLine()) {
-        String line = scanner.nextLine();
+    try (BufferedReader br = Files.newBufferedReader(Paths.get(inputFile))) {
+      String line;
+      while ((line = br.readLine()) != null) {
         Document doc = new Document();
         doc.add(new TextField(Lucene.FIELD_NAME, line, Field.Store.YES));
         doc.add(new TextField(Lucene.FIELD_NAME_LOWERCASE, line.toLowerCase(), Field.Store.YES));

--- a/languagetool-dev/src/main/java/org/languagetool/dev/diff/LightRuleMatchParser.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/diff/LightRuleMatchParser.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
@@ -53,19 +55,15 @@ class LightRuleMatchParser {
   private List<LightRuleMatch> parseAggregatedJson(File inputFile) throws IOException {
     ObjectMapper mapper = new ObjectMapper();
     List<LightRuleMatch> ruleMatches = new ArrayList<>();
-    int lineCount = 1;
-    try (Scanner scanner = new Scanner(inputFile)) {
-      while (scanner.hasNextLine()) {
-        String line = scanner.nextLine();
+    try (BufferedReader br = Files.newBufferedReader(inputFile.toPath())) {
+      String line;
+      while ((line = br.readLine()) != null) {
         JsonNode node = mapper.readTree(line);
         JsonNode matches = node.get("matches");
         for (JsonNode match : matches) {
           ruleMatches.add(nodeToLightMatch(node.get("title").asText(), match));
         }
-        lineCount++;
       }
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to parse line " + lineCount + " of " + inputFile, e);
     }
     return ruleMatches;
   }

--- a/languagetool-dev/src/main/java/org/languagetool/dev/httpchecker/HttpApiSentenceChecker.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/httpchecker/HttpApiSentenceChecker.java
@@ -80,11 +80,10 @@ class HttpApiSentenceChecker {
     return String.format("%d:%02d:%02d", absSeconds / 3600, (absSeconds % 3600) / 60, absSeconds % 60);
   }
 
-  private int countLines(File input) throws FileNotFoundException {
+  private int countLines(File input) throws IOException {
     int count = 0;
-    try (Scanner sc = new Scanner(input)) {
-      while (sc.hasNextLine()) {
-        sc.nextLine();
+    try (BufferedReader reader = Files.newBufferedReader(input.toPath())) {
+      while (reader.readLine() != null) {
         count++;
       }
     }
@@ -100,10 +99,10 @@ class HttpApiSentenceChecker {
     int lineCount = 0;
     File tempFile = getTempFile(fileCount);
     tempFiles.add(tempFile);
-    FileWriter fw = new FileWriter(tempFile);
-    try (Scanner sc = new Scanner(input)) {
-      while (sc.hasNextLine()) {
-        String line = sc.nextLine();
+    Writer fw = Files.newBufferedWriter(tempFile.toPath());
+    try (BufferedReader reader = Files.newBufferedReader(input.toPath())) {
+      String line;
+      while ((line = reader.readLine()) != null) {
         fw.write(line + "\n");
         lineCount++;
         if (lineCount > 0 && lineCount % batchSize == 0) {
@@ -114,7 +113,7 @@ class HttpApiSentenceChecker {
           FileUtils.moveFile(tempFile, destFile);
           tempFile = getTempFile(fileCount);
           tempFiles.add(destFile);
-          fw = new FileWriter(tempFile);
+          fw = Files.newBufferedWriter(tempFile.toPath());
         }
       }
     }

--- a/languagetool-dev/src/main/java/org/languagetool/dev/wiktionary/HomophoneExtractor.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/wiktionary/HomophoneExtractor.java
@@ -18,12 +18,12 @@
  */
 package org.languagetool.dev.wiktionary;
 
-import java.io.File;
-import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -35,38 +35,35 @@ public class HomophoneExtractor {
   
   private static final Pattern homophonePattern = Pattern.compile("\\{\\{homophones\\|(.*?)\\}\\}");
 
-  private void run(String filename) throws FileNotFoundException {
-    try (Scanner scanner = new Scanner(new File(filename))) {
-      String title = "";
-      int lineCount = 0;
-      long startTime = System.currentTimeMillis();
-      while (scanner.hasNextLine()) {
-        String line = scanner.nextLine();
-        lineCount++;
-        if (line.contains("<title>") && line.contains("</title>")) {
-          title = line.substring(line.indexOf("<title>") + 7, line.indexOf("</title>"));
-        } else if (line.contains("lang=en")) {
-          Matcher m = homophonePattern.matcher(line);
-          if (m.find()) {
-            String homophonesData = m.group(1).replaceFirst("\\|?lang=en\\|?", "");
-            String[] homophones = homophonesData.split("\\|");
-            List<String> allHomophones = new ArrayList<>();
-            allHomophones.add(title);
-            allHomophones.addAll(Arrays.asList(homophones));
-            allHomophones.sort(null);
-            System.out.println(String.join(", ", allHomophones));
-          }
+  private void run(String filename) throws IOException {
+    String title = "";
+    int lineCount = 0;
+    long startTime = System.currentTimeMillis();
+    for (String line : Files.readAllLines(Paths.get(filename))) {
+      lineCount++;
+      if (line.contains("<title>") && line.contains("</title>")) {
+        title = line.substring(line.indexOf("<title>") + 7, line.indexOf("</title>"));
+      } else if (line.contains("lang=en")) {
+        Matcher m = homophonePattern.matcher(line);
+        if (m.find()) {
+          String homophonesData = m.group(1).replaceFirst("\\|?lang=en\\|?", "");
+          String[] homophones = homophonesData.split("\\|");
+          List<String> allHomophones = new ArrayList<>();
+          allHomophones.add(title);
+          allHomophones.addAll(Arrays.asList(homophones));
+          allHomophones.sort(null);
+          System.out.println(String.join(", ", allHomophones));
         }
-        if (lineCount % 100_000 == 0) {
-          long endTime = System.currentTimeMillis();
-          System.err.println(lineCount  + " (" + (endTime-startTime) + "ms)...");
-          startTime = System.currentTimeMillis();
-        }
+      }
+      if (lineCount % 100_000 == 0) {
+        long endTime = System.currentTimeMillis();
+        System.err.println(lineCount  + " (" + (endTime-startTime) + "ms)...");
+        startTime = System.currentTimeMillis();
       }
     }
   }
 
-  public static void main(String[] args) throws FileNotFoundException {
+  public static void main(String[] args) throws IOException {
     if (args.length != 1) {
       System.out.println("Usage: " + HomophoneExtractor.class.getSimpleName() + " <xmlFilename>");
       System.out.println("       <xmlFilename> is an unpacked Wiktionary dump");

--- a/languagetool-dev/src/test/java/org/languagetool/dev/FrequencyIndexCreatorTest.java
+++ b/languagetool-dev/src/test/java/org/languagetool/dev/FrequencyIndexCreatorTest.java
@@ -31,7 +31,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Scanner;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 public class FrequencyIndexCreatorTest {
 
@@ -43,12 +44,9 @@ public class FrequencyIndexCreatorTest {
     try (FSDirectory directory = FSDirectory.open(INDEX_DIR.toPath())) {
       DirectoryReader reader = DirectoryReader.open(directory);
       IndexSearcher searcher = new IndexSearcher(reader);
-      try (Scanner scanner = new Scanner(new File("/lt/performance-test/en.txt"))) {
-        while (scanner.hasNextLine()) {
-          String line = scanner.nextLine();
-          String[] parts = line.split(" ");
-          accessNgrams(parts, searcher);
-        }
+      for (String line : Files.readAllLines(Paths.get("/lt/performance-test/en.txt"))) {
+        String[] parts = line.split(" ");
+        accessNgrams(parts, searcher);
       }
     }
   }

--- a/languagetool-standalone/src/main/java/org/languagetool/dev/RuleCreator.java
+++ b/languagetool-standalone/src/main/java/org/languagetool/dev/RuleCreator.java
@@ -27,6 +27,7 @@ import org.languagetool.tokenizers.WordTokenizer;
 import org.languagetool.tools.StringTools;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.*;
 
 /**
@@ -142,26 +143,23 @@ public class RuleCreator {
     ruleCount++;
   }
 
-  private void initMaps(File homophoneOccurrenceFile) throws FileNotFoundException {
-    try (Scanner s = new Scanner(homophoneOccurrenceFile)) {
-      while (s.hasNextLine()) {
-        String line = s.nextLine();
-        String[] parts = line.split("\t");
-        if (parts.length != 3) {
-          throw new RuntimeException("Unexpected format: '" + line + "'");
-        }
-        long occurrenceCount = Integer.parseInt(parts[1]);
-        OccurrenceInfo occurrenceInfo = new OccurrenceInfo(parts[2], occurrenceCount);
-        List<OccurrenceInfo> list;
-        if (occurrenceInfos.containsKey(parts[0])) {
-          list = occurrenceInfos.get(parts[0]);
-        } else {
-          list = new ArrayList<>();
-        }
-        list.add(occurrenceInfo);
-        occurrenceInfos.put(parts[0], list);
-        ngramToOccurrence.put(parts[2], occurrenceCount);
+  private void initMaps(File homophoneOccurrenceFile) throws IOException {
+    for (String line : Files.readAllLines(homophoneOccurrenceFile.toPath())) {
+      String[] parts = line.split("\t");
+      if (parts.length != 3) {
+        throw new RuntimeException("Unexpected format: '" + line + "'");
       }
+      long occurrenceCount = Integer.parseInt(parts[1]);
+      OccurrenceInfo occurrenceInfo = new OccurrenceInfo(parts[2], occurrenceCount);
+      List<OccurrenceInfo> list;
+      if (occurrenceInfos.containsKey(parts[0])) {
+        list = occurrenceInfos.get(parts[0]);
+      } else {
+        list = new ArrayList<>();
+      }
+      list.add(occurrenceInfo);
+      occurrenceInfos.put(parts[0], list);
+      ngramToOccurrence.put(parts[2], occurrenceCount);
     }
   }
 

--- a/languagetool-standalone/src/test/java/org/languagetool/TranslationTest.java
+++ b/languagetool-standalone/src/test/java/org/languagetool/TranslationTest.java
@@ -24,6 +24,7 @@ import org.languagetool.tools.StringTools;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.*;
 
 /**
@@ -69,7 +70,7 @@ public class TranslationTest {
         continue;
       }
       File file = file1.exists() ? file1 : file2;
-      List<String> lines = loadFile(file);
+      List<String> lines = Files.readAllLines(file.toPath());
       for (String line : lines) {
         line = line.trim();
         if (StringTools.isEmpty(line) || line.charAt(0)=='#') {
@@ -84,16 +85,6 @@ public class TranslationTest {
     }
   }
   
-  private List<String> loadFile(File file) throws IOException {
-    List<String> l = new ArrayList<>();
-    try (Scanner scanner = new Scanner(file)) {
-      while (scanner.hasNextLine()) {
-        l.add(scanner.nextLine());
-      }
-    }
-    return l;
-  }
-
   private File getEnglishTranslationFile() {
     String name = "../languagetool-core/src/main/resources/org/languagetool/MessagesBundle_en.properties";
     return new File(name.replace("/", File.separator));


### PR DESCRIPTION
Fixes #2202

The reason was: Scanner behavior is different with maven in Windows, and `Scanner(File)` had been replaced globally by `Files.readAllLines`.

However, there are still failed tests on windows, but would be handled separately.