### PR TITLE
AbstractCompoundRule: avoid locking overhead in a single-threaded queue

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractCompoundRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractCompoundRule.java
@@ -18,21 +18,15 @@
  */
 package org.languagetool.rules;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.ResourceBundle;
-import java.util.concurrent.ArrayBlockingQueue;
-
 import org.apache.commons.lang3.StringUtils;
 import org.languagetool.AnalyzedSentence;
 import org.languagetool.AnalyzedToken;
 import org.languagetool.AnalyzedTokenReadings;
 import org.languagetool.JLanguageTool;
 import org.languagetool.tools.StringTools;
+
+import java.io.IOException;
+import java.util.*;
 
 /**
  * Checks that compounds (if in the list) are not written as separate words.
@@ -103,7 +97,7 @@ public abstract class AbstractCompoundRule extends Rule {
     AnalyzedTokenReadings[] tokens = getSentenceWithImmunization(sentence).getTokensWithoutWhitespace();
 
     RuleMatch prevRuleMatch = null;
-    Queue<AnalyzedTokenReadings> prevTokens = new ArrayBlockingQueue<>(MAX_TERMS);
+    ArrayDeque<AnalyzedTokenReadings> prevTokens = new ArrayDeque<>(MAX_TERMS);
     for (int i = 0; i < tokens.length + MAX_TERMS-1; i++) {
       AnalyzedTokenReadings token;
       // we need to extend the token list so we find matches at the end of the original list:
@@ -234,12 +228,11 @@ public abstract class AbstractCompoundRule extends Rule {
     return sb.toString();
   }
 
-  private void addToQueue(AnalyzedTokenReadings token, Queue<AnalyzedTokenReadings> prevTokens) {
-    boolean inserted = prevTokens.offer(token);
-    if (!inserted) {
+  private static void addToQueue(AnalyzedTokenReadings token, ArrayDeque<AnalyzedTokenReadings> prevTokens) {
+    if (prevTokens.size() == MAX_TERMS) {
       prevTokens.poll();
-      prevTokens.offer(token);
     }
+    prevTokens.offer(token);
   }
 
 }


### PR DESCRIPTION
Minor, unlikely to result in an obvious performance improvement (except maybe if just this rule is run on huge texts), but it just felt wrong to see this in CPU snapshots.