### PR TITLE
Ergänzungen und Optimierungen

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
@@ -18,14 +18,13 @@
 Abbaulagerstädte/N
 Abbaustädte/N
 Abbruchstädte/N
-Abgangsgel
-Abgangsgel
+Abgangsgel/S
 Abiturabschuss
 Abiturenten
 Abiturrente/N
 Abkürzungsschreibwiese/N
 Ablassuhrkunde/N
-Ablaufgel
+Ablaufgel/S
 Ablaufstadion/S
 Abonnementreis
 Abrechnungsstechnische/N
@@ -70,14 +69,14 @@ Altenpflegestädte/N
 Altentagesstädte/N
 Alternativschreibwiese/N
 Alterswiese/N
-Altgel
+Altgel/S
 Altstadtabschuss
 Alttag/SE
 Alumini
 Aluminiumbauwiese/N
 Aluminiumerzlagerstädte/N
 Aluminiumgelände
-Aluminiumkleingel
+Aluminiumkleingel/S
 Amtsgedicht
 Amtsgesicht
 Ananastore/N
@@ -91,7 +90,7 @@ Anfangsstadion/S
 Angebots-Ire/N
 Angebots-Sri
 Angriffswiese/N
-Anlegegel
+Anlegegel/S
 Anleiheuhrkunde/N
 Anliegerverzehr
 Anrainerverzehr
@@ -109,7 +108,7 @@ Anwendungsstechnische/N
 Anwendungswiese/N
 Anzeigenabschuss
 Anzeigenaufschnitt
-Anzeigengel
+Anzeigengel/S
 Apfeltore/N
 Apfeltote/N
 Apfelweingaststädte/N
@@ -159,7 +158,7 @@ Auftragsnord
 Auftragsport
 Auftragswiese/N
 Auftrittsstädte/N
-Auktionsgel
+Auktionsgel/S
 Ausbildungsabschuss
 Ausbildungsstädte/N
 Ausbildungsstechnische/N
@@ -171,7 +170,7 @@ Ausflugsverzehr
 Ausführungswiese/N
 Ausgangspunk
 Ausgrabungsstädte/N
-Auslandskindergel
+Auslandskindergel/S
 Ausnahmegen
 Ausschankstädte/N
 Ausschlussmitglieder/N
@@ -184,7 +183,7 @@ Ausschussmöglichkeit
 Ausschussmöglichkeiten
 Ausschussstadion/S
 Außensichtwiese/N
-Ausstattungsgel
+Ausstattungsgel/S
 Ausstattungsuhrkunde/N
 Ausstellungsstädte/N
 Ausübungsstädte/N
@@ -243,12 +242,12 @@ Bärenstrauch
 Bärensträucher/N
 Bärenweine/NS
 Bärenwein/S
-Bargel
+Bargel/S
 Bargenbestände/N
 Baseballstadium/S
 Bauabschuss
 Bauchwehr
-Baugel
+Baugel/S
 Baumabschuss
 Baumontagestädte/N
 Baumrinder/N
@@ -291,7 +290,7 @@ Beitage
 Beitrittsuhrkunde/N
 Beizeichnung
 Beizeichnungen
-Belagerungsgel
+Belagerungsgel/S
 Belegschaf
 Belegtor
 Belegtordiode
@@ -309,7 +308,7 @@ Berggaststädte/N
 Berghüte/N
 Bergriffen
 Bergspritze/N
-Bergungsgel
+Bergungsgel/S
 Berufsabschuss
 Berufsausbildungsabschuss
 Berufsausbildungsstädte/N
@@ -353,7 +352,7 @@ Beweisuhrkunde/N
 Bewertungsspielträume/N
 Bewertungsstechnische/N
 Bewilligungsuhrkunde/N
-Bewirtungsgel
+Bewirtungsgel/S
 Bewirtungsstädte/N
 Bezirksausbildungsstädte/N
 Bezirksbildungsstädte/N
@@ -381,7 +380,7 @@ Binärschreibwiese/N
 Bindestrichschreibwiese/N
 Binnenflugverzehr
 Binnenfrachtverzehr
