### PR TITLE
Caching for remote rule results

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -1,6 +1,6 @@
-/* LanguageTool, a natural language style checker 
+/* LanguageTool, a natural language style checker
  * Copyright (C) 2005 Daniel Naber (http://www.danielnaber.de)
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -27,24 +27,32 @@ import org.languagetool.markup.AnnotatedText;
 import org.languagetool.markup.AnnotatedTextBuilder;
 import org.languagetool.rules.*;
 import org.languagetool.rules.neuralnetwork.Word2VecModel;
-import org.languagetool.rules.patterns.*;
+import org.languagetool.rules.patterns.AbstractPatternRule;
+import org.languagetool.rules.patterns.FalseFriendRuleLoader;
+import org.languagetool.rules.patterns.PatternRule;
+import org.languagetool.rules.patterns.PatternRuleLoader;
 import org.languagetool.rules.spelling.SpellingCheckRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
 import java.net.JarURLConnection;
 import java.net.URL;
 import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.FutureTask;
 import java.util.function.Function;
 import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * The main class used for checking text against different rules:
@@ -53,13 +61,13 @@ import java.util.stream.Stream;
  * <li>built-in pattern rules loaded from external XML files (usually called {@code grammar.xml})
  * <li>your own implementation of the abstract {@link Rule} classes added with {@link #addRule(Rule)}
  * </ul>
- * 
+ *
  * <p>You will probably want to use the sub class {@link MultiThreadedJLanguageTool} for best performance.
- * 
+ *
  * <p><b>Thread-safety:</b> this class is not thread safe. Create one instance per thread,
  * but create the language only once (e.g. {@code new AmericanEnglish()}) and use it for all
  * instances of JLanguageTool.</p>
- * 
+ *
  * @see MultiThreadedJLanguageTool
  */
 public class JLanguageTool {
@@ -69,25 +77,41 @@ public class JLanguageTool {
   public static final String VERSION = "5.1-SNAPSHOT";
   /** LanguageTool build date and time like {@code 2013-10-17 16:10} or {@code null} if not run from JAR. */
   @Nullable public static final String BUILD_DATE = getBuildDate();
-  /** 
+  /**
    * Abbreviated git id or {@code null} if not available.
+   *
    * @since 4.5
    */
-  @Nullable public static final String GIT_SHORT_ID = getShortGitId();
+  @Nullable
+  public static final String GIT_SHORT_ID = getShortGitId();
 
-  /** The name of the file with error patterns. */
+  /**
+   * The name of the file with error patterns.
+   */
   public static final String PATTERN_FILE = "grammar.xml";
-  /** The name of the file with false friend information. */
+  /**
+   * The name of the file with false friend information.
+   */
   public static final String FALSE_FRIEND_FILE = "false-friends.xml";
-  /** The internal tag used to mark the beginning of a sentence. */
+  /**
+   * The internal tag used to mark the beginning of a sentence.
+   */
   public static final String SENTENCE_START_TAGNAME = "SENT_START";
-  /** The internal tag used to mark the end of a sentence. */
+  /**
+   * The internal tag used to mark the end of a sentence.
+   */
   public static final String SENTENCE_END_TAGNAME = "SENT_END";
-  /** The internal tag used to mark the end of a paragraph. */
+  /**
+   * The internal tag used to mark the end of a paragraph.
+   */
   public static final String PARAGRAPH_END_TAGNAME = "PARA_END";
-  /** Name of the message bundle for translations. */
+  /**
+   * Name of the message bundle for translations.
+   */
   public static final String MESSAGE_BUNDLE = "org.languagetool.MessagesBundle";
-  /** Extension of dictionary files read by Spellers */
+  /**
+   * Extension of dictionary files read by Spellers
+   */
   public static final String DICTIONARY_FILENAME_EXTENSION = ".dict";
 
   private final ResultCache cache;
@@ -145,7 +169,7 @@ public class JLanguageTool {
   public static boolean isPremiumVersion() {
     return false;
   }
-  
+
   private static ResourceDataBroker dataBroker = new DefaultResourceDataBroker();
   private static ClassBroker classBroker = new DefaultClassBroker();
 
@@ -193,14 +217,20 @@ public class JLanguageTool {
   public enum Mode {
     // IMPORTANT: directly logged via toString into check_log database table.
     // column is varchar(32), so take care to not exceed this length here
-    /** Use all active rules for checking. */
+    /**
+     * Use all active rules for checking.
+     */
     ALL,
-    /** Use only text-level rules for checking. This is typically much faster then using all rules or {@code ALL_BUT_TEXTLEVEL_ONLY}. */
+    /**
+     * Use only text-level rules for checking. This is typically much faster then using all rules or {@code ALL_BUT_TEXTLEVEL_ONLY}.
+     */
     TEXTLEVEL_ONLY,
-    /** Use all activate rules for checking except the text-level rules. */
+    /**
+     * Use all activate rules for checking except the text-level rules.
+     */
     ALL_BUT_TEXTLEVEL_ONLY
   }
-  
+
   public enum Level {
     DEFAULT,
     PICKY
@@ -212,9 +242,9 @@ public class JLanguageTool {
    * Create a JLanguageTool and setup the built-in rules for the
    * given language and false friend rules for the text language / mother tongue pair.
    *
-   * @param lang the language of the text to be checked
+   * @param lang         the language of the text to be checked
    * @param motherTongue the user's mother tongue, used for false friend rules, or <code>null</code>.
-   *          The mother tongue may also be used as a source language for checking bilingual texts.
+   *                     The mother tongue may also be used as a source language for checking bilingual texts.
    */
   public JLanguageTool(Language lang, Language motherTongue) {
     this(lang, motherTongue, null);
@@ -234,11 +264,11 @@ public class JLanguageTool {
    * Create a JLanguageTool and setup the built-in rules for the
    * given language and false friend rules for the text language / mother tongue pair.
    *
-   * @param language the language of the text to be checked
+   * @param language     the language of the text to be checked
    * @param motherTongue the user's mother tongue, used for false friend rules, or <code>null</code>.
-   *          The mother tongue may also be used as a source language for checking bilingual texts.
-   * @param cache a cache to speed up checking if the same sentences get checked more than once,
-   *              e.g. when LT is running as a server and texts are re-checked due to changes
+   *                     The mother tongue may also be used as a source language for checking bilingual texts.
+   * @param cache        a cache to speed up checking if the same sentences get checked more than once,
+   *                     e.g. when LT is running as a server and texts are re-checked due to changes
    * @since 3.7
    */
   public JLanguageTool(Language language, Language motherTongue, ResultCache cache) {
@@ -248,11 +278,11 @@ public class JLanguageTool {
   /**
    * Create a JLanguageTool and setup the built-in rules for the
    * given language and false friend rules for the text language / mother tongue pair.
-   * 
+   *
    * @param language the language of the text to be checked
-   * @param cache a cache to speed up checking if the same sentences get checked more than once,
-   *              e.g. when LT is running as a server and texts are re-checked due to changes. Use
-   *              {@code null} to deactivate the cache.
+   * @param cache    a cache to speed up checking if the same sentences get checked more than once,
+   *                 e.g. when LT is running as a server and texts are re-checked due to changes. Use
+   *                 {@code null} to deactivate the cache.
    * @since 4.2
    */
   public JLanguageTool(Language language, ResultCache cache, UserConfig userConfig) {
@@ -266,8 +296,8 @@ public class JLanguageTool {
   /**
    * Create a JLanguageTool and setup the built-in rules for the
    * given language and false friend rules for the text language / mother tongue pair.
-   * 
-   * @param language the language of the text to be checked
+   *
+   * @param language     the language of the text to be checked
    * @param altLanguages The languages that are accepted as alternative languages - currently this means
    *                     words are accepted if they are in an alternative language and not similar to
    *                     a word from {@code language}. If there's a similar word in {@code language},
@@ -312,17 +342,17 @@ public class JLanguageTool {
    * Create a JLanguageTool and setup the built-in rules for the
    * given language and false friend rules for the text language / mother tongue pair.
    *
-   * @param language the language of the text to be checked
+   * @param language     the language of the text to be checked
    * @param motherTongue the user's mother tongue, used for false friend rules, or <code>null</code>.
-   *          The mother tongue may also be used as a source language for checking bilingual texts.
-   * @param cache a cache to speed up checking if the same sentences get checked more than once,
-   *              e.g. when LT is running as a server and texts are re-checked due to changes
+   *                     The mother tongue may also be used as a source language for checking bilingual texts.
+   * @param cache        a cache to speed up checking if the same sentences get checked more than once,
+   *                     e.g. when LT is running as a server and texts are re-checked due to changes
    * @since 4.2
    */
   public JLanguageTool(Language language, Language motherTongue, ResultCache cache, UserConfig userConfig) {
     this(language, Collections.emptyList(), motherTongue, cache, null, userConfig);
   }
-  
+
   /**
    * The grammar checker needs resources from following
    * directories:
@@ -330,6 +360,7 @@ public class JLanguageTool {
    *   <li>{@code /resource}</li>
    *   <li>{@code /rules}</li>
    * </ul>
+   *
    * @return The currently set data broker which allows to obtain
    * resources from the mentioned directories above. If no
    * data broker was set, a new {@link DefaultResourceDataBroker} will
@@ -342,7 +373,7 @@ public class JLanguageTool {
     }
     return JLanguageTool.dataBroker;
   }
-  
+
   /**
    * The grammar checker needs resources from following
    * directories:
@@ -350,6 +381,7 @@ public class JLanguageTool {
    * <li>{@code /resource}</li>
    * <li>{@code /rules}</li>
    * </ul>
+   *
    * @param broker The new resource broker to be used.
    * @since 1.0.1
    */
@@ -386,11 +418,12 @@ public class JLanguageTool {
   public void setListUnknownWords(boolean listUnknownWords) {
     this.listUnknownWords = listUnknownWords;
   }
-  
+
   /**
    * Whether the {@link #check(String)} methods return overlapping errors. If set to
-   * <code>true</code> (default: true), it removes overlapping errors according to 
-   * the priorities established for the language. 
+   * <code>true</code> (default: true), it removes overlapping errors according to
+   * the priorities established for the language.
+   *
    * @since 3.6
    */
   public void setCleanOverlappingMatches(boolean cleanOverlappingMatches) {
@@ -402,6 +435,7 @@ public class JLanguageTool {
    * For example, with a rate of 0.33, the checking would stop if the user's
    * text has so many errors that more than every 3rd word causes a rule match.
    * Note that this may not apply for very short texts.
+   *
    * @since 4.0
    */
   public void setMaxErrorsPerWordRate(float maxErrorsPerWordRate) {
@@ -414,7 +448,7 @@ public class JLanguageTool {
   public void setCheckCancelledCallback(CheckCancelledCallback callback) {
     this.checkCancelledCallback = callback;
   }
-  
+
   /**
    * Gets the ResourceBundle (i18n strings) for the default language of the user's system.
    */
@@ -424,12 +458,13 @@ public class JLanguageTool {
 
   /**
    * Gets the ResourceBundle (i18n strings) for the given user interface language.
+   *
    * @since 2.4 (public since 2.4)
    */
   public static ResourceBundle getMessageBundle(Language lang) {
     return ResourceBundleTools.getMessageBundle(lang);
   }
-  
+
   private List<Rule> getAllBuiltinRules(Language language, ResourceBundle messages, UserConfig userConfig, GlobalConfig globalConfig) {
     try {
       List<Rule> rules = new ArrayList<>(language.getRelevantRules(messages, userConfig, motherTongue, altLanguages));
@@ -451,6 +486,7 @@ public class JLanguageTool {
   /**
    * Load pattern rules from an XML file. Use {@link #addRule(Rule)} to add these
    * rules to the checking process.
+   *
    * @param filename path to an XML file in the classpath or in the filesystem - the classpath is checked first
    * @return a List of {@link PatternRule} objects
    */
@@ -476,11 +512,12 @@ public class JLanguageTool {
    * that match the current text language and the mother tongue specified in the
    * JLanguageTool constructor. Use {@link #addRule(Rule)} to add these rules to the
    * checking process.
+   *
    * @param filename path to an XML file in the classpath or in the filesystem - the classpath is checked first
    * @return a List of {@link PatternRule} objects, or an empty list if mother tongue is not set
    */
   public List<AbstractPatternRule> loadFalseFriendRules(String filename)
-      throws ParserConfigurationException, SAXException, IOException {
+    throws ParserConfigurationException, SAXException, IOException {
     if (motherTongue == null) {
       return Collections.emptyList();
     }
@@ -496,6 +533,7 @@ public class JLanguageTool {
 
   /**
    * Remove rules that can profit from a language model, recreate them with the given model and add them again
+   *
    * @param lm the language model or null if none is available
    */
   private void updateOptionalLanguageModelRules(@Nullable LanguageModel lm) {
@@ -506,13 +544,14 @@ public class JLanguageTool {
       optionalLanguageModelRules.clear();
       rules.stream().map(Rule::getId).forEach(optionalLanguageModelRules::add);
       userRules.addAll(rules);
-    } catch(Exception e) {
+    } catch (Exception e) {
       throw new RuntimeException("Could not load language model capable rules.", e);
     }
   }
 
   /**
    * Activate rules that depend on pretrained neural network models.
+   *
    * @param modelDir root dir of exported models
    * @since 4.4
    */
@@ -525,6 +564,7 @@ public class JLanguageTool {
   /**
    * Activate rules that depend on a language model. The language model currently
    * consists of Lucene indexes with ngram occurrence counts.
+   *
    * @param indexDir directory with a '3grams' sub directory which contains a Lucene index with 3gram occurrence counts
    * @since 2.7
    */
@@ -554,7 +594,7 @@ public class JLanguageTool {
       List<RemoteRuleConfig> configs;
       if (configFile != null) {
         configs = RemoteRuleConfig.load(configFile);
-      }  else {
+      } else {
         configs = Collections.emptyList();
       }
       List<Rule> rules = language.getRelevantRemoteRules(getMessageBundle(language), configs,
@@ -573,6 +613,7 @@ public class JLanguageTool {
 
   /**
    * Activate rules that depend on a word2vec language model.
+   *
    * @param indexDir directory with a subdirectories like 'en', each containing dictionary.txt and final_embeddings.txt
    * @since 4.0
    */
@@ -611,7 +652,7 @@ public class JLanguageTool {
    * <code>rules/false-friends.xml</code>.
    */
   private void activateDefaultFalseFriendRules()
-      throws ParserConfigurationException, SAXException, IOException {
+    throws ParserConfigurationException, SAXException, IOException {
     String falseFriendRulesFilename = JLanguageTool.getDataBroker().getRulesDir() + "/" + FALSE_FRIEND_FILE;
     userRules.addAll(loadFalseFriendRules(falseFriendRulesFilename));
   }
@@ -619,8 +660,9 @@ public class JLanguageTool {
   /**
    * Add a {@link RuleMatchFilter} for post-processing of rule matches
    * Filters are called sequentially in the same order as added
-   * @since 4.7
+   *
    * @param filter filter to add
+   * @since 4.7
    */
   public void addMatchFilter(@NotNull RuleMatchFilter filter) {
     matchFilters.add(Objects.requireNonNull(filter));
@@ -635,8 +677,9 @@ public class JLanguageTool {
 
   /**
    * Disable a given rule so the check methods like {@link #check(String)} won't use it.
+   *
    * @param ruleId the id of the rule to disable - no error will be thrown if the id does not exist
-   * @see #enableRule(String) 
+   * @see #enableRule(String)
    */
   public void disableRule(String ruleId) {
     disabledRules.add(ruleId);
@@ -645,6 +688,7 @@ public class JLanguageTool {
 
   /**
    * Disable the given rules so the check methods like {@link #check(String)} won't use them.
+   *
    * @param ruleIds the ids of the rules to disable - no error will be thrown if the id does not exist
    * @since 2.4
    */
@@ -655,9 +699,10 @@ public class JLanguageTool {
 
   /**
    * Disable the given rule category so the check methods like {@link #check(String)} won't use it.
+   *
    * @param id the id of the category to disable - no error will be thrown if the id does not exist
+   * @see #enableRuleCategory(CategoryId)
    * @since 3.3
-   * @see #enableRuleCategory(CategoryId) 
    */
   public void disableCategory(CategoryId id) {
     disabledRuleCategories.add(id);
@@ -666,11 +711,11 @@ public class JLanguageTool {
 
   /**
    * Returns true if a category is explicitly disabled.
-   * 
+   *
    * @param id the id of the category to check - no error will be thrown if the id does not exist
    * @return true if this category is explicitly disabled.
+   * @see #disableCategory(org.languagetool.rules.CategoryId)
    * @since 3.5
-   * @see #disableCategory(org.languagetool.rules.CategoryId) 
    */
   public boolean isCategoryDisabled(CategoryId id) {
     return disabledRuleCategories.contains(id);
@@ -693,6 +738,7 @@ public class JLanguageTool {
   /**
    * Enable a given rule so the check methods like {@link #check(String)} will use it.
    * This will <em>not</em> throw an exception if the given rule id doesn't exist.
+   *
    * @param ruleId the id of the rule to enable
    * @see #disableRule(String)
    */
@@ -704,8 +750,9 @@ public class JLanguageTool {
   /**
    * Enable all rules of the given category so the check methods like {@link #check(String)} will use it.
    * This will <em>not</em> throw an exception if the given rule id doesn't exist.
+   *
+   * @see #disableCategory(org.languagetool.rules.CategoryId)
    * @since 3.3
-   * @see #disableCategory(org.languagetool.rules.CategoryId) 
    */
   public void enableRuleCategory(CategoryId id) {
     disabledRuleCategories.remove(id);
@@ -722,7 +769,7 @@ public class JLanguageTool {
   /**
    * The main check method. Tokenizes the text into sentences and matches these
    * sentences against all currently active rules.
-   * 
+   *
    * @param text the text to be checked
    * @return a List of {@link RuleMatch} objects
    */
@@ -733,7 +780,7 @@ public class JLanguageTool {
   /**
    * The main check method. Tokenizes the text into sentences and matches these
    * sentences against all currently active rules.
-   * 
+   *
    * @param text the text to be checked
    * @return a List of {@link RuleMatch} objects
    * @since 3.7
@@ -755,48 +802,51 @@ public class JLanguageTool {
 
   /**
    * The main check method. Tokenizes the text into sentences and matches these
-   * sentences against all currently active rules, adjusting error positions so they refer 
+   * sentences against all currently active rules, adjusting error positions so they refer
    * to the original text <em>including</em> markup.
+   *
    * @since 2.3
    */
   public List<RuleMatch> check(AnnotatedText text) throws IOException {
     return check(text, true, ParagraphHandling.NORMAL);
   }
-  
+
   /**
    * @since 3.9
    */
   public List<RuleMatch> check(AnnotatedText text, RuleMatchListener listener) throws IOException {
     return check(text, true, ParagraphHandling.NORMAL, listener);
   }
-  
+
   /**
    * The main check method. Tokenizes the text into sentences and matches these
    * sentences against all currently active rules.
-   * @param annotatedText The text to be checked, created with {@link AnnotatedTextBuilder}. 
-   *          Call this method with the complete text to be checked. If you call it
-   *          repeatedly with smaller chunks like paragraphs or sentence, those rules that work across
-   *          paragraphs/sentences won't work (their status gets reset whenever this method is called).
-   * @param tokenizeText If true, then the text is tokenized into sentences.
-   *          Otherwise, it is assumed it's already tokenized, i.e. it is only one sentence
-   * @param paraMode Uses paragraph-level rules only if true.
+   *
+   * @param annotatedText The text to be checked, created with {@link AnnotatedTextBuilder}.
+   *                      Call this method with the complete text to be checked. If you call it
+   *                      repeatedly with smaller chunks like paragraphs or sentence, those rules that work across
+   *                      paragraphs/sentences won't work (their status gets reset whenever this method is called).
+   * @param tokenizeText  If true, then the text is tokenized into sentences.
+   *                      Otherwise, it is assumed it's already tokenized, i.e. it is only one sentence
+   * @param paraMode      Uses paragraph-level rules only if true.
    * @return a List of {@link RuleMatch} objects, describing potential errors in the text
    * @since 2.3
    */
   public List<RuleMatch> check(AnnotatedText annotatedText, boolean tokenizeText, ParagraphHandling paraMode) throws IOException {
     return check(annotatedText, tokenizeText, paraMode, null);
   }
-  
+
   /**
    * The main check method. Tokenizes the text into sentences and matches these
    * sentences against all currently active rules.
+   *
    * @since 3.7
    */
   public List<RuleMatch> check(AnnotatedText annotatedText, boolean tokenizeText, ParagraphHandling paraMode, RuleMatchListener listener) throws IOException {
     Mode mode;
-    if(paraMode == ParagraphHandling.ONLYNONPARA) {
+    if (paraMode == ParagraphHandling.ONLYNONPARA) {
       mode = Mode.ALL_BUT_TEXTLEVEL_ONLY;
-    } else if(paraMode == ParagraphHandling.ONLYPARA) {
+    } else if (paraMode == ParagraphHandling.ONLYPARA) {
       mode = Mode.TEXTLEVEL_ONLY;
     } else {
       mode = Mode.ALL;
@@ -807,6 +857,7 @@ public class JLanguageTool {
   /**
    * The main check method. Tokenizes the text into sentences and matches these
    * sentences against all currently active rules depending on {@code mode}.
+   *
    * @since 4.3
    */
   public List<RuleMatch> check(AnnotatedText annotatedText, boolean tokenizeText, ParagraphHandling paraMode, RuleMatchListener listener, Mode mode, Level level) throws IOException {
@@ -816,6 +867,7 @@ public class JLanguageTool {
   /**
    * The main check method. Tokenizes the text into sentences and matches these
    * sentences against all currently active rules depending on {@code mode}.
+   *
    * @param remoteRulesThreadPool when given, starts evaluating remote rules asynchronously before checking other rules,
    *                              then waits on result afterwards
    * @since 4.6
@@ -823,7 +875,7 @@ public class JLanguageTool {
   public List<RuleMatch> check(AnnotatedText annotatedText, boolean tokenizeText, ParagraphHandling paraMode, RuleMatchListener listener,
                                Mode mode, Level level, @Nullable ExecutorService remoteRulesThreadPool) throws IOException {
     List<String> sentences;
-    if (tokenizeText) { 
+    if (tokenizeText) {
       sentences = sentenceTokenize(annotatedText.getPlainText());
     } else {
       sentences = new ArrayList<>();
@@ -837,38 +889,26 @@ public class JLanguageTool {
     unknownWords = new HashSet<>();
     List<AnalyzedSentence> analyzedSentences = analyzeSentences(sentences);
 
-    List<RuleMatch> remoteMatches = Collections.emptyList();
-    List<FutureTask<List<RuleMatch>>> remoteRuleTasks = null;
     if (mode != Mode.TEXTLEVEL_ONLY && level == Level.DEFAULT) {
       allRules = allRules.stream().filter(rule -> !rule.hasTag(Tags.picky)).collect(Collectors.toList());
     }
+
+    List<RuleMatch> remoteMatches = new LinkedList<>();
+    List<FutureTask<RemoteRuleResult>> remoteRuleTasks = null;
+    List<RemoteRule> remoteRules = new LinkedList<>();
+    Map<AnalyzedSentence, List<RuleMatch>> cachedResults = new HashMap<>();
+    Map<AnalyzedSentence, Integer> matchOffset = new HashMap<>();
     if (remoteRulesThreadPool != null && mode != Mode.TEXTLEVEL_ONLY) {
-      remoteRuleTasks = allRules.stream()
-        .filter(rule -> rule instanceof RemoteRule)
-        .filter(rule -> !ignoreRule(rule))
-        .map(rule -> ((RemoteRule) rule).run(analyzedSentences, annotatedText))
-        .collect(Collectors.toList());
-      remoteRuleTasks.forEach(remoteRulesThreadPool::submit);
+      // trigger remote rules to run on whole text at once, at the start, then we wait for the results
+      remoteRuleTasks = new LinkedList<>();
+      checkRemoteRules(remoteRulesThreadPool, allRules, analyzedSentences, mode,
+        remoteRuleTasks, remoteRules, cachedResults, matchOffset);
     }
 
     List<RuleMatch> ruleMatches = performCheck(analyzedSentences, sentences, allRules,
       paraMode, annotatedText, listener, mode, level, remoteRulesThreadPool == null);
 
-    if (remoteRuleTasks != null) {
-      remoteMatches = remoteRuleTasks.stream()
-        .flatMap(task -> {
-          try {
-            return task.get().stream(); // can wait without timeout here, implemented in RemoteRule and TextChecker
-          } catch (InterruptedException | ExecutionException e) {
-            logger.warn("Failed to fetch result from remote rule.", e);
-            return Stream.empty();
-          }
-        }).collect(Collectors.toList());
-
-      for (RuleMatch match : remoteMatches) {
-        match.setSuggestedReplacementObjects(extendSuggestions(match.getSuggestedReplacementObjects()));
-      }
-    }
+    fetchRemoteRuleResults(mode, remoteMatches, remoteRuleTasks, remoteRules, cachedResults, matchOffset);
 
     ruleMatches.addAll(remoteMatches);
     ruleMatches = new SameRuleGroupFilter().filter(ruleMatches);
@@ -882,23 +922,140 @@ public class JLanguageTool {
 
     return ruleMatches;
   }
-  
+
+  protected void fetchRemoteRuleResults(Mode mode, List<RuleMatch> remoteMatches,
+                                        List<FutureTask<RemoteRuleResult>> remoteRuleTasks, List<RemoteRule> remoteRules,
+                                        Map<AnalyzedSentence, List<RuleMatch>> cachedResults,
+                                        Map<AnalyzedSentence, Integer> matchOffset) {
+    if (remoteRuleTasks != null) {
+      // fetch results from remote rules
+      for (int i = 0; i < remoteRuleTasks.size(); i++) {
+        FutureTask<RemoteRuleResult> task = remoteRuleTasks.get(i);
+        RemoteRule rule = remoteRules.get(i);
+        String ruleKey = rule.getId();
+        try {
+          RemoteRuleResult result = task.get(); // can wait without timeout here, implemented in RemoteRule and TextChecker
+          for (AnalyzedSentence sentence : result.matchedSentences()) {
+            List<RuleMatch> matches = result.matchesForSentence(sentence);
+            if (cache != null && result.isSuccess()) {
+              // store in cache
+              InputSentence cacheKey = new InputSentence(
+                sentence.getText(), language, motherTongue, disabledRules, disabledRuleCategories,
+                enabledRules, enabledRuleCategories, userConfig, altLanguages, mode);
+              Map<String, List<RuleMatch>> cacheEntry = cache.getRemoteMatchesCache().get(cacheKey, HashMap::new);
+              // TODO check if result is from fallback, don't cache?
+              logger.info("Caching: Remote rule '{}' - '{}' -> {}", ruleKey, sentence.getText(), matches);
+              // clone so that we don't adjust match position for cache
+              cacheEntry.put(ruleKey, matches.stream().map(RuleMatch::new).collect(Collectors.toList()));
+              // adjust rule match position
+              // rules check all sentences batched, but should keep position adjustment logic out of rule
+              int sentenceOffset = matchOffset.get(sentence);
+              for (RuleMatch match : matches) {
+                match.setOffsetPosition(match.getFromPos() + sentenceOffset, match.getToPos() + sentenceOffset);
+              }
+            } else if (cache  != null) {
+              logger.info("Not caching, fallback results: Remote rule '{}' - '{}' -> {}", ruleKey, sentence.getText(), matches);
+            }
+            remoteMatches.addAll(matches);
+          }
+        } catch (InterruptedException | ExecutionException e) {
+          logger.warn("Failed to fetch result from remote rule.", e);
+        }
+      }
+
+      for (AnalyzedSentence cachedSentence : cachedResults.keySet()) {
+        List<RuleMatch> cachedMatches = cachedResults.get(cachedSentence);
+        int sentenceOffset = matchOffset.get(cachedSentence);
+        for (RuleMatch cachedMatch : cachedMatches) {
+          // clone so that we don't adjust match position for cache
+          RuleMatch match = new RuleMatch(cachedMatch);
+          match.setOffsetPosition(match.getFromPos() + sentenceOffset, match.getToPos() + sentenceOffset);
+          remoteMatches.add(match);
+        }
+      }
+
+      for (RuleMatch match : remoteMatches) {
+        match.setSuggestedReplacementObjects(extendSuggestions(match.getSuggestedReplacementObjects()));
+      }
+    }
+  }
+
+  protected void checkRemoteRules(@NotNull ExecutorService remoteRulesThreadPool,
+                                  List<Rule> allRules, List<AnalyzedSentence> analyzedSentences, Mode mode,
+                                  List<FutureTask<RemoteRuleResult>> remoteRuleTasks, List<RemoteRule> remoteRules,
+                                  Map<AnalyzedSentence, List<RuleMatch>> cachedResults, Map<AnalyzedSentence, Integer> matchOffset) {
+    List<InputSentence> cacheKeys = new LinkedList<>();
+    int offset = 0;
+    // prepare keys for caching, offsets for adjusting match positions
+    for (AnalyzedSentence s : analyzedSentences) {
+      matchOffset.put(s, offset);
+      offset += s.getText().length();
+      InputSentence cacheKey = new InputSentence(s.getText(), language, motherTongue,
+        disabledRules, disabledRuleCategories, enabledRules, enabledRuleCategories,
+        userConfig, altLanguages, mode);
+      cacheKeys.add(cacheKey);
+    }
+    for (Rule r : allRules) {
+      if (r instanceof RemoteRule && !ignoreRule(r)) {
+        RemoteRule rule = (RemoteRule) r;
+        remoteRules.add(rule);
+        FutureTask<RemoteRuleResult> task;
+        if (cache != null) {
+          List<AnalyzedSentence> nonCachedSentences = new ArrayList<>();
+          for (int i = 0; i < analyzedSentences.size(); i++) {
+            // filter out sentences with cached results
+            InputSentence cacheKey = cacheKeys.get(i);
+            String ruleKey = rule.getId();
+            AnalyzedSentence sentence = analyzedSentences.get(i);
+            Map<String, List<RuleMatch>> cacheEntry = null;
+            try {
+              cacheEntry = cache.getRemoteMatchesCache().get(cacheKey, HashMap::new);
+            } catch (ExecutionException e) {
+              throw new RuntimeException(e);
+            }
+            if (cacheEntry == null) {
+              throw new RuntimeException("Couldn't access remote matches cache.");
+            }
+            List<RuleMatch> cachedMatches = cacheEntry.get(ruleKey);
+            // mark for check or retrieve from cache
+            if (cachedMatches == null) {
+              logger.info("Checking: Remote rule '{}' - '{}'", ruleKey, sentence.getText());
+              nonCachedSentences.add(sentence);
+            } else {
+              logger.info("Cached: Remote rule '{}' - '{}' -> {}", ruleKey, sentence.getText(), cachedMatches);
+              cachedResults.putIfAbsent(sentence, new LinkedList<>());
+              cachedResults.get(sentence).addAll(cachedMatches);
+            }
+          }
+          task = rule.run(nonCachedSentences);
+        } else {
+          task = rule.run(analyzedSentences);
+        }
+        remoteRuleTasks.add(task);
+        remoteRulesThreadPool.submit(task);
+      }
+    }
+  }
+
   /**
    * Use this method if you want to access LanguageTool's otherwise
    * internal analysis of the text. For actual text checking, use the {@code check...} methods instead.
-   * @param text The text to be analyzed 
+   *
+   * @param text The text to be analyzed
    * @since 2.5
    */
   public List<AnalyzedSentence> analyzeText(String text) throws IOException {
     List<String> sentences = sentenceTokenize(text);
     return analyzeSentences(sentences);
   }
-  
+
   protected List<AnalyzedSentence> analyzeSentences(List<String> sentences) throws IOException {
     List<AnalyzedSentence> analyzedSentences = new ArrayList<>();
     int j = 0;
     for (String sentence : sentences) {
-      if (checkCancelledCallback != null && checkCancelledCallback.checkCancelled()) break;
+      if (checkCancelledCallback != null && checkCancelledCallback.checkCancelled()) {
+        break;
+      }
       AnalyzedSentence analyzedSentence = getAnalyzedSentence(sentence);
       rememberUnknownWords(analyzedSentence);
       if (++j == sentences.size()) {
@@ -918,7 +1075,7 @@ public class JLanguageTool {
       printIfVerbose(analyzedSentence.getAnnotations());
     }
   }
-  
+
   protected List<RuleMatch> performCheck(List<AnalyzedSentence> analyzedSentences, List<String> sentences,
                                          List<Rule> allRules, ParagraphHandling paraMode, AnnotatedText annotatedText, Mode mode, Level level) throws IOException {
     return performCheck(analyzedSentences, sentences, allRules, paraMode, annotatedText, null, mode, level, true);
@@ -941,17 +1098,19 @@ public class JLanguageTool {
 
   /**
    * This is an internal method that's public only for technical reasons, please use one
-   * of the {@link #check(String)} methods instead. 
+   * of the {@link #check(String)} methods instead.
+   *
    * @since 2.3
    */
   public List<RuleMatch> checkAnalyzedSentence(ParagraphHandling paraMode,
                                                List<Rule> rules, AnalyzedSentence analyzedSentence) throws IOException {
     return checkAnalyzedSentence(paraMode, rules, analyzedSentence, false);
   }
-  
+
   /**
    * This is an internal method that's public only for technical reasons, please use one
-   * of the {@link #check(String)} methods instead. 
+   * of the {@link #check(String)} methods instead.
+   *
    * @since 4.9
    */
   public List<RuleMatch> checkAnalyzedSentence(ParagraphHandling paraMode,
@@ -959,7 +1118,9 @@ public class JLanguageTool {
     List<RuleMatch> sentenceMatches = new ArrayList<>();
     String analyzedSentenceText = analyzedSentence.getText();
     for (Rule rule : rules) {
-      if (checkCancelledCallback != null && checkCancelledCallback.checkCancelled()) break;
+      if (checkCancelledCallback != null && checkCancelledCallback.checkCancelled()) {
+        break;
+      }
 
       if (rule instanceof TextLevelRule) {
         continue;
@@ -970,7 +1131,7 @@ public class JLanguageTool {
       if (ignoreRule(rule)) {
         continue;
       }
-      if (rule instanceof PatternRule && ((PatternRule)rule).canBeIgnoredFor(analyzedSentence)) {
+      if (rule instanceof PatternRule && ((PatternRule) rule).canBeIgnoredFor(analyzedSentence)) {
         // this is a performance optimization, it should have no effect on matching logic
         continue;
       }
@@ -983,15 +1144,15 @@ public class JLanguageTool {
       }
     }
     AnnotatedText text = new AnnotatedTextBuilder().addText(analyzedSentenceText).build();
-    return applyCustomFilters(new SameRuleGroupFilter().filter(sentenceMatches),text);
+    return applyCustomFilters(new SameRuleGroupFilter().filter(sentenceMatches), text);
   }
 
   private boolean ignoreRule(Rule rule) {
     Category ruleCategory = rule.getCategory();
-    boolean isCategoryDisabled = (disabledRuleCategories.contains(ruleCategory.getId()) || rule.getCategory().isDefaultOff()) 
-            && !enabledRuleCategories.contains(ruleCategory.getId());
-    boolean isRuleDisabled = disabledRules.contains(rule.getId()) 
-            || (rule.isDefaultOff() && !enabledRules.contains(rule.getId()));
+    boolean isCategoryDisabled = (disabledRuleCategories.contains(ruleCategory.getId()) || rule.getCategory().isDefaultOff())
+      && !enabledRuleCategories.contains(ruleCategory.getId());
+    boolean isRuleDisabled = disabledRules.contains(rule.getId())
+      || (rule.isDefaultOff() && !enabledRules.contains(rule.getId()));
     boolean isDisabled;
     if (isCategoryDisabled) {
       isDisabled = !enabledRules.contains(rule.getId());
@@ -1003,20 +1164,21 @@ public class JLanguageTool {
 
   /**
    * Change RuleMatch positions so they are relative to the complete text,
-   * not just to the sentence. 
-   * @param charCount Count of characters in the sentences before
+   * not just to the sentence.
+   *
+   * @param charCount   Count of characters in the sentences before
    * @param columnCount Current column number
-   * @param lineCount Current line number
-   * @param sentence The text being checked
+   * @param lineCount   Current line number
+   * @param sentence    The text being checked
    * @return The RuleMatch object with adjustments
    */
   public RuleMatch adjustRuleMatchPos(RuleMatch match, int charCount,
-      int columnCount, int lineCount, String sentence, AnnotatedText annotatedText) {
+                                      int columnCount, int lineCount, String sentence, AnnotatedText annotatedText) {
     int fromPos = match.getFromPos() + charCount;
     int toPos = match.getToPos() + charCount;
     if (annotatedText != null) {
       fromPos = annotatedText.getOriginalTextPositionFor(fromPos, false);
-      toPos = annotatedText.getOriginalTextPositionFor(toPos -1, true) + 1;
+      toPos = annotatedText.getOriginalTextPositionFor(toPos - 1, true) + 1;
     }
     RuleMatch thisMatch = new RuleMatch(match);
     thisMatch.setOffsetPosition(fromPos, toPos);
@@ -1081,6 +1243,7 @@ public class JLanguageTool {
 
   /**
    * Get the alphabetically sorted list of unknown words in the latest run of one of the {@link #check(String)} methods.
+   *
    * @throws IllegalStateException if {@link #setListUnknownWords(boolean)} has been set to {@code false}
    */
   public List<String> getUnknownWords() {
@@ -1110,6 +1273,7 @@ public class JLanguageTool {
   /**
    * Tokenizes the given {@code sentence} into words and analyzes it,
    * and then disambiguates POS tags.
+   *
    * @param sentence sentence to be analyzed
    */
   public AnalyzedSentence getAnalyzedSentence(String sentence) throws IOException {
@@ -1135,6 +1299,7 @@ public class JLanguageTool {
    * Tokenizes the given {@code sentence} into words and analyzes it.
    * This is the same as {@link #getAnalyzedSentence(String)} but it does not run
    * the disambiguator.
+   *
    * @param sentence sentence to be analyzed
    * @since 0.9.8
    */
@@ -1161,9 +1326,9 @@ public class JLanguageTool {
     }
 
     int numTokens = aTokens.size();
-    int posFix = 0; 
+    int posFix = 0;
     for (int i = 0; i < numTokens; i++) {
-      if( i > 0 ) {
+      if (i > 0) {
         aTokens.get(i).setWhitespaceBefore(aTokens.get(i - 1).getToken());
         aTokens.get(i).setStartPos(aTokens.get(i).getStartPos() + posFix);
       }
@@ -1174,7 +1339,7 @@ public class JLanguageTool {
         aTokens.get(i).addReading(newToken, "softHyphenTokens");
       }
     }
-        
+
 
     // add additional tags
     int lastToken = toArrayCount - 1;
@@ -1212,7 +1377,7 @@ public class JLanguageTool {
 
   /**
    * Get all rule categories for the current language.
-   * 
+   *
    * @return a map of {@link Category Categories}, keyed by their {@link CategoryId id}.
    * @since 3.5
    */
@@ -1230,6 +1395,7 @@ public class JLanguageTool {
    * will appear as multiple rules with the same id. To tell them apart, check if
    * they are of type {@code AbstractPatternRule}, cast them to that type and call
    * their {@link AbstractPatternRule#getSubId()} method.
+   *
    * @return a List of {@link Rule} objects
    */
   public List<Rule> getAllRules() {
@@ -1238,11 +1404,12 @@ public class JLanguageTool {
     rules.addAll(userRules);
     return rules;
   }
-  
+
   /**
-   * Get all active (not disabled) rules for the current language that are built-in or that 
+   * Get all active (not disabled) rules for the current language that are built-in or that
    * have been added using e.g. {@link #addRule(Rule)}. See {@link #getAllRules()} for hints
    * about rule ids.
+   *
    * @return a List of {@link Rule} objects
    */
   public List<Rule> getAllActiveRules() {
@@ -1258,13 +1425,14 @@ public class JLanguageTool {
       if (!ignoreRule(rule)) {
         rulesActive.add(rule);
       }
-    }    
+    }
     return rulesActive;
   }
 
   /**
    * Get all spelling check rules for the current language that are built-in or
    * that have been added using {@link #addRule(Rule)}.
+   *
    * @return a List of {@link SpellingCheckRule} objects
    * @since 5.0
    */
@@ -1285,6 +1453,7 @@ public class JLanguageTool {
 
   /**
    * Works like getAllActiveRules but overrides defaults by office defaults
+   *
    * @return a List of {@link Rule} objects
    * @since 4.0
    */
@@ -1302,43 +1471,45 @@ public class JLanguageTool {
       } else if (!ignoreRule(rule) && rule.isOfficeDefaultOff() && !enabledRules.contains(rule.getId())) {
         disableRule(rule.getId());
       }
-    }    
+    }
     return rulesActive;
   }
-  
+
   /**
    * Get pattern rules by Id and SubId. This returns a list because rules that use {@code <or>...</or>}
    * are internally expanded into several rules.
+   *
    * @return a List of {@link Rule} objects
    * @since 2.3
    */
   public List<AbstractPatternRule> getPatternRulesByIdAndSubId(String id, String subId) {
     List<Rule> rules = getAllRules();
-    List<AbstractPatternRule> rulesById = new ArrayList<>();   
+    List<AbstractPatternRule> rulesById = new ArrayList<>();
     for (Rule rule : rules) {
       if (rule instanceof AbstractPatternRule &&
-          rule.getId().equals(id) && ((AbstractPatternRule) rule).getSubId().equals(subId)) {
+        rule.getId().equals(id) && ((AbstractPatternRule) rule).getSubId().equals(subId)) {
         rulesById.add((AbstractPatternRule) rule);
       }
-    }    
+    }
     return rulesById;
   }
-  
+
   protected void printIfVerbose(String s) {
     if (printStream != null) {
       printStream.println(s);
     }
   }
-  
+
   /**
    * Adds a temporary file to the internal list
    * (internal method, you should never need to call this as a user of LanguageTool)
+   *
    * @param file the file to be added.
    */
   public static void addTemporaryFile(File file) {
     temporaryFiles.add(file);
   }
-  
+
   /**
    * Clean up all temporary files, if there are any.
    */
@@ -1350,8 +1521,9 @@ public class JLanguageTool {
 
   /**
    * should be called just once with complete list of matches, before returning them to caller
+   *
    * @param matches matches after applying rules and default filters
-   * @param text text that matches refer to
+   * @param text    text that matches refer to
    * @return transformed matches (after applying filters in {@link matchFilters})
    * @since 4.7
    */
@@ -1430,7 +1602,9 @@ public class JLanguageTool {
     private List<RuleMatch> getTextLevelRuleMatches() throws IOException {
       List<RuleMatch> ruleMatches = new ArrayList<>();
       for (Rule rule : rules) {
-        if (checkCancelledCallback != null && checkCancelledCallback.checkCancelled()) break;
+        if (checkCancelledCallback != null && checkCancelledCallback.checkCancelled()) {
+          break;
+        }
         if (rule instanceof TextLevelRule && !ignoreRule(rule) && paraMode != ParagraphHandling.ONLYNONPARA) {
           RuleMatch[] matches = ((TextLevelRule) rule).match(analyzedSentences, annotatedText);
           List<RuleMatch> adaptedMatches = new ArrayList<>();
@@ -1467,7 +1641,9 @@ public class JLanguageTool {
       int i = 0;
       int wordCounter = 0;
       for (AnalyzedSentence analyzedSentence : analyzedSentences) {
-        if (checkCancelledCallback != null && checkCancelledCallback.checkCancelled()) break;
+        if (checkCancelledCallback != null && checkCancelledCallback.checkCancelled()) {
+          break;
+        }
         String sentence = sentences.get(i++);
         wordCounter += analyzedSentence.getTokensWithoutWhitespace().length;
         try {
@@ -1498,7 +1674,7 @@ public class JLanguageTool {
             }
           }
           ruleMatches.addAll(adaptedMatches);
-          float errorsPerWord = ruleMatches.size() / (float)wordCounter;
+          float errorsPerWord = ruleMatches.size() / (float) wordCounter;
           //System.out.println("errorPerWord " + errorsPerWord + " (matches: " + ruleMatches.size() + " / " + wordCounter + ")");
           if (maxErrorsPerWordRate > 0 && errorsPerWord > maxErrorsPerWordRate && wordCounter > 25) {
             //CommonWords commonWords = new CommonWords();
@@ -1550,7 +1726,7 @@ public class JLanguageTool {
           charCount += token.length();
           if (charCount == match.getFromPos()) {
             fromPos = new LineColumnPosition(pos.line, pos.column);
-          } 
+          }
           if (charCount == match.getToPos()) {
             toPos = new LineColumnPosition(pos.line, pos.column);
           }
@@ -1558,27 +1734,29 @@ public class JLanguageTool {
       }
       return new LineColumnRange(fromPos, toPos);
     }
-    
+
     private class LineColumnPosition {
       int line;
       int column;
+
       private LineColumnPosition(int line, int column) {
         this.line = line;
         this.column = column;
       }
     }
-  
+
     private class LineColumnRange {
       LineColumnPosition from;
       LineColumnPosition to;
+
       private LineColumnRange(LineColumnPosition from, LineColumnPosition to) {
         this.from = from;
         this.to = to;
       }
     }
-  
+
   }
-  
+
   public void setConfigValues(Map<String, Integer> v) {
     userConfig.insertConfigValues(v);
   }

--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -897,18 +897,19 @@ public class JLanguageTool {
     List<FutureTask<RemoteRuleResult>> remoteRuleTasks = null;
     List<RemoteRule> remoteRules = new LinkedList<>();
     Map<AnalyzedSentence, List<RuleMatch>> cachedResults = new HashMap<>();
-    Map<AnalyzedSentence, Integer> matchOffset = new HashMap<>();
+    Map<AnalyzedSentence, OffsetEntry> matchOffsets = null;
     if (remoteRulesThreadPool != null && mode != Mode.TEXTLEVEL_ONLY) {
       // trigger remote rules to run on whole text at once, at the start, then we wait for the results
+      matchOffsets = computeOffsets(analyzedSentences);
       remoteRuleTasks = new LinkedList<>();
       checkRemoteRules(remoteRulesThreadPool, allRules, analyzedSentences, mode,
-        remoteRuleTasks, remoteRules, cachedResults, matchOffset);
+        remoteRuleTasks, remoteRules, cachedResults, matchOffsets);
     }
 
     List<RuleMatch> ruleMatches = performCheck(analyzedSentences, sentences, allRules,
       paraMode, annotatedText, listener, mode, level, remoteRulesThreadPool == null);
 
-    fetchRemoteRuleResults(mode, remoteMatches, remoteRuleTasks, remoteRules, cachedResults, matchOffset);
+    fetchRemoteRuleResults(mode, remoteMatches, remoteRuleTasks, remoteRules, cachedResults, matchOffsets, annotatedText);
 
     ruleMatches.addAll(remoteMatches);
     ruleMatches = new SameRuleGroupFilter().filter(ruleMatches);
@@ -926,7 +927,7 @@ public class JLanguageTool {
   protected void fetchRemoteRuleResults(Mode mode, List<RuleMatch> remoteMatches,
                                         List<FutureTask<RemoteRuleResult>> remoteRuleTasks, List<RemoteRule> remoteRules,
                                         Map<AnalyzedSentence, List<RuleMatch>> cachedResults,
-                                        Map<AnalyzedSentence, Integer> matchOffset) {
+                                        Map<AnalyzedSentence, OffsetEntry> matchOffset, AnnotatedText annotatedText) {
     if (remoteRuleTasks != null) {
       // fetch results from remote rules
       for (int i = 0; i < remoteRuleTasks.size(); i++) {
@@ -949,9 +950,11 @@ public class JLanguageTool {
               cacheEntry.put(ruleKey, matches.stream().map(RuleMatch::new).collect(Collectors.toList()));
               // adjust rule match position
               // rules check all sentences batched, but should keep position adjustment logic out of rule
-              int sentenceOffset = matchOffset.get(sentence);
-              for (RuleMatch match : matches) {
-                match.setOffsetPosition(match.getFromPos() + sentenceOffset, match.getToPos() + sentenceOffset);
+              OffsetEntry offset = matchOffset.get(sentence);
+              for (int j = 0; j < matches.size(); j++) {
+                matches.set(j, adjustRuleMatchPos(matches.get(j),
+                  offset.charCount, offset.columnCount, offset.lineCount,
+                  sentence.getText(), annotatedText));
               }
             } else if (cache != null) {
               logger.info("Not caching, fallback results: Remote rule '{}'", ruleKey);
@@ -965,11 +968,11 @@ public class JLanguageTool {
 
       for (AnalyzedSentence cachedSentence : cachedResults.keySet()) {
         List<RuleMatch> cachedMatches = cachedResults.get(cachedSentence);
-        int sentenceOffset = matchOffset.get(cachedSentence);
+        OffsetEntry offset = matchOffset.get(cachedSentence);
         for (RuleMatch cachedMatch : cachedMatches) {
           // clone so that we don't adjust match position for cache
-          RuleMatch match = new RuleMatch(cachedMatch);
-          match.setOffsetPosition(match.getFromPos() + sentenceOffset, match.getToPos() + sentenceOffset);
+          RuleMatch match = adjustRuleMatchPos(cachedMatch, offset.charCount, offset.columnCount, offset.lineCount,
+            cachedSentence.getText(), annotatedText);
           remoteMatches.add(match);
         }
       }
@@ -980,16 +983,60 @@ public class JLanguageTool {
     }
   }
 
+  static class OffsetEntry {
+    final int charCount;
+    final int lineCount;
+    final int columnCount;
+
+    OffsetEntry(int charCount, int lineCount, int columnCount) {
+      this.charCount = charCount;
+      this.lineCount = lineCount;
+      this.columnCount = columnCount;
+    }
+  }
+
+  protected Map<AnalyzedSentence, OffsetEntry> computeOffsets(List<AnalyzedSentence> sentences) {
+    return computeOffsets(sentences, 0, 0, 1);
+  }
+
+  @SuppressWarnings("AssignmentToMethodParameter")
+  protected Map<AnalyzedSentence, OffsetEntry> computeOffsets(List<AnalyzedSentence> sentences,
+                                                              int charCount, int lineCount, int columnCount) {
+    Map<AnalyzedSentence, OffsetEntry> offsets = new HashMap<>();
+
+    for (AnalyzedSentence s: sentences) {
+      String sentence = s.getText();
+      charCount += sentence.length();
+      lineCount += countLineBreaks(sentence);
+
+      // calculate matching column:
+      int lineBreakPos = sentence.lastIndexOf('\n');
+      if (lineBreakPos == -1) {
+        columnCount += sentence.length();
+      } else {
+        if (lineBreakPos == 0) {
+          columnCount = sentence.length();
+          if (!language.getSentenceTokenizer().singleLineBreaksMarksPara()) {
+            columnCount--;
+          }
+        } else {
+          columnCount = sentence.length() - lineBreakPos;
+        }
+      }
+
+      offsets.put(s, new OffsetEntry(charCount, lineCount, columnCount));
+    }
+    return offsets;
+  }
+
   protected void checkRemoteRules(@NotNull ExecutorService remoteRulesThreadPool,
                                   List<Rule> allRules, List<AnalyzedSentence> analyzedSentences, Mode mode,
                                   List<FutureTask<RemoteRuleResult>> remoteRuleTasks, List<RemoteRule> remoteRules,
-                                  Map<AnalyzedSentence, List<RuleMatch>> cachedResults, Map<AnalyzedSentence, Integer> matchOffset) {
+                                  Map<AnalyzedSentence, List<RuleMatch>> cachedResults, Map<AnalyzedSentence, OffsetEntry> matchOffset) {
     List<InputSentence> cacheKeys = new LinkedList<>();
     int offset = 0;
     // prepare keys for caching, offsets for adjusting match positions
     for (AnalyzedSentence s : analyzedSentences) {
-      matchOffset.put(s, offset);
-      offset += s.getText().length();
       InputSentence cacheKey = new InputSentence(s.getText(), language, motherTongue,
         disabledRules, disabledRuleCategories, enabledRules, enabledRuleCategories,
         userConfig, altLanguages, mode);
@@ -1640,7 +1687,12 @@ public class JLanguageTool {
       List<RuleMatch> ruleMatches = new ArrayList<>();
       int i = 0;
       int wordCounter = 0;
+      Map<AnalyzedSentence, OffsetEntry> offsets = computeOffsets(analyzedSentences, charCount, lineCount, columnCount);
       for (AnalyzedSentence analyzedSentence : analyzedSentences) {
+        OffsetEntry offset = offsets.get(analyzedSentence);
+        charCount = offset.charCount;
+        lineCount = offset.lineCount;
+        columnCount = offset.columnCount;
         if (checkCancelledCallback != null && checkCancelledCallback.checkCancelled()) {
           break;
         }
@@ -1682,23 +1734,6 @@ public class JLanguageTool {
                     "% of words seem to have an error). Are you sure you have set the correct text language? Language set: " + JLanguageTool.this.language.getName() +
                     ", text length: " + annotatedText.getPlainText().length());
             //        ", text length: " + annotatedText.getPlainText().length() + ", common word count: " + commonWords.getKnownWordsPerLanguage(annotatedText.getPlainText()));
-          }
-          charCount += sentence.length();
-          lineCount += countLineBreaks(sentence);
-
-          // calculate matching column:
-          int lineBreakPos = sentence.lastIndexOf('\n');
-          if (lineBreakPos == -1) {
-            columnCount += sentence.length();
-          } else {
-            if (lineBreakPos == 0) {
-              columnCount = sentence.length();
-              if (!language.getSentenceTokenizer().singleLineBreaksMarksPara()) {
-                columnCount--;
-              }
-            } else {
-              columnCount = sentence.length() - lineBreakPos;
-            }
           }
         } catch (ErrorRateTooHighException e) {
           throw e;

--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -944,7 +944,7 @@ public class JLanguageTool {
                 enabledRules, enabledRuleCategories, userConfig, altLanguages, mode);
               Map<String, List<RuleMatch>> cacheEntry = cache.getRemoteMatchesCache().get(cacheKey, HashMap::new);
               // TODO check if result is from fallback, don't cache?
-              logger.info("Caching: Remote rule '{}' - '{}' -> {}", ruleKey, sentence.getText(), matches);
+              logger.info("Caching: Remote rule '{}'", ruleKey);
               // clone so that we don't adjust match position for cache
               cacheEntry.put(ruleKey, matches.stream().map(RuleMatch::new).collect(Collectors.toList()));
               // adjust rule match position
@@ -953,8 +953,8 @@ public class JLanguageTool {
               for (RuleMatch match : matches) {
                 match.setOffsetPosition(match.getFromPos() + sentenceOffset, match.getToPos() + sentenceOffset);
               }
-            } else if (cache  != null) {
-              logger.info("Not caching, fallback results: Remote rule '{}' - '{}' -> {}", ruleKey, sentence.getText(), matches);
+            } else if (cache != null) {
+              logger.info("Not caching, fallback results: Remote rule '{}'", ruleKey);
             }
             remoteMatches.addAll(matches);
           }
@@ -1019,10 +1019,10 @@ public class JLanguageTool {
             List<RuleMatch> cachedMatches = cacheEntry.get(ruleKey);
             // mark for check or retrieve from cache
             if (cachedMatches == null) {
-              logger.info("Checking: Remote rule '{}' - '{}'", ruleKey, sentence.getText());
+              logger.info("Checking: Remote rule '{}'", ruleKey);
               nonCachedSentences.add(sentence);
             } else {
-              logger.info("Cached: Remote rule '{}' - '{}' -> {}", ruleKey, sentence.getText(), cachedMatches);
+              logger.info("Cached: Remote rule '{}'", ruleKey);
               cachedResults.putIfAbsent(sentence, new LinkedList<>());
               cachedResults.get(sentence).addAll(cachedMatches);
             }

--- a/languagetool-core/src/main/java/org/languagetool/ResultCache.java
+++ b/languagetool-core/src/main/java/org/languagetool/ResultCache.java
@@ -24,6 +24,7 @@ import com.google.common.cache.Weigher;
 import org.languagetool.rules.RuleMatch;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -39,6 +40,11 @@ import java.util.concurrent.TimeUnit;
  */
 public class ResultCache {
 
+  /**
+   * rules can fail individually, results can be partial ->
+   * store list if success (can be empty), null -> failure/not checked
+   */
+  private final Cache<InputSentence, Map<String, List<RuleMatch>>> remoteMatchesCache;
   private final Cache<InputSentence, List<RuleMatch>> matchesCache;
   private final Cache<SimpleInputSentence, AnalyzedSentence> sentenceCache;
 
@@ -63,6 +69,11 @@ public class ResultCache {
             recordStats().
             expireAfterAccess(expireAfter, timeUnit).
             build();
+    remoteMatchesCache = CacheBuilder.newBuilder().
+      maximumWeight(maxSize/2).weigher(new RemoteMatchesWeigher()).
+      recordStats().
+      expireAfterAccess(expireAfter, timeUnit).
+      build();
     sentenceCache = CacheBuilder.newBuilder().
             maximumWeight(maxSize/2).weigher(new SentenceWeigher()).
             recordStats().
@@ -76,6 +87,15 @@ public class ResultCache {
       // this is just a rough guesstimate so that the cacheSize given by the user
       // is very roughly the number of average sentences the cache can keep:
       return sentence.getText().length() / 75 + matches.size();
+    }
+  }
+
+  class RemoteMatchesWeigher implements Weigher<InputSentence, Map<String, List<RuleMatch>>> {
+    @Override
+    public int weigh(InputSentence sentence, Map<String, List<RuleMatch>> matches) {
+      // this is just a rough guesstimate so that the cacheSize given by the user
+      // is very roughly the number of average sentences the cache can keep:
+      return sentence.getText().length() / 75;
     }
   }
 
@@ -117,6 +137,13 @@ public class ResultCache {
   /** @since 4.1 */
   public Cache<InputSentence, List<RuleMatch>> getMatchesCache() {
     return matchesCache;
+  }
+
+  /** @since 5.0
+   * @return
+   * */
+  public Cache<InputSentence, Map<String, List<RuleMatch>>> getRemoteMatchesCache() {
+    return remoteMatchesCache;
   }
 
   /** @since 4.1 */

--- a/languagetool-core/src/main/java/org/languagetool/UserConfig.java
+++ b/languagetool-core/src/main/java/org/languagetool/UserConfig.java
@@ -52,7 +52,7 @@ public class UserConfig {
   private final boolean filterDictionaryMatches;
 
   // partially indifferent for comparing UserConfigs (e.g. in PipelinePool)
-  // provided to rules only for A/B tests / partial rollout of remote rules
+  // provided to rules only for A/B tests
   private final Long textSessionId;
   private final String abTest;
 
@@ -166,9 +166,6 @@ public class UserConfig {
       // -> (cached) textSessionId on server may say group A, but ID on client (relevant for saved correction) says B
       // only group must match; keeps hit rate of pipeline cache up
       .append(abTest, other.abTest)
-      // partial rollout for remote rules based on this; similar logic as for A/B test
-      .append(textSessionId != null ? textSessionId % 100 : 0,
-        other.textSessionId != null ? other.textSessionId % 100 : 0)
       .isEquals();
   }
 
@@ -180,7 +177,6 @@ public class UserConfig {
       .append(userDictName)
       .append(configurableRuleValues)
       .append(abTest)
-      .append(textSessionId != null ? textSessionId % 100: 0)
       .append(filterDictionaryMatches)
       .toHashCode();
   }

--- a/languagetool-core/src/main/java/org/languagetool/UserConfig.java
+++ b/languagetool-core/src/main/java/org/languagetool/UserConfig.java
@@ -52,7 +52,7 @@ public class UserConfig {
   private final boolean filterDictionaryMatches;
 
   // partially indifferent for comparing UserConfigs (e.g. in PipelinePool)
-  // provided to rules only for A/B tests ->
+  // provided to rules only for A/B tests / partial rollout of remote rules
   private final Long textSessionId;
   private final String abTest;
 
@@ -166,6 +166,9 @@ public class UserConfig {
       // -> (cached) textSessionId on server may say group A, but ID on client (relevant for saved correction) says B
       // only group must match; keeps hit rate of pipeline cache up
       .append(abTest, other.abTest)
+      // partial rollout for remote rules based on this; similar logic as for A/B test
+      .append(textSessionId != null ? textSessionId % 100 : 0,
+        other.textSessionId != null ? other.textSessionId % 100 : 0)
       .isEquals();
   }
 
@@ -177,6 +180,7 @@ public class UserConfig {
       .append(userDictName)
       .append(configurableRuleValues)
       .append(abTest)
+      .append(textSessionId != null ? textSessionId % 100: 0)
       .append(filterDictionaryMatches)
       .toHashCode();
   }

--- a/languagetool-core/src/main/java/org/languagetool/rules/BERTSuggestionRanking.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/BERTSuggestionRanking.java
@@ -118,27 +118,13 @@ public class BERTSuggestionRanking extends RemoteRule {
     List<RuleMatch> matches = new LinkedList<>();
     List<RemoteLanguageModel.Request> requests = new LinkedList<>();
     try {
-      int offset = 0;
       for (AnalyzedSentence sentence : sentences) {
         RuleMatch[] sentenceMatches = wrappedRule.match(sentence);
         for (RuleMatch match : sentenceMatches) {
           match.setSuggestedReplacementObjects(prepareSuggestions(match.getSuggestedReplacementObjects()));
-          // build request before correcting offset, as we send only sentence as text
           requests.add(buildRequest(match));
-          int fromPos;
-          int toPos;
-          if (annotatedText != null) {
-            fromPos = annotatedText.getOriginalTextPositionFor(match.getFromPos() + offset, false);
-            toPos = annotatedText.getOriginalTextPositionFor(match.getToPos() + offset - 1, true) + 1;
-          } else {
-            // TODO: when can annotatedText be null?
-            fromPos = match.getFromPos() + offset;
-            toPos = match.getToPos() + offset;
-          }
-          match.setOffsetPosition(fromPos, toPos);
         }
         Collections.addAll(matches, sentenceMatches);
-        offset += sentence.getText().length();
       }
       return new MatchesForReordering(matches, requests);
     } catch (IOException e) {
@@ -149,7 +135,7 @@ public class BERTSuggestionRanking extends RemoteRule {
 
   @Override
   protected RemoteRuleResult fallbackResults(RemoteRequest request) {
-    return new RemoteRuleResult(false, ((MatchesForReordering) request).matches);
+    return new RemoteRuleResult(false, false, ((MatchesForReordering) request).matches);
   }
 
   @Override
@@ -167,7 +153,7 @@ public class BERTSuggestionRanking extends RemoteRule {
       requests = requests.stream().filter(Objects::nonNull).collect(Collectors.toList());
 
       if (requests.isEmpty()) {
-        return new RemoteRuleResult(false, matches);
+        return new RemoteRuleResult(false, true, matches);
       } else {
         List<List<Double>> results = model.batchScore(requests);
         // put curated at the top, then compare probabilities
@@ -204,7 +190,7 @@ public class BERTSuggestionRanking extends RemoteRule {
           //logger.info("Reordered correction for '{}' from {} to {}", error, req.candidates, ranked);
           match.setSuggestedReplacementObjects(ranked);
         }
-        return new RemoteRuleResult(true, matches);
+        return new RemoteRuleResult(true, true, matches);
       }
     };
   }

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
@@ -75,8 +75,7 @@ public abstract class RemoteRule extends Rule {
   protected abstract Callable<RemoteRuleResult> executeRequest(RemoteRequest request);
   protected abstract RemoteRuleResult fallbackResults(RemoteRequest request);
 
-  public FutureTask<List<RuleMatch>> run(List<AnalyzedSentence> sentences, AnnotatedText annotatedText) {
-    this.annotatedText = annotatedText;
+  public FutureTask<RemoteRuleResult> run(List<AnalyzedSentence> sentences) {
     return new FutureTask<>(() -> {
       long startTime = System.nanoTime();
       long characters = sentences.stream().mapToInt(sentence -> sentence.getText().length()).sum();
@@ -89,7 +88,7 @@ public abstract class RemoteRule extends Rule {
         if (failureInterval < serviceConfiguration.getDownMilliseconds()) {
           RemoteRuleMetrics.request(ruleId, 0, 0, characters, RemoteRuleMetrics.RequestResult.DOWN);
           result = fallbackResults(req);
-          return result.getMatches();
+          return result;
         }
       }
       RemoteRuleMetrics.up(ruleId, true);
@@ -115,7 +114,8 @@ public abstract class RemoteRule extends Rule {
           RemoteRuleMetrics.RequestResult requestResult = result.isRemote() ?
             RemoteRuleMetrics.RequestResult.SUCCESS : RemoteRuleMetrics.RequestResult.SKIPPED;
           RemoteRuleMetrics.request(ruleId, i, System.nanoTime() - startTime, characters, requestResult);
-          return result.getMatches();
+
+          return result;
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
           logger.warn("Error while fetching results for remote rule " + ruleId + ", tried " + (i + 1) + " times, timeout: " + timeout + "ms" , e);
 
@@ -138,7 +138,7 @@ public abstract class RemoteRule extends Rule {
         RemoteRuleMetrics.up(ruleId, false);
       }
       result = fallbackResults(req);
-      return result.getMatches();
+      return result;
     });
   }
 
@@ -149,10 +149,10 @@ public abstract class RemoteRule extends Rule {
 
   @Override
   public RuleMatch[] match(AnalyzedSentence sentence) throws IOException {
-    FutureTask<List<RuleMatch>> task = run(Collections.singletonList(sentence), annotatedText);
+    FutureTask<RemoteRuleResult> task = run(Collections.singletonList(sentence));
     task.run();
     try {
-      return task.get().toArray(new RuleMatch[0]);
+      return task.get().getMatches().toArray(new RuleMatch[0]);
     } catch (InterruptedException | ExecutionException e) {
       logger.warn("Fetching results for remote rule " + getId() + " failed.", e);
       return new RuleMatch[0];

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
@@ -50,6 +50,7 @@ public abstract class RemoteRule extends Rule {
 
   // needed to run callables with timeout
   private static final ConcurrentMap<String, ExecutorService> executors = new ConcurrentHashMap<>();
+
   protected final RemoteRuleConfig serviceConfiguration;
   protected final boolean inputLogging;
   private AnnotatedText annotatedText;
@@ -158,5 +159,10 @@ public abstract class RemoteRule extends Rule {
       return new RuleMatch[0];
     }
   }
+
+  public RemoteRuleConfig getServiceConfiguration() {
+    return serviceConfiguration;
+  }
+
 
 }

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleConfig.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleConfig.java
@@ -51,7 +51,6 @@ public class RemoteRuleConfig {
   private static final float DEFAULT_TIMEOUT_PER_CHAR = 0;
   private static final int DEFAULT_FALL = 1;
   private static final int DEFAULT_DOWN = 5000;
-  private static final int DEFAULT_ROLLOUT = 100;
 
   private static final LoadingCache<File, List<RemoteRuleConfig>> configCache = CacheBuilder.newBuilder()
     .expireAfterWrite(15, TimeUnit.MINUTES)
@@ -76,8 +75,6 @@ public class RemoteRuleConfig {
   private final Integer fall;
   private final Long downMilliseconds;
 
-  /** for partial rollout: percentage (0-100) */
-  private final Integer rollout;
 
   private final Map<String, String> options;
 
@@ -92,7 +89,6 @@ public class RemoteRuleConfig {
                           @JsonProperty("timeoutPerCharacterMilliseconds") Float timeoutPerCharacterMilliseconds,
                           @JsonProperty("fall") Integer fall,
                           @JsonProperty("downMilliseconds") Long downMilliseconds,
-                          @JsonProperty("rollout") Integer rollout,
                           @JsonProperty("options") Map<String, String> options) {
     this.ruleId = ruleId;
     this.url = url;
@@ -102,7 +98,6 @@ public class RemoteRuleConfig {
     this.timeoutPerCharacterMilliseconds = timeoutPerCharacterMilliseconds;
     this.fall = fall;
     this.downMilliseconds = downMilliseconds;
-    this.rollout = rollout;
     this.options = Collections.unmodifiableMap(options != null ? options : Collections.emptyMap());
   }
 
@@ -132,10 +127,6 @@ public class RemoteRuleConfig {
     return timeoutPerCharacterMilliseconds != null ? timeoutPerCharacterMilliseconds : DEFAULT_TIMEOUT_PER_CHAR;
   }
 
-  public int getRollout() {
-    return rollout != null ? rollout : DEFAULT_ROLLOUT;
-  }
-
   public Map<String, String> getOptions() {
     return options;
   }
@@ -161,7 +152,6 @@ public class RemoteRuleConfig {
       .append(timeoutPerCharacterMilliseconds, that.timeoutPerCharacterMilliseconds)
       .append(fall, that.fall)
       .append(downMilliseconds, that.downMilliseconds)
-      .append(rollout, that.rollout)
       .append(options, that.options)
       .isEquals();
   }
@@ -177,7 +167,6 @@ public class RemoteRuleConfig {
       .append(timeoutPerCharacterMilliseconds)
       .append(fall)
       .append(downMilliseconds)
-      .append(rollout)
       .append(options)
       .toHashCode();
   }
@@ -193,7 +182,6 @@ public class RemoteRuleConfig {
       .append("timeoutPerCharacter", timeoutPerCharacterMilliseconds)
       .append("fall", fall)
       .append("down", downMilliseconds)
-      .append("rollout", rollout)
       .append("options", options)
       .build();
   }

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleConfig.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleConfig.java
@@ -51,6 +51,7 @@ public class RemoteRuleConfig {
   private static final float DEFAULT_TIMEOUT_PER_CHAR = 0;
   private static final int DEFAULT_FALL = 1;
   private static final int DEFAULT_DOWN = 5000;
+  private static final int DEFAULT_ROLLOUT = 100;
 
   private static final LoadingCache<File, List<RemoteRuleConfig>> configCache = CacheBuilder.newBuilder()
     .expireAfterWrite(15, TimeUnit.MINUTES)
@@ -75,6 +76,9 @@ public class RemoteRuleConfig {
   private final Integer fall;
   private final Long downMilliseconds;
 
+  /** for partial rollout: percentage (0-100) */
+  private final Integer rollout;
+
   private final Map<String, String> options;
 
   // TODO configure health checks, load balancing, ...?
@@ -88,6 +92,7 @@ public class RemoteRuleConfig {
                           @JsonProperty("timeoutPerCharacterMilliseconds") Float timeoutPerCharacterMilliseconds,
                           @JsonProperty("fall") Integer fall,
                           @JsonProperty("downMilliseconds") Long downMilliseconds,
+                          @JsonProperty("rollout") Integer rollout,
                           @JsonProperty("options") Map<String, String> options) {
     this.ruleId = ruleId;
     this.url = url;
@@ -97,6 +102,7 @@ public class RemoteRuleConfig {
     this.timeoutPerCharacterMilliseconds = timeoutPerCharacterMilliseconds;
     this.fall = fall;
     this.downMilliseconds = downMilliseconds;
+    this.rollout = rollout;
     this.options = Collections.unmodifiableMap(options != null ? options : Collections.emptyMap());
   }
 
@@ -125,6 +131,11 @@ public class RemoteRuleConfig {
   public float getTimeoutPerCharacterMilliseconds() {
     return timeoutPerCharacterMilliseconds != null ? timeoutPerCharacterMilliseconds : DEFAULT_TIMEOUT_PER_CHAR;
   }
+
+  public int getRollout() {
+    return rollout != null ? rollout : DEFAULT_ROLLOUT;
+  }
+
   public Map<String, String> getOptions() {
     return options;
   }
@@ -150,6 +161,7 @@ public class RemoteRuleConfig {
       .append(timeoutPerCharacterMilliseconds, that.timeoutPerCharacterMilliseconds)
       .append(fall, that.fall)
       .append(downMilliseconds, that.downMilliseconds)
+      .append(rollout, that.rollout)
       .append(options, that.options)
       .isEquals();
   }
@@ -165,6 +177,7 @@ public class RemoteRuleConfig {
       .append(timeoutPerCharacterMilliseconds)
       .append(fall)
       .append(downMilliseconds)
+      .append(rollout)
       .append(options)
       .toHashCode();
   }
@@ -180,6 +193,7 @@ public class RemoteRuleConfig {
       .append("timeoutPerCharacter", timeoutPerCharacterMilliseconds)
       .append("fall", fall)
       .append("down", downMilliseconds)
+      .append("rollout", rollout)
       .append("options", options)
       .build();
   }

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleResult.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleResult.java
@@ -21,22 +21,51 @@
 
 package org.languagetool.rules;
 
-import java.util.List;
+import org.languagetool.AnalyzedSentence;
+
+import java.util.*;
 
 public class RemoteRuleResult {
-  private final boolean remote; // was remote needed/involved? rules may filter input sentences and only call remote on some
+  private final boolean remote; // was remote needed/involved? rules may filter input sentences and only call remote on some; for metrics
+  private final boolean success; // successful -> for caching, so that we can cache: remote not needed for this sentence
   private final List<RuleMatch> matches;
 
-  public RemoteRuleResult(boolean remote, List<RuleMatch> matches) {
+  private final Map<AnalyzedSentence, List<RuleMatch>> sentenceMatches = new HashMap<>();
+
+  public RemoteRuleResult(boolean remote, boolean success, List<RuleMatch> matches) {
     this.remote = remote;
+    this.success = success;
     this.matches = matches;
+
+    for (RuleMatch match : matches) {
+      sentenceMatches.compute(match.getSentence(), (sentence, ruleMatches) -> {
+        if (ruleMatches == null) {
+          return new ArrayList<>(Collections.singletonList(match));
+        } else {
+          ruleMatches.add(match);
+          return ruleMatches;
+        }
+      });
+    }
   }
 
   public boolean isRemote() {
     return remote;
   }
 
+  public boolean isSuccess() {
+    return success;
+  }
+
   public List<RuleMatch> getMatches() {
     return matches;
+  }
+
+  public Set<AnalyzedSentence> matchedSentences() {
+    return sentenceMatches.keySet();
+  }
+
+  public List<RuleMatch> matchesForSentence(AnalyzedSentence sentence) {
+    return sentenceMatches.get(sentence);
   }
 }

--- a/languagetool-core/src/test/java/org/languagetool/rules/GRPCRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/GRPCRuleTest.java
@@ -44,7 +44,7 @@ public class GRPCRuleTest {
   public void setUp() throws Exception {
     config = new RemoteRuleConfig(RULE_ID, "localhost", 50000,
       0, 0L, 0.0f,
-      1, 0L, 100, Collections.emptyMap());
+      1, 0L, Collections.emptyMap());
 
     rule = new GRPCRule(JLanguageTool.getMessageBundle(), config, true) {
       @Override

--- a/languagetool-core/src/test/java/org/languagetool/rules/GRPCRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/GRPCRuleTest.java
@@ -44,7 +44,7 @@ public class GRPCRuleTest {
   public void setUp() throws Exception {
     config = new RemoteRuleConfig(RULE_ID, "localhost", 50000,
       0, 0L, 0.0f,
-      1, 0L, Collections.emptyMap());
+      1, 0L, 100, Collections.emptyMap());
 
     rule = new GRPCRule(JLanguageTool.getMessageBundle(), config, true) {
       @Override

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -31,8 +31,8 @@ import org.languagetool.language.LanguageIdentifier;
 import org.languagetool.markup.AnnotatedText;
 import org.languagetool.markup.AnnotatedTextBuilder;
 import org.languagetool.rules.CategoryId;
-import org.languagetool.rules.RemoteRule;
 import org.languagetool.rules.DictionaryMatchFilter;
+import org.languagetool.rules.RemoteRule;
 import org.languagetool.rules.RuleMatch;
 import org.languagetool.rules.bitext.BitextRule;
 import org.languagetool.rules.spelling.morfologik.suggestions_ordering.SuggestionsOrdererConfig;
@@ -119,6 +119,7 @@ abstract class TextChecker {
     if (cache != null) {
       ServerMetricsCollector.getInstance().monitorCache("languagetool_matches_cache", cache.getMatchesCache());
       ServerMetricsCollector.getInstance().monitorCache("languagetool_sentences_cache", cache.getSentenceCache());
+      ServerMetricsCollector.getInstance().monitorCache("languagetool_remote_matches_cache", cache.getRemoteMatchesCache());
     }
 
     pipelinePool = new PipelinePool(config, cache, internalServer);

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -118,6 +118,7 @@ abstract class TextChecker {
 
     if (cache != null) {
       ServerMetricsCollector.getInstance().monitorCache("languagetool_matches_cache", cache.getMatchesCache());
+      ServerMetricsCollector.getInstance().monitorCache("languagetool_remote_matches_cache", cache.getRemoteMatchesCache());
       ServerMetricsCollector.getInstance().monitorCache("languagetool_sentences_cache", cache.getSentenceCache());
       ServerMetricsCollector.getInstance().monitorCache("languagetool_remote_matches_cache", cache.getRemoteMatchesCache());
     }

--- a/languagetool-server/src/test/java/org/languagetool/server/BertResortingBugTest.java
+++ b/languagetool-server/src/test/java/org/languagetool/server/BertResortingBugTest.java
@@ -1,6 +1,6 @@
-/* LanguageTool, a natural language style checker 
+/* LanguageTool, a natural language style checker
  * Copyright (C) 2020 Daniel Naber (http://www.danielnaber.de)
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -19,6 +19,7 @@
 package org.languagetool.server;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.junit.Ignore;
 import org.junit.Test;
 import org.languagetool.tools.Tools;


### PR DESCRIPTION
Separate cache, matches are stored by rule, so we can deal with request failures, empty results, fallback results, etc.
Refactored offset adjustment - now done out of the rule, works with AnnotatedText