### PR TITLE
[fr] COMME_PAR_EXEMPLE -> type="style"

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -163,7 +163,7 @@ though, and has since been slightly modified)-->
       <suggestion>\1</suggestion>
       <example correction="banqueroute"><marker>banqueroute frauduleuse</marker></example>
     </rule>
-    <rule id="COMME_PAR_EXEMPLE" name="comme par exemple">
+    <rule id="COMME_PAR_EXEMPLE" name="comme par exemple" type="style">
       <pattern>
         <token skip="1">comme</token>
         <token>par</token>


### PR DESCRIPTION
Ich habe den type="style" zur Regel COMME_PAR_EXEMPLE hinzugefügt. Das ist ein Test, ob das funktioniert – diesen Type würde ich gerne für ein paar Regeln vergeben, damit wir im frz. Demo-Text auch was blau unterstrichen haben :) 