### PR TITLE
only log remote check time if remote rules active

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -915,8 +915,10 @@ public class JLanguageTool {
 
     fetchRemoteRuleResults(mode, level, analyzedSentences, remoteMatches, remoteRuleTasks, remoteRules, cachedResults, matchOffset, annotatedText);
     long remoteRuleCheckEnd = System.currentTimeMillis();
-    logger.info("Local checks took {}ms, remote checks {}ms; waited {}ms on remote results",
-      textCheckEnd - textCheckStart, remoteRuleCheckEnd - remoteRuleCheckStart, remoteRuleCheckEnd - textCheckEnd);
+    if (remoteRules.size() > 0) {
+      logger.info("Local checks took {}ms, remote checks {}ms; waited {}ms on remote results",
+        textCheckEnd - textCheckStart, remoteRuleCheckEnd - remoteRuleCheckStart, remoteRuleCheckEnd - textCheckEnd);
+    }
 
     ruleMatches.addAll(remoteMatches);
     ruleMatches = new SameRuleGroupFilter().filter(ruleMatches);


### PR DESCRIPTION
Logging otherwise affects command line output
We should consider directing all logging to stderr; right now, a Logback configuration exists only for tests and languagetool-server.