### PR TITLE
Unify matching logic in PatternRuleMatcher and DisambiguationPatternRuleReplacer

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/AbstractPatternRulePerformer.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/AbstractPatternRulePerformer.java
@@ -52,6 +52,92 @@ public abstract class AbstractPatternRulePerformer {
     return patternTokenMatchers;
   }
 
+  protected void doMatch(List<PatternTokenMatcher> patternTokenMatchers, AnalyzedTokenReadings[] tokens, MatchConsumer consumer) throws IOException {
+    int[] tokenPositions = new int[patternTokenMatchers.size()];
+    int patternSize = patternTokenMatchers.size();
+    int limit = Math.max(0, tokens.length - patternSize + 1);
+    PatternTokenMatcher pTokenMatcher = null;
+    int i = 0;
+    int minOccurCorrection = getMinOccurrenceCorrection();
+    while (i < limit + minOccurCorrection && !(rule.isSentStart() && i > 0)) {
+      int skipShiftTotal = 0;
+      boolean allElementsMatch = false;
+      int matchingTokens = 0;
+      int firstMatchToken = -1;
+      int lastMatchToken = -1;
+      int firstMarkerMatchToken = -1;
+      int lastMarkerMatchToken = -1;
+      int prevSkipNext = 0;
+      if (rule.isTestUnification()) {
+        unifier.reset();
+      }
+      int minOccurSkip = 0;
+      for (int k = 0; k < patternSize; k++) {
+        PatternTokenMatcher prevTokenMatcher = pTokenMatcher;
+        pTokenMatcher = patternTokenMatchers.get(k);
+        pTokenMatcher.resolveReference(firstMatchToken, tokens, rule.getLanguage());
+        int nextPos = i + k + skipShiftTotal - minOccurSkip;
+        prevMatched = false;
+        if (prevSkipNext + nextPos >= tokens.length || prevSkipNext < 0) { // SENT_END?
+          prevSkipNext = tokens.length - (nextPos + 1);
+        }
+        int maxTok = Math.min(nextPos + prevSkipNext, tokens.length - (patternSize - k) + minOccurCorrection);
+        for (int m = nextPos; m <= maxTok; m++) {
+          allElementsMatch = testAllReadings(tokens, pTokenMatcher, prevTokenMatcher, m, firstMatchToken, prevSkipNext);
+
+          if (pTokenMatcher.getPatternToken().getMinOccurrence() == 0) {
+            boolean foundNext = false;
+            for (int k2 = k + 1; k2 < patternSize; k2++) {
+              PatternTokenMatcher nextElement = patternTokenMatchers.get(k2);
+              boolean nextElementMatch = testAllReadings(tokens, nextElement, pTokenMatcher, m,
+                firstMatchToken, prevSkipNext);
+              if (nextElementMatch) {
+                // this element doesn't match, but it's optional so accept this and continue
+                allElementsMatch = true;
+                minOccurSkip++;
+                tokenPositions[matchingTokens++] = 0;
+                foundNext = true;
+                break;
+              } else if (nextElement.getPatternToken().getMinOccurrence() > 0) {
+                break;
+              }
+            }
+            if (foundNext) {
+              break;
+            }
+          }
+
+          if (allElementsMatch) {
+            int skipForMax = skipMaxTokens(tokens, pTokenMatcher, firstMatchToken, prevSkipNext,
+              prevTokenMatcher, m, patternSize - k - 1);
+            lastMatchToken = m + skipForMax;
+            int skipShift = lastMatchToken - nextPos;
+            tokenPositions[matchingTokens++] = skipShift + 1;
+            prevSkipNext = translateElementNo(pTokenMatcher.getPatternToken().getSkipNext());
+            skipShiftTotal += skipShift;
+            if (firstMatchToken == -1) {
+              firstMatchToken = lastMatchToken - skipForMax;
+            }
+            if (firstMarkerMatchToken == -1 && pTokenMatcher.getPatternToken().isInsideMarker()) {
+              firstMarkerMatchToken = lastMatchToken - skipForMax;
+            }
+            if (pTokenMatcher.getPatternToken().isInsideMarker()) {
+              lastMarkerMatchToken = lastMatchToken;
+            }
+            break;
+          }
+        }
+        if (!allElementsMatch) {
+          break;
+        }
+      }
+      if (allElementsMatch && matchingTokens == patternSize) {
+        consumer.consume(tokenPositions, firstMatchToken, lastMatchToken, firstMarkerMatchToken, lastMarkerMatchToken);
+      }
+      i++;
+    }
+  }
+
   protected boolean testAllReadings(AnalyzedTokenReadings[] tokens,
       PatternTokenMatcher matcher, PatternTokenMatcher prevElement,
       int tokenNo, int firstMatchToken, int prevSkipNext)
