### PR TITLE
[de] fix EMPFOHLENE_GETRENNTSCHREIBUNG[6]

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -46485,7 +46485,7 @@ Andere Projekte</example>
             </rule>
             <rule>
                 <pattern>
-                    <token regexp="yes">tief((dring|blick|häng|sitz|steh|reich|geh|greif)end|beleidigt|betroffen|verschneit|bewegt|empfunden|gekränkt|erschüttert|gekühlt|betrübt).*</token>
+                    <token regexp="yes">tief((dring|blick|häng|sitz|steh|reich)end|beleidigt|betroffen|verschneit|bewegt|empfunden|gekränkt|erschüttert|betrübt).*</token>
                 </pattern>
                 <message>Empfehlung: Möchten Sie die Schreibweise <suggestion><match no="1" regexp_match="(.)ief(.*)" regexp_replace="$1ief $2"/></suggestion> verwenden?</message>
                 <example correction="Tief hängende"><marker>Tiefhängende</marker> Früchte sollte man zuerst ernten.</example>


### PR DESCRIPTION
Sebastian discovered this loop:

tiefgehend <-> tief gehend

I fixed it in grammar.xml so it doesn't clash with lt_recommendation_premium. I also fixed a few recommendations I didn't deem correct (not a good correction: tiefgekühlt --> tief gekühlt) and generally followed "official" recommendations. We might want to think about an even more coherent approach in the future (_tiefsitzend, tiefgehend, tiefgreifend_ have different official recommendations, but we are free to disagree...)