### PR TITLE
[de] revert disambiguation changes, fix FPs

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/SubjectVerbAgreementRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/SubjectVerbAgreementRule.java
@@ -73,6 +73,13 @@ public class SubjectVerbAgreementRule extends Rule {
 
   private static final List<List<PatternToken>> ANTI_PATTERNS = Arrays.asList(
     Arrays.asList(
+      // "Das andere Ende war am rechten vorderen Bettpfosten."
+      posRegex("ART:DEF:NOM:SIN:.*"),
+      posRegex("ADJ:NOM:SIN:.*"),
+      posRegex("SUB:NOM:SIN:.*"),
+      token("war")
+    ),
+    Arrays.asList(
       // "Zwei Schülern war aufgefallen, dass man im Fernsehen..."
       pos("ZAL"),
       posRegex("SUB:DAT:PLU:.*"),

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/disambiguation.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/disambiguation.xml
@@ -547,11 +547,6 @@ Copyright © 2013 Markus Brenneis, Daniel Naber, Jan Schreiber
         <disambig action="unify"/>
     </rule>
     <rule name="NP unify 1b" id="UNIFY_DET_SUB2">
-        <antipattern>
-            <token postag="ART:.*" postag_regexp="yes"></token>
-            <token postag="ADJ:.*" postag_regexp="yes"></token>
-            <token postag="SUB:.*" postag_regexp="yes"></token>
-        </antipattern>
         <pattern>
             <unify>
                 <feature id="number"/><feature id="case"/><feature id="gender"/>
@@ -561,7 +556,6 @@ Copyright © 2013 Markus Brenneis, Daniel Naber, Jan Schreiber
             </unify>
         </pattern>
         <disambig action="unify"/>
-        <example type="untouched">Das andere Gebäude war um ein Beträchtliches höher.</example>
     </rule>
     <!-- TODO: this would fix false alarm for 'die ältere der beiden Töchter' but causes other problems
     <rule name="NP unify 1c" id="UNIFY_DET_ADJ">


### PR DESCRIPTION
Warum findet `SubjectVerbAgreementRule.java` trotz dem AP immer noch einen Fehler im folgenden Satz?

_Das andere Ende **war** am rechten vorderen Bettpfosten._ (--> waren)