### PR TITLE
Correct URL to Penn Treebank tagset

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/tagset.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/tagset.txt
@@ -1,6 +1,6 @@
 These are mostly the tags of the Penn Treebank tagset as used by LanguageTool,
 with examples. See "new tag" for tags introduced by LanguageTool.
-For more details, also see http://www.cis.upenn.edu/~treebank/
+For more details, also see https://www.ling.upenn.edu/courses/Fall_2003/ling001/penn_treebank_pos.html
 
 CC    Coordinating conjunction: and, or, either, if, as, since, once, neither, less
 CD    Cardinal number: one, two, twenty-four


### PR DESCRIPTION
The existing URL is not found.

Also, the URL could be https://catalog.ldc.upenn.edu/docs/LDC95T7/cl93.html