### PR TITLE
MultiThreadedJLanguageTool: avoid overhead when analyzing just one sentence

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -1099,14 +1099,21 @@ public class JLanguageTool {
       AnalyzedSentence analyzedSentence = getAnalyzedSentence(sentence);
       rememberUnknownWords(analyzedSentence);
       if (++j == sentences.size()) {
-        AnalyzedTokenReadings[] anTokens = analyzedSentence.getTokens();
-        anTokens[anTokens.length - 1].setParagraphEnd();
-        analyzedSentence = new AnalyzedSentence(anTokens);
+        analyzedSentence = markAsParagraphEnd(analyzedSentence);
       }
       analyzedSentences.add(analyzedSentence);
       printSentenceInfo(analyzedSentence);
     }
     return analyzedSentences;
+  }
+
+  @NotNull
+  static AnalyzedSentence markAsParagraphEnd(AnalyzedSentence analyzedSentence) {
+    AnalyzedTokenReadings[] anTokens = analyzedSentence.getTokens();
+    anTokens[anTokens.length - 1].setParagraphEnd();
+    AnalyzedTokenReadings[] preDisambigAnTokens = analyzedSentence.getPreDisambigTokens();
+    preDisambigAnTokens[anTokens.length - 1].setParagraphEnd();
+    return new AnalyzedSentence(anTokens, preDisambigAnTokens);  ///TODO: why???
   }
 
   protected void printSentenceInfo(AnalyzedSentence analyzedSentence) {

--- a/languagetool-core/src/main/java/org/languagetool/MultiThreadedJLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/MultiThreadedJLanguageTool.java
@@ -121,6 +121,10 @@ public class MultiThreadedJLanguageTool extends JLanguageTool {
   
   @Override
   protected List<AnalyzedSentence> analyzeSentences(List<String> sentences) throws IOException {
+    if (sentences.size() < 2) {
+      return super.analyzeSentences(sentences);
+    }
+
     List<AnalyzedSentence> analyzedSentences = new ArrayList<>();
     
     ExecutorService executorService = getExecutorService();
@@ -213,13 +217,7 @@ public class MultiThreadedJLanguageTool extends JLanguageTool {
 
     @Override
     public AnalyzedSentence call() throws Exception {
-      AnalyzedSentence analyzedSentence = super.call();
-      AnalyzedTokenReadings[] anTokens = analyzedSentence.getTokens();
-      anTokens[anTokens.length - 1].setParagraphEnd();
-      AnalyzedTokenReadings[] preDisambigAnTokens = analyzedSentence.getPreDisambigTokens();
-      preDisambigAnTokens[anTokens.length - 1].setParagraphEnd();
-      analyzedSentence = new AnalyzedSentence(anTokens, preDisambigAnTokens);  ///TODO: why???
-      return analyzedSentence;
+      return markAsParagraphEnd(super.call());
     }
   }
 }


### PR DESCRIPTION
and unify "paragraph end" behavior between base and multithreaded implementations