### PR TITLE
[en,de,ru] speed up language and JLanguageTool initialization

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/OldSpellingRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/OldSpellingRule.java
@@ -18,11 +18,13 @@
  */
 package org.languagetool.rules.de;
 
+import com.google.common.base.Suppliers;
 import com.hankcs.algorithm.AhoCorasickDoubleArrayTrie;
 import org.languagetool.AnalyzedSentence;
 import org.languagetool.rules.*;
 
 import java.util.*;
+import java.util.function.Supplier;
 
 /**
  * Finds spellings that were only correct in the pre-reform orthography.
@@ -32,7 +34,7 @@ public class OldSpellingRule extends Rule {
 
   private static final String FILE_PATH = "/de/alt_neu.csv";
   private static final List<String> exceptions = Arrays.asList("Schloß Holte");
-  private static final SpellingData DATA = new SpellingData(FILE_PATH);
+  private static final Supplier<SpellingData> DATA = Suppliers.memoize(() -> new SpellingData(FILE_PATH));
 
   public OldSpellingRule(ResourceBundle messages) {
     super.setCategory(Categories.TYPOS.getCategory(messages));
@@ -55,7 +57,7 @@ public class OldSpellingRule extends Rule {
   public RuleMatch[] match(AnalyzedSentence sentence) {
     List<RuleMatch> matches = new ArrayList<>();
     String text = sentence.getText();
-    List<AhoCorasickDoubleArrayTrie.Hit<String>> hits = DATA.getTrie().parseText(text);
+    List<AhoCorasickDoubleArrayTrie.Hit<String>> hits = DATA.get().getTrie().parseText(text);
     Set<Integer> startPositions = new HashSet<>();
     Collections.reverse(hits);  // work on longest matches first
     for (AhoCorasickDoubleArrayTrie.Hit<String> hit : hits) {

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/AmericanReplaceRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/AmericanReplaceRule.java
@@ -18,6 +18,7 @@
  */
 package org.languagetool.rules.en;
 
+import com.google.common.base.Suppliers;
 import org.languagetool.Languages;
 import org.languagetool.rules.AbstractSimpleReplaceRule;
 import org.languagetool.rules.Example;
@@ -29,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.function.Supplier;
 
 /**
  * A rule that matches words or phrases which should not be used and suggests
@@ -40,7 +42,7 @@ public class AmericanReplaceRule extends AbstractSimpleReplaceRule {
   public static final String BRITISH_SIMPLE_REPLACE_RULE = "EN_US_SIMPLE_REPLACE";
 
   private static final Map<String, List<String>> wrongWords = loadFromPath("/en/en-US/replace.txt");
-  private static final Synthesizer synth = new EnglishSynthesizer(Languages.getLanguageForShortCode("en"));
+  private static final Supplier<Synthesizer> synth = Suppliers.memoize(() -> new EnglishSynthesizer(Languages.getLanguageForShortCode("en")));
   private static final Locale EN_US_LOCALE = new Locale("en-US");
 
   @Override
@@ -87,7 +89,7 @@ public class AmericanReplaceRule extends AbstractSimpleReplaceRule {
 
   @Override
   public Synthesizer getSynthesizer() {
-    return synth;
+    return synth.get();
   }
 
 }

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/BritishReplaceRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/BritishReplaceRule.java
@@ -18,6 +18,7 @@
  */
 package org.languagetool.rules.en;
 