-Bischofsgel
+Bischofsgel/S
 Bischofsuhrkunde/N
 Blastozystenstadion/S
 Blattspritze/N
@@ -403,7 +402,7 @@ Bogenbauwiese/N
 Bogenmal
 Bogenspritze/N
 Bohrstädte/N
-Bombengel
+Bombengel/S
 Boomorang/S
 Boomrang/S
 Bootstädte/N
@@ -426,7 +425,7 @@ Bravur
 bravurös/A
 Bremszuggriff.*
 Briefkaste
-Briefmarkengel
+Briefmarkengel/S
 Briefverzehr
 Bronzebürste/N
 Bronzeuhrkunde/N
@@ -470,7 +469,7 @@ Buchstab/S
 Buchstäbe
 Buchstabenschreibwiese/N
 Buchungsstechnische/N
-Budgetgel
+Budgetgel/S
 Bundesligastadium/S
 Bundesrastrasse/N
 Bundesrechnungsabschuss
@@ -496,7 +495,7 @@ Busenstoffe/NS
 Busenstoff/S
 Busgelder
 Busrissoutfit
-Bußgel
+Bußgel/S
 Busverzehr
 Busverzehrs
 Buswerkstädte/N
@@ -507,7 +506,7 @@ Charterflugverzehrs
 Charterverzehr
 Charterverzehrs
 Chemieweh
-Chipgel
+Chipgel/S
 Chipzuggriff.*
 Chorabschuss
 Christoper
@@ -620,7 +619,7 @@ Echograzie
 Eckbanken
 Edelstahlgelände
 Edelsteinlagerstädte/N
-Ehegel
+Ehegel/S
 Eheuhrkunde/N
 Ehrenabschuss
 Ehrenbürgeruhrkunde/N
@@ -629,7 +628,7 @@ Ehrengrabstädte/N
 Ehrenmond
 Ehrennord
 Ehrenreis
-Ehrenruhegel
+Ehrenruhegel/S
 Ehrenstädte/N
 Ehrenuhrkunde/N
 Eichenstädte/N
@@ -641,7 +640,7 @@ Eifersuchtsmond
 Eifersuchtsnord
 Eigenschaf
 Eigentumsuhrkunde/N
-Eilgel
+Eilgel/S
 Einbusse/N
 # Einbusse/N is actually correct for de-CH but we can't express that yet:
 Einfachhit
@@ -649,7 +648,7 @@ Eingangbereich
 Eingangbereiche/N
 Eingangbereiches
 Eingendrahtrollen
-Einlagengel
+Einlagengel/S
 Einlaufweh
 Einnahmebiberschussrechnung
 Einnahmegeberschussrechnung
@@ -2048,8 +2047,8 @@ Erdschwan/S
 Erdulan
 Erfahrungsgrundsalz
 Erfahrungssalz
-Erfindergel
-Erfrischungsgel
+Erfindergel/S
+Erfrischungsgel/S
 Erholungsgas
 Erholungsstädte/N
 Erinnerungsstädte/N
@@ -2075,7 +2074,7 @@ Erziehungsberechtigen
 Erziehungsstädte/N
 Erzlagerstädte/N
 Essball/S
-Eurobargel
+Eurobargel/S
 Europastadium/S
 Evolutionsstadion/S
 Exanthemstadion/S
@@ -2112,7 +2111,7 @@ Familienruhestädte/N
 Familienuhrkunde/N
 Familienweihstädte/N
 Familienwohnstädte/N
-Fantasiegel
+Fantasiegel/S
 Farbahn
 Farbahnen
 Faserverbundbauwiese/N
@@ -2120,7 +2119,7 @@ Faustfeueraffe/N
 Federglasmatte/N
 Federtordiode/N
 Fehleierinjektion
-Fehlgel
+Fehlgel/S
 Feierabendverzehr
 Feierglasmatte/N
 Feingendrahtrollen
@@ -2143,7 +2142,7 @@ Fertighausproduktionsstädte/N
 Fertigungsstädte/N
 Fertigungsstechnische/N
 Fertigungswiese/N
-Festgel
+Festgel/S
 Festmal
 Festplattenzuggriff.*
 Festspielgas
