### PR TITLE
don't invoke pattern rules with hints inapplicable to a sentence

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/MultiThreadedJLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/MultiThreadedJLanguageTool.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import org.languagetool.markup.AnnotatedText;
 import org.languagetool.rules.Rule;
 import org.languagetool.rules.RuleMatch;
+import org.languagetool.rules.patterns.RuleSet;
 
 import java.io.IOException;
 import java.util.*;
@@ -162,9 +163,18 @@ public class MultiThreadedJLanguageTool extends JLanguageTool {
   
   @Override
   protected List<RuleMatch> performCheck(List<AnalyzedSentence> analyzedSentences, List<String> sentenceTexts,
-                                         List<Rule> allRules, ParagraphHandling paraMode,
+                                         RuleSet ruleSet, ParagraphHandling paraMode,
                                          AnnotatedText annotatedText, RuleMatchListener listener, Mode mode, Level level, boolean checkRemoteRules) {
+    List<Rule> allRules = ruleSet.allRules();
     List<SentenceData> sentences = computeSentenceData(analyzedSentences, sentenceTexts);
+
+    Map<Rule, BitSet> map = new HashMap<>();
+    for (int i = 0; i < sentences.size(); i++) {
+      for (Rule rule : ruleSet.rulesForSentence(sentences.get(i).analyzed)) {
+        map.computeIfAbsent(rule, __ -> new BitSet()).set(i);
+      }
+    }
+
     AtomicInteger ruleIndex = new AtomicInteger();
     Map<Integer, List<RuleMatch>> ruleMatches = new TreeMap<>();
     List<Future<?>> futures = IntStream.range(0, getThreadPoolSize()).mapToObj(__ -> getExecutorService().submit(() -> {
@@ -172,8 +182,13 @@ public class MultiThreadedJLanguageTool extends JLanguageTool {
         int index = ruleIndex.getAndIncrement();
         if (index >= allRules.size()) return null;
 
+        Rule rule = allRules.get(index);
+        BitSet applicable = map.get(rule);
+        if (applicable == null) continue;
+
         // less need for special treatment of remote rules when execution is already parallel
-        List<RuleMatch> matches = new TextCheckCallable(Collections.singletonList(allRules.get(index)), sentences,
+        List<RuleMatch> matches = new TextCheckCallable(RuleSet.plain(Collections.singletonList(rule)),
+          RuleSet.filterList(applicable, sentences),
           paraMode, annotatedText, listener, mode, level, true).call();
         if (!matches.isEmpty()) {
           synchronized (ruleMatches) {

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/AbstractTokenBasedRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/AbstractTokenBasedRule.java
@@ -32,10 +32,10 @@ import java.util.stream.Collectors;
 public abstract class AbstractTokenBasedRule extends AbstractPatternRule {
   // Tokens used for fast checking whether a rule can ever match.
   @Nullable
-  private final String[] inflectedRuleTokens;
+  final String[] inflectedRuleTokens;
 
   @Nullable
-  private final String[][] formHints;
+  final String[][] formHints;
 
   protected AbstractTokenBasedRule(String id, String description, Language language, List<PatternToken> patternTokens, boolean getUnified) {
     super(id, description, language, patternTokens, getUnified);

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternToken.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternToken.java
@@ -677,7 +677,7 @@ public class PatternToken implements Cloneable {
    * This is used internally for performance optimizations.
    */
   @Nullable
-  public Set<String> calcFormHints() {
+  Set<String> calcFormHints() {
     Set<String> result = inflected ? null : calcOwnPossibleStringValues();
     if (result == null) return null;
 

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/RuleSet.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/RuleSet.java
@@ -1,0 +1,149 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2020 Daniel Naber (http://www.danielnaber.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.patterns;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.languagetool.AnalyzedSentence;
+import org.languagetool.rules.Rule;
+
+import java.util.*;
+
+/**
+ * An object holding a set of rules with an optional possibility to fetch only the ones applicable for a given sentence
+ * (via {@link #rulesForSentence}), to avoid even invoking the definitely inapplicable ones.
+ * The filtering is based on cues provided by the rules, e.g. possible token strings or lemmas in pattern rules.
+ *
+ * @since 5.2
+ */
+@ApiStatus.Internal
+public abstract class RuleSet {
+
+  /**
+   * @return all rules in this set, not filtered
+   */
+  public abstract List<Rule> allRules();
+
+  /**
+   * @return all rules from {@link #allRules} that might be applicable to the given sentence.
+   */
+  public abstract List<Rule> rulesForSentence(AnalyzedSentence sentence);
+
+  /**
+   * @return a simple RuleSet that returns all the rules from {@link #rulesForSentence}
+   */
+  public static RuleSet plain(List<Rule> rules) {
+    List<Rule> allRules = Collections.unmodifiableList(rules);
+    return new RuleSet() {
+      @Override
+      public List<Rule> allRules() {
+        return allRules;
+      }
+
+      @Override
+      public List<Rule> rulesForSentence(AnalyzedSentence sentence) {
+        return allRules;
+      }
+    };
+  }
+
+  /**
+   * @return a RuleSet whose {@link #rulesForSentence} excludes rules requiring token texts or lemmas
+   * that don't occur in the given sentence
+   */
+  public static RuleSet textLemmaHinted(List<? extends Rule> rules) {
+    return hinted(rules, true);
+  }
+
+  /**
+   * @return a RuleSet whose {@link #rulesForSentence} excludes rules requiring token texts
+   * that don't occur in the given sentence.
+   */
+  public static RuleSet textHinted(List<? extends Rule> rules) {
+    return hinted(rules, false);
+  }
+
+  private static RuleSet hinted(List<? extends Rule> rules, boolean withLemmaHints) {
+    List<Rule> allRules = Collections.unmodifiableList(rules);
+    Map<String, BitSet> byToken = new HashMap<>();
+    Map<String, BitSet> byLemma = new HashMap<>();
+    BitSet unclassified = new BitSet();
+    for (int i = 0; i < allRules.size(); i++) {
+      Rule rule = allRules.get(i);
+      if (rule instanceof AbstractTokenBasedRule) {
+        String[] inflectedRuleTokens = new String[0];
+        if (withLemmaHints) {
+          inflectedRuleTokens = ((AbstractTokenBasedRule) rule).inflectedRuleTokens;
+          if (inflectedRuleTokens != null) {
+            byLemma.computeIfAbsent(inflectedRuleTokens[0], __ -> new BitSet()).set(i);
+          }
+        }
+        String[][] formHints = ((AbstractTokenBasedRule) rule).formHints;
+        if (formHints != null) {
+          for (String token : formHints[0]) {
+            byToken.computeIfAbsent(token, __ -> new BitSet()).set(i);
+          }
+        } else if (inflectedRuleTokens == null || !withLemmaHints) {
+          unclassified.set(i);
+        }
+      } else {
+        unclassified.set(i);
+      }
+    }
+    return new RuleSet() {
+      @Override
+      public List<Rule> allRules() {
+        return allRules;
+      }
+
+      @Override
+      public List<Rule> rulesForSentence(AnalyzedSentence sentence) {
+        BitSet included = new BitSet();
+        included.or(unclassified);
+        if (!byLemma.isEmpty()) {
+          for (String lemma : sentence.getLemmaSet()) {
+            BitSet set = byLemma.get(lemma);
+            if (set != null) {
+              included.or(set);
+            }
+          }
+        }
+        for (String token : sentence.getTokenSet()) {
+          BitSet set = byToken.get(token);
+          if (set != null) {
+            included.or(set);
+          }
+        }
+        return filterList(included, allRules);
+      }
+    };
+  }
+
+  @ApiStatus.Internal
+  public static <T> List<T> filterList(BitSet includedIndices, List<T> list) {
+    List<T> result = new ArrayList<>();
+    int i = -1;
+    while (true) {
+      i = includedIndices.nextSetBit(i + 1);
+      if (i < 0) break;
+      result.add(list.get(i));
+    }
+    return result;
+  }
+
+}

--- a/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/XmlRuleDisambiguator.java
+++ b/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/XmlRuleDisambiguator.java
@@ -19,18 +19,18 @@
 
 package org.languagetool.tagging.disambiguation.rules;
 
-import org.jetbrains.annotations.NotNull;
 import org.languagetool.AnalyzedSentence;
-import org.languagetool.AnalyzedTokenReadings;
 import org.languagetool.JLanguageTool;
 import org.languagetool.Language;
-import org.languagetool.rules.patterns.PatternToken;
+import org.languagetool.rules.Rule;
+import org.languagetool.rules.patterns.RuleSet;
 import org.languagetool.tagging.disambiguation.AbstractDisambiguator;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
-import java.util.*;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Rule-based disambiguator.
@@ -42,94 +42,24 @@ public class XmlRuleDisambiguator extends AbstractDisambiguator {
 
   private static final String DISAMBIGUATION_FILE = "disambiguation.xml";
 
-  private final List<DisambiguationPatternRule> disambiguationRules;
-
-  /**
-   * A map containing indices rules with form hints,
-   * which are only called when the analyzed sentence contains any of the word forms that the rules have provided.
-   * The keys of the map are the known word forms, the values are sets of indices in {@link #disambiguationRules} list.
-   */
-  private final Map<String, BitSet> hintedRulesSensitive = new HashMap<>();
-
-  /**
-   * Same as {@link #hintedRulesSensitive}, but case-insensitively.
-   */
-  private final Map<String, BitSet> hintedRulesInsensitive = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-
-  /**
-   * Indices in {@link #disambiguationRules} that correspond to rules without form hints, which fall into
-   * neither {@link #hintedRulesSensitive} nor {@link #hintedRulesInsensitive}.
-   */
-  private final BitSet unhintedRules = new BitSet();
+  private final RuleSet disambiguationRules;
 
   public XmlRuleDisambiguator(Language language) {
     Objects.requireNonNull(language);
     String disambiguationFile = language.getShortCode() + "/" + DISAMBIGUATION_FILE;
     try {
-      disambiguationRules = loadPatternRules(disambiguationFile);
+      disambiguationRules = RuleSet.textHinted(loadPatternRules(disambiguationFile));
     } catch (Exception e) {
       throw new RuntimeException("Problems with loading disambiguation file: " + disambiguationFile, e);
     }
-    for (int i = 0; i < disambiguationRules.size(); i++) {
-      registerHints(disambiguationRules.get(i), i);
-    }
-  }
-
-  /**
-   * Classifies the given rule into {@link #unhintedRules}, {@link #hintedRulesInsensitive} or {@link #hintedRulesSensitive},
-   * based on the form hints provided by its token patterns.
-   */
-  private void registerHints(DisambiguationPatternRule rule, int index) {
-    for (PatternToken token : rule.getPatternTokens()) {
-      Set<String> hints = token.calcFormHints();
-      if (hints != null) {
-        Map<String, BitSet> map = token.isCaseSensitive() ? hintedRulesSensitive : hintedRulesInsensitive;
-        for (String hint : hints) {
-          map.computeIfAbsent(hint, __ -> new BitSet()).set(index);
-        }
-        return;
-      }
-    }
-    unhintedRules.set(index);
   }
 
   @Override
-  public AnalyzedSentence disambiguate(AnalyzedSentence input) throws IOException {
-    BitSet toCheck = getRelevantRules(input);
-    AnalyzedSentence sentence = input;
-    int i = -1;
-    while (true) {
-      i = toCheck.nextSetBit(i + 1);
-      if (i < 0) break;
-      sentence = disambiguationRules.get(i).replace(sentence);
+  public AnalyzedSentence disambiguate(AnalyzedSentence sentence) throws IOException {
+    for (Rule rule : disambiguationRules.rulesForSentence(sentence)) {
+      sentence = ((DisambiguationPatternRule) rule).replace(sentence);
     }
     return sentence;
-  }
-
-  /**
-   * @return rules that have a chance to be triggered by the given sentence: the ones whose form hints
-   * (see {@link PatternToken#calcFormHints()}) occur in the sentence and the ones without form hints ({@link #unhintedRules}).
-   */
-  @NotNull
-  private BitSet getRelevantRules(AnalyzedSentence input) {
-    BitSet toCheck = unhintedRules;
-    for (AnalyzedTokenReadings readings : input.getTokensWithoutWhitespace()) {
-      BitSet rules = hintedRulesSensitive.get(readings.getToken());
-      if (rules != null) {
-        if (toCheck == unhintedRules) {
-          toCheck = (BitSet) toCheck.clone();
-        }
-        toCheck.or(rules);
-      }
-      rules = hintedRulesInsensitive.get(readings.getToken());
-      if (rules != null) {
-        if (toCheck == unhintedRules) {
-          toCheck = (BitSet) toCheck.clone();
-        }
-        toCheck.or(rules);
-      }
-    }
-    return toCheck;
   }
 
   /**

--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/RuleSetTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/RuleSetTest.java
@@ -1,0 +1,78 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2020 Daniel Naber (http://www.danielnaber.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.patterns;
+
+import org.junit.Test;
+import org.languagetool.AnalyzedSentence;
+import org.languagetool.AnalyzedToken;
+import org.languagetool.AnalyzedTokenReadings;
+import org.languagetool.FakeLanguage;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.languagetool.rules.patterns.PatternRuleBuilderHelper.*;
+import static org.languagetool.rules.patterns.RuleSet.textLemmaHinted;
+
+public class RuleSetTest {
+  private static final AnalyzedSentence sampleSentence = new AnalyzedSentence(new AnalyzedTokenReadings[]{new AnalyzedTokenReadings(
+    new AnalyzedToken("token", "pos", "lemma")
+  )});
+
+  @Test
+  public void textHintsAreHonored() {
+    PatternRule suitable = ruleOf(csToken("token"));
+    assertRulesForSentence(RuleSet.textHinted(Collections.singletonList(suitable)), suitable);
+
+    suitable = ruleOf(token("Token"));
+    assertRulesForSentence(RuleSet.textHinted(Collections.singletonList(suitable)), suitable);
+
+    suitable = ruleOf(tokenRegex("token|another"));
+    assertRulesForSentence(RuleSet.textHinted(Collections.singletonList(suitable)), suitable);
+
+    assertRulesForSentence(RuleSet.textHinted(Collections.singletonList(ruleOf(csToken("unsuitable")))));
+  }
+
+  @Test
+  public void lemmaHintsAreHonored() {
+    PatternRule suitable = ruleOf(new PatternTokenBuilder().token("lemma").matchInflectedForms().build());
+    assertRulesForSentence(textLemmaHinted(Collections.singletonList(suitable)), suitable);
+
+    suitable = ruleOf(new PatternTokenBuilder().token("Lemma").matchInflectedForms().build());
+    assertRulesForSentence(textLemmaHinted(Collections.singletonList(suitable)), suitable);
+
+    suitable = ruleOf(new PatternTokenBuilder().csTokenRegex("lemm[ab]").matchInflectedForms().build());
+    assertRulesForSentence(textLemmaHinted(Collections.singletonList(suitable)), suitable);
+
+    PatternToken unsuitable = new PatternTokenBuilder().csToken("unsuitable").matchInflectedForms().build();
+    assertRulesForSentence(textLemmaHinted(Collections.singletonList(ruleOf(unsuitable))));
+
+    PatternRule unrelated = ruleOf(pos("somePos"));
+    assertRulesForSentence(textLemmaHinted(Arrays.asList(ruleOf(unsuitable), unrelated)), unrelated);
+  }
+
+  private static void assertRulesForSentence(RuleSet ruleSet, PatternRule... expected) {
+    assertEquals(Arrays.asList(expected), ruleSet.rulesForSentence(sampleSentence));
+  }
+
+  private static PatternRule ruleOf(PatternToken token) {
+    return new PatternRule("", new FakeLanguage(), Collections.singletonList(token), "", "", "");
+  }
+}


### PR DESCRIPTION
extract RuleSet out of XmlRuleDisambiguator, support lemma hints there, use it in JLanguageTool.check as well

~5% speedup on `Main -l en` and `Main -l de`; ~10% speedup in IntelliJ-specific English setup (1 thread, no spellchecker and `NoopChunker`)