### PR TITLE
Update language identification code for n-grams and fallback logic

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/language/LanguageIdentifier.java
+++ b/languagetool-core/src/main/java/org/languagetool/language/LanguageIdentifier.java
@@ -223,7 +223,7 @@ public class LanguageIdentifier {
         shortText = shortText.replaceAll("\uFEFF+", " ");  // used by the browser add-on to filter HTML etc. (_ignoreText() in validator.js)
         Map<String, Double> scores;
         boolean usingFastText = false;
-        if (text.length() <= SHORT_ALGO_THRESHOLD || fastText == null) {
+        if ((text.length() <= SHORT_ALGO_THRESHOLD || fastText == null) && ngram != null) {
           scores = ngram.detectLanguages(shortText, additionalLangs);
         } else {
           usingFastText = true;

--- a/languagetool-core/src/main/java/org/languagetool/language/NGramLangIdentifier.java
+++ b/languagetool-core/src/main/java/org/languagetool/language/NGramLangIdentifier.java
@@ -146,7 +146,7 @@ public class NGramLangIdentifier {
       }
     }
     catch(java.io.IOException e) {
-      // TODO
+      throw new RuntimeException(e);
     }
     return result;
   }

--- a/languagetool-dev/src/main/java/org/languagetool/dev/NGramLangIdentifierPerformanceTest.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/NGramLangIdentifierPerformanceTest.java
@@ -31,13 +31,13 @@ import java.util.Map;
 
 public class NGramLangIdentifierPerformanceTest {
 
-  private static final File ngramDir = new File("/home/languagetool/ngram-lang-id");
+  private static final File ngramZip = new File("/home/languagetool/ngram-lang-id/model_ml50_new.zip");
   private static final Path input = Paths.get("/home/dnaber/data/corpus/tatoeba/20191014/sentences_shuf.txt");
   private static final int limit = 10_000;
 
   public void testPerformance() throws IOException {
     System.out.println("Loading ngrams...");
-    NGramLangIdentifier ngram = new NGramLangIdentifier(ngramDir, 100, true, false);
+    NGramLangIdentifier ngram = new NGramLangIdentifier(ngramZip, 50);
     System.out.println("Loaded.");
     int i = 0;
     double totalMillis = 0;

--- a/languagetool-dev/src/test/java/org/languagetool/dev/eval/LangIdentExamples.java
+++ b/languagetool-dev/src/test/java/org/languagetool/dev/eval/LangIdentExamples.java
@@ -33,7 +33,7 @@ class LangIdentExamples {
   private static final String MODE = "fasttext";   // 'ngram' or 'fasttext'
   private static final File MODEL_PATH = new File("/prg/fastText-0.1.0/data/lid.176.bin");
   private static final File BINARY_PATH = new File("/prg/fastText-0.1.0/fasttext");
-  private static final File NGRAM_DIR = new File("/home/languagetool/ngram-lang-id");
+  private static final File NGRAM_ZIP = new File("/home/languagetool/ngram-lang-id/model_ml50_new.zip");
 
   private static final String DE = "de";
   private static final String EN = "en";
@@ -50,7 +50,7 @@ class LangIdentExamples {
 
   private LangIdentExamples() throws IOException {
     if (MODE.equals("ngram")) {
-      ngram = new NGramLangIdentifier(NGRAM_DIR, 100, true, false);
+      ngram = new NGramLangIdentifier(NGRAM_ZIP, 50);
       ft = null;
     } else if (MODE.equals("fasttext")) {
       ngram = null;


### PR DESCRIPTION
From the commit message: Update language identifier to use pre-calculated smoothed probabilities, load model from ZIP and faster, add support for thresholds in the case of low confidence, simplify and speed up code, update language checking logic, update dev tests