@@ -2175,7 +2174,7 @@ Filmzuggriff.*
 Finalabschuss
 Fingerglasmatte/N
 Finnenstadion/S
-Firmengel
+Firmengel/S
 Firmenwaagen
 Fischerhüte/N
 Fischgaststädte/N
@@ -2211,7 +2210,7 @@ Flugverzehr
 Flugzeugabschluss
 Flugzug
 Flugzug/S
-Fluthilfegel
+Fluthilfegel/S
 Flutschutzweh
 Folgeeiche/N
 Folienmitglieder/N
@@ -2248,7 +2247,7 @@ Freistädte/N
 Freit
 freit
 Freizeitflugverzehr
-Fremdengel
+Fremdengel/S
 Fremdzuggriff
 Fressstadion/S
 Freundschaftsuhrkunde/N
@@ -2259,7 +2258,7 @@ Friedensuhrkunde/N
 Friedrich-Löffler-Institut
 Friedrich-Löffler-Instituts
 Frieseurin
-Friseurgel
+Friseurgel/S
 Fronttriebbär
 Fronttriebbären
 Fronttriebberg
@@ -2331,7 +2330,7 @@ Gaststädte/N
 Gebäudeabschuss
 Gebetsstädte/N
 Gebrauchswiese/N
-Gebührengel
+Gebührengel/S
 Geburtsstädte/N
 Geburtstagseier
 Geburtstagsfreier/N
@@ -2342,7 +2341,7 @@ Geburtstagstote/N
 Geburtsuhrkunde/N
 Gedächtnisstädte/N
 Gedenkstädte/N
-Gefahrengel
+Gefahrengel/S
 Gefangenentran
 Gefängnisstädte/N
 Geflügelausschnitt
@@ -2372,9 +2371,9 @@ Gerichtsstädte/N
 Gerichtsuhrkunde/N
 Gerichtszunahme
 Gesamtabschuss
-Gesamtaltgel
+Gesamtaltgel/S
 Gesamthochschulabschuss
-Gesamtpreisgel
+Gesamtpreisgel/S
 Gesamtschulabschuss
 Gesamtuhrkunde/N
 Gesangsstechnische/N
@@ -2497,9 +2496,9 @@ Grislibär
 Grislibären
 Grobire/N
 Grobtonlinien
-Großbürgergel
+Großbürgergel/S
 Großgaststädte/N
-Großnotgel
+Großnotgel/S
 Großschreibwiese/N
 Großsportstädte/N
 Großstadium/S
@@ -2547,7 +2546,7 @@ Handelsschulabschuss
 Handelsstechnische/N
 Handelsverzehr
 Handfeueraffe/N
-Händlergel
+Händlergel/S
 Handlungsstädte/N
 Handlungswiese/N
 Handwerksstädte/N
@@ -2563,7 +2562,7 @@ Hauptausbildungsstädte/N
 Hauptfährverzehr
 Hauptgesichtspunk
 Haupthase/N
-Hauptpreisgel
+Hauptpreisgel/S
 Hauptproduktionsstädte/N
 Hauptreihenstadion/S
 Hauptsalz
@@ -3654,7 +3653,7 @@ hervorgesagt/A
 Herzloch
 Herzlochen
 Herzwehr
-Hexengel
+Hexengel/S
 Himbeertote/N
 Himmeleiche/N
 Himmelkörper/N
@@ -3976,7 +3975,7 @@ Implementationsstechnische/N
 Indexschreibwiese/N
 Industriebauwiese/N
 Industrieelle/N
-Industriegel
+Industriegel/S
 Informationsstädte/N
 Informationsstechnische/N
 Ingenieurabschuss
@@ -3987,7 +3986,7 @@ Inlandsabschuss
 Innenasche/N
 Innenstadthaltepunk/S
 Inseleiche/N
-Inselgel
+Inselgel/S
 Insulinspitze/N
 Intermediärstadion/S
 Internetdatenverzehr
@@ -4020,7 +4019,7 @@ Jugendstadion/S
 Jugendstädte/N
 Jugendwohnstädte/N
 Jungend.*
