### PR TITLE
fix IDs created by GRPCSubRule

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/GRPCRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/GRPCRule.java
@@ -70,19 +70,24 @@ import java.util.stream.Collectors;
 public abstract class GRPCRule extends RemoteRule {
   private static final Logger logger = LoggerFactory.getLogger(GRPCRule.class);
 
+  public static String cleanID(String id) {
+    return id.replaceAll("[^a-zA-Z_]", "_");
+  }
   /**
    * Internal rule to create rule matches with IDs based on Match Sub-IDs
    */
   protected class GRPCSubRule extends Rule {
     private final String subId;
+    private final String matchId;
 
     GRPCSubRule(String subId) {
       this.subId = subId;
+      this.matchId = GRPCRule.this.getId() + "_" + cleanID(subId);
     }
 
     @Override
     public String getId() {
-      return GRPCRule.this.getId() + "_" + subId;
+      return matchId;
     }
 
     @Override

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/English.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/English.java
@@ -247,11 +247,11 @@ public class English extends Language implements AutoCloseable {
 
   @Override
   protected int getPriorityForId(String id) {
+    // higher priority for testing/evaluation; only activated by configuring remote rule
+    if (id.startsWith("AI_")) {
+      return 50;
+    }
     switch (id) {
-      case "THE_INS_RULE": return 50; // higher priority for testing/evaluation; only activated by configuring remote rule
-      case "CONFPAIRS_EN_GPT2": return 50; // higher priority for testing/evaluation; only activated by configuring remote rule
-      case "CONFPAIRS_EN_GPT2_L": return 50; // higher priority for testing/evaluation; only activated by configuring remote rule
-      case "CONFPAIRS_EN_GPT2_XL": return 50; // higher priority for testing/evaluation; only activated by configuring remote rule
       case "I_E":                       return 10; // needs higher prio than EN_COMPOUNDS ("i.e learning")
       case "MISSING_HYPHEN":            return 5;
       case "TRANSLATION_RULE":          return 5;   // Premium


### PR DESCRIPTION
sub-IDs could contain characters illegal in rule IDs
replace all illegal characters with underscores

also: prioritise all AI_* rules instead of only explicitly listed
ones (with old names)