+import com.google.common.base.Suppliers;
 import org.languagetool.Languages;
 import org.languagetool.rules.AbstractSimpleReplaceRule;
 import org.languagetool.rules.Example;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.function.Supplier;
 
 /**
  * A rule that matches words or phrases which should not be used and suggests
@@ -42,7 +44,7 @@ public class BritishReplaceRule extends AbstractSimpleReplaceRule {
   public static final String BRITISH_SIMPLE_REPLACE_RULE = "EN_GB_SIMPLE_REPLACE";
 
   private static final Map<String, List<String>> wrongWords = loadFromPath("/en/en-GB/replace.txt");
-  private static final Synthesizer synth = new EnglishSynthesizer(Languages.getLanguageForShortCode("en"));
+  private static final Supplier<Synthesizer> synth = Suppliers.memoize(() -> new EnglishSynthesizer(Languages.getLanguageForShortCode("en")));
   private static final Locale EN_GB_LOCALE = new Locale("en-GB");
 
   @Override
@@ -89,6 +91,6 @@ public class BritishReplaceRule extends AbstractSimpleReplaceRule {
 
   @Override
   public Synthesizer getSynthesizer() {
-    return synth;
+    return synth.get();
   }
 }

--- a/languagetool-language-modules/ru/src/main/java/org/languagetool/language/Russian.java
+++ b/languagetool-language-modules/ru/src/main/java/org/languagetool/language/Russian.java
@@ -65,12 +65,12 @@ public class Russian extends Language implements AutoCloseable {
   @NotNull
   @Override
   public Tagger createDefaultTagger() {
-    return new RussianTagger();
+    return RussianTagger.INSTANCE;
   }
 
   @Override
   public Disambiguator createDefaultDisambiguator() {
-    return new RussianHybridDisambiguator();
+    return RussianHybridDisambiguator.INSTANCE;
   }
 
   @Nullable

--- a/languagetool-language-modules/ru/src/main/java/org/languagetool/tagging/disambiguation/ru/RussianHybridDisambiguator.java
+++ b/languagetool-language-modules/ru/src/main/java/org/languagetool/tagging/disambiguation/ru/RussianHybridDisambiguator.java
@@ -19,14 +19,14 @@
 
 package org.languagetool.tagging.disambiguation.ru;
 
-import java.io.IOException;
-
 import org.languagetool.AnalyzedSentence;
 import org.languagetool.language.Russian;
 import org.languagetool.tagging.disambiguation.AbstractDisambiguator;
 import org.languagetool.tagging.disambiguation.Disambiguator;
 import org.languagetool.tagging.disambiguation.MultiWordChunker;
 import org.languagetool.tagging.disambiguation.rules.XmlRuleDisambiguator;
+
+import java.io.IOException;
 
 /**
  * Hybrid chunker-disambiguator for Russian.
@@ -35,6 +35,7 @@ import org.languagetool.tagging.disambiguation.rules.XmlRuleDisambiguator;
  */
 
 public class RussianHybridDisambiguator extends AbstractDisambiguator {
+  public static final RussianHybridDisambiguator INSTANCE = new RussianHybridDisambiguator();
 
   private final Disambiguator chunker = new MultiWordChunker("/ru/multiwords.txt");
   private final Disambiguator disambiguator = new XmlRuleDisambiguator(new Russian());

--- a/languagetool-language-modules/ru/src/main/java/org/languagetool/tagging/ru/RussianTagger.java
+++ b/languagetool-language-modules/ru/src/main/java/org/languagetool/tagging/ru/RussianTagger.java
@@ -33,8 +33,9 @@ import java.util.*;
  * See readme.txt for details, the POS tagset is described in tagset.txt
  */
 public class RussianTagger extends BaseTagger {
+  public static final RussianTagger INSTANCE = new RussianTagger();
 
-  public RussianTagger() {
+  private RussianTagger() {
     super("/ru/russian.dict", new Locale("ru"));
   }
 

--- a/languagetool-language-modules/ru/src/test/java/org/languagetool/tagging/ru/RussianTaggerTest.java
+++ b/languagetool-language-modules/ru/src/test/java/org/languagetool/tagging/ru/RussianTaggerTest.java
@@ -18,7 +18,6 @@
  */
 package org.languagetool.tagging.ru;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.languagetool.TestTools;
 import org.languagetool.language.Russian;
@@ -27,23 +26,16 @@ import org.languagetool.tokenizers.WordTokenizer;
 import java.io.IOException;
 
 public class RussianTaggerTest {
-    
-  private RussianTagger tagger;
-  private WordTokenizer tokenizer;
-      
-  @Before
-  public void setUp() {
-    tagger = new RussianTagger();
-    tokenizer = new WordTokenizer();
-  }
 
   @Test
   public void testDictionary() throws IOException {
-    TestTools.testDictionary(tagger, new Russian());
+    TestTools.testDictionary(RussianTagger.INSTANCE, new Russian());
   }
 
   @Test
   public void testTagger() throws IOException {
+    WordTokenizer tokenizer = new WordTokenizer();
+    RussianTagger tagger = RussianTagger.INSTANCE;
     TestTools.myAssert("Все счастливые семьи похожи друг на друга,  каждая  несчастливая  семья несчастлива по-своему.",
         "Все/[весь]ADJ:MPR:PL:Nom|Все/[весь]ADJ:MPR:PL:V|Все/[все]PNN:PL:Nom|Все/[все]PNN:PL:V|Все/[все]PNN:Sin:Nom|Все/[все]PNN:Sin:V -- счастливые/[счастливый]ADJ:Posit:PL:Nom|счастливые/[счастливый]ADJ:Posit:PL:V -- семьи/[семья]NN:Inanim:Fem:PL:Nom|семьи/[семья]NN:Inanim:Fem:PL:V|семьи/[семья]NN:Inanim:Fem:Sin:R -- похожи/[похожий]ADJ:Short:PL -- друг/[друг]NN:Anim:Masc:Sin:Nom -- на/[на]PREP -- друга/[друг]NN:Anim:Masc:Sin:R|друга/[друг]NN:Anim:Masc:Sin:V -- каждая/[каждый]ADJ:MPR:Fem:Nom -- несчастливая/[несчастливый]ADJ:Posit:Fem:Nom -- семья/[семья]NN:Inanim:Fem:Sin:Nom -- несчастлива/[несчастливый]ADJ:Short:Fem -- по-своему/[по-своему]ADV", tokenizer, tagger);
     TestTools.myAssert("Все смешалось в доме Облонских.",


### PR DESCRIPTION
make some expensive fields lazy, so that they'll be loaded later, hopefully even in parallel

this improves startup time a bit,
and the IDE responsiveness when LT needs to be initialized in the background to highlight a file