-Jungferngel
+Jungferngel/S
 Jungraubmütter/N
 Justizausbildungsstädte/N
 Justizmond
@@ -4036,7 +4035,7 @@ kalvinistisch/A
 Kamingendrahtrollen
 Kampfwiese/N
 Kanossa
-Kantinengel
+Kantinengel/S
 Kapazitätsstechnische/N
 Kargo
 Karriereabschuss
@@ -4047,9 +4046,9 @@ Käserinder/N
 Käseschichtenerzählen
 Kassenabschuss
 Kastenbanken
-Katzengel
+Katzengel/S
 Kaufabschuss
-Kaufgel
+Kaufgel/S
 Kaufreis
 Kaufstädte/N
 Kaufuhrkunde/N
@@ -4068,8 +4067,8 @@ Kindererholungsstädte/N
 Kindergartenverhaltenswiese/N
 Kindergel/S
 Kinderheilstädte/N
-Kinderpflegekrankengel
-Kindertagesgel
+Kinderpflegekrankengel/S
+Kindertagesgel/S
 Kindertagesstädte/N
 Kinderwaldstädte/N
 Kindheitsstadion/S
@@ -4153,7 +4152,7 @@ Kopfwehr
 Kopierwerkstädte/N
 Korallenbanken
 Korbtonlinien
-Korkengel
+Korkengel/S
 Korkstoffwahl
 Korngendrahtrollen
 Körperabschuss
@@ -4170,7 +4169,7 @@ Krankheitsstadion/S
 Krantonlinien
 Krebstonlinien
 Kreditgewebe/S
-Kreditkartengel
+Kreditkartengel/S
 Kreisaufschnitt
 Kreisheimstädte/N
 Kreislaus
@@ -4191,7 +4190,7 @@ Kuchentuch/S
 Kugelschreier/NS
 Kugelschreiner/NS
 Kuherde/N
-Kuhgel
+Kuhgel/S
 Kühleierinjektion
 Kuhweise/N
 Kultureiche/N
@@ -4204,7 +4203,7 @@ Kündigungswolle
 Kunsteisstadium/S
 Kunsthofindustrie
 Kunstostindustrie
-Kunststoffgel
+Kunststoffgel/S
 Kunstuhrkunde/N
 Kupferlagerstädte/N
 Kurarbeit
@@ -4266,7 +4265,7 @@ Laubhaken
 Laufabschuss
 Lebensaufschnitt
 Lebenserhaltungskosten
-Lebensgel
+Lebensgel/S
 Lebensmittelproduktionsstädte/N
 Lebensstadion/S
 Lebenswaise/N
@@ -4310,7 +4309,7 @@ Leichensammelstädte/N
 Leichenstädte/N
 Leichtathletikstadium/S
 Leichtbauwiese/N
-Leichtgel
+Leichtgel/S
 Leichtmetalleiter/N
 Leistungsstechnische/N
 Leistungsuhrkunde/N
@@ -4440,8 +4439,8 @@ Memtoren
 Memtor/S
 Mengenschreibwiese/N
 Menscheneiche/N
-Messegel
-Messergel
+Messegel/S
+Messergel/S
 Messestadium/S
 Messstechnische/N
 Metallabschuss
@@ -4457,7 +4456,7 @@ Mietreis
 Mikrowellenerde/N
 Milchkontinent/ES
 Milchstadion/S
-Millionengel
+Millionengel/S
 Millionenmal
 Minerallagerstädte/N
 Mineralstofflagerstädte/N
@@ -4677,7 +4676,7 @@ Namensänderungsuhrkunde/N
 Namenslos
 Namensloses
 Namensschreibwiese/N
-Nationalbankgel
+Nationalbankgel/S
 Nationalhymen
 Nationalsoziallisten
 Nationalstadion/S
@@ -4707,12 +4706,12 @@ Niederrheinstadium/S
 Niederwetter
 Nierenwetter
 Niststädte/N
-Nobelpreisgel
+Nobelpreisgel/S
 Nobelreis
 Notensalz
 Notenschreibwiese/N
 Notfalz
-Notgel
+Notgel/S
 Notgottesdienststädte/N
 Notwenigkeit
 Nuklearsprengsalz
