### PR TITLE
MorfologikSpellerRule: calculate suggestions only when they're needed

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -1286,8 +1286,7 @@ public class JLanguageTool {
     int endPos = match.getPatternToPos() + charCount;
     thisMatch.setPatternPosition(startPos, endPos);
 
-    List<SuggestedReplacement> replacements = match.getSuggestedReplacementObjects();
-    thisMatch.setSuggestedReplacementObjects(extendSuggestions(replacements));
+    thisMatch.setLazySuggestedReplacements(() -> extendSuggestions(match.getSuggestedReplacementObjects()));
 
     String sentencePartToError = sentence.substring(0, match.getFromPos());
     String sentencePartToEndOfError = sentence.substring(0, match.getToPos());

--- a/languagetool-core/src/main/java/org/languagetool/rules/RuleMatch.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RuleMatch.java
@@ -18,6 +18,9 @@
  */
 package org.languagetool.rules;
 
+import com.google.common.base.Suppliers;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.languagetool.AnalyzedSentence;
@@ -28,8 +31,10 @@ import org.languagetool.tools.StringTools;
 
 import java.net.URL;
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Information about an error rule that matches text and the position of the match.
@@ -49,7 +54,7 @@ public class RuleMatch implements Comparable<RuleMatch> {
   private OffsetPosition offsetPosition;
   private LinePosition linePosition = new LinePosition(-1, -1);
   private ColumnPosition columnPosition = new ColumnPosition(-1, -1);
-  private List<SuggestedReplacement> suggestedReplacements = new ArrayList<>();
+  private Supplier<List<SuggestedReplacement>> suggestedReplacements;
   private URL url;
   private Type type = Type.Other;
   private SortedMap<String, Float> features = Collections.emptySortedMap();
@@ -138,13 +143,14 @@ public class RuleMatch implements Comparable<RuleMatch> {
     if (toPos <= fromPos) {
       throw new IllegalArgumentException("fromPos (" + fromPos + ") must be less than toPos (" + toPos + ")");
     }
-    this.patternPosition = new PatternPosition(patternFromPos, patternToPos);
-    this.offsetPosition = new OffsetPosition(fromPos, toPos);
+    patternPosition = new PatternPosition(patternFromPos, patternToPos);
+    offsetPosition = new OffsetPosition(fromPos, toPos);
     this.message = Objects.requireNonNull(message);
     this.shortMessage = shortMessage;
     // extract suggestion from <suggestion>...</suggestion> in message:
     Matcher matcher = SUGGESTION_PATTERN.matcher(message + suggestionsOutMsg);
     int pos = 0;
+    LinkedHashSet<SuggestedReplacement> replacements = new LinkedHashSet<>();
     while (matcher.find(pos)) {
       pos = matcher.end();
       String replacement = matcher.group(1);
@@ -154,7 +160,7 @@ public class RuleMatch implements Comparable<RuleMatch> {
       if (startWithUppercase) {
         replacement = StringTools.uppercaseFirstChar(replacement);
       }
-      SuggestedReplacement repl = new SuggestedReplacement(replacement);
+      replacements.add(new SuggestedReplacement(replacement));
       /*if (getRule() instanceof AbstractPatternRule) {
         String covered = sentence.getText().substring(fromPos, toPos);
         if (covered.equals(repl.getReplacement()) && ((AbstractPatternRule) getRule()).getFilter() == null) {
@@ -163,40 +169,40 @@ public class RuleMatch implements Comparable<RuleMatch> {
           System.out.println("WARN: suggestion == covered text for rule " + getRule().getFullId());
         }
       }*/
-      if (!suggestedReplacements.contains(repl)) {
-        suggestedReplacements.add(repl);
-      }
     }
     this.sentence = sentence;
+
+    suggestedReplacements = Suppliers.ofInstance(new ArrayList<>(replacements));
   }
 
+  @SuppressWarnings("CopyConstructorMissesField")
   public RuleMatch(RuleMatch clone) {
     this(clone.getRule(), clone.getSentence(), clone.getFromPos(), clone.getToPos(), clone.getMessage(), clone.getShortMessage());
-    this.setPatternPosition(clone.getPatternFromPos(), clone.getPatternToPos());
-    this.setSuggestedReplacementObjects(clone.getSuggestedReplacementObjects());
-    this.setAutoCorrect(clone.isAutoCorrect());
-    this.setFeatures(clone.getFeatures());
-    this.setUrl(clone.getUrl());
-    this.setType(clone.getType());
-    this.setLine(clone.getLine());
-    this.setEndLine(clone.getEndLine());
-    this.setColumn(clone.getColumn());
-    this.setEndColumn(clone.getEndColumn());
+    setPatternPosition(clone.getPatternFromPos(), clone.getPatternToPos());
+    suggestedReplacements = clone.suggestedReplacements;
+    setAutoCorrect(clone.isAutoCorrect());
+    setFeatures(clone.getFeatures());
+    setUrl(clone.getUrl());
+    setType(clone.getType());
+    setLine(clone.getLine());
+    setEndLine(clone.getEndLine());
+    setColumn(clone.getColumn());
+    setEndColumn(clone.getEndColumn());
   }
   
   //clone with new replacements
   public RuleMatch(RuleMatch clone, List<String> replacements) {
     this(clone.getRule(), clone.getSentence(), clone.getFromPos(), clone.getToPos(), clone.getMessage(), clone.getShortMessage());
-    this.setPatternPosition(clone.getPatternFromPos(), clone.getPatternToPos());
-    this.setSuggestedReplacements(replacements);
-    this.setAutoCorrect(clone.isAutoCorrect());
-    this.setFeatures(clone.getFeatures());
-    this.setUrl(clone.getUrl());
-    this.setType(clone.getType());
-    this.setLine(clone.getLine());
-    this.setEndLine(clone.getEndLine());
-    this.setColumn(clone.getColumn());
-    this.setEndColumn(clone.getEndColumn());
+    setPatternPosition(clone.getPatternFromPos(), clone.getPatternToPos());
+    setSuggestedReplacements(replacements);
+    setAutoCorrect(clone.isAutoCorrect());
+    setFeatures(clone.getFeatures());
+    setUrl(clone.getUrl());
+    setType(clone.getType());
+    setLine(clone.getLine());
+    setEndLine(clone.getEndLine());
+    setColumn(clone.getColumn());
+    setEndColumn(clone.getEndColumn());
   }
 
   @NotNull
@@ -263,7 +269,7 @@ public class RuleMatch implements Comparable<RuleMatch> {
    * @deprecated (deprecated since 3.5)
    */
   public void setColumn(int column) {
-    this.columnPosition = new ColumnPosition(column, columnPosition.getEnd());
+    columnPosition = new ColumnPosition(column, columnPosition.getEnd());
   }
 
   /**
@@ -279,7 +285,7 @@ public class RuleMatch implements Comparable<RuleMatch> {
    * @deprecated (deprecated since 3.5)
    */
   public void setEndColumn(int endColumn) {
-    this.columnPosition = new ColumnPosition(columnPosition.getStart(), endColumn);
+    columnPosition = new ColumnPosition(columnPosition.getStart(), endColumn);
   }
 
   /**
@@ -355,19 +361,14 @@ public class RuleMatch implements Comparable<RuleMatch> {
   
   public void addSuggestedReplacement(String replacement) {
     Objects.requireNonNull(replacement, "replacement may be empty but not null");
-    List<String> l = new ArrayList<>();
-    for (SuggestedReplacement repl : suggestedReplacements) {
-      l.add(repl.getReplacement());
-    }
-    l.add(replacement);
-    setSuggestedReplacements(l);
+    addSuggestedReplacements(Collections.singletonList(replacement));
   }
 
   public void addSuggestedReplacements(List<String> replacements) {
     Objects.requireNonNull(replacements, "replacements may be empty but not null");
-    for (String replacement : replacements) {
-      this.suggestedReplacements.add(new SuggestedReplacement(replacement));
-    }
+    Supplier<List<SuggestedReplacement>> prev = suggestedReplacements;
+    setLazySuggestedReplacements(() ->
+      Lists.newArrayList(Iterables.concat(prev.get(), Iterables.transform(replacements, SuggestedReplacement::new))));
   }
   /**
    * The text fragments which might be an appropriate fix for the problem. One
@@ -376,11 +377,9 @@ public class RuleMatch implements Comparable<RuleMatch> {
    * @return unmodifiable list of String objects or an empty List
    */
   public List<String> getSuggestedReplacements() {
-    List<String> l = new ArrayList<>();
-    for (SuggestedReplacement repl : suggestedReplacements) {
-      l.add(repl.getReplacement());
-    }
-    return Collections.unmodifiableList(l);
+    return Collections.unmodifiableList(
+      suggestedReplacements.get().stream().map(SuggestedReplacement::getReplacement).collect(Collectors.toList())
+    );
   }
 
   /**
@@ -388,21 +387,33 @@ public class RuleMatch implements Comparable<RuleMatch> {
    */
   public void setSuggestedReplacements(List<String> replacements) {
     Objects.requireNonNull(replacements, "replacements may be empty but not null");
-    this.suggestedReplacements.clear();
-    for (String replacement : replacements) {
-      this.suggestedReplacements.add(new SuggestedReplacement(replacement));
-    }
+    suggestedReplacements = Suppliers.ofInstance(
+      replacements.stream().map(SuggestedReplacement::new).collect(Collectors.toList())
+    );
   }
 
   public List<SuggestedReplacement> getSuggestedReplacementObjects() {
-    return Collections.unmodifiableList(suggestedReplacements);
+    return Collections.unmodifiableList(suggestedReplacements.get());
   }
 
   /**
    * @see #getSuggestedReplacements()
    */
   public void setSuggestedReplacementObjects(List<SuggestedReplacement> replacements) {
-    this.suggestedReplacements = Objects.requireNonNull(replacements, "replacements may be empty but not null");
+    Objects.requireNonNull(replacements, "replacements may be empty but not null");
+    suggestedReplacements = Suppliers.ofInstance(replacements);
+  }
+
+  /**
+   * Set a lazy supplier that will compute suggested replacements
+   * when {@link #getSuggestedReplacements()} or {@link #getSuggestedReplacementObjects()} is called.
+   * This can be used to speed up sentence analysis
+   * in cases when computationally expensive replacements won't necessarily be needed
+   * (e.g. for an IDE in the same process).
+   */
+  public void setLazySuggestedReplacements(@NotNull Supplier<List<SuggestedReplacement>> replacements) {
+    Objects.requireNonNull(replacements, "replacements may not be null");
+    suggestedReplacements = Suppliers.memoize(replacements::get);
   }
 
   /**
@@ -431,7 +442,7 @@ public class RuleMatch implements Comparable<RuleMatch> {
    * @since 4.3
    */
   public Type getType() {
-    return this.type;
+    return type;
   }
   
   /**
@@ -456,7 +467,7 @@ public class RuleMatch implements Comparable<RuleMatch> {
 
   /** Compare by start position. */
   @Override
-  public int compareTo(RuleMatch other) {
+  public int compareTo(@NotNull RuleMatch other) {
     Objects.requireNonNull(other);
     return Integer.compare(getFromPos(), other.getFromPos());
   }
@@ -470,14 +481,13 @@ public class RuleMatch implements Comparable<RuleMatch> {
         && Objects.equals(patternPosition, other.patternPosition)
         && Objects.equals(offsetPosition, other.offsetPosition)
         && Objects.equals(message, other.message)
-        && Objects.equals(suggestedReplacements, other.suggestedReplacements)
         && Objects.equals(sentence, other.sentence)
         && Objects.equals(type, other.type);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(rule.getId(), offsetPosition, patternPosition, message, suggestedReplacements, sentence, type);
+    return Objects.hash(rule.getId(), offsetPosition, patternPosition, message, sentence, type);
   }
 
   /**

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/AbstractEnglishSpellerRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/AbstractEnglishSpellerRule.java
@@ -18,10 +18,14 @@
  */
 package org.languagetool.rules.en;
 
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import org.jetbrains.annotations.Nullable;
 import org.languagetool.*;
 import org.languagetool.languagemodel.LanguageModel;
-import org.languagetool.rules.*;
+import org.languagetool.rules.Example;
+import org.languagetool.rules.RuleMatch;
+import org.languagetool.rules.SuggestedReplacement;
 import org.languagetool.rules.en.translation.BeoLingusTranslator;
 import org.languagetool.rules.spelling.morfologik.MorfologikSpellerRule;
 import org.languagetool.rules.translation.Translator;
@@ -125,53 +129,57 @@ public abstract class AbstractEnglishSpellerRule extends MorfologikSpellerRule {
       }
     }
     // filter "re ..." (#2562):
-    for (RuleMatch ruleMatch : ruleMatches) {
-      List<SuggestedReplacement> cleaned = ruleMatch.getSuggestedReplacementObjects().stream()
-        .filter(k -> !k.getReplacement().startsWith("re ") &&
-                     !k.getReplacement().startsWith("en ") &&
-                     !k.getReplacement().startsWith("co ") &&
-                     !k.getReplacement().startsWith("de ") &&
-                     !k.getReplacement().startsWith("mid ") &&
-                     !k.getReplacement().toLowerCase().startsWith("non ") &&
-                     !k.getReplacement().toLowerCase().startsWith("bio ") &&
-                     !k.getReplacement().startsWith("con ") &&
-                     !k.getReplacement().startsWith("ins ") && // instable (ins table)
-                     !k.getReplacement().toLowerCase().startsWith("pre ") &&
-                     !k.getReplacement().toLowerCase().startsWith("inter ") &&
-                     !k.getReplacement().toLowerCase().startsWith("anti ") &&
-                     !k.getReplacement().toLowerCase().startsWith("photo ") &&
-                     !k.getReplacement().startsWith("sub ") &&
-                     !k.getReplacement().toLowerCase().startsWith("auto ") &&
-                     !k.getReplacement().startsWith("sh ") &&
-                     !k.getReplacement().startsWith("li ") &&
-                     !k.getReplacement().startsWith("ha ") &&
-                     !k.getReplacement().toLowerCase().startsWith("dis ") &&
-                     !k.getReplacement().toLowerCase().startsWith("mono ") &&
-                     !k.getReplacement().toLowerCase().startsWith("trans ") &&
-                     !k.getReplacement().toLowerCase().startsWith("ultra ") &&
-                     !k.getReplacement().toLowerCase().startsWith("mini ") &&
-                     !k.getReplacement().toLowerCase().startsWith("hyper ") &&
-                     !k.getReplacement().toLowerCase().startsWith("fore ") &&
-                     !k.getReplacement().toLowerCase().startsWith("pseudo ") &&
-                     !k.getReplacement().toLowerCase().startsWith("lo ") &&
-                     !k.getReplacement().startsWith("mu ") &&
-                     !k.getReplacement().startsWith("e ") &&
-                     !k.getReplacement().startsWith("c ") &&
-                     !k.getReplacement().endsWith(" able") &&
-                     !k.getReplacement().endsWith(" less") && // (e.g. permissionless)
-                     !k.getReplacement().endsWith(" sly") && // uneccesary suggestion (e.g. for continuesly)
-                     !k.getReplacement().endsWith(" OO") && // unecessary suggestion (e.g. for "HELLOOO")
-                     !k.getReplacement().endsWith(" HHH") && // unecessary suggestion (e.g. for "OHHHH")
-                     !k.getReplacement().endsWith(" ally") && // adverbs ending in "ally" that LT doesn't know (yet)
-                     !k.getReplacement().endsWith(" ize") && // "advertize"
-                     !k.getReplacement().endsWith(" sh") &&
-                     !k.getReplacement().endsWith(" ward") &&
-                     !k.getReplacement().endsWith(" en") && // "Antwerpen" suggests "Antwerp en"
-                     !k.getReplacement().endsWith(" ed"))
-        .collect(Collectors.toList());
-      ruleMatch.setSuggestedReplacementObjects(cleaned);
-    }
-    return ruleMatches;
+    return ruleMatches.stream().map(m -> {
+      RuleMatch copy = new RuleMatch(m);
+      copy.setLazySuggestedReplacements(() -> cleanSuggestions(m));
+      return copy;
+    }).collect(Collectors.toList());
+  }
+
+  private static List<SuggestedReplacement> cleanSuggestions(RuleMatch ruleMatch) {
+    return ruleMatch.getSuggestedReplacementObjects().stream()
+      .filter(k -> !k.getReplacement().startsWith("re ") &&
+                   !k.getReplacement().startsWith("en ") &&
+                   !k.getReplacement().startsWith("co ") &&
+                   !k.getReplacement().startsWith("de ") &&
+                   !k.getReplacement().startsWith("mid ") &&
+                   !k.getReplacement().toLowerCase().startsWith("non ") &&
+                   !k.getReplacement().toLowerCase().startsWith("bio ") &&
+                   !k.getReplacement().startsWith("con ") &&
+                   !k.getReplacement().startsWith("ins ") && // instable (ins table)
+                   !k.getReplacement().toLowerCase().startsWith("pre ") &&
+                   !k.getReplacement().toLowerCase().startsWith("inter ") &&
+                   !k.getReplacement().toLowerCase().startsWith("anti ") &&
+                   !k.getReplacement().toLowerCase().startsWith("photo ") &&
+                   !k.getReplacement().startsWith("sub ") &&
+                   !k.getReplacement().toLowerCase().startsWith("auto ") &&
+                   !k.getReplacement().startsWith("sh ") &&
+                   !k.getReplacement().startsWith("li ") &&
+                   !k.getReplacement().startsWith("ha ") &&
+                   !k.getReplacement().toLowerCase().startsWith("dis ") &&
+                   !k.getReplacement().toLowerCase().startsWith("mono ") &&
+                   !k.getReplacement().toLowerCase().startsWith("trans ") &&
+                   !k.getReplacement().toLowerCase().startsWith("ultra ") &&
+                   !k.getReplacement().toLowerCase().startsWith("mini ") &&
+                   !k.getReplacement().toLowerCase().startsWith("hyper ") &&
+                   !k.getReplacement().toLowerCase().startsWith("fore ") &&
+                   !k.getReplacement().toLowerCase().startsWith("pseudo ") &&
+                   !k.getReplacement().toLowerCase().startsWith("lo ") &&
+                   !k.getReplacement().startsWith("mu ") &&
+                   !k.getReplacement().startsWith("e ") &&
+                   !k.getReplacement().startsWith("c ") &&
+                   !k.getReplacement().endsWith(" able") &&
+                   !k.getReplacement().endsWith(" less") && // (e.g. permissionless)
+                   !k.getReplacement().endsWith(" sly") && // uneccesary suggestion (e.g. for continuesly)
+                   !k.getReplacement().endsWith(" OO") && // unecessary suggestion (e.g. for "HELLOOO")
+                   !k.getReplacement().endsWith(" HHH") && // unecessary suggestion (e.g. for "OHHHH")
+                   !k.getReplacement().endsWith(" ally") && // adverbs ending in "ally" that LT doesn't know (yet)
+                   !k.getReplacement().endsWith(" ize") && // "advertize"
+                   !k.getReplacement().endsWith(" sh") &&
+                   !k.getReplacement().endsWith(" ward") &&
+                   !k.getReplacement().endsWith(" en") && // "Antwerpen" suggests "Antwerp en"
+                   !k.getReplacement().endsWith(" ed"))
+      .collect(Collectors.toList());
   }
 
   /**
@@ -187,13 +195,10 @@ public abstract class AbstractEnglishSpellerRule extends MorfologikSpellerRule {
     // this has precedence
     RuleMatch oldMatch = ruleMatches.get(0);
     RuleMatch newMatch = new RuleMatch(this, sentence, oldMatch.getFromPos(), oldMatch.getToPos(), message);
-    List<String> allSuggestions = new ArrayList<>(forms);
-    for (String repl : oldMatch.getSuggestedReplacements()) {
-      if (!allSuggestions.contains(repl)) {
-        allSuggestions.add(repl);
-      }
-    }
-    newMatch.setSuggestedReplacements(allSuggestions);
+    newMatch.setLazySuggestedReplacements(() -> new ArrayList<>(Sets.newLinkedHashSet(Iterables.concat(
+      Iterables.transform(forms, SuggestedReplacement::new),
+      oldMatch.getSuggestedReplacementObjects()
+    ))));
     ruleMatches.set(0, newMatch);
   }
 


### PR DESCRIPTION
add new RuleMatch.setLazySuggestedReplacements API for that

For single-threaded analysis of AmericanEnglish without requesting suggestions, this gives ~40-45% analysis speedup.