### PR TITLE
Add Word Lösegeldversicherung

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -27499,3 +27499,5 @@ Potenzialwertes
 Tutoraufgabe/N
 Permeabilitätskoeffizient
 Permeabilitätskoeffizienten
+Lösegeldversicherung #https://de.wikipedia.org/wiki/Entf%C3%BChrungsversicherung
+Lösegeldversicherungen


### PR DESCRIPTION
https://de.wikipedia.org/wiki/Entf%C3%BChrungsversicherung
Diese Versicherung existiert und sollte deswegen aufgenommen werden.