### PR TITLE
filters for remote rule results

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/BERTSuggestionRanking.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/BERTSuggestionRanking.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Streams;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 import org.languagetool.AnalyzedSentence;
+import org.languagetool.Language;
 import org.languagetool.languagemodel.bert.RemoteLanguageModel;
 import org.languagetool.markup.AnnotatedText;
 import org.slf4j.Logger;
@@ -73,8 +74,8 @@ public class BERTSuggestionRanking extends RemoteRule {
   private final RemoteLanguageModel model;
   private final Rule wrappedRule;
 
-  public BERTSuggestionRanking(Rule rule, RemoteRuleConfig config, boolean inputLogging) {
-    super(rule.messages, config, inputLogging, rule.getId());
+  public BERTSuggestionRanking(Language language, Rule rule, RemoteRuleConfig config, boolean inputLogging) {
+    super(language, rule.messages, config, inputLogging, rule.getId());
     this.wrappedRule = rule;
     super.setCategory(wrappedRule.getCategory());
     synchronized (models) {

--- a/languagetool-core/src/main/java/org/languagetool/rules/GRPCRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/GRPCRule.java
@@ -33,6 +33,7 @@ import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import org.jetbrains.annotations.Nullable;
 import org.languagetool.AnalyzedSentence;
 import org.languagetool.JLanguageTool;
+import org.languagetool.Language;
 import org.languagetool.markup.AnnotatedText;
 import org.languagetool.rules.ml.MLServerGrpc;
 import org.languagetool.rules.ml.MLServerProto;
@@ -171,8 +172,8 @@ public abstract class GRPCRule extends RemoteRule {
 
   private final Connection conn;
 
-  public GRPCRule(ResourceBundle messages, RemoteRuleConfig config, boolean inputLogging) {
-    super(messages, config, inputLogging);
+  public GRPCRule(Language language, ResourceBundle messages, RemoteRuleConfig config, boolean inputLogging) {
+    super(language, messages, config, inputLogging);
 
     synchronized (servers) {
       Connection conn = null;
@@ -256,6 +257,7 @@ public abstract class GRPCRule extends RemoteRule {
 
   /**
    * Helper method to create instances of RemoteMLRule
+   * @param language rule language
    * @param messages for i18n; = JLanguageTool.getMessageBundle(lang)
    * @param config configuration for remote rule server;
    *               options: secure, clientKey, clientCertificate, rootCertificate
@@ -266,9 +268,9 @@ public abstract class GRPCRule extends RemoteRule {
    * @param messagesByID mapping match.sub_id -&gt; key in MessageBundle.properties for RuleMatch's message
    * @return instance of RemoteMLRule
    */
-  public static GRPCRule create(ResourceBundle messages, RemoteRuleConfig config, boolean inputLogging,
+  public static GRPCRule create(Language language, ResourceBundle messages, RemoteRuleConfig config, boolean inputLogging,
                                 String id, String descriptionKey, Map<String, String> messagesByID) {
-    return new GRPCRule(messages, config, inputLogging) {
+    return new GRPCRule(language, messages, config, inputLogging) {
 
 
       @Override
@@ -285,6 +287,7 @@ public abstract class GRPCRule extends RemoteRule {
 
   /**
    * Helper method to create instances of RemoteMLRule
+   * @param language rule language
    * @param config configuration for remote rule server;
    *               options: secure, clientKey, clientCertificate, rootCertificate
                    use RemoteRuleConfig.getRelevantConfig(id, configs)
@@ -294,9 +297,9 @@ public abstract class GRPCRule extends RemoteRule {
    * @param messagesByID mapping match.sub_id to RuleMatch's message
    * @return instance of RemoteMLRule
    */
-  public static GRPCRule create(RemoteRuleConfig config, boolean inputLogging,
+  public static GRPCRule create(Language language, RemoteRuleConfig config, boolean inputLogging,
                                 String id, String description, Map<String, String> messagesByID) {
-    return new GRPCRule(JLanguageTool.getMessageBundle(), config, inputLogging) {
+    return new GRPCRule(language, JLanguageTool.getMessageBundle(), config, inputLogging) {
 
 
       @Override
@@ -311,10 +314,10 @@ public abstract class GRPCRule extends RemoteRule {
     };
   }
 
-  public static List<GRPCRule> createAll(List<RemoteRuleConfig> configs, boolean inputLogging, String prefix, String defaultDescription) {
+  public static List<GRPCRule> createAll(Language language, List<RemoteRuleConfig> configs, boolean inputLogging, String prefix, String defaultDescription) {
     return configs.stream()
       .filter(cfg -> cfg.getRuleId().startsWith(prefix))
-      .map(cfg -> create(cfg, inputLogging, cfg.getRuleId(), defaultDescription, Collections.emptyMap()))
+      .map(cfg -> create(language, cfg, inputLogging, cfg.getRuleId(), defaultDescription, Collections.emptyMap()))
       .collect(Collectors.toList());
   }
 }

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
@@ -24,6 +24,7 @@ package org.languagetool.rules;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.jetbrains.annotations.Nullable;
 import org.languagetool.AnalyzedSentence;
+import org.languagetool.Language;
 import org.languagetool.markup.AnnotatedText;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,22 +56,26 @@ public abstract class RemoteRule extends Rule {
   protected final RemoteRuleConfig serviceConfiguration;
   protected final boolean inputLogging;
   private AnnotatedText annotatedText;
+  protected final boolean filterMatches;
+  protected final Language ruleLanguage;
 
-  public RemoteRule(ResourceBundle messages, RemoteRuleConfig config, boolean inputLogging, @Nullable String ruleId) {
+  public RemoteRule(Language language, ResourceBundle messages, RemoteRuleConfig config, boolean inputLogging, @Nullable String ruleId) {
     super(messages);
     serviceConfiguration = config;
+    this.ruleLanguage = language;
     this.inputLogging = inputLogging;
     if (ruleId == null) { // allow both providing rule ID in constructor or overriding getId
       ruleId = getId();
     }
+    filterMatches = Boolean.parseBoolean(serviceConfiguration.getOptions().getOrDefault("filterMatches", "false"));
     lastFailure.putIfAbsent(ruleId, 0L);
     consecutiveFailures.putIfAbsent(ruleId, new AtomicInteger());
     // TODO maybe use fixed pool, take number of concurrent requests from configuration?
     executors.putIfAbsent(ruleId, Executors.newCachedThreadPool(threadFactory));
   }
 
-  public RemoteRule(ResourceBundle messages, RemoteRuleConfig config, boolean inputLogging) {
-    this(messages, config, inputLogging, null);
+  public RemoteRule(Language language, ResourceBundle messages, RemoteRuleConfig config, boolean inputLogging) {
+    this(language, messages, config, inputLogging, null);
   }
 
   public static void shutdown() {
@@ -134,6 +139,17 @@ public abstract class RemoteRule extends Rule {
           RemoteRuleMetrics.RequestResult requestResult = result.isRemote() ?
             RemoteRuleMetrics.RequestResult.SUCCESS : RemoteRuleMetrics.RequestResult.SKIPPED;
           RemoteRuleMetrics.request(ruleId, i, System.nanoTime() - startTime, characters, requestResult);
+
+          if (filterMatches) {
+            List<RuleMatch> filteredMatches = new ArrayList<>();
+            for (AnalyzedSentence sentence : sentences) {
+              List<RuleMatch> sentenceMatches = result.matchesForSentence(sentence);
+              List<RuleMatch> filteredSentenceMatches = RemoteRuleFilters.filterMatches(
+                ruleLanguage, sentence, sentenceMatches);
+              filteredMatches.addAll(filteredSentenceMatches);
+            }
+            result = new RemoteRuleResult(result.isRemote(), result.isSuccess(), filteredMatches);
+          }
 
           return result;
         } catch (InterruptedException | ExecutionException | TimeoutException e) {

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleFilters.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleFilters.java
@@ -1,0 +1,122 @@
+/*
+ *  LanguageTool, a natural language style checker
+ *  * Copyright (C) 2020 Fabian Richter
+ *  *
+ *  * This library is free software; you can redistribute it and/or
+ *  * modify it under the terms of the GNU Lesser General Public
+ *  * License as published by the Free Software Foundation; either
+ *  * version 2.1 of the License, or (at your option) any later version.
+ *  *
+ *  * This library is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  * Lesser General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Lesser General Public
+ *  * License along with this library; if not, write to the Free Software
+ *  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  * USA
+ *
+ */
+
+package org.languagetool.rules;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.jetbrains.annotations.NotNull;
+import org.languagetool.AnalyzedSentence;
+import org.languagetool.JLanguageTool;
+import org.languagetool.Language;
+import org.languagetool.Languages;
+import org.languagetool.broker.ResourceDataBroker;
+import org.languagetool.rules.patterns.AbstractPatternRule;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+/**
+ * rules in remote-rule-filter.xml, same syntax as pattern rules
+ * used as filters for results from matches provided by remote rule
+ * i.e. if there is a match with equal match span from remote rule and a corresponding filter (i.e. with the same ID as the match)
+ * the match is discarded
+ * filtering uses the IDs from the matches, so dynamically created rules using different IDs will work
+ */
+public class RemoteRuleFilters {
+  public static final String RULE_FILE = "remote-rule-filters.xml";
+
+  private static final LoadingCache<Language, Map<String, List<AbstractPatternRule>>> rules =
+    CacheBuilder.newBuilder()
+      .build(CacheLoader.from(RemoteRuleFilters::load));
+
+
+  public static final List<RuleMatch> filterMatches(Language lang, AnalyzedSentence sentence, List<RuleMatch> matches) throws ExecutionException, IOException {
+    // load all relevant filters for given matches
+    Set<String> matchIds = matches.stream().map(m -> m.getRule().getId()).collect(Collectors.toSet());
+    List<AbstractPatternRule> filters = rules.get(lang).entrySet()
+      .stream().filter(e -> matchIds.contains(e.getKey())).flatMap(e -> e.getValue().stream()).collect(Collectors.toList());
+
+    // prepare for lookup of matches
+    Map<MatchPosition, Set<AbstractPatternRule>> filterRulesByPosition = new HashMap<>();
+    for (AbstractPatternRule rule : filters) {
+      RuleMatch[] filterMatches = rule.match(sentence);
+      for (RuleMatch match : filterMatches) {
+        MatchPosition pos = new MatchPosition(match.getFromPos(), match.getToPos());
+        filterRulesByPosition.computeIfAbsent(pos, k -> new HashSet<>()).add(rule);
+      }
+    }
+
+    List<RuleMatch>  filteredMatches = matches.stream()
+      .filter(match -> {
+        MatchPosition pos = new MatchPosition(match.getFromPos(), match.getToPos());
+        // is there a filter match with the right ID at this position?
+        boolean matched = filterRulesByPosition.getOrDefault(pos, Collections.emptySet())
+          .stream().anyMatch(rule -> rule.getId().equals(match.getRule().getId()));
+        if (matched) {
+          System.out.println("Removing match " + match + " - matched filter");
+        }
+        return !matched;
+      })
+      .collect(Collectors.toList());
+    return filteredMatches;
+  }
+
+
+  public static void main(String[] args) throws ExecutionException {
+    String langCode;
+    if (args.length > 0) {
+      langCode = args[0];
+    } else {
+      langCode = "en";
+    }
+    Language lang = Languages.getLanguageForShortCode(langCode);
+    rules.get(lang).forEach((id, rules) -> {
+      System.out.println("=== " + id + " ===");
+      rules.forEach(System.out::println);
+      System.out.println();
+    });
+  }
+
+  static Map<String, List<AbstractPatternRule>> load(Language lang) {
+    JLanguageTool lt = new JLanguageTool(lang);
+    ResourceDataBroker dataBroker = JLanguageTool.getDataBroker();
+    String filename = dataBroker.getRulesDir() + "/" + getFilename(lang);
+    try {
+      List<AbstractPatternRule> allRules = lt.loadPatternRules(filename);
+      Map<String, List<AbstractPatternRule>> rules = new HashMap<>();
+      for (AbstractPatternRule rule : allRules) {
+        rules.computeIfAbsent(rule.getId(), k -> new ArrayList<>()).add(rule);
+      }
+      return rules;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @NotNull
+  static String getFilename(Language lang) {
+      return lang.getShortCode() + "/" + RULE_FILE;
+  }
+}

--- a/languagetool-core/src/test/java/org/languagetool/RemoteRuleCacheTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/RemoteRuleCacheTest.java
@@ -23,6 +23,7 @@ package org.languagetool;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.languagetool.language.Demo;
 import org.languagetool.markup.AnnotatedText;
 import org.languagetool.markup.AnnotatedTextBuilder;
 import org.languagetool.rules.*;
@@ -52,7 +53,7 @@ public class RemoteRuleCacheTest {
       "TEST_REMOTE_RULE", "example.com", 1234, 0, 0L, 0.0f, 1, 10L, Collections.emptyMap());
 
     TestRemoteRule() {
-      super(JLanguageTool.getMessageBundle(), testConfig, false);
+      super(new Demo(), JLanguageTool.getMessageBundle(), testConfig, false);
     }
 
     class TestRemoteRequest extends RemoteRequest {

--- a/languagetool-core/src/test/java/org/languagetool/rules/DemoRemoteRuleFilterTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/DemoRemoteRuleFilterTest.java
@@ -1,0 +1,35 @@
+/*
+ *  LanguageTool, a natural language style checker
+ *  * Copyright (C) 2020 Fabian Richter
+ *  *
+ *  * This library is free software; you can redistribute it and/or
+ *  * modify it under the terms of the GNU Lesser General Public
+ *  * License as published by the Free Software Foundation; either
+ *  * version 2.1 of the License, or (at your option) any later version.
+ *  *
+ *  * This library is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  * Lesser General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Lesser General Public
+ *  * License along with this library; if not, write to the Free Software
+ *  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  * USA
+ *
+ */
+
+package org.languagetool.rules;
+
+import org.junit.Test;
+import org.languagetool.TestTools;
+
+import java.io.IOException;
+
+public class DemoRemoteRuleFilterTest extends RemoteRuleFilterTest {
+
+  @Test
+  public void testRules() throws IOException {
+    runGrammarRuleForLanguage(TestTools.getDemoLanguage());
+  }
+}

--- a/languagetool-core/src/test/java/org/languagetool/rules/GRPCRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/GRPCRuleTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.languagetool.AnalyzedSentence;
 import org.languagetool.JLanguageTool;
 import org.languagetool.TestTools;
+import org.languagetool.language.Demo;
 import org.languagetool.rules.ml.MLServerProto;
 
 import java.io.IOException;
@@ -46,7 +47,7 @@ public class GRPCRuleTest {
       0, 0L, 0.0f,
       1, 0L, Collections.emptyMap());
 
-    rule = new GRPCRule(JLanguageTool.getMessageBundle(), config, true) {
+    rule = new GRPCRule(new Demo(), JLanguageTool.getMessageBundle(), config, true) {
       @Override
       protected String getMessage(MLServerProto.Match match, AnalyzedSentence sentence) {
         return "Matched: " + match.toString().replaceAll("\n", " | ");

--- a/languagetool-core/src/test/java/org/languagetool/rules/RemoteRuleFilterTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/RemoteRuleFilterTest.java
@@ -1,0 +1,70 @@
+/*
+ *  LanguageTool, a natural language style checker
+ *  * Copyright (C) 2020 Fabian Richter
+ *  *
+ *  * This library is free software; you can redistribute it and/or
+ *  * modify it under the terms of the GNU Lesser General Public
+ *  * License as published by the Free Software Foundation; either
+ *  * version 2.1 of the License, or (at your option) any later version.
+ *  *
+ *  * This library is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  * Lesser General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Lesser General Public
+ *  * License along with this library; if not, write to the Free Software
+ *  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  * USA
+ *
+ */
+
+package org.languagetool.rules;
+
+import org.languagetool.Language;
+import org.languagetool.MultiThreadedJLanguageTool;
+import org.languagetool.rules.patterns.AbstractPatternRule;
+import org.languagetool.rules.patterns.PatternRuleTest;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * base class to test rules in remote-rule-filters.xml, like PatternRuleTest for grammar.xml
+ */
+public class RemoteRuleFilterTest extends PatternRuleTest {
+
+  @Override
+  protected List<String> getGrammarFileNames(Language lang) {
+    return Collections.singletonList(RemoteRuleFilters.getFilename(lang));
+  }
+
+  @Override
+  public void runTestForLanguage(Language lang) throws IOException {
+    // looser requirements for rules, e.g. empty name;
+    // skip validation, if invalid, RemoteRuleFilters.load will fail anyway
+    //validatePatternFile(lang);
+    //
+    System.out.println("Running remote rule filter tests for " + lang.getName() + "... ");
+    MultiThreadedJLanguageTool lt = createToolForTesting(lang);
+
+    List<AbstractPatternRule> rules = RemoteRuleFilters.load(lang)
+      .values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+    MultiThreadedJLanguageTool allRulesLt = new MultiThreadedJLanguageTool(lang);
+    allRulesLt.disableRules(allRulesLt.getAllRules().stream().map(Rule::getId).collect(Collectors.toList()));
+    rules.forEach(allRulesLt::addRule);
+
+    validateRuleIds(lang, allRulesLt);
+    validateSentenceStartNotInMarker(allRulesLt);
+    testRegexSyntax(lang, rules);
+    testExamplesExist(rules);
+    testGrammarRulesFromXML(rules, allRulesLt, lang);
+    System.out.println(rules.size() + " rules tested.");
+    allRulesLt.shutdown();
+    lt.shutdown();
+  }
+
+}

--- a/languagetool-core/src/test/java/org/languagetool/rules/RemoteRuleFiltersTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/RemoteRuleFiltersTest.java
@@ -1,0 +1,136 @@
+/*
+ *  LanguageTool, a natural language style checker
+ *  * Copyright (C) 2020 Fabian Richter
+ *  *
+ *  * This library is free software; you can redistribute it and/or
+ *  * modify it under the terms of the GNU Lesser General Public
+ *  * License as published by the Free Software Foundation; either
+ *  * version 2.1 of the License, or (at your option) any later version.
+ *  *
+ *  * This library is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  * Lesser General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Lesser General Public
+ *  * License along with this library; if not, write to the Free Software
+ *  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  * USA
+ *
+ */
+
+package org.languagetool.rules;
+
+import org.junit.Test;
+import org.languagetool.AnalyzedSentence;
+import org.languagetool.JLanguageTool;
+import org.languagetool.Language;
+import org.languagetool.TestTools;
+import org.languagetool.rules.patterns.AbstractPatternRule;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.*;
+
+/**
+ * test the filtering logic implemented in RemoteRuleFilters
+ * @see RemoteRuleFilterTest for testing pattern rules in remote-rule-filters.xml
+ *  */
+public class RemoteRuleFiltersTest {
+  private static Language testLang = TestTools.getDemoLanguage();
+  private static final String TEST_RULE = "TEST_REMOTE_RULE";
+
+  @Test
+  public void load() throws Exception {
+    Map<String, List<AbstractPatternRule>> rules = RemoteRuleFilters.load(testLang);
+    assertTrue("loaded test rule", rules.containsKey(TEST_RULE));
+    assertEquals("loaded test rule", rules.get(TEST_RULE).size(), 1);
+  }
+
+  private RuleMatch matchSubstring(String ruleId, AnalyzedSentence sentence, String substring) {
+    Rule r = new FakeRule() {
+      @Override
+      public String getId() {
+        return ruleId;
+      }
+    };
+    int start = sentence.getText().indexOf(substring);
+    int end = start + substring.length();
+    return new RuleMatch(r, sentence, start, end, "test match");
+  }
+
+  @Test
+  public void testSimpleFilter() throws IOException, ExecutionException {
+    JLanguageTool lt = new JLanguageTool(testLang);
+    AnalyzedSentence s = lt.getAnalyzedSentence("This is a test.");
+    assertTrue("Simple filter works", RemoteRuleFilters.filterMatches(testLang, s,
+      Arrays.asList(matchSubstring(TEST_RULE, s, "test"))
+      ).isEmpty());
+    assertFalse("Filter respects IDs", RemoteRuleFilters.filterMatches(testLang, s,
+      Arrays.asList(matchSubstring(TEST_RULE + "_NEW", s, "test"))).isEmpty()
+    );
+  }
+
+  @Test
+  public void testMultiTokenWhitespace() throws IOException, ExecutionException {
+    String ruleId = "TEST_WHITESPACE";
+    JLanguageTool lt = new JLanguageTool(testLang);
+    String sub; AnalyzedSentence s;
+
+    sub = "foo bar";
+    s = lt.getAnalyzedSentence("This is " + sub + " test.");
+    assertTrue("Filter works", RemoteRuleFilters.filterMatches(testLang, s,
+      Arrays.asList(matchSubstring(ruleId, s, "foo bar"))
+    ).isEmpty());
+
+    sub = "foo   bar";
+    s = lt.getAnalyzedSentence("This is " + sub +  " test.");
+    assertTrue("Filter works with multiple spaces", RemoteRuleFilters.filterMatches(testLang, s,
+      Arrays.asList(matchSubstring(ruleId, s, sub))
+    ).isEmpty());
+
+    sub = "foo \n bar";
+    s = lt.getAnalyzedSentence("This is " + sub +  " test.");
+    assertTrue("Filter works with newlines", RemoteRuleFilters.filterMatches(testLang, s,
+      Arrays.asList(matchSubstring(ruleId, s, sub))
+    ).isEmpty());
+  }
+
+  @Test
+  public void testMarker() throws IOException, ExecutionException {
+    String ruleId = "TEST_MARKER";
+    JLanguageTool lt = new JLanguageTool(testLang);
+    String sub; AnalyzedSentence s;
+
+    s = lt.getAnalyzedSentence("I went to the bar.");
+    assertFalse("Filter doesn't apply because of pre-marker context", RemoteRuleFilters.filterMatches(testLang, s,
+      Arrays.asList(matchSubstring(ruleId, s, "bar"))
+    ).isEmpty());
+
+    s = lt.getAnalyzedSentence("I went to the foo bar.");
+    assertTrue("Filter applies, marker wroks", RemoteRuleFilters.filterMatches(testLang, s,
+      Arrays.asList(matchSubstring(ruleId, s, "bar"))
+    ).isEmpty());
+  }
+
+  @Test
+  public void testAntipattern() throws IOException, ExecutionException {
+    String ruleId = "TEST_ANTIPATTERN";
+    JLanguageTool lt = new JLanguageTool(testLang);
+    String sub; AnalyzedSentence s;
+
+    s = lt.getAnalyzedSentence("I went to the test bar.");
+    assertFalse("Filter doesn't apply because of antipattern", RemoteRuleFilters.filterMatches(testLang, s,
+      Arrays.asList(matchSubstring(ruleId, s, "test bar"))
+    ).isEmpty());
+
+    s = lt.getAnalyzedSentence("I went to the best bar.");
+    assertTrue("Filter applies, antipattern did not match", RemoteRuleFilters.filterMatches(testLang, s,
+      Arrays.asList(matchSubstring(ruleId, s, "best bar"))
+    ).isEmpty());
+  }
+}

--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/AbstractPatternRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/AbstractPatternRuleTest.java
@@ -71,7 +71,7 @@ public class AbstractPatternRuleTest {
   }
 
   protected boolean skipCountryVariant(Language lang) {
-    if (Languages.get().get(0).equals(lang)) { // test always the first one
+    if (Languages.get().isEmpty() || Languages.get().get(0).equals(lang)) { // test always the first one
       return false;
     }
     ResourceDataBroker dataBroker = JLanguageTool.getDataBroker();

--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternRuleTest.java
@@ -171,7 +171,7 @@ public class PatternRuleTest extends AbstractPatternRuleTest {
   }
 
   @NotNull
-  private static MultiThreadedJLanguageTool createToolForTesting(Language lang) {
+  protected static MultiThreadedJLanguageTool createToolForTesting(Language lang) {
     MultiThreadedJLanguageTool lt = new MultiThreadedJLanguageTool(lang);
     if (CHECK_WITH_SENTENCE_SPLITTING) {
       disableSpellingRules(lt);
@@ -179,7 +179,7 @@ public class PatternRuleTest extends AbstractPatternRuleTest {
     return lt;
   }
 
-  private void validatePatternFile(Language lang) throws IOException {
+  protected void validatePatternFile(Language lang) throws IOException {
     validatePatternFile(getGrammarFileNames(lang));
   }
   
@@ -210,7 +210,7 @@ public class PatternRuleTest extends AbstractPatternRuleTest {
     }
   }
 
-  private void validateRuleIds(Language lang, JLanguageTool lt) {
+  protected void validateRuleIds(Language lang, JLanguageTool lt) {
     List<Rule> allRules = lt.getAllRules();
     Set<String> categoryIds = new HashSet<>();
     new RuleIdValidator(lang).validateUniqueness();
@@ -232,7 +232,7 @@ public class PatternRuleTest extends AbstractPatternRuleTest {
   /*
    * A <marker> that covers the SENT_START can lead to obscure offset issues, so warn about that. 
    */
-  private void validateSentenceStartNotInMarker(JLanguageTool lt) {
+  protected void validateSentenceStartNotInMarker(JLanguageTool lt) {
     System.out.println("Check that sentence start tag is not included in <marker>....");
     List<Rule> rules = lt.getAllRules();
     for (Rule rule : rules) {
@@ -260,7 +260,7 @@ public class PatternRuleTest extends AbstractPatternRuleTest {
     }
   }
 
-  private void testRegexSyntax(Language lang, List<AbstractPatternRule> rules) {
+  protected void testRegexSyntax(Language lang, List<AbstractPatternRule> rules) {
     System.out.println("Checking regexp syntax of " + rules.size() + " rules for " + lang + "...");
     for (AbstractPatternRule rule : rules) {
       // Test the rule pattern.
@@ -286,7 +286,7 @@ public class PatternRuleTest extends AbstractPatternRuleTest {
     }
   }
 
-  private void testExamplesExist(List<AbstractPatternRule> rules) {
+  protected void testExamplesExist(List<AbstractPatternRule> rules) {
     for (AbstractPatternRule rule : rules) {
       if (rule.getCorrectExamples().isEmpty()) {
         boolean correctionExists = false;
@@ -311,7 +311,7 @@ public class PatternRuleTest extends AbstractPatternRuleTest {
     }
   }
 
-  private void testGrammarRulesFromXML(List<AbstractPatternRule> rules, JLanguageTool allRulesLt, Language lang) {
+  protected void testGrammarRulesFromXML(List<AbstractPatternRule> rules, JLanguageTool allRulesLt, Language lang) {
     System.out.println("Checking example sentences of " + rules.size() + " rules for " + lang + "...");
 
     int threadCount = Math.max(1, Runtime.getRuntime().availableProcessors() / 2);

--- a/languagetool-core/src/test/resources/org/languagetool/rules/xx/remote-rule-filters.xml
+++ b/languagetool-core/src/test/resources/org/languagetool/rules/xx/remote-rule-filters.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/print.xsl" ?>
+<?xml-stylesheet type="text/css" href="../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.css"
+        title="Easy editing stylesheet" ?>
+<!--
+  ~ /* LanguageTool, a natural language style checker
+  ~  * Copyright (C) 2021 Fabian Richter
+  ~  *
+  ~  * This library is free software; you can redistribute it and/or
+  ~  * modify it under the terms of the GNU Lesser General Public
+  ~  * License as published by the Free Software Foundation; either
+  ~  * version 2.1 of the License, or (at your option) any later version.
+  ~  *
+  ~  * This library is distributed in the hope that it will be useful,
+  ~  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  ~  * Lesser General Public License for more details.
+  ~  *
+  ~  * You should have received a copy of the GNU Lesser General Public
+  ~  * License along with this library; if not, write to the Free Software
+  ~  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+  ~  * USA
+  ~  */
+  -->
+<rules lang="xx" xsi:noNamespaceSchemaLocation="../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <category name="Test rules" id="TEST_RULES">
+        <rulegroup id="TEST_REMOTE_RULE" name="">
+            <rule>
+                <pattern>
+                    <token>test</token>
+                </pattern>
+                <example correction=""><marker>test</marker></example>
+                <example>nottest</example>
+            </rule>
+        </rulegroup>
+        <rule id="TEST_WHITESPACE" name="">
+            <pattern>
+                <token>foo</token>
+                <token>bar</token>
+            </pattern>
+            <example correction=""><marker>foo bar</marker></example>
+            <example>foo baz</example>
+        </rule>
+        <rule id="TEST_MARKER" name="">
+            <pattern>
+                <token>foo</token>
+                <marker><token>bar</token></marker>
+            </pattern>
+            <example correction="">foo <marker>bar</marker></example>
+            <example>foo baz</example>
+            <example>bar fight</example>
+        </rule>
+        <rule id="TEST_ANTIPATTERN" name="">
+            <antipattern>
+                <token>test</token>
+                <token>bar</token>
+            </antipattern>
+            <pattern>
+                <token/>
+                <token>bar</token>
+            </pattern>
+            <example correction="">I went to the <marker>best bar</marker>.</example>
+            <example>I went to the test bar.</example>
+        </rule>
+    </category>
+</rules>

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
@@ -355,8 +355,8 @@ public class German extends Language implements AutoCloseable {
       messageBundle, configs, globalConfig, userConfig, motherTongue, altLanguages, inputLogging));
 
     // no description needed - matches based on automatically created rules with descriptions provided by remote server
-    rules.addAll(GRPCRule.createAll(configs, inputLogging, "AI_DE_",
-      "INTERNAL - dynamically loaded rule supported by remote server"));
+    rules.addAll(GRPCRule.createAll(this, configs, inputLogging,
+            "AI_DE_", "INTERNAL - dynamically loaded rule supported by remote server"));
 
     return rules;
   }

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/English.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/English.java
@@ -493,7 +493,7 @@ public class English extends Language implements AutoCloseable {
     return original -> {
       if (original.isDictionaryBasedSpellingRule() && original.getId().startsWith("MORFOLOGIK_RULE_EN")) {
         if (bert != null) {
-          return new BERTSuggestionRanking(original, bert, inputLogging);
+          return new BERTSuggestionRanking(this, original, bert, inputLogging);
         }
       }
       return fallback.apply(original);
@@ -506,10 +506,10 @@ public class English extends Language implements AutoCloseable {
       messageBundle, configs, globalConfig, userConfig, motherTongue, altLanguages, inputLogging));
 
     // no description needed - matches based on automatically created rules with descriptions provided by remote server
-    rules.addAll(GRPCRule.createAll(configs, inputLogging, "AI_EN_",
-      "INTERNAL - dynamically loaded rule supported by remote server"));
-    rules.addAll(GRPCRule.createAll(configs, inputLogging, "AI_HYDRA_LEO",
-      "INTERNAL - dynamically loaded rule supported by remote server"));
+    rules.addAll(GRPCRule.createAll(this, configs, inputLogging,
+      "AI_EN_", "INTERNAL - dynamically loaded rule supported by remote server"));
+    rules.addAll(GRPCRule.createAll(this, configs, inputLogging,
+      "AI_HYDRA_LEO", "INTERNAL - dynamically loaded rule supported by remote server"));
 
     return rules;
   }

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/remote-rule-filters.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/remote-rule-filters.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/print.xsl" ?>
+<?xml-stylesheet type="text/css" href="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.css"
+        title="Easy editing stylesheet" ?>
+<!--
+  ~ /* LanguageTool, a natural language style checker
+  ~  * Copyright (C) 2020 Fabian Richter
+  ~  *
+  ~  * This library is free software; you can redistribute it and/or
+  ~  * modify it under the terms of the GNU Lesser General Public
+  ~  * License as published by the Free Software Foundation; either
+  ~  * version 2.1 of the License, or (at your option) any later version.
+  ~  *
+  ~  * This library is distributed in the hope that it will be useful,
+  ~  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  ~  * Lesser General Public License for more details.
+  ~  *
+  ~  * You should have received a copy of the GNU Lesser General Public
+  ~  * License along with this library; if not, write to the Free Software
+  ~  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+  ~  * USA
+  ~  */
+  -->
+
+<rules lang="en" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <category name="Machine learning rules" id="AI_RULES">
+        <!-- FIXME: EXAMPLE
+        <rulegroup id="AI_HYDRA_LEO_MISSING_TO" name="">
+            <rule>
+                <pattern>
+                    <token>send</token>
+                    <token postag_regexp="yes" postag="PRP|NNP"/>
+                    <marker>
+                        <token>peace</token>
+                    </marker>
+                </pattern>
+                <example correction="">I suggest you talk to him and send him <marker>peace</marker>.</example>
+                <example>I suggest you talk to him and send the email him.</example>
+            </rule>
+        </rulegroup>
+        -->
+    </category>
+</rules>

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishRemoteRuleFilterTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishRemoteRuleFilterTest.java
@@ -1,6 +1,6 @@
 /*
  *  LanguageTool, a natural language style checker
- *  * Copyright (C) 2018 Fabian Richter
+ *  * Copyright (C) 2020 Fabian Richter
  *  *
  *  * This library is free software; you can redistribute it and/or
  *  * modify it under the terms of the GNU Lesser General Public
@@ -19,29 +19,30 @@
  *
  */
 
-package org.languagetool.rules;
+package org.languagetool.rules.en;
 
-import org.languagetool.AnalyzedSentence;
-import org.languagetool.rules.ml.MLServerProto;
+import org.junit.Test;
+import org.languagetool.Language;
+import org.languagetool.rules.RemoteRuleFilterTest;
 
-import java.util.ResourceBundle;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
-public class GRPCConfusionRule extends GRPCRule {
+public class EnglishRemoteRuleFilterTest extends RemoteRuleFilterTest {
 
-  public GRPCConfusionRule(ResourceBundle messages, RemoteRuleConfig config, boolean inputLogging) {
-    super(messages, config, inputLogging);
+  @Test
+  public void testRules() throws IOException {
+    runGrammarRulesFromXmlTest();
   }
 
   @Override
-  protected String getMessage(MLServerProto.Match match, AnalyzedSentence sentence) {
-    // fallback, should be provided by server
-    String covered = sentence.getText().substring(match.getOffset(), match.getOffset() + match.getLength());
-    return "You might be confusing '" + covered + "' with another word.";
-  }
-
-  @Override
-  public String getDescription() {
-    // fallback, should be provided by server
-    return "This rule discerns confusion pairs.";
+  protected List<String> getGrammarFileNames(Language lang) {
+    // no variant support included for now
+    if (lang.isVariant()) {
+      return Collections.emptyList();
+    } else {
+      return super.getGrammarFileNames(lang);
+    }
   }
 }


### PR DESCRIPTION
using pattern rule syntax, in new file remote-rule-filters.xml
allow excluding matches from remote rules that have corresponding matches from rules in remote-rule-filters.xml