### PR TITLE
implemented 'fall' option for hidden matches

### DIFF
--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
@@ -89,6 +89,7 @@ public class HTTPServerConfig {
   protected String hiddenMatchesServer;
   protected int hiddenMatchesServerTimeout;
   protected int hiddenMatchesServerFailTimeout;
+  protected int hiddenMatchesServerFall;
   protected List<Language> hiddenMatchesLanguages = new ArrayList<>();
   protected String dbDriver = null;
   protected String dbUrl = null;
@@ -114,7 +115,7 @@ public class HTTPServerConfig {
     "beolingusFile", "blockedReferrers", "cacheSize", "cacheTTLSeconds",
     "dbDriver", "dbPassword", "dbUrl", "dbUsername", "disabledRuleIds", "fasttextBinary", "fasttextModel", "grammalectePassword",
     "grammalecteServer", "grammalecteUser", "hiddenMatchesLanguages", "hiddenMatchesServer", "hiddenMatchesServerFailTimeout",
-    "hiddenMatchesServerTimeout", "ipFingerprintFactor", "languageModel", "maxCheckThreads", "maxCheckTimeMillis",
+    "hiddenMatchesServerTimeout", "hiddenMatchesServerFall", "ipFingerprintFactor", "languageModel", "maxCheckThreads", "maxCheckTimeMillis",
     "maxCheckTimeWithApiKeyMillis", "maxErrorsPerWordRate", "maxPipelinePoolSize", "maxSpellingSuggestions", "maxTextHardLength",
     "maxTextLength", "maxTextLengthWithApiKey", "maxWorkQueueSize", "neuralNetworkModel", "pipelineCaching",
     "pipelineExpireTimeInSeconds", "pipelinePrewarming", "prometheusMonitoring", "prometheusPort", "remoteRulesFile",
@@ -287,6 +288,7 @@ public class HTTPServerConfig {
         hiddenMatchesServer = getOptionalProperty(props, "hiddenMatchesServer", null);
         hiddenMatchesServerTimeout = Integer.parseInt(getOptionalProperty(props, "hiddenMatchesServerTimeout", "1000"));
         hiddenMatchesServerFailTimeout = Integer.parseInt(getOptionalProperty(props, "hiddenMatchesServerFailTimeout", "10000"));
+        hiddenMatchesServerFall = Integer.parseInt(getOptionalProperty(props, "hiddenMatchesServerFall", "1"));
         String langCodes = getOptionalProperty(props, "hiddenMatchesLanguages", "");
         for (String code : langCodes.split(",\\s*")) {
           if (!code.isEmpty()) {
@@ -812,6 +814,15 @@ public class HTTPServerConfig {
    */
   List<Language> getHiddenMatchesLanguages() {
     return hiddenMatchesLanguages;
+  }
+
+  /**
+   * Number of failed/timed out requests after which server gets marked as down
+   * @since 5.1
+   */
+  @Experimental
+  int getHiddenMatchesServerFall() {
+    return hiddenMatchesServerFall;
   }
 
   /**

--- a/languagetool-server/src/main/java/org/languagetool/server/ResultExtender.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/ResultExtender.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jetbrains.annotations.NotNull;
 import org.languagetool.AnalyzedSentence;
 import org.languagetool.AnalyzedTokenReadings;
-import org.languagetool.Experimental;
 import org.languagetool.rules.ITSIssueType;
 import org.languagetool.rules.Rule;
 import org.languagetool.rules.RuleMatch;
@@ -119,7 +118,7 @@ class ResultExtender {
     } catch (Exception e) {
       // These are issue that can be request-specific, like wrong parameters. We don't throw an
       // exception, as the calling code would otherwise assume this is a persistent error:
-      logger.warn("Warn: Failed to query hidden matches server at " + url + ": " + e.getClass() + ": " + e.getMessage() + ", input was " + plainText.length() + " characters");
+      logger.warn("Warn: Failed to query hidden matches server at " + url + ": " + e.getClass() + ": " + e.getMessage() + ", input was " + plainText.length() + " characters - request-specific error, ignoring");
       return Collections.emptyList();
     } finally {
       huc.disconnect();

--- a/languagetool-server/src/main/java/org/languagetool/server/ServerMetricsCollector.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/ServerMetricsCollector.java
@@ -128,6 +128,9 @@ public class ServerMetricsCollector {
     .build("languagetool_hidden_matches_server_enabled", "Configuration of hidden matches server").register();
   private final Gauge hiddenMatchesServerStatus = Gauge
     .build("languagetool_hidden_matches_server_up", "Status of hidden matches server").register();
+  private final Counter hiddenMatchesServerRequests = Counter
+    .build("languagetool_hidden_matches_server_requests_total", "Number of hidden server requests by status")
+    .labelNames("status").register();
 
   private final CacheMetricsCollector cacheMetrics = new CacheMetricsCollector().register();
 
@@ -155,6 +158,16 @@ public class ServerMetricsCollector {
 
   public void logHiddenServerStatus(boolean up) {
     hiddenMatchesServerStatus.set(up ? 1.0 : 0.0);
+  }
+
+  public void logHiddenServerRequest(boolean success) {
+    if (hiddenMatchesServerStatus.get() == 0.0) {
+      hiddenMatchesServerRequests.labels("down").inc();
+    } else if (success) {
+      hiddenMatchesServerRequests.labels("success").inc();
+    } else {
+      hiddenMatchesServerRequests.labels("failure").inc();
+    }
   }
 
   public void logCheck(Language language, long milliseconds, int textSize, int matchCount,

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -86,6 +86,8 @@ abstract class TextChecker {
   // keep track of timeouts of the hidden matches server, check health periodically;
   // -1 => healthy, else => check timed out at given date, check back if time difference > config.getHiddenMatchesFailTimeout()
   private long lastHiddenMatchesServerTimeout;
+  // counter; mark as down if this reaches hidenMatchesServerFall
+  private long hiddenMatchesServerFailures = 0;
   private final LanguageIdentifier identifier;
   private final ExecutorService executorService;
   private final ResultCache cache;
@@ -185,7 +187,7 @@ abstract class TextChecker {
     executorService.shutdownNow();
     RemoteRule.shutdown();
   }
-  
+
   void checkText(AnnotatedText aText, HttpExchange httpExchange, Map<String, String> parameters, ErrorRequestLimiter errorRequestLimiter,
                  String remoteAddress) throws Exception {
     checkParams(parameters);
@@ -342,7 +344,7 @@ abstract class TextChecker {
     int textSize = aText.getPlainText().length();
 
     List<RuleMatch> ruleMatchesSoFar = Collections.synchronizedList(new ArrayList<>());
-    
+
     Future<List<RuleMatch>> future = executorService.submit(new Callable<List<RuleMatch>>() {
       @Override
       public List<RuleMatch> call() throws Exception {
@@ -396,7 +398,7 @@ abstract class TextChecker {
       if (params.allowIncompleteResults) {
         logger.info(message + " - returning " + ruleMatchesSoFar.size() + " matches found so far");
         matches = new ArrayList<>(ruleMatchesSoFar);  // threads might still be running, so make a copy
-        incompleteResultReason = "Results are incomplete: text checking took longer than allowed maximum of " + 
+        incompleteResultReason = "Results are incomplete: text checking took longer than allowed maximum of " +
                 String.format(Locale.ENGLISH, "%.2f", limits.getMaxCheckTimeMillis()/1000.0) + " seconds";
       } else {
         ServerMetricsCollector.getInstance().logRequestError(ServerMetricsCollector.RequestErrorType.MAX_CHECK_TIME);
@@ -414,6 +416,7 @@ abstract class TextChecker {
       if(config.getHiddenMatchesServerFailTimeout() > 0 && lastHiddenMatchesServerTimeout != -1 &&
         System.currentTimeMillis() - lastHiddenMatchesServerTimeout < config.getHiddenMatchesServerFailTimeout()) {
         ServerMetricsCollector.getInstance().logHiddenServerStatus(false);
+        ServerMetricsCollector.getInstance().logHiddenServerRequest(false);
         logger.warn("Warn: Skipped querying hidden matches server at " +
           config.getHiddenMatchesServer() + " because of recent error/timeout (timeout=" + config.getHiddenMatchesServerFailTimeout() + "ms).");
       } else {
@@ -426,10 +429,18 @@ abstract class TextChecker {
           logger.info("Hidden matches: " + extensionMatches.size() + " -> " + hiddenMatches.size() + " in " + (end - start) + "ms for " + lang.getShortCodeWithCountryAndVariant());
           ServerMetricsCollector.getInstance().logHiddenServerStatus(true);
           lastHiddenMatchesServerTimeout = -1;
+          hiddenMatchesServerFailures = 0;
+          ServerMetricsCollector.getInstance().logHiddenServerRequest(true);
         } catch (Exception e) {
-          ServerMetricsCollector.getInstance().logHiddenServerStatus(false);
-          logger.warn("Failed to query hidden matches server at " + config.getHiddenMatchesServer() + ": " + e.getClass() + ": " + e.getMessage() + ", input was " + aText.getPlainText().length() + " characters");
-          lastHiddenMatchesServerTimeout = System.currentTimeMillis();
+          ServerMetricsCollector.getInstance().logHiddenServerRequest(false);
+          hiddenMatchesServerFailures++;
+          if (hiddenMatchesServerFailures >= config.getHiddenMatchesServerFall()) {
+            ServerMetricsCollector.getInstance().logHiddenServerStatus(false);
+            logger.warn("Failed to query hidden matches server at " + config.getHiddenMatchesServer() + ": " + e.getClass() + ": " + e.getMessage() + ", input was " + aText.getPlainText().length() + " characters - marked as down now");
+            lastHiddenMatchesServerTimeout = System.currentTimeMillis();
+          } else {
+            logger.warn("Failed to query hidden matches server at " + config.getHiddenMatchesServer() + ": " + e.getClass() + ": " + e.getMessage() + ", input was " + aText.getPlainText().length() + " characters - " + (config.getHiddenMatchesServerFall() - hiddenMatchesServerFailures) + " errors until marked as down");
+          }
         }
       }
     }


### PR DESCRIPTION
new configuration option: hiddenMatchesServerFall
mark as down after N consecutive failures
improved monitoring for hidden matches: Counter
languagetool_hidden_matches_server_requests_total with 'status' label