@@ -4722,7 +4721,7 @@ Nusstote/N
 Nutzungsuhrkunde/N
 Nutzungswiese/N
 Nymphenstadion/S
-Obergel
+Obergel/S
 Oberschulabschuss
 Oberstadium/S
 Objektzuggriff.*
@@ -4746,7 +4745,7 @@ Operationsstechnische/N
 Operationswiese/N
 Opferstädte/N
 Oppositionsbanken
-Optionsgel
+Optionsgel/S
 Orakelstädte/N
 Organisationswiese/N
 Originalschreibwiese/N
@@ -4757,10 +4756,10 @@ Ostellen
 Osterdhase/N
 Osterreich
 Osterreichs
-Ostgel
+Ostgel/S
 Ostseestadium/S
 Palastwerkstädte/N
-Papiergel
+Papiergel/S
 Papierproduktionsstädte/N
 Papierstadion/S
 Papstellen
@@ -4785,8 +4784,8 @@ Passagierflugverzehr
 Passagierluftverzehr
 Passagierverzehr
 passee
-Passiergel
-Patentgel
+Passiergel/S
+Patentgel/S
 Patenttante/N
 Patentuhrkunde/N
 Pauschalabschuss
@@ -4833,7 +4832,7 @@ Poltänzers
 Poltisch
 Poltische/N
 Portrait
-Porzellangel
+Porzellangel/S
 Poststadium/S
 Postuhrkunde/N
 Postzustellungsuhrkunde/N
@@ -4864,7 +4863,7 @@ Profikamp
 Programmzuggriff.*
 Projektabschuss
 Projekteiter/S
-Projektgel
+Projektgel/S
 Projektleier
 Projektstadion/S
 Protestuhrkunde/N
@@ -4954,12 +4953,12 @@ Regenschauder/NS
 Regentanne
 Regierungspo
 Regierungspolis
-Regionalgel
+Regionalgel/S
 Registerzuggriff.*
 Registrierangstdaten
 Registrierangsterfahren
 Registrierangstverfahren
-Registriergel
+Registriergel/S
 Registrierlängsdaten
 Registrierlängsverfahren
 Registrierung-baden
@@ -4983,8 +4982,8 @@ Reisebusen
 Reitendaschenrevolver/NS
 Reiterstadium/S
 Reitstadium/S
-Rekordbußgel
-Rekordpreisgel
+Rekordbußgel/S
+Rekordpreisgel/S
 Relativsalz
 Rennwerkstädte/N
 Reparaturwerkstädte/N
@@ -5007,7 +5006,7 @@ Rohkitz
 Rohölreis
 Rohrstoffsektor/S
 Rohstofflagerstädte/N
-Rollengel
+Rollengel/S
 Rosenaustadium/S
 Rosenstadium/S
 Rotarschfilet/S
@@ -5072,7 +5071,7 @@ Ruhestädte/N
 Ruhrstadium/S
 Rumpfsteak/S
 Rundbanken
-Rüstungsgel
+Rüstungsgel/S
 Rüstungsproduktionsstädte/N
 Rüstungsstechnische/N
 Sachen-Anhalt
@@ -5219,7 +5218,7 @@ Schlusswiese/N
 Schmand
 Schmelzhüte/N
 Schmiedewerkstädte/N
-Schmiergel
+Schmiergel/S
 Schmucktragewiese/N
 Schmugglerband
 Schneeflug
@@ -5238,7 +5237,7 @@ Schokoladentore/N
 Schokoladentote/N
 Schönheitsreis
 Schönstädte/N
-Schönwettergel
+Schönwettergel/S
 Schraubenschüssel
 Schreibstiel
 Schreibtischstahl
@@ -5265,7 +5264,7 @@ Schulabschuss
 Schulbanken
 Schulduhrkunde/N
 Schuleiter/NS
-Schulgel
+Schulgel/S
 Schuljuniformvorschrift
 Schulungsstädte/N
 Schussaffe/N
@@ -5282,7 +5281,7 @@ Schwanzgegendrehsitz
 Schweineteak
 Schwermüdigkeit
 Schwimmstadium/S
