### PR TITLE
[en] add rule HAVE_A_SHOWER

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-US/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-US/grammar.xml
@@ -373,7 +373,30 @@ USA
             <example correction="In the future"><marker>In future</marker>, we will do better.</example>
             <example><marker>In the future</marker>, we will do better.</example>
         </rule>
-
+        <rule id="HAVE_A_SHOWER" name="have a shower -> take a shower" default="temp_off">
+            <antipattern>
+                <token regexp="yes">\w*(room|house|home)$</token>
+                <token />
+            </antipattern>
+            <pattern>
+                <marker>
+                    <token inflected="yes">have</token>
+                </marker>
+                <token min="0" postag="RB" />
+                <token postag_regexp="yes" postag="DT|CD" />
+                <token min="0" postag_regexp="yes" postag="JJ|RB"><exception regexp="yes">baby|steam|spacious|big|large|small</exception></token>
+                <token regexp="yes">shower|bath</token>
+            </pattern>
+            <message>In the US, the verb <suggestion><match no="1" postag="VB.*">take</match></suggestion> is usually used before '\5'.</message>
+            <example correction="took">He <marker>had</marker> a shower before breakfast.</example>
+            <example correction="takes">He <marker>has</marker> a shower every day.</example>
+            <example correction="taken">I haven't <marker>had</marker> a bath in years.</example>
+            <example>I haven't taken a bath in years.</example>
+            <example>They have a baby shower.</example>
+            <example>I have two really cold showers per day.</example>
+            <example>If your home has a shower</example>
+            <example>My bathroom has a spacious shower.</example>
+        </rule>
     </category>
 
     <category id="SEMANTICS" name="Semantics" type="inconsistency">


### PR DESCRIPTION
Draft, possibly pending whether the rule should be set to `picky` or `en-US/CA`-only or something of that sort.

[Google Books Ngram Viewer data](https://books.google.com/ngrams/graph?content=have_INF+a+shower%2C+take_INF+a+shower&year_start=1800&year_end=2019&corpus=26&smoothing=3&direct_url=t3%3B%2Chave_INF%20a%20shower%3B%2Cc0%3B%2Cs0%3B%3Bhave%20a%20shower%3B%2Cc0%3B%3Bhad%20a%20shower%3B%2Cc0%3B%3Bhaving%20a%20shower%3B%2Cc0%3B%3Bhas%20a%20shower%3B%2Cc0%3B.t3%3B%2Ctake_INF%20a%20shower%3B%2Cc0%3B%2Cs0%3B%3Btake%20a%20shower%3B%2Cc0%3B%3Btook%20a%20shower%3B%2Cc0%3B%3Btaking%20a%20shower%3B%2Cc0%3B%3Btaken%20a%20shower%3B%2Cc0%3B%3Btakes%20a%20shower%3B%2Cc0#t3%3B%2Chave_INF%20a%20shower%3B%2Cc0%3B%2Cs0%3B%3Bhave%20a%20shower%3B%2Cc0%3B%3Bhad%20a%20shower%3B%2Cc0%3B%3Bhaving%20a%20shower%3B%2Cc0%3B%3Bhas%20a%20shower%3B%2Cc0%3B.t3%3B%2Ctake_INF%20a%20shower%3B%2Cc0%3B%2Cs0%3B%3Btake%20a%20shower%3B%2Cc0%3B%3Btook%20a%20shower%3B%2Cc0%3B%3Btaking%20a%20shower%3B%2Cc0%3B%3Btaken%20a%20shower%3B%2Cc0%3B%3Btakes%20a%20shower%3B%2Cc0) shows that the usage of `take a shower` is around 5× that of `have a shower`. GloWbE shows that `have` may be a primarily Commonwealth usage (GB, IE, AU, NZ):

<img width="1192" alt="Screen Shot 2020-12-28 at 01 56 53" src="https://user-images.githubusercontent.com/312957/103195335-134a1c00-48b0-11eb-88c0-3345d44b5038.png">
