### PR TITLE
Fix interactions of disabledRules and RemoteRule implementations

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -921,6 +921,12 @@ public class JLanguageTool {
     }
 
     ruleMatches.addAll(remoteMatches);
+
+    // rules can create matches with rule IDs different from the original rule (see e.g. RemoteRules)
+    // so while we can't avoid execution of these rules, we still want disabling them to work
+    // so do another pass with ignoreRule here
+    ruleMatches = ruleMatches.stream().filter(match -> !ignoreRule(match.getRule())).collect(Collectors.toList());
+
     ruleMatches = new SameRuleGroupFilter().filter(ruleMatches);
     // no sorting: SameRuleGroupFilter sorts rule matches already
     if (cleanOverlappingMatches) {
@@ -1176,6 +1182,11 @@ public class JLanguageTool {
       Collections.addAll(sentenceMatches, thisMatches);
     }
     AnnotatedText text = new AnnotatedTextBuilder().addText(analyzedSentenceText).build();
+    // rules can create matches with rule IDs different from the original rule (see e.g. RemoteRules)
+    // so while we can't avoid execution of these rules, we still want disabling them to work
+    // so do another pass with ignoreRule here
+    sentenceMatches = sentenceMatches.stream()
+      .filter(match -> !ignoreRule(match.getRule())).collect(Collectors.toList());
     return applyCustomFilters(new SameRuleGroupFilter().filter(sentenceMatches), text);
   }
 

--- a/languagetool-core/src/main/java/org/languagetool/rules/BERTSuggestionRanking.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/BERTSuggestionRanking.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
  */
 public class BERTSuggestionRanking extends RemoteRule {
 
+  // only for RemoteRuleConfig
   public static final String RULE_ID = "BERT_SUGGESTION_RANKING";
 
   private static final Logger logger = LoggerFactory.getLogger(BERTSuggestionRanking.class);
@@ -74,7 +75,7 @@ public class BERTSuggestionRanking extends RemoteRule {
   private final Rule wrappedRule;
 
   public BERTSuggestionRanking(Rule rule, RemoteRuleConfig config, UserConfig userConfig, boolean inputLogging) {
-    super(rule.messages, config, inputLogging);
+    super(rule.messages, config, inputLogging, rule.getId());
     this.wrappedRule = rule;
     super.setCategory(wrappedRule.getCategory());
     synchronized (models) {
@@ -194,12 +195,13 @@ public class BERTSuggestionRanking extends RemoteRule {
 
   @Override
   public String getId() {
-    return RULE_ID;
+    // return values of wrapped rule so that enabling/disabling rules works
+    return wrappedRule.getId();
   }
 
   @Override
   public String getDescription() {
-    return "Suggestion reordering based on the BERT model";
+    return wrappedRule.getDescription();
   }
 
   private static class CuratedAndSameCaseComparator implements Comparator<Pair<SuggestedReplacement, Double>> {

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
@@ -22,6 +22,7 @@
 package org.languagetool.rules;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.jetbrains.annotations.Nullable;
 import org.languagetool.AnalyzedSentence;
 import org.languagetool.markup.AnnotatedText;
 import org.slf4j.Logger;
@@ -55,15 +56,21 @@ public abstract class RemoteRule extends Rule {
   protected final boolean inputLogging;
   private AnnotatedText annotatedText;
 
-  public RemoteRule(ResourceBundle messages, RemoteRuleConfig config, boolean inputLogging) {
+  public RemoteRule(ResourceBundle messages, RemoteRuleConfig config, boolean inputLogging, @Nullable String ruleId) {
     super(messages);
     serviceConfiguration = config;
     this.inputLogging = inputLogging;
-    String ruleId = getId();
+    if (ruleId == null) { // allow both providing rule ID in constructor or overriding getId
+      ruleId = getId();
+    }
     lastFailure.putIfAbsent(ruleId, 0L);
     consecutiveFailures.putIfAbsent(ruleId, new AtomicInteger());
     // TODO maybe use fixed pool, take number of concurrent requests from configuration?
     executors.putIfAbsent(ruleId, Executors.newCachedThreadPool(threadFactory));
+  }
+
+  public RemoteRule(ResourceBundle messages, RemoteRuleConfig config, boolean inputLogging) {
+    this(messages, config, inputLogging, null);
   }
 
   public static void shutdown() {


### PR DESCRIPTION
GRPCRule and BERTSuggestionRanking return matches with Rules whose IDs don't match the original rule,
this lead to some bugs. Now you can disable the execution of the rule as a whole (by setting disabledRules to the ID of the base rule) or exclude specific matches (by setting disabledRules to the respective IDs).
There are still issues with enabledOnly left to be fixed later