-Sechsmonatsgel
+Sechsmonatsgel/S
 Seegas
 Seeschwäche
 Seetest/S
@@ -5310,7 +5309,7 @@ Sexualnord
 Shakeholder/NS
 # should be "Strickmuster"
 Sicheleierinjektion
-Sicherheitsgel
+Sicherheitsgel/S
 Sicherheitsschüssel
 Sicherheitsstechnische/N
 Sicherheitswerkbanken
@@ -5320,7 +5319,7 @@ Sicherungsstechnische/N
 Sichteierinjektion
 Siegesreis
 Silbergas
-Silberkleingel
+Silberkleingel/S
 Silberlagerstädte/N
 Silbermünzstädte/N
 Singraubmütter/N
@@ -5372,16 +5371,16 @@ Sparzielverkäuferin
 Sparzielverkäuferinnen
 Sparzielverkäufer/NS
 Spätstadion/S
-Speichergel
+Speichergel/S
 Speicherzuggriff.*
 Speisegaststädte/N
 Speisesatz
-Spezialgel
+Spezialgel/S
 Speziallist
 Spezialwerkstädte/N
 Spiegelstadion/S
 Spielabschuss
-Spielgel
+Spielgel/S
 Spielstädte/N
 Spielwerkstädte/N
 Spitzendrehbanken
@@ -5396,7 +5395,7 @@ Sprachabschuss
 Sprachstadion/S
 Sprechrinne/N
 Sprechwiese/N
-Spritzgel
+Spritzgel/S
 Staatsbürgeruhrkunde/N
 Staatsekretär
 Staatsgas
@@ -5436,7 +5435,7 @@ Stehgreifrede/N
 Stehgreiftheater/S
 Steinbanken
 Steinbauwiese/N
-Steingel
+Steingel/S
 Steingrabstädte/N
 Steinkohlelagerstädte/N
 Steinkohlestadion/S
@@ -5448,7 +5447,7 @@ Stellungsnahme/N
 Sterbeuhrkunde/N
 Sternenderbachter
 Steuerabschuss
-Steuergel
+Steuergel/S
 Steueruhrkunde/N
 Steuerungsstechnische/N
 Stichprobenwiese/N
@@ -5462,7 +5461,7 @@ Straßenbahnverzehr
 Straßenbeuger
 Straßendeuter
 Straßengaststädte/N
-Straßengel
+Straßengel/S
 Straßenindividualverzehr
 Straßenpersonennähverkehr
 Straßenpersonennähverzehr
@@ -5485,12 +5484,12 @@ Stromreis
 Studienabschuss
 Stuhleierinjektion
 Stundensalz
-Sturmgel
+Sturmgel/S
 Suchrum
 Suchrums
 Suchtfunktion
 Suchtfunktionen
-Südgel
+Südgel/S
 Sympatikus
 Systemabschuss
 Systembauwiese/N
@@ -5512,7 +5511,7 @@ Taiwanese/N
 Talkgas
 Tarifabschuss
 Tarifvertragsabschuss
-Taschengel
+Taschengel/S
 Tatrastreich
 Taufuhrkunde/N
 Tauschuhrkunde/N
@@ -5557,12 +5556,12 @@ Tonlagerstädte/N
 Tonwiese/N
 Töpferlehrwerkstädte/N
 Torabschuss
-Torgel
+Torgel/S
 Torluv
 Torrum
 Tortor
 Tortour
-Touristeneintrittsgel
+Touristeneintrittsgel/S
 Touristenschwämme/N
 Traditionsstadium/S
 Tragewiese/N
@@ -5579,13 +5578,13 @@ Treibwerke/NS
 Treibwerk/S
 Trennungsuhrkunde/N
 Treppengang
-Treppengel
+Treppengel/S
 Treppengelände
 Treueeber/NS
 Trickmuster/NS
 Triebholz
 Triebholzes
-Trinkgel
+Trinkgel/S
 Trümmerlagerstädte/N
 Trümmerstädte/N
 Truppenlagerstädte/N
@@ -5598,8 +5597,8 @@ Turmabschuss
 Turmbeutel/S
 Turmgaststädte/N
 Turnbanken
