### PR TITLE
Blumenkran statt Blumenkrans

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
@@ -6579,3 +6579,5 @@ Volksbänder/N
 Eiswurf/S
 Eiswurfe/S
 Eiswürfe/N
+Blumenkran/S
+Blumenkräne/N


### PR DESCRIPTION
Das habe ich durch einen Fehler gefunden, denn das Nomen war falsch. Die Regel hat das richtig erkannt.