### PR TITLE
[de] compile regexps in TokenPredicate just once, not on every call 

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/StringMatcher.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/StringMatcher.java
@@ -20,6 +20,7 @@ package org.languagetool.rules.patterns;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.languagetool.tools.InterruptibleCharSequence;
@@ -34,7 +35,8 @@ import java.util.stream.Stream;
  * An object encapsulating a text pattern and the way it's matched (case-sensitivity / regular expression),
  * plus some optimizations over standard regular expression matching.
  */
-abstract class StringMatcher {
+@ApiStatus.Internal
+public abstract class StringMatcher {
   final String pattern;
   final boolean caseSensitive;
   final boolean isRegExp;
@@ -55,9 +57,9 @@ abstract class StringMatcher {
   /**
    * @return whether the given string is accepted by this matcher.
    */
-  abstract boolean matches(String s);
+  public abstract boolean matches(String s);
 
-  static StringMatcher create(String pattern, boolean isRegExp, boolean caseSensitive) {
+  public static StringMatcher create(String pattern, boolean isRegExp, boolean caseSensitive) {
     return create(pattern, isRegExp, caseSensitive, Function.identity());
   }
 
@@ -85,7 +87,7 @@ abstract class StringMatcher {
           }
 
           @Override
-          boolean matches(String s) {
+          public boolean matches(String s) {
             return Arrays.binarySearch(sorted, s, String.CASE_INSENSITIVE_ORDER) >= 0;
           }
         };
@@ -97,7 +99,7 @@ abstract class StringMatcher {
         }
 
         @Override
-        boolean matches(String s) {
+        public boolean matches(String s) {
           return set.contains(s);
         }
       };
@@ -116,7 +118,7 @@ abstract class StringMatcher {
       }
 
       @Override
-      boolean matches(String s) {
+      public boolean matches(String s) {
         if (substrings != null && !substrings.matches(s, caseSensitive)) return false;
         if (substringsAreSufficient) return true;
         return compiled.matcher(new InterruptibleCharSequence(s)).matches();
@@ -133,7 +135,7 @@ abstract class StringMatcher {
       }
 
       @Override
-      boolean matches(String s) {
+      public boolean matches(String s) {
         return caseSensitive ? s.equals(pattern) : s.equalsIgnoreCase(pattern);
       }
     };

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/chunking/TokenPredicate.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/chunking/TokenPredicate.java
@@ -21,87 +21,90 @@ package org.languagetool.chunking;
 import edu.washington.cs.knowitall.logic.Expression;
 import org.languagetool.AnalyzedToken;
 import org.languagetool.AnalyzedTokenReadings;
+import org.languagetool.rules.patterns.StringMatcher;
 
-import java.util.regex.Pattern;
+import java.util.function.Predicate;
 
 final class TokenPredicate extends Expression.Arg.Pred<ChunkTaggedToken> {
-
-  private final boolean caseSensitive;
+  private final Predicate<ChunkTaggedToken> predicate;
 
   TokenPredicate(String description, boolean caseSensitive) {
     super(description);
-    this.caseSensitive = caseSensitive;
+    predicate = compile(description, caseSensitive);
   }
 
-  @Override
-  public boolean apply(ChunkTaggedToken analyzedToken) {
-    String[] parts = getDescription().split("=");
+  private Predicate<ChunkTaggedToken> compile(String description, boolean caseSensitive) {
+    String[] parts = description.split("=");
     String exprType;
     String exprValue;
     if (parts.length == 1) {
       exprType = "string";
-      exprValue = parts[0];
+      exprValue = unquote(parts[0]);
     } else if (parts.length == 2) {
       exprType = parts[0];
-      exprValue = parts[1];
+      exprValue = unquote(parts[1]);
     } else {
       throw new RuntimeException("Could not parse expression: " + getDescription());
     }
-    if (exprValue.startsWith("'") && exprValue.endsWith("'")) {
-      exprValue = exprValue.substring(1, exprValue.length()-1);
-    }
+
     switch (exprType) {
-
       case "string":
-        if (caseSensitive) {
-          return analyzedToken.getToken().equals(exprValue);
-        } else {
-          return analyzedToken.getToken().equalsIgnoreCase(exprValue);
-        }
-
       case "regex":
-        Pattern p1 = caseSensitive ? Pattern.compile(exprValue) : Pattern.compile(exprValue, Pattern.CASE_INSENSITIVE);
-        return p1.matcher(analyzedToken.getToken()).matches();
-
-      case "regexCS":  // case sensitive
-        Pattern p2 = Pattern.compile(exprValue);
-        return p2.matcher(analyzedToken.getToken()).matches();
+      case "regexCS":
+        StringMatcher matcher = StringMatcher.create(exprValue, !"string".equals(exprType), caseSensitive || "regexCS".equals(exprType));
+        return analyzedToken -> matcher.matches(analyzedToken.getToken());
 
       case "chunk":
-        Pattern chunkPattern = Pattern.compile(exprValue);
-        for (ChunkTag chunkTag : analyzedToken.getChunkTags()) {
-          if (chunkPattern.matcher(chunkTag.getChunkTag()).matches()) {
-            return true;
-          }
-        }
-        return false;
-
-      case "pos":
-        AnalyzedTokenReadings readings = analyzedToken.getReadings();
-        if (readings != null) {
-          for (AnalyzedToken token : readings) {
-            if (token.getPOSTag() != null && token.getPOSTag().contains(exprValue)) {
+        StringMatcher chunkPattern = StringMatcher.create(exprValue, true, true);
+        return analyzedToken -> {
+          for (ChunkTag chunkTag : analyzedToken.getChunkTags()) {
+            if (chunkPattern.matches(chunkTag.getChunkTag())) {
               return true;
             }
           }
-        }
-        return false;
+          return false;
+        };
+
+      case "pos":
+        return analyzedToken -> {
+          AnalyzedTokenReadings readings = analyzedToken.getReadings();
+          if (readings != null) {
+            for (AnalyzedToken token : readings) {
+              if (token.getPOSTag() != null && token.getPOSTag().contains(exprValue)) {
+                return true;
+              }
+            }
+          }
+          return false;
+        };
 
       case "posre":
       case "posregex":
-        Pattern posPattern = Pattern.compile(exprValue);
-        AnalyzedTokenReadings readings2 = analyzedToken.getReadings();
-        if (readings2 != null) {
-          for (AnalyzedToken token : readings2) {
-            if (token.getPOSTag() != null && posPattern.matcher(token.getPOSTag()).matches()) {
-              return true;
+        StringMatcher posPattern = StringMatcher.create(exprValue, true, true);
+        return analyzedToken -> {
+          AnalyzedTokenReadings readings = analyzedToken.getReadings();
+          if (readings != null) {
+            for (AnalyzedToken token : readings) {
+              if (token.getPOSTag() != null && posPattern.matches(token.getPOSTag())) {
+                return true;
+              }
             }
           }
-        }
-        return false;
+          return false;
+        };
 
       default:
         throw new RuntimeException("Expression type not supported: '" + exprType + "'");
     }
+
+  }
+
+  private static String unquote(String s) {
+    return s.startsWith("'") && s.endsWith("'") ? s.substring(1, s.length() - 1) : s;
+  }
+
+  @Override
+  public boolean apply(ChunkTaggedToken analyzedToken) {
+    return predicate.test(analyzedToken);
   }
 }


### PR DESCRIPTION
and use StringMatcher for further speedup

Some 7% speedup for me on `Main -l de`

#4168