-Turniergel
-Turnierpreisgel
+Turniergel/S
+Turnierpreisgel/S
 Turnieruhrkunde/N
 Typenglasmatte/N
 Überblock
@@ -5745,7 +5744,7 @@ Umwandlungsstadion/S
 Umweltbildungsstädte/N
 Umzugsstechnische/N
 Unfallscheit
-Unfallsterbegel
+Unfallsterbegel/S
 Unglücksstädte/N
 Universaleiche/N
 Universitätsabschuss
@@ -5977,7 +5976,7 @@ Wachstumsstadion/S
 Waffenproduktionsstädte/N
 Wagenverzehr
 Wahleierinjektion
-Wahlgel
+Wahlgel/S
 Wahlgesänge/N
 Wahlgesanges
 Wahlgesang/S
@@ -6009,7 +6008,7 @@ Waschbataillon/S
 Wasserabschuss
 Wasserstadium/S
 Wechseluhrkunde/N
-Weggel
+Weggel/S
 Weidegas
 Weihestädte/N
 Weihnachtfreier/NS
@@ -6024,7 +6023,7 @@ weitreichendste
 Weizenreis/E
 Wellenesswochenende/NS
 Welteiche/N
-Weltgel
+Weltgel/S
 Weltrum
 Weltwirtschaftskir
 Weltzugangswiese/N
@@ -6075,7 +6074,7 @@ Wiederrum
 Wiedersachen
 Wiedersetzen
 Wildgas
-Wildgel
+Wildgel/S
 Wildparkstadium/S
 Windheilung
 Windschlüpfrigkeit
@@ -6099,7 +6098,7 @@ Wissensstechnische/N
 Wochenabschuss
 Wochenmal
 Wohleierinjektion
-Wohlfahrtsgel
+Wohlfahrtsgel/S
 Wohlpfeil
 Wohnlebenswiese/N
 Wok-Shop/S
@@ -6131,7 +6130,7 @@ Zahnwehr
 Zaubertank
 Zaubertran
 Zaungas
-Zaungel
+Zaungel/S
 Zaunzeug
 Zeichenwiese/N
 Zeilenabschuss
@@ -6151,7 +6150,7 @@ Zeitungsernte
 Zeitwagen
 Zeitwien/S
 Zellstadion/S
-Zentralbankengel
+Zentralbankengel/S
 Zentralstadium/S
 Zerfallsstadion/S
 Zeugenbanken
@@ -6175,7 +6174,7 @@ Zitronentote/N
 Zollstädte/N
 Zollwiese/N
 Zubereitungswiese/N
-Zuchtgel
+Zuchtgel/S
 Zuchtstädte/N
 Zufallszuggriff.*
 Zufluchtsstädte/N
@@ -6187,7 +6186,7 @@ Zukunftsstädte/N
 Zulassungsstechnische/N
 Zulassungsuhrkunde/N
 Zuschauerbanken
-Zuschlagsgel
+Zuschlagsgel/S
 Zustellungsuhrkunde/N
 Zwangsarbeitsstädte/N
 Zweiaktmotoren
@@ -6209,9 +6208,8 @@ Zwischeneiche/N
 Zwischenlagerstädte/N
 Zwischenmoorstadion/S
 Zwischenstadion/S
-Zwölfmonatsgel
-# https://www.duden.de/rechtschreibung/gleich_konvergent_einfoermig / https://www.dwds.de/wb/gleichgro%C3%9F
-gleichgroß
+Zwölfmonatsgel/S
+gleichgroß # https://www.duden.de/rechtschreibung/gleich_konvergent_einfoermig / https://www.dwds.de/wb/gleichgro%C3%9F
 gleichgross
 gleichgroße
 gleichgrosse


### PR DESCRIPTION
+ Duplikatk "Abgangsgel" entfernt
+ /S bei Wörtern mit der Endung Gel ergänzt
+ https://www.duden.de/rechtschreibung/gleich_konvergent_einfoermig / https://www.dwds.de/wb/gleichgro%C3%9F hinter dem Wort "gleichgroß" verschoben

Grüße Dallun511