### PR TITLE
[en] improves some false positives for !Kung

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
@@ -1227,6 +1227,10 @@
 <beforebreak>(?i)FRITZ!</beforebreak>
 <afterbreak>(?i)Box</afterbreak>
 </rule>
+<rule break="no"><!-- names with exclamation mark in them -->
+<beforebreak>!</beforebreak>
+<afterbreak>Kung|Xun|Xoo|Xóõ|Xoon|Khong</afterbreak>
+</rule>
 <rule break="no"><!-- https://de.wikipedia.org/wiki/VW_ID.3 -->
 <beforebreak>ID.</beforebreak>
 <afterbreak>3|Buzz|Crozz</afterbreak>

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/tokenizers/en/EnglishWordTokenizer.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/tokenizers/en/EnglishWordTokenizer.java
@@ -30,8 +30,11 @@ import org.languagetool.tokenizers.WordTokenizer;
  */
 public class EnglishWordTokenizer extends WordTokenizer {
 
-  private static final String[] EXCEPTIONS = {"fo'c'sle"};
-  private static final String[] EXCEPTION_REPLACEMENT = {"fo\u2626c\u2626sle"};
+  private static final String[] EXCEPTIONS = {"fo'c'sle",
+    "!Kung", "!Xun", "!Xoo", "!Xóõ", "!Xoon", "!Khong"};
+  // Caution: replacement should never be a plausible token on its own.
+  private static final String[] EXCEPTION_REPLACEMENT = {"fo\u2626c\u2626sle",
+    "\u2626ǃKung", "\u2626ǃXun", "\u2626ǃXoo", "\u2626ǃXóõ", "\u2626ǃXoon", "\u2626ǃKhong"};
 
   @Override
   public String getTokenizingCharacters() {

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/added.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/added.txt
@@ -6,6 +6,12 @@
 ǂHõã	ǂHõã	NNP
 ǂKxʼaoǁʼae	ǂKxʼaoǁʼae	NNP
 ǂKxʼauǁʼein	ǂKxʼauǁʼein	NNP
+!Kung	!Kung	NNP
+!Xun	!Xun	NNP
+!Xoo	!Xoo	NNP
+!Xóõ	!Xóõ	NNP
+!Xoon	!Xoon	NNP
+!Khong	!Khong	NNP
 µm	µm	NN
 1st	1st	RB
 2019-nCoV	2019-nCoV	NN:U

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
@@ -28234,3 +28234,9 @@ pre-veterinary
 Byung-soo
 spired
 Dmitrovskaya
+!Kung
+!Xun
+!Xoo
+!Xóõ
+!Xoon
+!Khong

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/multiwords.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/multiwords.txt
@@ -1517,3 +1517,9 @@ North Dakotan	JJ
 South Devon	NNP
 Iset River	NNP
 Nizhny Novgorod	NNP
+!Kung	NNP
+!Xun	NNP
+!Xoo	NNP
+!Xóõ	NNP
+!Xoon	NNP
+!Khong	NNP


### PR DESCRIPTION
Several improvements involving false positives where the `SENTENCE_WHITESPACE` rule suggested to "Add a space between sentences" for some names (demonyms/ethnonyms) containing terminal punctuation (exclamation points), such as `!Kung`.