### PR TITLE
JLanguageTool: cache active rules

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -1155,6 +1155,10 @@ public class JLanguageTool {
     }
   }
 
+  /**
+   * @deprecated use {@link #performCheck(List, List, List, ParagraphHandling, AnnotatedText, RuleMatchListener, Mode, Level, boolean)}
+   */
+  @Deprecated
   protected List<RuleMatch> performCheck(List<AnalyzedSentence> analyzedSentences, List<String> sentences,
                                          List<Rule> allRules, ParagraphHandling paraMode, AnnotatedText annotatedText, Mode mode, Level level) throws IOException {
     List<Rule> nonIgnored = allRules.stream().filter(r -> !ignoreRule(r)).collect(Collectors.toList());
@@ -1207,11 +1211,12 @@ public class JLanguageTool {
   }
 
   /**
-   * This is an internal method that's public only for technical reasons, please use one
-   * of the {@link #check(String)} methods instead.
+   * This is an internal method that's public only for technical reasons.
    *
    * @since 2.3
+   * @deprecated use one of the {@link #check} methods instead.
    */
+  @Deprecated
   public List<RuleMatch> checkAnalyzedSentence(ParagraphHandling paraMode,
                                                List<Rule> rules, AnalyzedSentence analyzedSentence) throws IOException {
     List<Rule> nonIgnored = rules.stream().filter(r -> !ignoreRule(r)).collect(Collectors.toList());

--- a/languagetool-core/src/main/java/org/languagetool/tools/Tools.java
+++ b/languagetool-core/src/main/java/org/languagetool/tools/Tools.java
@@ -64,7 +64,7 @@ public final class Tools {
                                             List<BitextRule> bRules) throws IOException {
     AnalyzedSentence srcText = srcLt.getAnalyzedSentence(src);
     AnalyzedSentence trgText = trgLt.getAnalyzedSentence(trg);
-    List<Rule> nonBitextRules = trgLt.getAllRules();
+    List<Rule> nonBitextRules = trgLt.getAllActiveRules();
     List<RuleMatch> ruleMatches = trgLt.checkAnalyzedSentence(JLanguageTool.ParagraphHandling.NORMAL, nonBitextRules, trgText, true);
     for (BitextRule bRule : bRules) {
       RuleMatch[] curMatch = bRule.match(srcText, trgText);


### PR DESCRIPTION
to avoid calling `ignoreRule` for each rule in each `check` invocation, often for each sentence
and to avoid filtering out picky rules by tag on each `check` call