### PR TITLE
[en] Various improvements to EN_A_VS_AN determiner rule

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_a.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_a.txt
@@ -41,7 +41,12 @@ eucharist
 euclidean
 eugene
 eugenic
+eugenically
+eugenicist
+eugenicists
 eugenics
+eugenist
+eugenol
 eulogy
 eulogist
 eulogized
@@ -253,6 +258,7 @@ Ugandan
 *UJM
 *UK
 ukase
+uke
 *UKR
 Ukrainian
 ukulele

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_a.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_a.txt
@@ -352,6 +352,7 @@ uniliteralist
 union
 unionism
 unionist
+# this is for "union-ized"; the different lemma "un-ionized" requires "an"
 unionized
 unipolar
 uniprocessor

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_a.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_a.txt
@@ -3,7 +3,6 @@
 # line starts with '*').
 # Add words that allow both 'a' and 'an' to det_a.txt and det_an.txt.
 # Also see: http://www.learnenglish.org.uk/grammar/archive/articles_pronunciation.html
-BSc
 Eucharistic
 eukaryote
 eukaryotic
@@ -71,7 +70,6 @@ habitual
 historic
 historical
 homage
-Ms
 one
 onetime
 oneness
@@ -581,5 +579,3 @@ uvular
 Uyghur
 *UZ
 *UZB
-*VIP
-WebExtension

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_an.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_an.txt
@@ -1839,7 +1839,7 @@ h-bomb
 *HDMI
 *HDO
 *HDPS
--*HDR
+*HDR
 *HDS
 *HDSL
 *HDTV
@@ -3409,7 +3409,7 @@ R&D
 *RGPP
 *RGS
 *RGU
-**Rh
+*Rh
 *Rh-
 *RHA
 *RHC
@@ -3981,6 +3981,8 @@ S
 *SXM
 *SZ
 *SZL
+# this is for "un-ionized"; the different lemma "union-ized" requires "a"
+unionized
 X
 *X10
 *X11

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_an.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_an.txt
@@ -3312,7 +3312,6 @@ Nvidia
 *OWS
 *OXT
 *OXY
-*QNH
 R
 *R10
 *R11
@@ -4030,5 +4029,4 @@ X-rays
 *XTP
 *XXL
 *XXX
-*YHWH
 Yttrium


### PR DESCRIPTION
1. Added several missing /ju-/ words to `det_a.txt`
2. Removed some words from `det_a.txt` and `det_an.txt` whose inclusion seems moot or incorrect (not 100% confident)
3. Fixed a few seeming minor issues (not 100% confident)