### PR TITLE
fix bug in remote rule caching

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/BERTSuggestionRanking.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/BERTSuggestionRanking.java
@@ -90,9 +90,11 @@ public class BERTSuggestionRanking extends RemoteRule {
   }
 
   class MatchesForReordering extends RemoteRequest {
+    final List<AnalyzedSentence> sentences;
     final List<RuleMatch> matches;
     final List<RemoteLanguageModel.Request> requests;
-    MatchesForReordering(List<RuleMatch> matches, List<RemoteLanguageModel.Request> requests) {
+    MatchesForReordering(List<AnalyzedSentence> sentences, List<RuleMatch> matches, List<RemoteLanguageModel.Request> requests) {
+      this.sentences = sentences;
       this.matches = matches;
       this.requests = requests;
     }
@@ -125,16 +127,17 @@ public class BERTSuggestionRanking extends RemoteRule {
         }
         Collections.addAll(matches, sentenceMatches);
       }
-      return new MatchesForReordering(matches, requests);
+      return new MatchesForReordering(sentences, matches, requests);
     } catch (IOException e) {
       logger.error("Error while executing rule " + wrappedRule.getId(), e);
-      return new MatchesForReordering(Collections.emptyList(), Collections.emptyList());
+      return new MatchesForReordering(sentences, Collections.emptyList(), Collections.emptyList());
     }
   }
 
   @Override
   protected RemoteRuleResult fallbackResults(RemoteRequest request) {
-    return new RemoteRuleResult(false, false, ((MatchesForReordering) request).matches);
+    MatchesForReordering req = (MatchesForReordering) request;
+    return new RemoteRuleResult(false, false, req.matches, req.sentences);
   }
 
   @Override
@@ -152,7 +155,7 @@ public class BERTSuggestionRanking extends RemoteRule {
       requests = requests.stream().filter(Objects::nonNull).collect(Collectors.toList());
 
       if (requests.isEmpty()) {
-        return new RemoteRuleResult(false, true, matches);
+        return new RemoteRuleResult(false, true, matches, data.sentences);
       } else {
         List<List<Double>> results = model.batchScore(requests);
         // put curated at the top, then compare probabilities
@@ -175,7 +178,7 @@ public class BERTSuggestionRanking extends RemoteRule {
           //logger.info("Reordered correction for '{}' from {} to {}", error, req.candidates, ranked);
           match.setSuggestedReplacementObjects(ranked);
         }
-        return new RemoteRuleResult(true, true, matches);
+        return new RemoteRuleResult(true, true, matches, data.sentences);
       }
     };
   }

--- a/languagetool-core/src/main/java/org/languagetool/rules/GRPCRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/GRPCRule.java
@@ -239,7 +239,7 @@ public abstract class GRPCRule extends RemoteRule {
           }
         )
       ).flatMap(Function.identity()).collect(Collectors.toList());
-      RemoteRuleResult result = new RemoteRuleResult(true, true, matches);
+      RemoteRuleResult result = new RemoteRuleResult(true, true, matches, req.sentences);
       return result;
     };
   }
