### PR TITLE
Make methods of ChunkTaggedToken public

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/chunking/ChunkTaggedToken.java
+++ b/languagetool-core/src/main/java/org/languagetool/chunking/ChunkTaggedToken.java
@@ -43,11 +43,11 @@ public class ChunkTaggedToken {
     this.readings = readings;
   }
 
-  String getToken() {
+  public String getToken() {
     return token;
   }
 
-  List<ChunkTag> getChunkTags() {
+  public List<ChunkTag> getChunkTags() {
     return chunkTags;
   }
 
@@ -55,7 +55,7 @@ public class ChunkTaggedToken {
    * @return readings or {@code null}
    */
   @Nullable
-  AnalyzedTokenReadings getReadings() {
+  public AnalyzedTokenReadings getReadings() {
     return readings;
   }
 


### PR DESCRIPTION
If an English or German module is loaded with a different classloader than Core, you will get an IllegalAccessError.