### PR TITLE
[en] Add "it" to "'ll" disambiguation

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/disambiguation.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/disambiguation.xml
@@ -2372,7 +2372,7 @@ Incorrectly touched. <example type="untouched">Incorrect grammar. Those present 
     </rule>
     <rule name="ll -> will" id="ll_MD">
       <pattern>
-        <token regexp="yes">I|s?he|they|we|what|who|you|that</token>
+        <token regexp="yes">I|s?he|they|it|we|what|who|you|that</token>
         <token regexp="yes">&apostrophe;</token>
         <marker>
           <token spacebefore="no">ll</token>


### PR DESCRIPTION
I discovered this error when attempting to debug why LT was not properly
flagging the phrase "as if it'll means something" against the
MD_BASEFORM[2] rule.

I validated that the behavior doesn't cause any incorrect behavior by
testing the patched version of the disambiguator against the gutenberg
extracts corpus and comparing the flagged rules to the unpatched
version. I then manually verified the tagged output (`-t`) was correct
for all instances of the word "it'll" in the Alice in Wonderland
extract.