### PR TITLE
implemented loading gRPC rules for German

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/GRPCRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/GRPCRule.java
@@ -311,9 +311,9 @@ public abstract class GRPCRule extends RemoteRule {
     };
   }
 
-  public static List<GRPCRule> createAll(List<RemoteRuleConfig> configs, boolean inputLogging, String defaultDescription) {
+  public static List<GRPCRule> createAll(List<RemoteRuleConfig> configs, boolean inputLogging, String prefix, String defaultDescription) {
     return configs.stream()
-      .filter(cfg -> cfg.getRuleId().startsWith("AI_"))
+      .filter(cfg -> cfg.getRuleId().startsWith(prefix))
       .map(cfg -> create(cfg, inputLogging, cfg.getRuleId(), defaultDescription, Collections.emptyMap()))
       .collect(Collectors.toList());
   }

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
@@ -346,4 +346,16 @@ public class German extends Language implements AutoCloseable {
     return super.getPriorityForId(id);
   }
 
+  @Override
+  public List<Rule> getRelevantRemoteRules(ResourceBundle messageBundle, List<RemoteRuleConfig> configs, GlobalConfig globalConfig, UserConfig userConfig, Language motherTongue, List<Language> altLanguages, boolean inputLogging) throws IOException {
+    List<Rule> rules = new ArrayList<>(super.getRelevantRemoteRules(
+      messageBundle, configs, globalConfig, userConfig, motherTongue, altLanguages, inputLogging));
+
+    // no description needed - matches based on automatically created rules with descriptions provided by remote server
+    rules.addAll(GRPCRule.createAll(configs, inputLogging, "AI_DE_",
+      "INTERNAL - dynamically loaded rule supported by remote server"));
+
+    return rules;
+  }
+
 }

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/English.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/English.java
@@ -490,8 +490,10 @@ public class English extends Language implements AutoCloseable {
     List<Rule> rules = new ArrayList<>(super.getRelevantRemoteRules(
       messageBundle, configs, globalConfig, userConfig, motherTongue, altLanguages, inputLogging));
 
-    // matches should be based on automatically created rules with descriptions provided by remote server
-    rules.addAll(GRPCRule.createAll(configs, inputLogging,
+    // no description needed - matches based on automatically created rules with descriptions provided by remote server
+    rules.addAll(GRPCRule.createAll(configs, inputLogging, "AI_EN_",
+      "INTERNAL - dynamically loaded rule supported by remote server"));
+    rules.addAll(GRPCRule.createAll(configs, inputLogging, "AI_HYDRA_LEO",
       "INTERNAL - dynamically loaded rule supported by remote server"));
 
     return rules;


### PR DESCRIPTION
differentiate using prefix: AI_EN/AI_DE
special case for now: AI_HYDRA_LEO