### PR TITLE
Make constructor of ChunkTaggedToken public

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/chunking/ChunkTaggedToken.java
+++ b/languagetool-core/src/main/java/org/languagetool/chunking/ChunkTaggedToken.java
@@ -37,7 +37,7 @@ public class ChunkTaggedToken {
   /**
    * @param readings may be null, caused by differences in tokenization we don't always have a 1:1 mapping
    */
-  ChunkTaggedToken(String token, List<ChunkTag> chunkTags, AnalyzedTokenReadings readings) {
+  public ChunkTaggedToken(String token, List<ChunkTag> chunkTags, AnalyzedTokenReadings readings) {
     this.token = Objects.requireNonNull(token);
     this.chunkTags = Objects.requireNonNull(chunkTags);
     this.readings = readings;


### PR DESCRIPTION
If an English or German module is loaded with a different classloader than Core, you will get an IllegalAccessError.