### PR TITLE
[en] fix missing '?' in en-GB ANYMORE

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-GB/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-GB/grammar.xml
@@ -355,7 +355,7 @@ USA
             <pattern>
                 <token>anymore</token>
             </pattern>
-            <message>In British English, the spelling '\1' is sometimes considered incorrect. Did you mean <suggestion>any more</suggestion>.</message>
+            <message>In British English, the spelling '\1' is sometimes considered incorrect. Did you mean <suggestion>any more</suggestion>?</message>
             <url>https://www.collinsdictionary.com/dictionary/english/anymore</url>
             <short>AmE/BrE: anymore/any more</short>
             <example correction="any more">I don't want to do this <marker>anymore</marker>.</example>


### PR DESCRIPTION
Spotted a period where there should be a question mark.