### PR TITLE
"-speiche" statt "-speicher"

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
@@ -6153,3 +6153,6 @@ Mitausfall.*
 Mitatelier.*
 Mitangebot.*
 Regenschauder/NS
+Hauptspeiche
+Festplattenspeiche
+RAM-Speiche


### PR DESCRIPTION
Hauptspeiche statt Hauptspeicher
Festplattenspeiche statt Festplattenspeicher
RAM-Speiche statt RAM-Speicher

@danielnaber solltest du eine bessere Lösung haben, kannst du diese auch nutzen. Das ist mir nur bei meinen Aufgaben aufgefallen, dass diese Beispiel vom LanguageTool und LibreOffice nicht als Fehler markiert werden.