### PR TITLE
Use java 11 (and cleanup dangling whitespace in pom.xml)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>oss-parent</artifactId>
     <version>7</version>
   </parent>
-  
+
   <scm>
     <connection>scm:git:git@github.com:languagetool-org/languagetool.git</connection>
     <developerConnection>scm:git:git@github.com:languagetool-org/languagetool.git</developerConnection>
@@ -33,18 +33,18 @@
       <jackson.version>2.11.2</jackson.version>
       <lucene.version>5.5.5</lucene.version>
   </properties>
-  
+
   <build>
-      
+
       <extensions>
-		  <!-- needed to deploy to https://repository-languagetool.forge.cloudbees.com/snapshot/ -->
+      <!-- needed to deploy to https://repository-languagetool.forge.cloudbees.com/snapshot/ -->
           <extension>
               <groupId>org.apache.maven.wagon</groupId>
               <artifactId>wagon-webdav</artifactId>
               <version>1.0-beta-2</version>
           </extension>
       </extensions>
-      
+
       <pluginManagement>
           <plugins>
 
@@ -70,7 +70,7 @@
                       </execution>
                   </executions>
               </plugin>
-              
+
               <plugin>
                   <groupId>pl.project13.maven</groupId>
                   <artifactId>git-commit-id-plugin</artifactId>
@@ -89,7 +89,7 @@
                       <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
                   </configuration>
               </plugin>
-              
+
               <plugin>
                   <artifactId>maven-compiler-plugin</artifactId>
                   <version>3.8.1</version>
@@ -164,7 +164,7 @@
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
             <configuration>
-              <useAgent>true</useAgent>  
+              <useAgent>true</useAgent>
             </configuration>
             <executions>
               <execution>
@@ -180,7 +180,7 @@
       </build>
     </profile>
   </profiles>
-    
+
   <modules>
     <module>languagetool-core</module>
     <module>languagetool-language-modules/en</module>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
   <properties>
       <languagetool.version>5.2-SNAPSHOT</languagetool.version>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <maven.compiler.source>1.8</maven.compiler.source>
-      <maven.compiler.target>1.8</maven.compiler.target>
+      <maven.compiler.source>11</maven.compiler.source>
+      <maven.compiler.target>11</maven.compiler.target>
       <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
       <maven.jar.plugin>2.6</maven.jar.plugin>  <!-- NOTE: don't update without testing OpenOffice, 3.0.2 caused "Got no data stream!" after add-on installation -->
       <maven.assemby.plugin>2.6</maven.assemby.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
       <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
       <maven.jar.plugin>2.6</maven.jar.plugin>  <!-- NOTE: don't update without testing OpenOffice, 3.0.2 caused "Got no data stream!" after add-on installation -->
       <maven.assemby.plugin>2.6</maven.assemby.plugin>
-      <junit.version>4.12</junit.version>
+      <junit.version>4.13</junit.version>
       <morfologik.version>2.1.7</morfologik.version>
       <jackson.version>2.11.2</jackson.version>
       <lucene.version>5.5.5</lucene.version>


### PR DESCRIPTION
This merge requests bumps the compile version to 11. Not sure Whether you are interested in that.
It also removes dangling whitespace and replaces tabs from the pom.xml 

It includes an earlier merge request which bumps junit to 4.13