### PR TITLE
[en] Update det_a.txt: add british spelling of words with "utiliz*" root

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_a.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_a.txt
@@ -530,6 +530,9 @@ uterine
 uterus
 *UTF
 *UTG
+utilisable
+utilisation
+utilised
 utilitarian
 utilitarianism
 utility


### PR DESCRIPTION
Added "utilisable", "utilisation" and "utilised" corresponding to the British spelling of the equivalent words already present with the "-ize" ending.