### PR TITLE
Volksband statt Volksbank

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
@@ -6570,3 +6570,6 @@ Verzweifel
 # should be "Strickmuster"
 Trickmuster/NS
 Mitglieder-innen
+Volksband/S
+Volksbandes
+Volksbänder/N


### PR DESCRIPTION
Ob ihr die Pluralversion wollt, könnt ihr selbst entscheiden.