### PR TITLE
[en] add "reCAPTCHA" as exception in UpperCaseSentenceStartRule

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/UppercaseSentenceStartRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/UppercaseSentenceStartRule.java
@@ -71,7 +71,8 @@ public class UppercaseSentenceStartRule extends TextLevelRule {
           "iHeartRadio",
           "iMessage",
           "iFood",
-          "x86"
+          "x86",
+          "reCAPTCHA"
   ));
 
   private final Language language;


### PR DESCRIPTION
To resolve the ReCAPTCHA <-> reCAPTCHA loop ([#3755](https://github.com/languagetool-org/languagetool/issues/3755))