### PR TITLE
[de] make message for German "article before date" clearer

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -39748,7 +39748,7 @@ Andere Projekte</example>
                     <token>.</token>
                     <token regexp='yes'>\d\d?|&monate;</token>
                 </pattern>
-                <message>Meinten Sie <suggestion>dem</suggestion>?</message>
+                <message>Standardsprachlich wird in diesem Fall empfohlen, <suggestion>dem</suggestion> zu schreiben.</message>
                 <example correction="dem">Wir sehen uns am Samstag, <marker>den</marker> 23.08.2014.</example>
                 <example correction="dem">Wir sehen uns am Samstag, <marker>den</marker> 23.08.2014.</example>
                 <example correction="dem">Wir sehen uns am Sa., <marker>den</marker> 23. Februar.</example>


### PR DESCRIPTION
This came up because of the German demo text on languagetool.org.