@@ -211,4 +297,13 @@ public abstract class AbstractPatternRulePerformer {
     return maxSkip;
   }
 
+  int translateElementNo(int i) {
+    return i;
+  }
+
+  protected interface MatchConsumer {
+    void consume(int[] tokenPositions,
+                 int firstMatchToken,
+                 int lastMatchToken, int firstMarkerMatchToken, int lastMarkerMatchToken) throws IOException;
+  }
 }

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/AbstractPatternRulePerformer.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/AbstractPatternRulePerformer.java
@@ -62,6 +62,7 @@ public abstract class AbstractPatternRulePerformer {
     while (i < limit + minOccurCorrection && !(rule.isSentStart() && i > 0)) {
       int skipShiftTotal = 0;
       boolean allElementsMatch = false;
+      unifiedTokens = null;
       int matchingTokens = 0;
       int firstMatchToken = -1;
       int lastMatchToken = -1;
@@ -280,10 +281,7 @@ public abstract class AbstractPatternRulePerformer {
     return minOccurCorrection;
   }
 
-  /**
-   * @since 2.5
-   */
-  protected int skipMaxTokens(AnalyzedTokenReadings[] tokens, PatternTokenMatcher elem, int firstMatchToken, int prevSkipNext, PatternTokenMatcher prevElement, int m, int remainingElems) throws IOException {
+  private int skipMaxTokens(AnalyzedTokenReadings[] tokens, PatternTokenMatcher elem, int firstMatchToken, int prevSkipNext, PatternTokenMatcher prevElement, int m, int remainingElems) throws IOException {
     int maxSkip = 0;
     int maxOccurrences = elem.getPatternToken().getMaxOccurrence() == -1 ? Integer.MAX_VALUE : elem.getPatternToken().getMaxOccurrence();
     for (int j = 1; j < maxOccurrences && m+j < tokens.length - remainingElems; j++) {

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/AbstractPatternRulePerformer.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/AbstractPatternRulePerformer.java
@@ -19,14 +19,14 @@
  */
 package org.languagetool.rules.patterns;
 
+import org.languagetool.AnalyzedToken;
+import org.languagetool.AnalyzedTokenReadings;
+import org.languagetool.chunking.ChunkTag;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
-import org.languagetool.AnalyzedToken;
-import org.languagetool.AnalyzedTokenReadings;
-import org.languagetool.chunking.ChunkTag;
 
 /**
  * @since 2.3
@@ -201,8 +201,7 @@ public abstract class AbstractPatternRulePerformer {
     int maxSkip = 0;
     int maxOccurrences = elem.getPatternToken().getMaxOccurrence() == -1 ? Integer.MAX_VALUE : elem.getPatternToken().getMaxOccurrence();
     for (int j = 1; j < maxOccurrences && m+j < tokens.length - remainingElems; j++) {
-      boolean nextAllElementsMatch = !tokens[m+j].isImmunized() &&
-          testAllReadings(tokens, elem, prevElement, m+j, firstMatchToken, prevSkipNext);
+      boolean nextAllElementsMatch = testAllReadings(tokens, elem, prevElement, m+j, firstMatchToken, prevSkipNext);
       if (nextAllElementsMatch) {
         maxSkip++;
       } else {

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleMatcher.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleMatcher.java
@@ -99,13 +99,13 @@ final public class PatternRuleMatcher extends AbstractPatternRulePerformer imple
         }
         int maxTok = Math.min(nextPos + prevSkipNext, tokens.length - (patternSize - k) + minOccurCorrection);
         for (int m = nextPos; m <= maxTok; m++) {
-          allElementsMatch = !tokens[m].isImmunized() && testAllReadings(tokens, pTokenMatcher, prevTokenMatcher, m, firstMatchToken, prevSkipNext);
+          allElementsMatch = testAllReadings(tokens, pTokenMatcher, prevTokenMatcher, m, firstMatchToken, prevSkipNext);
 
           if (pTokenMatcher.getPatternToken().getMinOccurrence() == 0) {
             boolean foundNext = false;
             for (int k2 = k + 1; k2 < patternSize; k2++) {
               PatternTokenMatcher nextElement = patternTokenMatchers.get(k2);
-              boolean nextElementMatch = !tokens[m].isImmunized() && testAllReadings(tokens, nextElement, pTokenMatcher, m,
+              boolean nextElementMatch = testAllReadings(tokens, nextElement, pTokenMatcher, m,
                 firstMatchToken, prevSkipNext);
               if (nextElementMatch) {
                 // this element doesn't match, but it's optional so accept this and continue
@@ -190,6 +190,13 @@ final public class PatternRuleMatcher extends AbstractPatternRulePerformer imple
     void consume(List<Integer> tokenPositions,
                  int firstMatchToken,
                  int lastMatchToken, int firstMarkerMatchToken, int lastMarkerMatchToken) throws IOException;
+  }
+
+  @Override
+  protected boolean testAllReadings(AnalyzedTokenReadings[] tokens, PatternTokenMatcher matcher, PatternTokenMatcher prevElement, int tokenNo, int firstMatchToken, int prevSkipNext) throws IOException {
+    if (tokens[tokenNo].isImmunized()) return false;
+
+    return super.testAllReadings(tokens, matcher, prevElement, tokenNo, firstMatchToken, prevSkipNext);
   }
 
   @Nullable

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleMatcher.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleMatcher.java
@@ -69,92 +69,6 @@ final public class PatternRuleMatcher extends AbstractPatternRulePerformer imple
     return currentlyActiveRules;
   }
 
-  private void doMatch(List<PatternTokenMatcher> patternTokenMatchers, AnalyzedTokenReadings[] tokens, MatchConsumer consumer) throws IOException {
-    int[] tokenPositions = new int[patternTokenMatchers.size()];
-    int patternSize = patternTokenMatchers.size();
-    int limit = Math.max(0, tokens.length - patternSize + 1);
-    PatternTokenMatcher pTokenMatcher = null;
-    int i = 0;
-    int minOccurCorrection = getMinOccurrenceCorrection();
-    while (i < limit + minOccurCorrection && !(rule.isSentStart() && i > 0)) {
-      int skipShiftTotal = 0;
-      boolean allElementsMatch = false;
-      int matchingTokens = 0;
-      int firstMatchToken = -1;
-      int lastMatchToken = -1;
-      int firstMarkerMatchToken = -1;
-      int lastMarkerMatchToken = -1;
-      int prevSkipNext = 0;
-      if (rule.isTestUnification()) {
-        unifier.reset();
-      }
-      int minOccurSkip = 0;
-      for (int k = 0; k < patternSize; k++) {
-        PatternTokenMatcher prevTokenMatcher = pTokenMatcher;
-        pTokenMatcher = patternTokenMatchers.get(k);
-        pTokenMatcher.resolveReference(firstMatchToken, tokens, rule.getLanguage());
-        int nextPos = i + k + skipShiftTotal - minOccurSkip;
-        prevMatched = false;
-        if (prevSkipNext + nextPos >= tokens.length || prevSkipNext < 0) { // SENT_END?
-          prevSkipNext = tokens.length - (nextPos + 1);
-        }
-        int maxTok = Math.min(nextPos + prevSkipNext, tokens.length - (patternSize - k) + minOccurCorrection);
-        for (int m = nextPos; m <= maxTok; m++) {
-          allElementsMatch = testAllReadings(tokens, pTokenMatcher, prevTokenMatcher, m, firstMatchToken, prevSkipNext);
-
-          if (pTokenMatcher.getPatternToken().getMinOccurrence() == 0) {
-            boolean foundNext = false;
-            for (int k2 = k + 1; k2 < patternSize; k2++) {
-              PatternTokenMatcher nextElement = patternTokenMatchers.get(k2);
-              boolean nextElementMatch = testAllReadings(tokens, nextElement, pTokenMatcher, m,
-                firstMatchToken, prevSkipNext);
-              if (nextElementMatch) {
-                // this element doesn't match, but it's optional so accept this and continue
-                allElementsMatch = true;
-                minOccurSkip++;
-                tokenPositions[matchingTokens++] = 0;
-                foundNext = true;
-                break;
-              } else if (nextElement.getPatternToken().getMinOccurrence() > 0) {
-                break;
-              }
-            }
-            if (foundNext) {
-              break;
-            }
-          }
-
-          if (allElementsMatch) {
-            int skipForMax = skipMaxTokens(tokens, pTokenMatcher, firstMatchToken, prevSkipNext,
-              prevTokenMatcher, m, patternSize - k - 1);
-            lastMatchToken = m + skipForMax;
-            int skipShift = lastMatchToken - nextPos;
-            tokenPositions[matchingTokens++] = skipShift + 1;
-            prevSkipNext = translateElementNo(pTokenMatcher.getPatternToken().getSkipNext());
-            skipShiftTotal += skipShift;
-            if (firstMatchToken == -1) {
-              firstMatchToken = lastMatchToken - skipForMax;
-            }
-            if (firstMarkerMatchToken == -1 && pTokenMatcher.getPatternToken().isInsideMarker()) {
-              firstMarkerMatchToken = lastMatchToken - skipForMax;
-            }
-            if (pTokenMatcher.getPatternToken().isInsideMarker()) {
-              lastMarkerMatchToken = lastMatchToken;
-            }
-            break;
-          }
-        }
-        if (!allElementsMatch) {
-          break;
-        }
-      }
-      if (allElementsMatch && matchingTokens == patternSize) {
-        consumer.consume(tokenPositions, firstMatchToken, lastMatchToken, firstMarkerMatchToken, lastMarkerMatchToken);
-      }
-      i++;
-    }
-  }
-
   @Override
   public RuleMatch[] match(AnalyzedSentence sentence) throws IOException {
 //    long startTime = System.currentTimeMillis();
@@ -185,12 +99,6 @@ final public class PatternRuleMatcher extends AbstractPatternRulePerformer imple
         currentlyActiveRules.computeIfPresent(key, (k, v) -> v - 1 > 0 ? v - 1 : null);
       }
     }
-  }
-
-  protected interface MatchConsumer {
-    void consume(int[] tokenPositions,
-                 int firstMatchToken,
-                 int lastMatchToken, int firstMarkerMatchToken, int lastMarkerMatchToken) throws IOException;
   }
 
   @Override
@@ -302,7 +210,8 @@ final public class PatternRuleMatcher extends AbstractPatternRulePerformer imple
    * @param i Current element index.
    * @return int Index translated into XML element no.
    */
-  private int translateElementNo(int i) {
+  @Override
+  int translateElementNo(int i) {
     if (!useList || i < 0) {
       return i;
     }

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleMatcher.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleMatcher.java
@@ -68,6 +68,92 @@ final public class PatternRuleMatcher extends AbstractPatternRulePerformer imple
     return currentlyActiveRules;
   }
 
+  private void doMatch(List<PatternTokenMatcher> patternTokenMatchers, AnalyzedTokenReadings[] tokens, MatchConsumer consumer) throws IOException {
+    List<Integer> tokenPositions = new ArrayList<>(tokens.length + 1);
+    int patternSize = patternTokenMatchers.size();
+    int limit = Math.max(0, tokens.length - patternSize + 1);
+    PatternTokenMatcher pTokenMatcher = null;
+    int i = 0;
+    int minOccurCorrection = getMinOccurrenceCorrection();
+    while (i < limit + minOccurCorrection && !(rule.isSentStart() && i > 0)) {
+      int skipShiftTotal = 0;
+      boolean allElementsMatch = false;
+      int firstMatchToken = -1;
+      int lastMatchToken = -1;
+      int firstMarkerMatchToken = -1;
+      int lastMarkerMatchToken = -1;
+      int prevSkipNext = 0;
+      if (rule.isTestUnification()) {
+        unifier.reset();
+      }
+      tokenPositions.clear();
+      int minOccurSkip = 0;
+      for (int k = 0; k < patternSize; k++) {
+        PatternTokenMatcher prevTokenMatcher = pTokenMatcher;
+        pTokenMatcher = patternTokenMatchers.get(k);
+        pTokenMatcher.resolveReference(firstMatchToken, tokens, rule.getLanguage());
+        int nextPos = i + k + skipShiftTotal - minOccurSkip;
+        prevMatched = false;
+        if (prevSkipNext + nextPos >= tokens.length || prevSkipNext < 0) { // SENT_END?
+          prevSkipNext = tokens.length - (nextPos + 1);
+        }
+        int maxTok = Math.min(nextPos + prevSkipNext, tokens.length - (patternSize - k) + minOccurCorrection);
+        for (int m = nextPos; m <= maxTok; m++) {
+          allElementsMatch = !tokens[m].isImmunized() && testAllReadings(tokens, pTokenMatcher, prevTokenMatcher, m, firstMatchToken, prevSkipNext);
+
+          if (pTokenMatcher.getPatternToken().getMinOccurrence() == 0) {
+            boolean foundNext = false;
+            for (int k2 = k + 1; k2 < patternSize; k2++) {
+              PatternTokenMatcher nextElement = patternTokenMatchers.get(k2);
+              boolean nextElementMatch = !tokens[m].isImmunized() && testAllReadings(tokens, nextElement, pTokenMatcher, m,
+                firstMatchToken, prevSkipNext);
+              if (nextElementMatch) {
+                // this element doesn't match, but it's optional so accept this and continue
+                allElementsMatch = true;
+                minOccurSkip++;
+                tokenPositions.add(0);
+                foundNext = true;
+                break;
+              } else if (nextElement.getPatternToken().getMinOccurrence() > 0) {
+                break;
+              }
+            }
+            if (foundNext) {
+              break;
+            }
+          }
+
+          if (allElementsMatch) {
+            int skipForMax = skipMaxTokens(tokens, pTokenMatcher, firstMatchToken, prevSkipNext,
+              prevTokenMatcher, m, patternSize - k - 1);
+            lastMatchToken = m + skipForMax;
+            int skipShift = lastMatchToken - nextPos;
+            tokenPositions.add(skipShift + 1);
+            prevSkipNext = translateElementNo(pTokenMatcher.getPatternToken().getSkipNext());
+            skipShiftTotal += skipShift;
+            if (firstMatchToken == -1) {
+              firstMatchToken = lastMatchToken - skipForMax;
+            }
+            if (firstMarkerMatchToken == -1 && pTokenMatcher.getPatternToken().isInsideMarker()) {
+              firstMarkerMatchToken = lastMatchToken - skipForMax;
+            }
+            if (pTokenMatcher.getPatternToken().isInsideMarker()) {
+              lastMarkerMatchToken = lastMatchToken;
+            }
+            break;
+          }
+        }
+        if (!allElementsMatch) {
+          break;
+        }
+      }
+      if (allElementsMatch && tokenPositions.size() == patternSize) {
+        consumer.consume(tokenPositions, firstMatchToken, lastMatchToken, firstMarkerMatchToken, lastMarkerMatchToken);
+      }
+      i++;
+    }
+  }
+
   @Override
   public RuleMatch[] match(AnalyzedSentence sentence) throws IOException {
 //    long startTime = System.currentTimeMillis();
@@ -79,93 +165,12 @@ final public class PatternRuleMatcher extends AbstractPatternRulePerformer imple
     try {
       boolean isPreDisambigMatch = rule instanceof PatternRule && ((PatternRule)rule).isInterpretPosTagsPreDisambiguation();
       AnalyzedTokenReadings[] tokens = isPreDisambigMatch ? sentence.getPreDisambigTokensWithoutWhitespace() : sentence.getTokensWithoutWhitespace();
-      List<Integer> tokenPositions = new ArrayList<>(tokens.length + 1);
-      int patternSize = patternTokenMatchers.size();
-      int limit = Math.max(0, tokens.length - patternSize + 1);
-      PatternTokenMatcher pTokenMatcher = null;
-      int i = 0;
-      int minOccurCorrection = getMinOccurrenceCorrection();
-      while (i < limit + minOccurCorrection && !(rule.isSentStart() && i > 0)) {
-        int skipShiftTotal = 0;
-        boolean allElementsMatch = false;
-        int firstMatchToken = -1;
-        int lastMatchToken = -1;
-        int firstMarkerMatchToken = -1;
-        int lastMarkerMatchToken = -1;
-        int prevSkipNext = 0;
-        if (rule.isTestUnification()) {
-          unifier.reset();
+      doMatch(patternTokenMatchers, tokens, (tokenPositions, firstMatchToken, lastMatchToken, firstMarkerMatchToken, lastMarkerMatchToken) -> {
+        RuleMatch ruleMatch = createRuleMatch(tokenPositions, tokens, firstMatchToken, lastMatchToken, firstMarkerMatchToken, lastMarkerMatchToken, sentence);
+        if (ruleMatch != null) {
+          ruleMatches.add(ruleMatch);
         }
-        tokenPositions.clear();
-        int minOccurSkip = 0;
-        for (int k = 0; k < patternSize; k++) {
-          PatternTokenMatcher prevTokenMatcher = pTokenMatcher;
-          pTokenMatcher = patternTokenMatchers.get(k);
-          pTokenMatcher.resolveReference(firstMatchToken, tokens, rule.getLanguage());
-          int nextPos = i + k + skipShiftTotal - minOccurSkip;
-          prevMatched = false;
-          if (prevSkipNext + nextPos >= tokens.length || prevSkipNext < 0) { // SENT_END?
-            prevSkipNext = tokens.length - (nextPos + 1);
-          }
-          int maxTok = Math.min(nextPos + prevSkipNext, tokens.length - (patternSize - k) + minOccurCorrection);
-          for (int m = nextPos; m <= maxTok; m++) {
-            allElementsMatch = !tokens[m].isImmunized() && testAllReadings(tokens, pTokenMatcher, prevTokenMatcher, m, firstMatchToken, prevSkipNext);
-
-            if (pTokenMatcher.getPatternToken().getMinOccurrence() == 0) {
-              boolean foundNext = false;
-              for (int k2 = k + 1; k2 < patternSize; k2++) {
-                PatternTokenMatcher nextElement = patternTokenMatchers.get(k2);
-                boolean nextElementMatch = !tokens[m].isImmunized() && testAllReadings(tokens, nextElement, pTokenMatcher, m,
-                  firstMatchToken, prevSkipNext);
-                if (nextElementMatch) {
-                  // this element doesn't match, but it's optional so accept this and continue
-                  allElementsMatch = true;
-                  minOccurSkip++;
-                  tokenPositions.add(0);
-                  foundNext = true;
-                  break;
-                } else if (nextElement.getPatternToken().getMinOccurrence() > 0) {
-                  break;
-                }
-              }
-              if (foundNext) {
-                break;
-              }
-            }
-
-            if (allElementsMatch) {
-              int skipForMax = skipMaxTokens(tokens, pTokenMatcher, firstMatchToken, prevSkipNext,
-                prevTokenMatcher, m, patternSize - k - 1);
-              lastMatchToken = m + skipForMax;
-              int skipShift = lastMatchToken - nextPos;
-              tokenPositions.add(skipShift + 1);
-              prevSkipNext = translateElementNo(pTokenMatcher.getPatternToken().getSkipNext());
-              skipShiftTotal += skipShift;
-              if (firstMatchToken == -1) {
-                firstMatchToken = lastMatchToken - skipForMax;
-              }
-              if (firstMarkerMatchToken == -1 && pTokenMatcher.getPatternToken().isInsideMarker()) {
-                firstMarkerMatchToken = lastMatchToken - skipForMax;
-              }
-              if (pTokenMatcher.getPatternToken().isInsideMarker()) {
-                lastMarkerMatchToken = lastMatchToken;
-              }
-              break;
-            }
-          }
-          if (!allElementsMatch) {
-            break;
-          }
-        }
-        if (allElementsMatch && tokenPositions.size() == patternSize) {
-          RuleMatch ruleMatch = createRuleMatch(tokenPositions,
-            tokens, firstMatchToken, lastMatchToken, firstMarkerMatchToken, lastMarkerMatchToken, sentence);
-          if (ruleMatch != null) {
-            ruleMatches.add(ruleMatch);
-          }
-        }
-        i++;
-      }
+      });
       RuleMatchFilter maxFilter = new RuleWithMaxFilter();
       List<RuleMatch> filteredMatches = maxFilter.filter(ruleMatches);
       /*if (slowMatchThreshold != null) {
@@ -179,6 +184,12 @@ final public class PatternRuleMatcher extends AbstractPatternRulePerformer imple
         currentlyActiveRules.computeIfPresent(key, (k, v) -> v - 1 > 0 ? v - 1 : null);
       }
     }
+  }
+
+  protected interface MatchConsumer {
+    void consume(List<Integer> tokenPositions,
+                 int firstMatchToken,
+                 int lastMatchToken, int firstMarkerMatchToken, int lastMarkerMatchToken) throws IOException;
   }
 
   @Nullable

--- a/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/DisambiguationPatternRuleReplacer.java
+++ b/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/DisambiguationPatternRuleReplacer.java
@@ -201,25 +201,6 @@ class DisambiguationPatternRuleReplacer extends AbstractPatternRulePerformer {
     return true;
   }
 
-  /* (non-Javadoc)
-   * @see org.languagetool.rules.patterns.AbstractPatternRulePerformer#skipMaxTokens(org.languagetool.AnalyzedTokenReadings[], org.languagetool.rules.patterns.PatternTokenMatcher, int, int, org.languagetool.rules.patterns.PatternTokenMatcher, int, int)
-   */
-  @Override
-  protected int skipMaxTokens(AnalyzedTokenReadings[] tokens, PatternTokenMatcher matcher, int firstMatchToken, int prevSkipNext, PatternTokenMatcher prevElement, int m, int remainingElems) throws IOException {
-    int maxSkip = 0;
-    int maxOccurrences = matcher.getPatternToken().getMaxOccurrence() == -1 ? Integer.MAX_VALUE : matcher.getPatternToken().getMaxOccurrence();
-    for (int j = 1; j < maxOccurrences && m+j < tokens.length - remainingElems; j++) {
-      boolean nextAllElementsMatch = testAllReadings(tokens, matcher, prevElement, m+j, firstMatchToken, prevSkipNext);
-      if (nextAllElementsMatch) {
-        maxSkip++;
-      } else {
-        break;
-      }
-    }
-    return maxSkip;
-  }
-
-
   private AnalyzedTokenReadings[] executeAction(AnalyzedSentence sentence,
                                                 AnalyzedTokenReadings[] whiteTokens,
                                                 AnalyzedTokenReadings[] unifiedTokens,


### PR DESCRIPTION
So that if matching is optimized, both places profit from that.

Interestingly, this also seems to unexpectedly result in some small performance improvement (~5% in `Main -l en`).

This branch contains several small commits in case you find that easier to review. They have no historical significance and can be squashed before merging into master.