### PR TITLE
CommandLineTools: calculate expensive lazy suggestions in parallel

### DIFF
--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineTools.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineTools.java
@@ -107,11 +107,14 @@ public final class CommandLineTools {
     long startTime = System.currentTimeMillis();
     List<RuleMatch> ruleMatches = lt.check(new AnnotatedTextBuilder().addText(contents).build(), true, JLanguageTool.ParagraphHandling.NORMAL,
       null, JLanguageTool.Mode.ALL, level);
-    // adjust line numbers
-    for (RuleMatch r : ruleMatches) {
+    ruleMatches.parallelStream().forEach(r -> {
+      // adjust line numbers
       r.setLine(r.getLine() + lineOffset);
       r.setEndLine(r.getEndLine() + lineOffset);
-    }
+
+      // calculate lazy suggestions in parallel and cache them
+      r.getSuggestedReplacementObjects();
+    });
     if (isXmlFormat) {
       if (listUnknownWords && apiMode == StringTools.ApiPrintMode.NORMAL_API) {
         unknownWords = lt.getUnknownWords();


### PR DESCRIPTION
to speed up the result printing

For me, this speeds up `Main -l de-DE` by ~45%