### PR TITLE
Eiswürfe/N statt Eiswürfel/N

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -23073,3 +23073,4 @@ raus_bohren
 hinterher_telefonieren
 rüber_schwappen #ugs
 rein_gehören
+Eiswürfe/N

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -23073,4 +23073,6 @@ raus_bohren
 hinterher_telefonieren
 rüber_schwappen #ugs
 rein_gehören
+Eiswurf/S
+Eiswurfe/S
 Eiswürfe/N


### PR DESCRIPTION
Der Duden kennt das Wort nicht und Google zeigt mir nur Eiswürfel.