### PR TITLE
[de] revert disambiguation changes because of FPs

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/disambiguation.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/disambiguation.xml
@@ -547,12 +547,7 @@ Copyright © 2013 Markus Brenneis, Daniel Naber, Jan Schreiber
         <disambig action="unify"/>
     </rule>
     <rule name="NP unify 1b" id="UNIFY_DET_SUB2">
-        <antipattern>
-            <token postag="ART:.*" postag_regexp="yes"></token>
-            <token postag="ADJ:.*" postag_regexp="yes"></token>
-            <token postag="SUB:.*" postag_regexp="yes"></token>
-        </antipattern>
-        <pattern>
+         <pattern>
             <unify>
                 <feature id="number"/><feature id="case"/><feature id="gender"/>
                 <!--"beiden Filmen", but: "dass sie Geliebte waren"-->
@@ -561,7 +556,6 @@ Copyright © 2013 Markus Brenneis, Daniel Naber, Jan Schreiber
             </unify>
         </pattern>
         <disambig action="unify"/>
-        <example type="untouched">Das andere Gebäude war um ein Beträchtliches höher.</example>
     </rule>
     <!-- TODO: this would fix false alarm for 'die ältere der beiden Töchter' but causes other problems
     <rule name="NP unify 1c" id="UNIFY_DET_ADJ">


### PR DESCRIPTION
Needs to be undone because of [these FPs](https://internal1.languagetool.org/regression-tests/via-http/2020-12-10/de-DE/result_java_DE_AGREEMENT.html)