### PR TITLE
Kurgewinn statt Kursgewinn

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
@@ -6238,3 +6238,4 @@ Gleichgrossem
 Magentarif/A
 Magentarifes
 Magentarife/N
+Kurgewinn.*


### PR DESCRIPTION
"Kur" wird von der Regel nicht erkannt, weswegen ich es eintrage.