### PR TITLE
speed up XmlRuleDisambiguator

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRule.java
@@ -18,7 +18,9 @@
  */
 package org.languagetool.rules.patterns;
 
-import org.languagetool.*;
+import org.languagetool.AnalyzedSentence;
+import org.languagetool.JLanguageTool;
+import org.languagetool.Language;
 import org.languagetool.rules.RuleMatch;
 import org.languagetool.tagging.disambiguation.rules.DisambiguationPatternRule;
 import org.languagetool.tools.StringTools;
@@ -241,14 +243,10 @@ public class PatternRule extends AbstractPatternRule {
   // tokens that just refer to a word - no regex and optionally no inflection etc.
   private Set<String> getSet(boolean isInflected) {
     Set<String> set = new HashSet<>();
-    for (PatternToken patternToken : patternTokens) {
-      boolean acceptInflectionValue = isInflected ? patternToken.isInflected() : !patternToken.isInflected();
-      if (acceptInflectionValue && !patternToken.getNegation() && !patternToken.isRegularExpression()
-              && !patternToken.isReferenceElement() && patternToken.getMinOccurrence() > 0) {
-        String str = patternToken.getString();
-        if (!StringTools.isEmpty(str)) {
-          set.add(str.toLowerCase());
-        }
+    for (PatternToken token : patternTokens) {
+      if (isInflected == token.isInflected() && !token.isRegularExpression() && !token.getNegation() &&
+          token.hasStringThatMustMatch()) {
+        set.add(Objects.requireNonNull(token.getString()).toLowerCase());
       }
     }
     if (set.isEmpty()) return Collections.emptySet();

--- a/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/XmlRuleDisambiguator.java
+++ b/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/XmlRuleDisambiguator.java
@@ -42,10 +42,25 @@ public class XmlRuleDisambiguator extends AbstractDisambiguator {
 
   private static final String DISAMBIGUATION_FILE = "disambiguation.xml";
 
-  private final BitSet unhintedRules = new BitSet();
-  private final Map<String, BitSet> hintedRulesSensitive = new HashMap<>();
-  private final Map<String, BitSet> hintedRulesInsensitive = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
   private final List<DisambiguationPatternRule> disambiguationRules;
+
+  /**
+   * A map containing indices rules with form hints,
+   * which are only called when the analyzed sentence contains any of the word forms that the rules have provided.
+   * The keys of the map are the known word forms, the values are sets of indices in {@link #disambiguationRules} list.
+   */
+  private final Map<String, BitSet> hintedRulesSensitive = new HashMap<>();
+
+  /**
+   * Same as {@link #hintedRulesSensitive}, but case-insensitively.
+   */
+  private final Map<String, BitSet> hintedRulesInsensitive = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+  /**
+   * Indices in {@link #disambiguationRules} that correspond to rules without form hints, which fall into
+   * neither {@link #hintedRulesSensitive} nor {@link #hintedRulesInsensitive}.
+   */
+  private final BitSet unhintedRules = new BitSet();
 
   public XmlRuleDisambiguator(Language language) {
     Objects.requireNonNull(language);
@@ -60,6 +75,10 @@ public class XmlRuleDisambiguator extends AbstractDisambiguator {
     }
   }
 
+  /**
+   * Classifies the given rule into {@link #unhintedRules}, {@link #hintedRulesInsensitive} or {@link #hintedRulesSensitive},
+   * based on the form hints provided by its token patterns.
+   */
   private void registerHints(DisambiguationPatternRule rule, int index) {
     for (PatternToken token : rule.getPatternTokens()) {
       Set<String> hints = token.calcFormHints();
@@ -87,6 +106,10 @@ public class XmlRuleDisambiguator extends AbstractDisambiguator {
     return sentence;
   }
 
+  /**
+   * @return rules that have a chance to be triggered by the given sentence: the ones whose form hints
+   * (see {@link PatternToken#calcFormHints()}) occur in the sentence and the ones without form hints ({@link #unhintedRules}).
+   */
   @NotNull
   private BitSet getRelevantRules(AnalyzedSentence input) {
     BitSet toCheck = unhintedRules;

--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternTokenTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternTokenTest.java
@@ -19,11 +19,11 @@
 
 package org.languagetool.rules.patterns;
 
+import com.google.common.collect.Sets;
 import org.junit.Test;
 import org.languagetool.AnalyzedToken;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.languagetool.JLanguageTool.*;
 import static org.languagetool.rules.patterns.PatternToken.UNKNOWN_TAG;
 
@@ -150,4 +150,21 @@ public class PatternTokenTest {
 
   }
 
+  @Test
+  public void testFormHints() {
+    PatternToken token = new PatternTokenBuilder().tokenRegex("an?|the|th[eo]se").build();
+    assertEquals(token.calcFormHints(), Sets.newHashSet("a", "an", "the", "these", "those"));
+
+    token = new PatternTokenBuilder().token("foo").build();
+    assertEquals(token.calcFormHints(), Sets.newHashSet("foo"));
+
+    token = new PatternTokenBuilder().tokenRegex("(foo)?.*").build();
+    assertNull(token.calcFormHints());
+
+    token = new PatternTokenBuilder().csTokenRegex("a|b").build();
+    assertEquals(token.calcFormHints(), Sets.newHashSet("a", "b"));
+
+    token = new PatternTokenBuilder().token("a").min(0).build();
+    assertNull(token.calcFormHints());
+  }
 }


### PR DESCRIPTION
don't even run rules that can't possibly match, judging by their token strings/regexps

to determine that, parse simple yet most frequent regexps that have just |?[] in them, extract all possible values from them
and use that set for faster PatternToken.isStringTokenMatched and to build index of rules by word form in XmlRuleDisambiguator