### PR TITLE
[de] make message for GLEICHBEHANDLUNG more cautious and user-friendly

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -19014,7 +19014,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 </marker>
                 <token>)</token>
             </pattern>
-            <message>Sollte hier <suggestion>m/w/d</suggestion> stehen, um niemanden auszugrenzen?</message>
+            <message>Wenn es sich hier um eine Stellenausschreibung handelt, wird die inklusive Schreibweise <suggestion>m/w/d</suggestion> empfohlen.</message>
 	        <url>https://de.wikipedia.org/wiki/Divers#Genderneutrale_Stellenausschreibung</url>
             <example correction="m/w/d">Wir suchen Maler (<marker>m/w</marker>).</example>
         </rule>


### PR DESCRIPTION
[Im Diff](https://internal1.languagetool.org/regression-tests/via-http/2020-11-26/de-DE/result_grammar_GLEICHBEHANDLUNG[1].html) wird klar, dass "(m/w)" sinnvoll sein kann, wenn es sich nicht um eine Stellenausschreibung handelt.

Die Message habe ich auch etwas weniger präskriptiv gemacht, damit niemand sie als moralistisch empfindet.