@@ -252,7 +252,8 @@ public abstract class GRPCRule extends RemoteRule {
 
   @Override
   protected RemoteRuleResult fallbackResults(RemoteRule.RemoteRequest request) {
-    return new RemoteRuleResult(false, false, Collections.emptyList());
+    MLRuleRequest req = (MLRuleRequest) request;
+    return new RemoteRuleResult(false, false, Collections.emptyList(), req.sentences);
   }
 
   /**

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
@@ -99,7 +99,7 @@ public abstract class RemoteRule extends Rule {
    */
   public FutureTask<RemoteRuleResult> run(List<AnalyzedSentence> sentences, @Nullable Long textSessionId) {
     if (sentences.isEmpty()) {
-      return new FutureTask<>(() -> new RemoteRuleResult(false, true, Collections.emptyList()));
+      return new FutureTask<>(() -> new RemoteRuleResult(false, true, Collections.emptyList(), sentences));
     }
     return new FutureTask<>(() -> {
       long startTime = System.nanoTime();
@@ -148,7 +148,7 @@ public abstract class RemoteRule extends Rule {
                 ruleLanguage, sentence, sentenceMatches);
               filteredMatches.addAll(filteredSentenceMatches);
             }
-            result = new RemoteRuleResult(result.isRemote(), result.isSuccess(), filteredMatches);
+            result = new RemoteRuleResult(result.isRemote(), result.isSuccess(), filteredMatches, sentences);
           }
 
           return result;

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleResult.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleResult.java
@@ -21,7 +21,7 @@
 
 package org.languagetool.rules;
 
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.languagetool.AnalyzedSentence;
 
 import java.util.*;
@@ -30,13 +30,17 @@ public class RemoteRuleResult {
   private final boolean remote; // was remote needed/involved? rules may filter input sentences and only call remote on some; for metrics
   private final boolean success; // successful -> for caching, so that we can cache: remote not needed for this sentence
   private final List<RuleMatch> matches;
+  private final Set<AnalyzedSentence> processedSentences;
+  // which sentences were processed? to distinguish between no matches because not processed (e.g. cached)
+  // and no errors/corrections found
 
   private final Map<AnalyzedSentence, List<RuleMatch>> sentenceMatches = new HashMap<>();
 
-  public RemoteRuleResult(boolean remote, boolean success, List<RuleMatch> matches) {
+  public RemoteRuleResult(boolean remote, boolean success, List<RuleMatch> matches, List<AnalyzedSentence> processedSentences) {
     this.remote = remote;
     this.success = success;
     this.matches = matches;
+    this.processedSentences = Collections.unmodifiableSet(new HashSet<>(processedSentences));
 
     for (RuleMatch match : matches) {
       sentenceMatches.compute(match.getSentence(), (sentence, ruleMatches) -> {
@@ -66,8 +70,19 @@ public class RemoteRuleResult {
     return sentenceMatches.keySet();
   }
 
-  @NotNull
+  public Set<AnalyzedSentence> processedSentences() {
+    return processedSentences;
+  }
+
+  /**
+   * get matches for a specific sentence
+   * @param sentence sentence to look up
+   * @return null if sentence not processed, else returned matches
+   */
+  @Nullable
   public List<RuleMatch> matchesForSentence(AnalyzedSentence sentence) {
-    return sentenceMatches.getOrDefault(sentence, Collections.emptyList());
+    List<RuleMatch> defaultValue = processedSentences.contains(sentence) ?
+      Collections.emptyList() : null;
+    return sentenceMatches.getOrDefault(sentence, defaultValue);
   }
 }

--- a/languagetool-core/src/test/java/org/languagetool/RemoteRuleCacheTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/RemoteRuleCacheTest.java
@@ -78,13 +78,14 @@ public class RemoteRuleCacheTest {
       return () -> {
         TestRemoteRequest req = (TestRemoteRequest) request;
         List<RuleMatch> matches = req.sentences.stream().map(this::testMatch).collect(Collectors.toList());
-        return new RemoteRuleResult(true, true, matches);
+        return new RemoteRuleResult(true, true, matches, req.sentences);
       };
     }
 
     @Override
     protected RemoteRuleResult fallbackResults(RemoteRequest request) {
-      return new RemoteRuleResult(false, false, Collections.emptyList());
+      TestRemoteRequest req = (TestRemoteRequest) request;
+      return new RemoteRuleResult(false, false, Collections.emptyList(), req.sentences);
     }
 
     @Override


### PR DESCRIPTION
introduced by 250298d04af59d05d7b731efff686f6328d32f33
cached results were overwritten with empty list
need to distinguish in RemoteRuleResult.matchesForSentence between:
- not processed (null)
- processed but no matches (empty list)
- actual matches