### PR TITLE
[fr] fix incorrect message for AUX_ETRE_VCONJ

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -13029,7 +13029,7 @@ though, and has since been slightly modified)-->
                   </token>
               </marker>
           </pattern>
-          <message>Après l’auxiliaire « \1 », le verbe devrait être au participe passé. Quant à l’accord, celui-ci s’accorde avec le COD s’il est placé avant l’auxiliaire ; sinon il restera au masculin singulier.</message>
+          <message>Après l’auxiliaire « \1 », le verbe devrait être au participe passé. Quant à l’accord, celui-ci s’accorde en genre et en nombre avec le sujet du verbe.</message>
           <suggestion><match no="5" postag="V.*" postag_regexp="yes" postag_replace="V ppa m s"/></suggestion>
           <suggestion><match no="5" postag="V.*" postag_regexp="yes" postag_replace="V ppa f s"/></suggestion>
           <suggestion><match no="5" postag="V.*" postag_regexp="yes" postag_replace="V ppa m p"/></suggestion>
@@ -13066,7 +13066,7 @@ though, and has since been slightly modified)-->
               </token>
             </marker>
           </pattern>
-          <message>Après l’auxiliaire « \1 », le verbe devrait être au participe passé. Quant à l’accord, celui-ci s’accorde avec le COD s’il est placé avant l’auxiliaire ; sinon il restera au masculin singulier.</message>
+          <message>Après l’auxiliaire « \1 », le verbe devrait être au participe passé. Quant à l’accord, celui-ci s’accorde en genre et en nombre avec le sujet du verbe.</message>
           <suggestion><match no="5" postag="V.*" postag_regexp="yes" postag_replace="V ppa m s"/></suggestion>
           <suggestion><match no="5" postag="V.*" postag_regexp="yes" postag_replace="V ppa f s"/></suggestion>
           <suggestion><match no="5" postag="V.*" postag_regexp="yes" postag_replace="V ppa m p"/></suggestion>


### PR DESCRIPTION
Correctly spotted by user, as addressed in [#3766](https://github.com/languagetool-org/languagetool/issues/3766)