### PR TITLE
remove decimeters from UnitConversionRule

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractUnitConversionRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractUnitConversionRule.java
@@ -223,7 +223,7 @@ public abstract class AbstractUnitConversionRule extends Rule {
 
     addUnit("km", METRE, "km", 1e3, true);
     addUnit("m", METRE, "m",   1e0, true);
-    addUnit("dm", METRE, "dm", 1e-1,  false/*true*/); // Metric, but not commonly used
+    //addUnit("dm", METRE, "dm", 1e-1,  /*true*/); // Metric, but not commonly used
     addUnit("cm", METRE, "cm", 1e-2, true);
     addUnit("mm", METRE, "mm", 1e-3, true);
     addUnit("µm", METRE, "µm", 1e-6, true);
@@ -233,7 +233,7 @@ public abstract class AbstractUnitConversionRule extends Rule {
     addUnit("ha", SQUARE_METRE, "ha", 1e4, true);
     addUnit("a", SQUARE_METRE, "a", 1e2, true);
     addUnit("km(?:\\^2|2|²)", SQUARE_METRE, "km²", 1e6, true);
-    addUnit("dm(?:\\^2|2|²)", SQUARE_METRE, "dm²", 1e-2,  false/*true*/); // Metric, but not commonly used
+    //addUnit("dm(?:\\^2|2|²)", SQUARE_METRE, "dm²", 1e-2,  false/*true*/); // Metric, but not commonly used
     addUnit("cm(?:\\^2|2|²)", SQUARE_METRE, "cm²", 1e-4, true);
     addUnit("mm(?:\\^2|2|²)", SQUARE_METRE, "mm²", 1e-6, true);
     addUnit("µm(?:\\^2|2|²)", SQUARE_METRE, "µm²", 1e-12, true);
@@ -251,7 +251,7 @@ public abstract class AbstractUnitConversionRule extends Rule {
 
     addUnit("m(?:\\^3|3|³)", CUBIC_METRE, "m³", 1, true);
     addUnit("km(?:\\^3|3|³)", CUBIC_METRE, "km³", 1e9, true);
-    addUnit("dm(?:\\^3|3|³)", CUBIC_METRE, "dm³", 1e-3,  false/*true*/); // Metric, but not commonly used
+    //addUnit("dm(?:\\^3|3|³)", CUBIC_METRE, "dm³", 1e-3,  false/*true*/); // Metric, but not commonly used
     addUnit("cm(?:\\^3|3|³)", CUBIC_METRE, "cm³", 1e-6, true);
     addUnit("mm(?:\\^3|3|³)", CUBIC_METRE, "mm³", 1e-9, true);
     addUnit("µm(?:\\^3|3|³)", CUBIC_METRE, "µm³", 1e-18, true);

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/UnitConversionRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/UnitConversionRule.java
@@ -60,7 +60,7 @@ public class UnitConversionRule extends AbstractUnitConversionRule {
 
     addUnit("Meter", METRE, "Meter", 1, true);
     addUnit("Kilometer", METRE, "Kilometer", 1e3, true);
-    addUnit("Dezimeter", METRE, "Dezimeter", 1e-1, false); // metric, but should not be suggested
+    //addUnit("Dezimeter", METRE, "Dezimeter", 1e-1, false); // metric, but should not be suggested
     addUnit("Zentimeter", METRE, "Zentimeter", 1e-2, true);
     addUnit("Millimeter", METRE, "Millimeter", 1e-3, true);
     addUnit("Mikrometer", METRE, "Mikrometer", 1e-6, true);
@@ -72,7 +72,7 @@ public class UnitConversionRule extends AbstractUnitConversionRule {
     addUnit("Hektar", SQUARE_METRE, "Hektar", 1e4, true);
     addUnit("Ar", SQUARE_METRE, "Ar", 1e2, true);
     addUnit("Quadratkilometer", SQUARE_METRE,  "Quadratkilometer",  1e6, true);
-    addUnit("Quadratdezimeter", SQUARE_METRE,  "Quadratdezimeter",  1e-2, false/*true*/); // Metric, but not commonly used
+    //addUnit("Quadratdezimeter", SQUARE_METRE,  "Quadratdezimeter",  1e-2, false/*true*/); // Metric, but not commonly used
     addUnit("Quadratzentimeter", SQUARE_METRE, "Quadratzentimeter", 1e-4, true);
     addUnit("Quadratmillimeter", SQUARE_METRE, "Quadratmillimeter", 1e-6, true);
     addUnit("Quadratmikrometer", SQUARE_METRE, "Quadratmikrometer", 1e-12, true);
@@ -80,7 +80,7 @@ public class UnitConversionRule extends AbstractUnitConversionRule {
 
     addUnit("Kubikmeter", CUBIC_METRE,     "Kubikmeter",      1, true);
     addUnit("Kubikkilometer", CUBIC_METRE, "Kubikkilometer",  1e9, true);
-    addUnit("Kubikdezimeter", CUBIC_METRE, "Kubikdezimeter",  1e-3, false/*true*/); // Metric, but not commonly used
+    //addUnit("Kubikdezimeter", CUBIC_METRE, "Kubikdezimeter",  1e-3, false/*true*/); // Metric, but not commonly used
     addUnit("Kubikzentimeter", CUBIC_METRE,"Kubikzentimeter", 1e-6, true);
     addUnit("Kubikmillimeter", CUBIC_METRE,"Kubikmillimeter", 1e-9, true);
     addUnit("Kubikmikrometer", CUBIC_METRE,"Kubikmikrometer", 1e-18, true);


### PR DESCRIPTION
fixes languagetooler-gmbh/languagetool-premium#2173
uncommonly used, so we don't want to suggest it
previously: hack, added as non-metric; leads to conversions from e.g.
dm3 to liter