### PR TITLE
make ShortDescriptionProvider thread-safer and shorter

### DIFF
--- a/languagetool-standalone/src/test/java/org/languagetool/ShortDescriptionProviderTest.java
+++ b/languagetool-standalone/src/test/java/org/languagetool/ShortDescriptionProviderTest.java
@@ -53,7 +53,7 @@ public class ShortDescriptionProviderTest {
         continue;
       }
       ShortDescriptionProvider provider = new ShortDescriptionProvider();
-      Map<String, String> map = provider.getAllDescriptions(lang);
+      Map<String, String> map = ShortDescriptionProvider.getAllDescriptions(lang);
       for (Map.Entry<String, String> entry : map.entrySet()) {
         String desc = entry.getValue();
         int len = desc.length();


### PR DESCRIPTION
use a single concurrent map with all language descriptions computed on-demand,
instead of two racy non-synchronized collections

this fixes a flaky CCE from internals of HashMap accessed from multiple threads