### PR TITLE
[en] add 'birdsongs' to spelling.txt

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
@@ -24331,3 +24331,4 @@ tie-dyes
 tie-dyed
 tie-dying
 liras
+birdsongs


### PR DESCRIPTION
Das fixt übrigens einen Loop. 'Birdsong' existiert definitiv auch im Plural und ich finde keine Hinweise darauf, dass es im AmE falsch ist.