### PR TITLE
[en] strip diacritics to prevent clobbering important initial letter in "a vs. an" determiner rule

### DIFF
--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/AvsAnRuleTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/AvsAnRuleTest.java
@@ -95,7 +95,24 @@ public class AvsAnRuleTest {
     assertCorrect("Anyone for an XMR-based writer?");
 
     //Test on apostrophes
-    assertCorrect("Its name in English is a[1] (), plural A's, As, as, or a's.");
+    assertCorrect("Its name in English is a[1] (), plural A's, As, as, a’s, or a's.");
+
+    //Test diacritics:
+    assertCorrect("This is an Édouard Manet painting.");
+    assertIncorrect("This is a Édouard Manet painting.");
+    assertCorrect("This is an étude.");
+    assertIncorrect("This is a étude.");
+    assertCorrect("This is a Čakavian dialect, not a Štokavian dialect.");
+    assertIncorrect("This is an Čakavian dialect, not a Štokavian dialect.");
+    assertIncorrect("This is a Čakavian dialect, not an Štokavian dialect.");
+    assertCorrect("This is an ʻaʻā lava flow.");
+    assertIncorrect("This is a ʻaʻā lava flow.");
+    assertCorrect("This is an ‘a‘ā lava flow.");
+    assertIncorrect("This is a ‘a‘ā lava flow.");
+    assertCorrect("This is an 'a'ā lava flow.");
+    assertIncorrect("This is a 'a'ā lava flow.");
+    assertCorrect("This is an ōzeki.");
+    assertIncorrect("This is a ōzeki.");
 
     // Both are correct according to Merriam Webster (http://www.merriam-webster.com/dictionary/a%5B2%5D),
     // although some people disagree (http://www.theslot.com/a-an.html):


### PR DESCRIPTION
Split off from the original pull request #3967.

Improved the "a vs. an" rule by stripping diacritics and keeping the initial letter, rather than lopping it off; added test cases.

Note: The localized test case `AvsAnRuleTest.java` succeeded for me inside IntelliJ and I also manually tested the standalone build on the command line, but the full test suite still fails regardless despite new progress on troubleshooting that.