### PR TITLE
Remote rule rollout and regression test stabilty

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/InputSentence.java
+++ b/languagetool-core/src/main/java/org/languagetool/InputSentence.java
@@ -41,11 +41,12 @@ class InputSentence {
   private final List<Language> altLanguages;
   private final JLanguageTool.Mode mode;
   private final JLanguageTool.Level level;
+  private final Long textSessionID;
 
   InputSentence(String text, Language lang, Language motherTongue,
                 Set<String> disabledRules, Set<CategoryId> disabledRuleCategories,
                 Set<String> enabledRules, Set<CategoryId> enabledRuleCategories, UserConfig userConfig,
-                List<Language> altLanguages, JLanguageTool.Mode mode, JLanguageTool.Level level) {
+                List<Language> altLanguages, JLanguageTool.Mode mode, JLanguageTool.Level level, Long textSessionID) {
     this.text = Objects.requireNonNull(text);
     this.lang = Objects.requireNonNull(lang);
     this.motherTongue = motherTongue;
@@ -54,9 +55,19 @@ class InputSentence {
     this.enabledRules = enabledRules;
     this.enabledRuleCategories = enabledRuleCategories;
     this.userConfig = userConfig;
+    this.textSessionID = textSessionID;
     this.altLanguages = altLanguages;
     this.mode = Objects.requireNonNull(mode);
     this.level = Objects.requireNonNull(level);
+  }
+
+  InputSentence(String text, Language lang, Language motherTongue,
+                Set<String> disabledRules, Set<CategoryId> disabledRuleCategories,
+                Set<String> enabledRules, Set<CategoryId> enabledRuleCategories, UserConfig userConfig,
+                List<Language> altLanguages, JLanguageTool.Mode mode, JLanguageTool.Level level) {
+    this(text, lang, motherTongue, disabledRules, disabledRuleCategories,
+      enabledRules, enabledRuleCategories, userConfig, altLanguages,
+      mode, level, userConfig != null ? userConfig.getTextSessionId() : null);
   }
 
   /** @since 4.1 */
@@ -78,6 +89,7 @@ class InputSentence {
            Objects.equals(enabledRules, other.enabledRules) &&
            Objects.equals(enabledRuleCategories, other.enabledRuleCategories) &&
            Objects.equals(userConfig, other.userConfig) &&
+           Objects.equals(textSessionID, other.textSessionID) &&
            Objects.equals(altLanguages, other.altLanguages) &&
            Objects.equals(mode, other.mode) &&
            Objects.equals(level, other.level);
@@ -86,7 +98,7 @@ class InputSentence {
   @Override
   public int hashCode() {
     return Objects.hash(text, lang, motherTongue, disabledRules, disabledRuleCategories,
-            enabledRules, enabledRuleCategories, userConfig, altLanguages, mode, level);
+            enabledRules, enabledRuleCategories, userConfig, textSessionID, altLanguages, mode, level);
   }
 
   @Override

--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -590,25 +590,28 @@ public class JLanguageTool {
   }
 
   public void activateRemoteRules(@Nullable File configFile) throws IOException {
+    List<RemoteRuleConfig> configs;
     try {
-      List<RemoteRuleConfig> configs;
       if (configFile != null) {
         configs = RemoteRuleConfig.load(configFile);
       } else {
         configs = Collections.emptyList();
       }
-      List<Rule> rules = language.getRelevantRemoteRules(getMessageBundle(language), configs,
-        globalConfig, userConfig, motherTongue, altLanguages, inputLogging);
-      userRules.addAll(rules);
-      Function<Rule, Rule> enhanced = language.getRemoteEnhancedRules(getMessageBundle(language), configs, userConfig, motherTongue, altLanguages, inputLogging);
-      transformRules(enhanced, builtinRules);
-      transformRules(enhanced, userRules);
-
+      activateRemoteRules(configs);
     } catch (IOException e) {
       throw new IOException("Could not load remote rules.", e);
     } catch (ExecutionException e) {
       throw new IOException("Could not load remote rules configuration at " + configFile.getAbsolutePath(), e);
     }
+  }
+
+  public void activateRemoteRules(List<RemoteRuleConfig> configs) throws IOException {
+    List<Rule> rules = language.getRelevantRemoteRules(getMessageBundle(language), configs,
+      globalConfig, userConfig, motherTongue, altLanguages, inputLogging);
+    userRules.addAll(rules);
+    Function<Rule, Rule> enhanced = language.getRemoteEnhancedRules(getMessageBundle(language), configs, userConfig, motherTongue, altLanguages, inputLogging);
+    transformRules(enhanced, builtinRules);
+    transformRules(enhanced, userRules);
   }
 
   /**

--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -1067,9 +1067,9 @@ public class JLanguageTool {
               cachedResults.get(sentenceIndex).addAll(cachedMatches);
             }
           }
-          task = rule.run(nonCachedSentences);
+          task = rule.run(nonCachedSentences, userConfig.getTextSessionId());
         } else {
-          task = rule.run(analyzedSentences);
+          task = rule.run(analyzedSentences, userConfig.getTextSessionId());
         }
         remoteRuleTasks.add(task);
         remoteRulesThreadPool.submit(task);

--- a/languagetool-core/src/main/java/org/languagetool/rules/BERTSuggestionRanking.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/BERTSuggestionRanking.java
@@ -115,7 +115,7 @@ public class BERTSuggestionRanking extends RemoteRule {
   }
 
   @Override
-  protected RemoteRequest prepareRequest(List<AnalyzedSentence> sentences, AnnotatedText annotatedText) {
+  protected RemoteRequest prepareRequest(List<AnalyzedSentence> sentences, AnnotatedText annotatedText, Long textSessionId) {
     List<RuleMatch> matches = new LinkedList<>();
     List<RemoteLanguageModel.Request> requests = new LinkedList<>();
     try {

--- a/languagetool-core/src/main/java/org/languagetool/rules/GRPCRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/GRPCRule.java
@@ -196,11 +196,17 @@ public abstract class GRPCRule extends RemoteRule {
   }
 
   @Override
-  protected RemoteRule.RemoteRequest prepareRequest(List<AnalyzedSentence> sentences, AnnotatedText annotatedText, Long textSessionId) {
+  protected RemoteRule.RemoteRequest prepareRequest(List<AnalyzedSentence> sentences, AnnotatedText annotatedText, @Nullable Long textSessionId) {
     List<String> text = sentences.stream().map(AnalyzedSentence::getText).collect(Collectors.toList());
+    List<Long> ids = Collections.emptyList();
+    if (textSessionId != null) {
+      ids = Collections.nCopies(text.size(), textSessionId);
+    }
+
     MLServerProto.MatchRequest req = MLServerProto.MatchRequest.newBuilder()
       .addAllSentences(text)
       .setInputLogging(inputLogging)
+      .addAllTextSessionID(ids)
       .build();
     return new MLRuleRequest(req, sentences);
   }

--- a/languagetool-core/src/main/java/org/languagetool/rules/GRPCRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/GRPCRule.java
@@ -196,7 +196,7 @@ public abstract class GRPCRule extends RemoteRule {
   }
 
   @Override
-  protected RemoteRule.RemoteRequest prepareRequest(List<AnalyzedSentence> sentences, AnnotatedText annotatedText) {
+  protected RemoteRule.RemoteRequest prepareRequest(List<AnalyzedSentence> sentences, AnnotatedText annotatedText, Long textSessionId) {
     List<String> text = sentences.stream().map(AnalyzedSentence::getText).collect(Collectors.toList());
     MLServerProto.MatchRequest req = MLServerProto.MatchRequest.newBuilder()
       .addAllSentences(text)

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
@@ -78,12 +78,12 @@ public abstract class RemoteRule extends Rule {
   }
 
   public FutureTask<RemoteRuleResult> run(List<AnalyzedSentence> sentences) {
-    return run(sentences, 0L);
+    return run(sentences, null);
   }
 
   protected class RemoteRequest {}
 
-  protected abstract RemoteRequest prepareRequest(List<AnalyzedSentence> sentences, AnnotatedText annotatedText, Long textSessionId);
+  protected abstract RemoteRequest prepareRequest(List<AnalyzedSentence> sentences, AnnotatedText annotatedText, @Nullable Long textSessionId);
   protected abstract Callable<RemoteRuleResult> executeRequest(RemoteRequest request);
   protected abstract RemoteRuleResult fallbackResults(RemoteRequest request);
 
@@ -92,7 +92,10 @@ public abstract class RemoteRule extends Rule {
    * @param textSessionId ID for texts, should stay constant for a user session; used for A/B tests of experimental rules
    * @return Future with result
    */
-  public FutureTask<RemoteRuleResult> run(List<AnalyzedSentence> sentences, Long textSessionId) {
+  public FutureTask<RemoteRuleResult> run(List<AnalyzedSentence> sentences, @Nullable Long textSessionId) {
+    if (sentences.isEmpty()) {
+      return new FutureTask<>(() -> new RemoteRuleResult(false, true, Collections.emptyList()));
+    }
     return new FutureTask<>(() -> {
       long startTime = System.nanoTime();
       long characters = sentences.stream().mapToInt(sentence -> sentence.getText().length()).sum();

--- a/languagetool-core/src/main/java/org/languagetool/rules/ml/MLServerProto.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/ml/MLServerProto.java
@@ -68,6 +68,35 @@ public final class MLServerProto {
      * @return The inputLogging.
      */
     boolean getInputLogging();
+
+    /**
+     * <pre>
+     * session ID, for partial rollout &amp; A/B tests
+     * </pre>
+     *
+     * <code>repeated int64 textSessionID = 3;</code>
+     * @return A list containing the textSessionID.
+     */
+    java.util.List<java.lang.Long> getTextSessionIDList();
+    /**
+     * <pre>
+     * session ID, for partial rollout &amp; A/B tests
+     * </pre>
+     *
+     * <code>repeated int64 textSessionID = 3;</code>
+     * @return The count of textSessionID.
+     */
+    int getTextSessionIDCount();
+    /**
+     * <pre>
+     * session ID, for partial rollout &amp; A/B tests
+     * </pre>
+     *
+     * <code>repeated int64 textSessionID = 3;</code>
+     * @param index The index of the element to return.
+     * @return The textSessionID at the given index.
+     */
+    long getTextSessionID(int index);
   }
   /**
    * Protobuf type {@code lt_ml_server.MatchRequest}
@@ -83,6 +112,7 @@ public final class MLServerProto {
     }
     private MatchRequest() {
       sentences_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      textSessionID_ = emptyLongList();
     }
 
     @java.lang.Override
@@ -130,6 +160,27 @@ public final class MLServerProto {
               inputLogging_ = input.readBool();
               break;
             }
+            case 24: {
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+                textSessionID_ = newLongList();
+                mutable_bitField0_ |= 0x00000002;
+              }
+              textSessionID_.addLong(input.readInt64());
+              break;
+            }
+            case 26: {
+              int length = input.readRawVarint32();
+              int limit = input.pushLimit(length);
+              if (!((mutable_bitField0_ & 0x00000002) != 0) && input.getBytesUntilLimit() > 0) {
+                textSessionID_ = newLongList();
+                mutable_bitField0_ |= 0x00000002;
+              }
+              while (input.getBytesUntilLimit() > 0) {
+                textSessionID_.addLong(input.readInt64());
+              }
+              input.popLimit(limit);
+              break;
+            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -147,6 +198,9 @@ public final class MLServerProto {
       } finally {
         if (((mutable_bitField0_ & 0x00000001) != 0)) {
           sentences_ = sentences_.getUnmodifiableView();
+        }
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
+          textSessionID_.makeImmutable(); // C
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -230,6 +284,45 @@ public final class MLServerProto {
       return inputLogging_;
     }
 
+    public static final int TEXTSESSIONID_FIELD_NUMBER = 3;
+    private com.google.protobuf.Internal.LongList textSessionID_;
+    /**
+     * <pre>
+     * session ID, for partial rollout &amp; A/B tests
+     * </pre>
+     *
+     * <code>repeated int64 textSessionID = 3;</code>
+     * @return A list containing the textSessionID.
+     */
+    public java.util.List<java.lang.Long>
+        getTextSessionIDList() {
+      return textSessionID_;
+    }
+    /**
+     * <pre>
+     * session ID, for partial rollout &amp; A/B tests
+     * </pre>
+     *
+     * <code>repeated int64 textSessionID = 3;</code>
+     * @return The count of textSessionID.
+     */
+    public int getTextSessionIDCount() {
+      return textSessionID_.size();
+    }
+    /**
+     * <pre>
+     * session ID, for partial rollout &amp; A/B tests
+     * </pre>
+     *
+     * <code>repeated int64 textSessionID = 3;</code>
+     * @param index The index of the element to return.
+     * @return The textSessionID at the given index.
+     */
+    public long getTextSessionID(int index) {
+      return textSessionID_.getLong(index);
+    }
+    private int textSessionIDMemoizedSerializedSize = -1;
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -244,11 +337,19 @@ public final class MLServerProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
+      getSerializedSize();
       for (int i = 0; i < sentences_.size(); i++) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, sentences_.getRaw(i));
       }
       if (inputLogging_ != false) {
         output.writeBool(2, inputLogging_);
+      }
+      if (getTextSessionIDList().size() > 0) {
+        output.writeUInt32NoTag(26);
+        output.writeUInt32NoTag(textSessionIDMemoizedSerializedSize);
+      }
+      for (int i = 0; i < textSessionID_.size(); i++) {
+        output.writeInt64NoTag(textSessionID_.getLong(i));
       }
       unknownFields.writeTo(output);
     }
@@ -271,6 +372,20 @@ public final class MLServerProto {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(2, inputLogging_);
       }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < textSessionID_.size(); i++) {
+          dataSize += com.google.protobuf.CodedOutputStream
+            .computeInt64SizeNoTag(textSessionID_.getLong(i));
+        }
+        size += dataSize;
+        if (!getTextSessionIDList().isEmpty()) {
+          size += 1;
+          size += com.google.protobuf.CodedOutputStream
+              .computeInt32SizeNoTag(dataSize);
+        }
+        textSessionIDMemoizedSerializedSize = dataSize;
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -290,6 +405,8 @@ public final class MLServerProto {
           .equals(other.getSentencesList())) return false;
       if (getInputLogging()
           != other.getInputLogging()) return false;
+      if (!getTextSessionIDList()
+          .equals(other.getTextSessionIDList())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -308,6 +425,10 @@ public final class MLServerProto {
       hash = (37 * hash) + INPUTLOGGING_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
           getInputLogging());
+      if (getTextSessionIDCount() > 0) {
+        hash = (37 * hash) + TEXTSESSIONID_FIELD_NUMBER;
+        hash = (53 * hash) + getTextSessionIDList().hashCode();
+      }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -445,6 +566,8 @@ public final class MLServerProto {
         bitField0_ = (bitField0_ & ~0x00000001);
         inputLogging_ = false;
 
+        textSessionID_ = emptyLongList();
+        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
 
@@ -478,6 +601,11 @@ public final class MLServerProto {
         }
         result.sentences_ = sentences_;
         result.inputLogging_ = inputLogging_;
+        if (((bitField0_ & 0x00000002) != 0)) {
+          textSessionID_.makeImmutable();
+          bitField0_ = (bitField0_ & ~0x00000002);
+        }
+        result.textSessionID_ = textSessionID_;
         onBuilt();
         return result;
       }
@@ -538,6 +666,16 @@ public final class MLServerProto {
         }
         if (other.getInputLogging() != false) {
           setInputLogging(other.getInputLogging());
+        }
+        if (!other.textSessionID_.isEmpty()) {
+          if (textSessionID_.isEmpty()) {
+            textSessionID_ = other.textSessionID_;
+            bitField0_ = (bitField0_ & ~0x00000002);
+          } else {
+            ensureTextSessionIDIsMutable();
+            textSessionID_.addAll(other.textSessionID_);
+          }
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -753,6 +891,113 @@ public final class MLServerProto {
       public Builder clearInputLogging() {
         
         inputLogging_ = false;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.Internal.LongList textSessionID_ = emptyLongList();
+      private void ensureTextSessionIDIsMutable() {
+        if (!((bitField0_ & 0x00000002) != 0)) {
+          textSessionID_ = mutableCopy(textSessionID_);
+          bitField0_ |= 0x00000002;
+         }
+      }
+      /**
+       * <pre>
+       * session ID, for partial rollout &amp; A/B tests
+       * </pre>
+       *
+       * <code>repeated int64 textSessionID = 3;</code>
+       * @return A list containing the textSessionID.
+       */
+      public java.util.List<java.lang.Long>
+          getTextSessionIDList() {
+        return ((bitField0_ & 0x00000002) != 0) ?
+                 java.util.Collections.unmodifiableList(textSessionID_) : textSessionID_;
+      }
+      /**
+       * <pre>
+       * session ID, for partial rollout &amp; A/B tests
+       * </pre>
+       *
+       * <code>repeated int64 textSessionID = 3;</code>
+       * @return The count of textSessionID.
+       */
+      public int getTextSessionIDCount() {
+        return textSessionID_.size();
+      }
+      /**
+       * <pre>
+       * session ID, for partial rollout &amp; A/B tests
+       * </pre>
+       *
+       * <code>repeated int64 textSessionID = 3;</code>
+       * @param index The index of the element to return.
+       * @return The textSessionID at the given index.
+       */
+      public long getTextSessionID(int index) {
+        return textSessionID_.getLong(index);
+      }
+      /**
+       * <pre>
+       * session ID, for partial rollout &amp; A/B tests
+       * </pre>
+       *
+       * <code>repeated int64 textSessionID = 3;</code>
+       * @param index The index to set the value at.
+       * @param value The textSessionID to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTextSessionID(
+          int index, long value) {
+        ensureTextSessionIDIsMutable();
+        textSessionID_.setLong(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * session ID, for partial rollout &amp; A/B tests
+       * </pre>
+       *
+       * <code>repeated int64 textSessionID = 3;</code>
+       * @param value The textSessionID to add.
+       * @return This builder for chaining.
+       */
+      public Builder addTextSessionID(long value) {
+        ensureTextSessionIDIsMutable();
+        textSessionID_.addLong(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * session ID, for partial rollout &amp; A/B tests
+       * </pre>
+       *
+       * <code>repeated int64 textSessionID = 3;</code>
+       * @param values The textSessionID to add.
+       * @return This builder for chaining.
+       */
+      public Builder addAllTextSessionID(
+          java.lang.Iterable<? extends java.lang.Long> values) {
+        ensureTextSessionIDIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, textSessionID_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * session ID, for partial rollout &amp; A/B tests
+       * </pre>
+       *
+       * <code>repeated int64 textSessionID = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTextSessionID() {
+        textSessionID_ = emptyLongList();
+        bitField0_ = (bitField0_ & ~0x00000002);
         onChanged();
         return this;
       }
@@ -4372,19 +4617,20 @@ public final class MLServerProto {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\017ml_server.proto\022\014lt_ml_server\"7\n\014Match" +
+      "\n\017ml_server.proto\022\014lt_ml_server\"N\n\014Match" +
       "Request\022\021\n\tsentences\030\001 \003(\t\022\024\n\014inputLoggi" +
-      "ng\030\002 \001(\010\"A\n\rMatchResponse\0220\n\017sentenceMat" +
-      "ches\030\001 \003(\0132\027.lt_ml_server.MatchList\"1\n\tM" +
-      "atchList\022$\n\007matches\030\001 \003(\0132\023.lt_ml_server" +
-      ".Match\"\252\001\n\005Match\022\016\n\006offset\030\001 \001(\r\022\016\n\006leng" +
-      "th\030\002 \001(\r\022\n\n\002id\030\003 \001(\t\022\016\n\006sub_id\030\004 \001(\t\022\023\n\013" +
-      "suggestions\030\005 \003(\t\022\027\n\017ruleDescription\030\006 \001" +
-      "(\t\022\030\n\020matchDescription\030\007 \001(\t\022\035\n\025matchSho" +
-      "rtDescription\030\010 \001(\t2N\n\010MLServer\022B\n\005Match" +
-      "\022\032.lt_ml_server.MatchRequest\032\033.lt_ml_ser" +
-      "ver.MatchResponse\"\000B*\n\031org.languagetool." +
-      "rules.mlB\rMLServerProtob\006proto3"
+      "ng\030\002 \001(\010\022\025\n\rtextSessionID\030\003 \003(\003\"A\n\rMatch" +
+      "Response\0220\n\017sentenceMatches\030\001 \003(\0132\027.lt_m" +
+      "l_server.MatchList\"1\n\tMatchList\022$\n\007match" +
+      "es\030\001 \003(\0132\023.lt_ml_server.Match\"\252\001\n\005Match\022" +
+      "\016\n\006offset\030\001 \001(\r\022\016\n\006length\030\002 \001(\r\022\n\n\002id\030\003 " +
+      "\001(\t\022\016\n\006sub_id\030\004 \001(\t\022\023\n\013suggestions\030\005 \003(\t" +
+      "\022\027\n\017ruleDescription\030\006 \001(\t\022\030\n\020matchDescri" +
+      "ption\030\007 \001(\t\022\035\n\025matchShortDescription\030\010 \001" +
+      "(\t2N\n\010MLServer\022B\n\005Match\022\032.lt_ml_server.M" +
+      "atchRequest\032\033.lt_ml_server.MatchResponse" +
+      "\"\000B*\n\031org.languagetool.rules.mlB\rMLServe" +
+      "rProtob\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -4395,7 +4641,7 @@ public final class MLServerProto {
     internal_static_lt_ml_server_MatchRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_lt_ml_server_MatchRequest_descriptor,
-        new java.lang.String[] { "Sentences", "InputLogging", });
+        new java.lang.String[] { "Sentences", "InputLogging", "TextSessionID", });
     internal_static_lt_ml_server_MatchResponse_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_lt_ml_server_MatchResponse_fieldAccessorTable = new

--- a/languagetool-core/src/main/proto/ml_server.proto
+++ b/languagetool-core/src/main/proto/ml_server.proto
@@ -11,6 +11,7 @@ service MLServer {
 message MatchRequest {
     repeated string sentences = 1; // input text to be analyzed
     bool inputLogging = 2; // allow logging of input on error
+    repeated int64 textSessionID = 3; // session ID, for partial rollout & A/B tests
 }
 
 message MatchResponse {

--- a/languagetool-core/src/test/java/org/languagetool/RemoteRuleCacheTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/RemoteRuleCacheTest.java
@@ -64,7 +64,7 @@ public class RemoteRuleCacheTest {
     }
 
     @Override
-    protected RemoteRequest prepareRequest(List<AnalyzedSentence> sentences, AnnotatedText annotatedText) {
+    protected RemoteRequest prepareRequest(List<AnalyzedSentence> sentences, AnnotatedText annotatedText, Long textSessionId) {
       return new TestRemoteRequest(sentences);
     }
 

--- a/languagetool-server/src/main/java/org/languagetool/server/Pipeline.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/Pipeline.java
@@ -21,10 +21,7 @@ package org.languagetool.server;
 
 import org.jetbrains.annotations.NotNull;
 import org.languagetool.*;
-import org.languagetool.rules.Category;
-import org.languagetool.rules.CategoryId;
-import org.languagetool.rules.Rule;
-import org.languagetool.rules.RuleMatchFilter;
+import org.languagetool.rules.*;
 import org.languagetool.rules.patterns.AbstractPatternRule;
 import org.xml.sax.SAXException;
 
@@ -134,6 +131,12 @@ class Pipeline extends JLanguageTool {
   public void activateRemoteRules(File configFile) throws IOException {
     preventModificationAfterSetup();
     super.activateRemoteRules(configFile);
+  }
+
+  @Override
+  public void activateRemoteRules(List<RemoteRuleConfig> configs) throws IOException {
+    preventModificationAfterSetup();
+    super.activateRemoteRules(configs);
   }
 
   @Override

--- a/languagetool-server/src/main/java/org/languagetool/server/PipelinePool.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/PipelinePool.java
@@ -30,17 +30,20 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.languagetool.*;
 import org.languagetool.gui.Configuration;
 import org.languagetool.rules.DictionaryMatchFilter;
+import org.languagetool.rules.RemoteRuleConfig;
 import org.languagetool.tools.Tools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * Caches pre-configured JLanguageTool instances to avoid costly setup time of rules, etc.
@@ -206,7 +209,25 @@ class PipelinePool {
     } else {
       configureFromGUI(lt, lang);
     }
-    lt.activateRemoteRules(config.getRemoteRulesConfigFile());
+    if (params.regressionTestMode) {
+      List<RemoteRuleConfig> rules = Collections.emptyList();
+      try {
+        if (config.getRemoteRulesConfigFile() != null) {
+          rules = RemoteRuleConfig.load(config.getRemoteRulesConfigFile());
+        }
+      } catch (Exception e) {
+        logger.error("Could not load remote rule configuration", e);
+      }
+      // modify remote rule configuration: no timeouts, downtime, ...
+      rules = rules.stream().map(c -> {
+        return new RemoteRuleConfig(c.getRuleId(), c.getUrl(), c.getPort(),
+          0, 0L, 0f,
+          0, 0L, c.getOptions());
+      }).collect(Collectors.toList());
+      lt.activateRemoteRules(rules);
+    } else {
+      lt.activateRemoteRules(config.getRemoteRulesConfigFile());
+    }
     if (params.useQuerySettings) {
       Tools.selectRules(lt, new HashSet<>(params.disabledCategories), new HashSet<>(params.enabledCategories),
         new HashSet<>(params.disabledRules), new HashSet<>(params.enabledRules), params.useEnabledOnly, params.enableTempOffRules);

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -228,12 +228,16 @@ abstract class TextChecker {
     try {
       if (parameters.containsKey("textSessionId")) {
         String textSessionIdStr = parameters.get("textSessionId");
-        if (textSessionIdStr.contains(":")) { // transitioning to new format used in chrome addon
+        if (textSessionIdStr.startsWith("user:")) {
+          int sepPos = textSessionIdStr.indexOf(':');
+          String sessionId = textSessionIdStr.substring(sepPos + 1);
+          textSessionId = Long.valueOf(sessionId);
+        } else if (textSessionIdStr.contains(":")) { // transitioning to new format used in chrome addon
           // format: "{random number in 0..99999}:{unix time}"
           long random, timestamp;
           int sepPos = textSessionIdStr.indexOf(':');
-          random = Long.valueOf(textSessionIdStr.substring(0, sepPos));
-          timestamp = Long.valueOf(textSessionIdStr.substring(sepPos + 1));
+          random = Long.parseLong(textSessionIdStr.substring(0, sepPos));
+          timestamp = Long.parseLong(textSessionIdStr.substring(sepPos + 1));
           // use random number to choose a slice in possible range of values
           // then choose position in slice by timestamp
           long maxRandom = 100000;

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -638,7 +638,8 @@ abstract class TextChecker {
     try {
       settings = new PipelinePool.PipelineSettings(lang, motherTongue, params, config.globalConfig, userConfig);
       lt = pipelinePool.getPipeline(settings);
-      matches.addAll(lt.check(aText, true, JLanguageTool.ParagraphHandling.NORMAL, listener, params.mode, params.level, executorService));
+      matches.addAll(lt.check(aText, true, JLanguageTool.ParagraphHandling.NORMAL, listener,
+        params.mode, params.level, executorService, userConfig.getTextSessionId()));
     } finally {
       if (lt != null) {
         pipelinePool.returnPipeline(settings, lt);

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -638,8 +638,12 @@ abstract class TextChecker {
     try {
       settings = new PipelinePool.PipelineSettings(lang, motherTongue, params, config.globalConfig, userConfig);
       lt = pipelinePool.getPipeline(settings);
+      Long textSessionId = userConfig.getTextSessionId();
+      if (params.regressionTestMode) {
+        textSessionId = -2L; // magic value for remote rule roll-out - includes all results, even from disabled models
+      }
       matches.addAll(lt.check(aText, true, JLanguageTool.ParagraphHandling.NORMAL, listener,
-        params.mode, params.level, executorService, userConfig.getTextSessionId()));
+        params.mode, params.level, executorService, textSessionId));
     } finally {
       if (lt != null) {
         pipelinePool.returnPipeline(settings, lt);

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -746,6 +746,8 @@ abstract class TextChecker {
     /** allowed to log input with stack traces to reproduce errors? */
     final boolean inputLogging;
 
+    final boolean regressionTestMode; // no fallbacks for remote rules, retries, enable all rules
+
     QueryParams(List<Language> altLanguages, List<String> enabledRules, List<String> disabledRules, List<CategoryId> enabledCategories, List<CategoryId> disabledCategories,
                 boolean useEnabledOnly, boolean useQuerySettings, boolean allowIncompleteResults, boolean enableHiddenRules, boolean enableTempOffRules, JLanguageTool.Mode mode, JLanguageTool.Level level, @Nullable String callback) {
       this(altLanguages, enabledRules, disabledRules, enabledCategories, disabledCategories, useEnabledOnly, useQuerySettings, allowIncompleteResults, enableHiddenRules, enableTempOffRules, mode, level, callback, true);
@@ -763,6 +765,7 @@ abstract class TextChecker {
       this.allowIncompleteResults = allowIncompleteResults;
       this.enableHiddenRules = enableHiddenRules;
       this.enableTempOffRules = enableTempOffRules;
+      this.regressionTestMode = enableTempOffRules;
       this.mode = Objects.requireNonNull(mode);
       this.level = Objects.requireNonNull(level);
       if (callback != null && !callback.matches("[a-zA-Z]+")) {
@@ -785,6 +788,7 @@ abstract class TextChecker {
         .append(allowIncompleteResults)
         .append(enableHiddenRules)
         .append(enableTempOffRules)
+        .append(regressionTestMode)
         .append(mode)
         .append(level)
         .append(callback)
@@ -810,6 +814,7 @@ abstract class TextChecker {
         .append(allowIncompleteResults, other.allowIncompleteResults)
         .append(enableHiddenRules, other.enableHiddenRules)
         .append(enableTempOffRules, other.enableTempOffRules)
+        .append(regressionTestMode, other.regressionTestMode)
         .append(mode, other.mode)
         .append(level, other.level)
         .append(callback, other.callback)
@@ -830,6 +835,7 @@ abstract class TextChecker {
         .append("allowIncompleteResults", allowIncompleteResults)
         .append("enableHiddenRules", enableHiddenRules)
         .append("enableTempOffRules", enableTempOffRules)
+        .append("regressionTestMode", regressionTestMode)
         .append("mode", mode)
         .append("level", level)
         .append("callback", callback)


### PR DESCRIPTION
Allow server-side decision about partial rule rollout for remote rule
Enable reconfiguration of remote rules to avoid strict timeouts, e.g. for regression tests