### PR TITLE
call sentence.getText only when it's needed to speed up the analysis

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -1163,7 +1163,6 @@ public class JLanguageTool {
   public List<RuleMatch> checkAnalyzedSentence(ParagraphHandling paraMode,
                                                List<Rule> rules, AnalyzedSentence analyzedSentence, boolean checkRemoteRules) throws IOException {
     List<RuleMatch> sentenceMatches = new ArrayList<>();
-    String analyzedSentenceText = analyzedSentence.getText();
     for (Rule rule : rules) {
       if (checkCancelledCallback != null && checkCancelledCallback.checkCancelled()) {
         break;
@@ -1188,7 +1187,11 @@ public class JLanguageTool {
       RuleMatch[] thisMatches = rule.match(analyzedSentence);
       Collections.addAll(sentenceMatches, thisMatches);
     }
-    AnnotatedText text = new AnnotatedTextBuilder().addText(analyzedSentenceText).build();
+    if (sentenceMatches.isEmpty()) {
+      return sentenceMatches;
+    }
+
+    AnnotatedText text = new AnnotatedTextBuilder().addText(analyzedSentence.getText()).build();
     // rules can create matches with rule IDs different from the original rule (see e.g. RemoteRules)
     // so while we can't avoid execution of these rules, we still want disabling them to work
     // so do another pass with ignoreRule here

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleMatcher.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleMatcher.java
@@ -54,7 +54,7 @@ final public class PatternRuleMatcher extends AbstractPatternRulePerformer imple
   private final boolean useList;
   private final List<PatternTokenMatcher> patternTokenMatchers;
   //private final Integer slowMatchThreshold;
-  private final boolean monitorRules;
+  private static final boolean monitorRules = System.getProperty("monitorActiveRules") != null;
 
   PatternRuleMatcher(PatternRule rule, boolean useList) {
     super(rule, rule.getLanguage().getUnifier());
@@ -62,7 +62,6 @@ final public class PatternRuleMatcher extends AbstractPatternRulePerformer imple
     this.patternTokenMatchers = createElementMatchers();
     //String slowMatchThresholdStr = System.getProperty("slowMatchThreshold");
     //slowMatchThreshold = slowMatchThresholdStr != null ? Integer.parseInt(slowMatchThresholdStr) : null;
-    this.monitorRules = System.getProperty("monitorActiveRules") != null;
   }
 
   public static Map<String, Integer> getCurrentRules() {
@@ -71,10 +70,10 @@ final public class PatternRuleMatcher extends AbstractPatternRulePerformer imple
 
   @Override
   public RuleMatch[] match(AnalyzedSentence sentence) throws IOException {
-    long startTime = System.currentTimeMillis();
+//    long startTime = System.currentTimeMillis();
     List<RuleMatch> ruleMatches = new ArrayList<>();
-    String key = rule.getFullId() + ": " + sentence.getText();
-    if (monitorRules) {
+    String key = monitorRules ? rule.getFullId() + ": " + sentence.getText() : null;
+    if (key != null) {
       currentlyActiveRules.compute(key, (k, v) -> v == null ? 1 : v + 1);
     }
     try {
@@ -176,7 +175,7 @@ final public class PatternRuleMatcher extends AbstractPatternRulePerformer imple
       }
     }*/return filteredMatches.toArray(new RuleMatch[0]);
     } finally {
-      if (monitorRules) {
+      if (key != null) {
         currentlyActiveRules.computeIfPresent(key, (k, v) -> v - 1 > 0 ? v - 1 : null);
       }
     }


### PR DESCRIPTION
For me, this results in ~10% English text checking speedup.