### PR TITLE
Add Alternativensuche/N

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -29644,3 +29644,4 @@ Cost per Action #eng
 Cost per Acquisition #eng
 Cost per Lead #eng
 Cost per Click #eng
+Alternativensuche/N


### PR DESCRIPTION
Alternativensuche kennt das LanguageTool nicht, nur die falschen Wörter.
Siehe  #4243