### PR TITLE
PatternToken rules: match only from likely tokens if possible

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/AnalyzedSentence.java
+++ b/languagetool-core/src/main/java/org/languagetool/AnalyzedSentence.java
@@ -19,7 +19,9 @@
 package org.languagetool;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
@@ -35,8 +37,8 @@ public final class AnalyzedSentence {
   private final AnalyzedTokenReadings[] nonBlankTokens;
   private final AnalyzedTokenReadings[] nonBlankPreDisambigTokens;
   private final int[] whPositions;  // maps positions without whitespace to positions that include whitespaces
-  private final Set<String> tokenSet;
-  private final Set<String> lemmaSet;
+  private final Map<String, List<Integer>> tokenOffsets;
+  private final Map<String, List<Integer>> lemmaOffsets;
 
   /**
    * Creates an AnalyzedSentence from the given {@link AnalyzedTokenReadings}. Whitespace is also a token.
@@ -54,8 +56,8 @@ public final class AnalyzedSentence {
     this.whPositions = mapping;
     this.nonBlankTokens = getNonBlankReadings(tokens, whCounter, nonWhCounter, mapping).toArray(new AnalyzedTokenReadings[0]);
     this.nonBlankPreDisambigTokens = getNonBlankReadings(preDisambigTokens, whCounter, nonWhCounter, mapping).toArray(new AnalyzedTokenReadings[0]);
-    this.tokenSet = getTokenSet(tokens);
-    this.lemmaSet = getLemmaSet(tokens);
+    tokenOffsets = indexTokens(nonBlankTokens);
+    lemmaOffsets = indexLemmas(nonBlankTokens);
   }
 
   @NotNull
@@ -78,30 +80,41 @@ public final class AnalyzedSentence {
     this.whPositions = mapping;
     this.nonBlankTokens = nonBlankTokens;
     this.nonBlankPreDisambigTokens = nonBlankPreDisambigTokens;
-    this.tokenSet = getTokenSet(tokens);
-    this.lemmaSet = getLemmaSet(tokens);
+    tokenOffsets = indexTokens(nonBlankTokens);
+    lemmaOffsets = indexLemmas(nonBlankTokens);
   }
 
-  private Set<String> getTokenSet(AnalyzedTokenReadings[] tokens) {
-    Set<String> tokenSet = new HashSet<>();
-    for (AnalyzedTokenReadings token : tokens) {
-      tokenSet.add(token.getToken().toLowerCase());
+  private static Map<String, List<Integer>> indexTokens(AnalyzedTokenReadings[] tokens) {
+    Map<String, List<Integer>> result = new HashMap<>(tokens.length);
+    for (int i = 0; i < tokens.length; i++) {
+      result.computeIfAbsent(tokens[i].getToken().toLowerCase(), __ -> new ArrayList<>(1)).add(i);
     }
-    return Collections.unmodifiableSet(tokenSet);
+    return makeUnmodifiable(result);
   }
 
-  private Set<String> getLemmaSet(AnalyzedTokenReadings[] tokens) {
-    Set<String> lemmaSet = new HashSet<>();
-    for (AnalyzedTokenReadings token : tokens) {
-      for (AnalyzedToken lemmaTok : token.getReadings()) {
-        if (lemmaTok.getLemma() != null) {
-          lemmaSet.add(lemmaTok.getLemma().toLowerCase());
-        } else {
-          lemmaSet.add(lemmaTok.getToken().toLowerCase());
+  private static Map<String, List<Integer>> indexLemmas(AnalyzedTokenReadings[] tokens) {
+    Map<String, List<Integer>> result = new HashMap<>(tokens.length);
+    for (int i = 0; i < tokens.length; i++) {
+      AnalyzedTokenReadings tr = tokens[i];
+      int readingsLength = tr.getReadingsLength();
+      for (int j = 0; j < readingsLength; j++) {
+        AnalyzedToken token = tr.getAnalyzedToken(j);
+        String lemma = token.getLemma();
+        String key = (lemma != null ? lemma : token.getToken()).toLowerCase();
+        List<Integer> list = result.computeIfAbsent(key, __ -> new ArrayList<>(1));
+        if (list.isEmpty() || list.get(list.size() - 1) != i) {
+          list.add(i);
         }
       }
     }
-    return Collections.unmodifiableSet(lemmaSet);
+    return makeUnmodifiable(result);
+  }
+
+  private static Map<String, List<Integer>> makeUnmodifiable(Map<String, List<Integer>> result) {
+    for (Map.Entry<String, List<Integer>> entry : result.entrySet()) {
+      entry.setValue(Collections.unmodifiableList(entry.getValue()));
+    }
+    return Collections.unmodifiableMap(result);
   }
 
   /**
@@ -300,7 +313,7 @@ public final class AnalyzedSentence {
    * @since 2.4
    */
   public Set<String> getTokenSet() {
-    return tokenSet;
+    return tokenOffsets.keySet();
   }
 
   /**
@@ -309,7 +322,29 @@ public final class AnalyzedSentence {
    * @since 2.5
    */
   public Set<String> getLemmaSet() {
-    return lemmaSet;
+    return lemmaOffsets.keySet();
+  }
+
+  /**
+   * @return all offsets in {@link #getTokensWithoutWhitespace()} where tokens with the given text occur (case-insensitive),
+   * or {@code null} if there are no such occurrences
+   * @since 5.2
+   */
+  @Nullable
+  @ApiStatus.Internal
+  public List<Integer> getTokenOffsets(String token) {
+    return tokenOffsets.get(token);
+  }
+
+  /**
+   * @return all offsets in {@link #getTokensWithoutWhitespace()} where tokens with the given lemma occur (case-insensitive),
+   * or {@code null} if there are no such occurrences
+   * @since 5.2
+   */
+  @Nullable
+  @ApiStatus.Internal
+  public List<Integer> getLemmaOffsets(String token) {
+    return lemmaOffsets.get(token);
   }
 
   @SuppressWarnings("ControlFlowStatementWithoutBraces")

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/AbstractPatternRulePerformer.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/AbstractPatternRulePerformer.java
@@ -19,6 +19,7 @@
  */
 package org.languagetool.rules.patterns;
 
+import org.languagetool.AnalyzedSentence;
 import org.languagetool.AnalyzedToken;
 import org.languagetool.AnalyzedTokenReadings;
 import org.languagetool.chunking.ChunkTag;
@@ -34,16 +35,22 @@ import java.util.Objects;
 public abstract class AbstractPatternRulePerformer {
 
   protected boolean prevMatched;
-  protected AbstractPatternRule rule;
+  protected AbstractTokenBasedRule rule;
   protected Unifier unifier;
   protected AnalyzedTokenReadings[] unifiedTokens;
+  private final List<PatternTokenMatcher> patternTokenMatchers;
+  private final int patternSize;
+  private final int minOccurCorrection;
 
-  protected AbstractPatternRulePerformer(AbstractPatternRule rule, Unifier unifier) {
+  protected AbstractPatternRulePerformer(AbstractTokenBasedRule rule, Unifier unifier) {
     this.rule = Objects.requireNonNull(rule);
     this.unifier = Objects.requireNonNull(unifier);
+    patternTokenMatchers = createElementMatchers();
+    patternSize = patternTokenMatchers.size();
+    minOccurCorrection = getMinOccurrenceCorrection();
   }
 
-  protected List<PatternTokenMatcher> createElementMatchers() {
+  private List<PatternTokenMatcher> createElementMatchers() {
     List<PatternTokenMatcher> patternTokenMatchers = new ArrayList<>(rule.patternTokens.size());
     for (PatternToken pToken : rule.patternTokens) {
       PatternTokenMatcher matcher = new PatternTokenMatcher(pToken);
@@ -52,96 +59,112 @@ public abstract class AbstractPatternRulePerformer {
     return patternTokenMatchers;
   }
 
-  protected void doMatch(List<PatternTokenMatcher> patternTokenMatchers, AnalyzedTokenReadings[] tokens, MatchConsumer consumer) throws IOException {
+  protected void doMatch(AnalyzedSentence sentence, AnalyzedTokenReadings[] tokens, MatchConsumer consumer) throws IOException {
+    AbstractTokenBasedRule.TokenHint anchor = rule.anchorHint;
+    List<Integer> anchorIndices = anchor == null || isInterpretPosTagsPreDisambiguation() ? null : anchor.getPossibleIndices(sentence);
+
     int[] tokenPositions = new int[patternTokenMatchers.size()];
-    int patternSize = patternTokenMatchers.size();
-    int limit = Math.max(0, tokens.length - patternSize + 1);
-    PatternTokenMatcher pTokenMatcher = null;
-    int i = 0;
-    int minOccurCorrection = getMinOccurrenceCorrection();
-    while (i < limit + minOccurCorrection && !(rule.isSentStart() && i > 0)) {
-      int skipShiftTotal = 0;
-      boolean allElementsMatch = false;
-      unifiedTokens = null;
-      int matchingTokens = 0;
-      int firstMatchToken = -1;
-      int lastMatchToken = -1;
-      int firstMarkerMatchToken = -1;
-      int lastMarkerMatchToken = -1;
-      int prevSkipNext = 0;
-      if (rule.isTestUnification()) {
-        unifier.reset();
-      }
-      int minOccurSkip = 0;
-      for (int k = 0; k < patternSize; k++) {
-        PatternTokenMatcher prevTokenMatcher = pTokenMatcher;
-        pTokenMatcher = patternTokenMatchers.get(k);
-        pTokenMatcher.resolveReference(firstMatchToken, tokens, rule.getLanguage());
-        int nextPos = i + k + skipShiftTotal - minOccurSkip;
-        prevMatched = false;
-        if (prevSkipNext + nextPos >= tokens.length || prevSkipNext < 0) { // SENT_END?
-          prevSkipNext = tokens.length - (nextPos + 1);
-        }
-        int maxTok = Math.min(nextPos + prevSkipNext, tokens.length - (patternSize - k) + minOccurCorrection);
-        for (int m = nextPos; m <= maxTok; m++) {
-          allElementsMatch = testAllReadings(tokens, pTokenMatcher, prevTokenMatcher, m, firstMatchToken, prevSkipNext);
-
-          if (pTokenMatcher.getPatternToken().getMinOccurrence() == 0) {
-            boolean foundNext = false;
-            for (int k2 = k + 1; k2 < patternSize; k2++) {
-              PatternTokenMatcher nextElement = patternTokenMatchers.get(k2);
-              boolean nextElementMatch = testAllReadings(tokens, nextElement, pTokenMatcher, m,
-                firstMatchToken, prevSkipNext);
-              if (nextElementMatch) {
-                // this element doesn't match, but it's optional so accept this and continue
-                allElementsMatch = true;
-                minOccurSkip++;
-                tokenPositions[matchingTokens++] = 0;
-                foundNext = true;
-                break;
-              } else if (nextElement.getPatternToken().getMinOccurrence() > 0) {
-                break;
-              }
-            }
-            if (foundNext) {
-              break;
-            }
-          }
-
-          if (allElementsMatch) {
-            int skipForMax = skipMaxTokens(tokens, pTokenMatcher, firstMatchToken, prevSkipNext,
-              prevTokenMatcher, m, patternSize - k - 1);
-            lastMatchToken = m + skipForMax;
-            int skipShift = lastMatchToken - nextPos;
-            tokenPositions[matchingTokens++] = skipShift + 1;
-            prevSkipNext = translateElementNo(pTokenMatcher.getPatternToken().getSkipNext());
-            skipShiftTotal += skipShift;
-            if (firstMatchToken == -1) {
-              firstMatchToken = lastMatchToken - skipForMax;
-            }
-            if (firstMarkerMatchToken == -1 && pTokenMatcher.getPatternToken().isInsideMarker()) {
-              firstMarkerMatchToken = lastMatchToken - skipForMax;
-            }
-            if (pTokenMatcher.getPatternToken().isInsideMarker()) {
-              lastMarkerMatchToken = lastMatchToken;
-            }
-            break;
-          }
-        }
-        if (!allElementsMatch) {
-          break;
+    int limit = rule.isSentStart() ? 1 : Math.max(0, tokens.length - patternSize + 1) + minOccurCorrection;
+    if (anchorIndices != null) {
+      for (Integer anchorIndex : anchorIndices) {
+        int i = anchorIndex - anchor.tokenIndex;
+        if (i >= 0 && i < limit) {
+          matchFrom(i, tokens, consumer, tokenPositions);
         }
       }
-      if (allElementsMatch && matchingTokens == patternSize) {
-        consumer.consume(tokenPositions, firstMatchToken, lastMatchToken, firstMarkerMatchToken, lastMarkerMatchToken);
+    } else {
+      for (int i = 0; i < limit; i++) {
+        matchFrom(i, tokens, consumer, tokenPositions);
       }
-      i++;
     }
   }
 
+  private void matchFrom(int startIndex, AnalyzedTokenReadings[] tokens, MatchConsumer consumer, int[] tokenPositions) throws IOException {
+    PatternTokenMatcher pTokenMatcher = null;
+    int skipShiftTotal = 0;
+    boolean allElementsMatch = false;
+    unifiedTokens = null;
+    int matchingTokens = 0;
+    int firstMatchToken = -1;
+    int lastMatchToken = -1;
+    int firstMarkerMatchToken = -1;
+    int lastMarkerMatchToken = -1;
+    int prevSkipNext = 0;
+    if (rule.isTestUnification()) {
+      unifier.reset();
+    }
+    int minOccurSkip = 0;
+    for (int k = 0; k < patternSize; k++) {
+      PatternTokenMatcher prevTokenMatcher = pTokenMatcher;
+      pTokenMatcher = patternTokenMatchers.get(k);
+      pTokenMatcher.resolveReference(firstMatchToken, tokens, rule.getLanguage());
+      int nextPos = startIndex + k + skipShiftTotal - minOccurSkip;
+      prevMatched = false;
+      if (prevSkipNext + nextPos >= tokens.length || prevSkipNext < 0) { // SENT_END?
+        prevSkipNext = tokens.length - (nextPos + 1);
+      }
+      int maxTok = Math.min(nextPos + prevSkipNext, tokens.length - (patternSize - k) + minOccurCorrection);
+      for (int m = nextPos; m <= maxTok; m++) {
+        allElementsMatch = testAllReadings(tokens, pTokenMatcher, prevTokenMatcher, m, firstMatchToken, prevSkipNext);
+
+        if (pTokenMatcher.getPatternToken().getMinOccurrence() == 0) {
+          boolean foundNext = false;
+          for (int k2 = k + 1; k2 < patternSize; k2++) {
+            PatternTokenMatcher nextElement = patternTokenMatchers.get(k2);
+            boolean nextElementMatch = testAllReadings(tokens, nextElement, pTokenMatcher, m,
+              firstMatchToken, prevSkipNext);
+            if (nextElementMatch) {
+              // this element doesn't match, but it's optional so accept this and continue
+              allElementsMatch = true;
+              minOccurSkip++;
+              tokenPositions[matchingTokens++] = 0;
+              foundNext = true;
+              break;
+            } else if (nextElement.getPatternToken().getMinOccurrence() > 0) {
+              break;
+            }
+          }
+          if (foundNext) {
+            break;
+          }
+        }
+
+        if (allElementsMatch) {
+          int skipForMax = skipMaxTokens(tokens, pTokenMatcher, firstMatchToken, prevSkipNext,
+            prevTokenMatcher, m, patternSize - k - 1);
+          lastMatchToken = m + skipForMax;
+          int skipShift = lastMatchToken - nextPos;
+          tokenPositions[matchingTokens++] = skipShift + 1;
+          prevSkipNext = translateElementNo(pTokenMatcher.getPatternToken().getSkipNext());
+          skipShiftTotal += skipShift;
+          if (firstMatchToken == -1) {
+            firstMatchToken = lastMatchToken - skipForMax;
+          }
+          if (firstMarkerMatchToken == -1 && pTokenMatcher.getPatternToken().isInsideMarker()) {
+            firstMarkerMatchToken = lastMatchToken - skipForMax;
+          }
+          if (pTokenMatcher.getPatternToken().isInsideMarker()) {
+            lastMarkerMatchToken = lastMatchToken;
+          }
+          break;
+        }
+      }
+      if (!allElementsMatch) {
+        break;
+      }
+    }
+    if (allElementsMatch && matchingTokens == patternSize) {
+      consumer.consume(tokenPositions, firstMatchToken, lastMatchToken, firstMarkerMatchToken, lastMarkerMatchToken);
+    }
+  }
+
+  protected boolean isInterpretPosTagsPreDisambiguation() {
+    return rule instanceof PatternRule && ((PatternRule) rule).isInterpretPosTagsPreDisambiguation();
+  }
+
   protected boolean testAllReadings(AnalyzedTokenReadings[] tokens,
-      PatternTokenMatcher matcher, PatternTokenMatcher prevElement,
-      int tokenNo, int firstMatchToken, int prevSkipNext)
+                                    PatternTokenMatcher matcher, PatternTokenMatcher prevElement,
+                                    int tokenNo, int firstMatchToken, int prevSkipNext)
           throws IOException {
     boolean thisMatched = false;
     int numberOfReadings = tokens[tokenNo].getReadingsLength();
@@ -268,10 +291,7 @@ public abstract class AbstractPatternRulePerformer {
     return thisMatched;
   }
 
-  /**
-   * @since 2.5
-   */
-  protected int getMinOccurrenceCorrection() {
+  private int getMinOccurrenceCorrection() {
     int minOccurCorrection = 0;
     for (PatternToken patternToken : rule.getPatternTokens()) {
       if (patternToken.getMinOccurrence() == 0) {

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/AbstractTokenBasedRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/AbstractTokenBasedRule.java
@@ -18,48 +18,62 @@
  */
 package org.languagetool.rules.patterns;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import org.languagetool.AnalyzedSentence;
 import org.languagetool.Language;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * A base class for {@link PatternToken}-based rules.
  * It's public for implementation reasons and should not be used outside LanguageTool.
  */
+@ApiStatus.Internal
 public abstract class AbstractTokenBasedRule extends AbstractPatternRule {
   // Tokens used for fast checking whether a rule can ever match.
   @Nullable
-  final String[] inflectedRuleTokens;
+  final TokenHint[] tokenHints;
 
+  // Token/lemma hints together with offset of a matching token from any match start
   @Nullable
-  final String[][] formHints;
+  final TokenHint anchorHint;
 
   protected AbstractTokenBasedRule(String id, String description, Language language, List<PatternToken> patternTokens, boolean getUnified) {
     super(id, description, language, patternTokens, getUnified);
 
-    Set<String> inflectedRuleTokens = new HashSet<>();
-    Set<Set<String>> formHints = new HashSet<>();
+    Set<TokenHint> tokenHints = new HashSet<>();
+    TokenHint anchorHint = null;
 
-    for (PatternToken pToken : patternTokens) {
-      if (pToken.isInflected() && !pToken.getNegation() && pToken.hasStringThatMustMatch() && !pToken.isRegularExpression()) {
-        inflectedRuleTokens.add(Objects.requireNonNull(pToken.getString()).toLowerCase());
+    boolean fixedOffset = true;
+    for (int i = 0; i < patternTokens.size(); i++) {
+      PatternToken token = patternTokens.get(i);
+
+      boolean inflected = false;
+      Set<String> hints = token.calcFormHints();
+      if (hints == null) {
+        inflected = true;
+        hints = token.calcLemmaHints();
       }
-      Set<String> hints = pToken.calcFormHints();
       if (hints != null) {
-        formHints.add(hints.stream().map(String::toLowerCase).collect(Collectors.toSet()));
+        TokenHint hint = new TokenHint(inflected, hints, i);
+        tokenHints.add(hint);
+        if (fixedOffset && anchorHint == null) {
+          anchorHint = hint;
+        }
+      }
+
+      if (fixedOffset && (token.getMinOccurrence() != 1 || token.getSkipNext() != 0 || token.getMaxOccurrence() != 1)) {
+        fixedOffset = false;
       }
     }
 
-    this.inflectedRuleTokens = inflectedRuleTokens.isEmpty() ? null : inflectedRuleTokens.toArray(new String[0]);
-    this.formHints = formHints.isEmpty() ? null : formHints.stream()
-      .map(set -> set.toArray(new String[0]))
+    this.tokenHints = tokenHints.isEmpty() ? null : tokenHints.stream()
       .sorted(Comparator
-        .comparing((String[] a) -> a.length)
-        .thenComparing((String[] a) -> -Arrays.stream(a).mapToInt(String::length).min().orElse(0)))
-      .toArray(String[][]::new);
+        .comparing((TokenHint th) -> th.lowerCaseValues.length)
+        .thenComparing(th -> -Arrays.stream(th.lowerCaseValues).mapToInt(String::length).min().orElse(0))
+      ).toArray(TokenHint[]::new);
+    this.anchorHint = anchorHint;
   }
 
   /**
@@ -67,31 +81,81 @@ public abstract class AbstractTokenBasedRule extends AbstractPatternRule {
    * because it can never match. Used for performance optimization.
    */
   protected boolean canBeIgnoredFor(AnalyzedSentence sentence) {
-    if (inflectedRuleTokens != null) {
-      for (String token : inflectedRuleTokens) {
-        if (!sentence.getLemmaSet().contains(token)) {
-          return true;
-        }
-      }
-    }
-    if (formHints != null) {
-      Set<String> tokenSet = sentence.getTokenSet();
-      for (String[] hints : formHints) {
-        if (!containsAny(tokenSet, hints)) {
-          return true;
-        }
+    if (tokenHints == null) return false;
+    for (TokenHint th : tokenHints) {
+      if (th.canBeIgnoredFor(sentence)) {
+        return true;
       }
     }
     return false;
   }
 
-  private static boolean containsAny(Set<String> set, String[] elements) {
-    for (String hint : elements) {
-      if (set.contains(hint)) {
-        return true;
-      }
+  /**
+   * Represents possible values of a {@link PatternToken}'s lemma or text.
+   */
+  static class TokenHint {
+    final boolean inflected;
+    final String[] lowerCaseValues;
+    final int tokenIndex;
+
+    private TokenHint(boolean inflected, Set<String> possibleValues, int tokenIndex) {
+      this.inflected = inflected;
+      this.tokenIndex = tokenIndex;
+      lowerCaseValues = possibleValues.stream().map(String::toLowerCase).distinct().toArray(String[]::new);
     }
-    return false;
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof TokenHint)) return false;
+      TokenHint tokenHint = (TokenHint) o;
+      return inflected == tokenHint.inflected &&
+             tokenIndex == tokenHint.tokenIndex &&
+             Arrays.equals(lowerCaseValues, tokenHint.lowerCaseValues);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(inflected, tokenIndex, Arrays.hashCode(lowerCaseValues));
+    }
+
+    /**
+     * @return all indices inside sentence's non-blank tokens where this token could possibly match
+     */
+    List<Integer> getPossibleIndices(AnalyzedSentence sentence) {
+      boolean needMerge = false;
+      List<Integer> result = null;
+      for (String hint : lowerCaseValues) {
+        List<Integer> hintIndices = getHintIndices(sentence, hint);
+        if (hintIndices != null) {
+          if (result == null) {
+            result = hintIndices;
+          } else {
+            if (!needMerge) {
+              result = new ArrayList<>(result);
+              needMerge = true;
+            }
+            result.addAll(hintIndices);
+          }
+        }
+      }
+      if (result == null) return Collections.emptyList();
+      return needMerge ? new ArrayList<>(new TreeSet<>(result)) : result;
+    }
+
+    private boolean canBeIgnoredFor(AnalyzedSentence sentence) {
+      for (String hint : lowerCaseValues) {
+        if (getHintIndices(sentence, hint) != null) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    @Nullable
+    private List<Integer> getHintIndices(AnalyzedSentence sentence, String hint) {
+      return inflected ? sentence.getLemmaOffsets(hint) : sentence.getTokenOffsets(hint);
+    }
   }
 
 }

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleMatcher.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleMatcher.java
@@ -53,14 +53,12 @@ final public class PatternRuleMatcher extends AbstractPatternRulePerformer imple
           + SUGGESTION_END_TAG);
 
   private final boolean useList;
-  private final List<PatternTokenMatcher> patternTokenMatchers;
   //private final Integer slowMatchThreshold;
   private static final boolean monitorRules = System.getProperty("monitorActiveRules") != null;
 
   PatternRuleMatcher(PatternRule rule, boolean useList) {
     super(rule, rule.getLanguage().getUnifier());
     this.useList = useList;
-    this.patternTokenMatchers = createElementMatchers();
     //String slowMatchThresholdStr = System.getProperty("slowMatchThreshold");
     //slowMatchThreshold = slowMatchThresholdStr != null ? Integer.parseInt(slowMatchThresholdStr) : null;
   }
@@ -78,9 +76,10 @@ final public class PatternRuleMatcher extends AbstractPatternRulePerformer imple
       currentlyActiveRules.compute(key, (k, v) -> v == null ? 1 : v + 1);
     }
     try {
-      boolean isPreDisambigMatch = rule instanceof PatternRule && ((PatternRule)rule).isInterpretPosTagsPreDisambiguation();
-      AnalyzedTokenReadings[] tokens = isPreDisambigMatch ? sentence.getPreDisambigTokensWithoutWhitespace() : sentence.getTokensWithoutWhitespace();
-      doMatch(patternTokenMatchers, tokens, (tokenPositions, firstMatchToken, lastMatchToken, firstMarkerMatchToken, lastMarkerMatchToken) -> {
+      AnalyzedTokenReadings[] tokens = isInterpretPosTagsPreDisambiguation()
+                                       ? sentence.getPreDisambigTokensWithoutWhitespace()
+                                       : sentence.getTokensWithoutWhitespace();
+      doMatch(sentence, tokens, (tokenPositions, firstMatchToken, lastMatchToken, firstMarkerMatchToken, lastMarkerMatchToken) -> {
         RuleMatch ruleMatch = createRuleMatch(tokenPositions, tokens, firstMatchToken, lastMatchToken, firstMarkerMatchToken, lastMarkerMatchToken, sentence);
         if (ruleMatch != null) {
           ruleMatches.add(ruleMatch);

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternToken.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternToken.java
@@ -678,14 +678,27 @@ public class PatternToken implements Cloneable {
    */
   @Nullable
   Set<String> calcFormHints() {
-    Set<String> result = inflected ? null : calcOwnPossibleStringValues();
+    return calcStringHints(false);
+  }
+
+  /**
+   * @return all possible forms that this token pattern can accept, or {@code null} if such set is unknown/unbounded.
+   * This is used internally for performance optimizations.
+   */
+  @Nullable
+  Set<String> calcLemmaHints() {
+    return calcStringHints(true);
+  }
+
+  private Set<String> calcStringHints(boolean inflected) {
+    Set<String> result = inflected != this.inflected ? null : calcOwnPossibleStringValues();
     if (result == null) return null;
 
     if (andGroupList != null) {
       result = new HashSet<>(result);
 
       for (PatternToken token : andGroupList) {
-        Set<String> hints = token.calcFormHints();
+        Set<String> hints = token.calcStringHints(inflected);
         if (hints != null) {
           result.retainAll(hints);
         }
@@ -694,14 +707,14 @@ public class PatternToken implements Cloneable {
       result = new HashSet<>(result);
 
       for (PatternToken token : orGroupList) {
-        Set<String> hints = token.calcFormHints();
+        Set<String> hints = token.calcStringHints(inflected);
         if (hints == null) return null;
 
         result.addAll(hints);
       }
     }
 
-    return result;
+    return result.isEmpty() ? null : result;
   }
 
   @Nullable

--- a/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/DisambiguationPatternRuleReplacer.java
+++ b/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/DisambiguationPatternRuleReplacer.java
@@ -43,16 +43,13 @@ class DisambiguationPatternRuleReplacer extends AbstractPatternRulePerformer {
     super(rule, rule.getLanguage().getDisambiguationUnifier());
   }
 
-  public final AnalyzedSentence replace(AnalyzedSentence sentence)
-      throws IOException {
-    List<PatternTokenMatcher> patternTokenMatchers = createElementMatchers();
-
+  AnalyzedSentence replace(AnalyzedSentence sentence) throws IOException {
     AnalyzedTokenReadings[] tokens = sentence.getTokensWithoutWhitespace();
     AnalyzedTokenReadings[] preDisambigTokens = sentence.getTokens();
     AnalyzedTokenReadings[][] whTokens = {sentence.getTokens()};
     boolean[] changed = {false};
 
-    doMatch(patternTokenMatchers, tokens, (tokenPositions, firstMatchToken, lastMatchToken, firstMarkerMatchToken, lastMarkerMatchToken) -> {
+    doMatch(sentence, tokens, (tokenPositions, firstMatchToken, lastMatchToken, firstMarkerMatchToken, lastMarkerMatchToken) -> {
       int ruleMatchFromPos = -1;
       int ruleMatchToPos = -1;
       int tokenCount = 0;

--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/AbstractPatternRulePerformerTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/AbstractPatternRulePerformerTest.java
@@ -37,7 +37,7 @@ public class AbstractPatternRulePerformerTest {
     PatternRule simpleRule = new PatternRule("FAKE", new Demo(), Collections.singletonList(patternToken1), "descr", "message", "short");
     PatternTokenMatcher elemMatcher = new PatternTokenMatcher(patternToken1);
 
-    AbstractPatternRulePerformer p = new MockAbstractPatternRulePerformer(simpleRule, new Unifier(null, null));
+    AbstractPatternRulePerformer p = new AbstractPatternRulePerformer(simpleRule, new Unifier(null, null)){};
 
     assertTrue(p.testAllReadings(tokenReadings("foo", null), elemMatcher, null, 0, 0, 0));
     assertFalse(p.testAllReadings(tokenReadings("bar", null), elemMatcher, null, 0, 0, 0));
@@ -52,7 +52,7 @@ public class AbstractPatternRulePerformerTest {
     PatternRule simpleRule = new PatternRule("FAKE", new Demo(), Collections.singletonList(chunkPatternToken), "descr", "message", "short");
     PatternTokenMatcher elemMatcher = new PatternTokenMatcher(chunkPatternToken);
 
-    AbstractPatternRulePerformer p = new MockAbstractPatternRulePerformer(simpleRule, new Unifier(null, null));
+    AbstractPatternRulePerformer p = new AbstractPatternRulePerformer(simpleRule, new Unifier(null, null)){};
 
     assertFalse(p.testAllReadings(tokenReadings("bar", null), elemMatcher, null, 0, 0, 0));
     assertTrue(p.testAllReadings(tokenReadings("bar", "myChunk"), elemMatcher, null, 0, 0, 0));
@@ -67,9 +67,4 @@ public class AbstractPatternRulePerformerTest {
     return new AnalyzedTokenReadings[] { tokenReadings1 };
   }
 
-  static class MockAbstractPatternRulePerformer extends AbstractPatternRulePerformer {
-    protected MockAbstractPatternRulePerformer(AbstractPatternRule rule, Unifier unifier) {
-      super(rule, unifier);
-    }
-  }
 }


### PR DESCRIPTION
track token indices by lemma/token text in AnalyzedSentence

if a pattern has a token with token/lemma hints and fixed offset from the start,
use these indices to narrow down the search space

7-10% speedup in `Main -l en` for me