### PR TITLE
Use junit 4.13. Allows for smoother migration path to 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
       <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
       <maven.jar.plugin>2.6</maven.jar.plugin>  <!-- NOTE: don't update without testing OpenOffice, 3.0.2 caused "Got no data stream!" after add-on installation -->
       <maven.assemby.plugin>2.6</maven.assemby.plugin>
-      <junit.version>4.12</junit.version>
+      <junit.version>4.13</junit.version>
       <morfologik.version>2.1.7</morfologik.version>
       <jackson.version>2.11.2</jackson.version>
       <lucene.version>5.5.5</lucene.version>


### PR DESCRIPTION
As developer I migrated and company internal library to use Junit 5. Junit 5 runs some tests faster and in the end some  test code is easier to read and write. For example tests with exceptions do not need a _Rule_ but a simple Lambda will do. Also Junit 5 new features open a ton of new test features that make it easier to write tests.

As an inbetween I used junit 4.13 to find deprecations and change the tests first. Then I moved to 5 without using a compatability layer very easily. 

Languagetool is a bit more complex. If you are interested into moving to 5 this might be an interesting step in between. 

I ran the build on both Java 8 and 11 and it succeeded.