### PR TITLE
[en] improve many messages

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractUnitConversionRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractUnitConversionRule.java
@@ -135,11 +135,11 @@ public abstract class AbstractUnitConversionRule extends Rule {
   protected String getMessage(Message message) {
     switch(message) {
       case CHECK:
-        return "This conversion doesn't seem right. Do you want to correct it automatically?";
+        return "This unit conversion doesn't seem right. Do you want to correct it automatically?";
       case SUGGESTION:
         return "Writing for an international audience? Consider adding the metric equivalent.";
       case CHECK_UNKNOWN_UNIT:
-        return "This conversion doesn't seem right, unable to recognize the used unit.";
+        return "This unit conversion doesn't seem right, unable to recognize the used unit.";
       case UNIT_MISMATCH:
         return "These units don't seem to be compatible.";
       default:
@@ -153,7 +153,7 @@ public abstract class AbstractUnitConversionRule extends Rule {
   protected String getShortMessage(Message message) {
     switch(message) {
       case CHECK:
-        return "Incorrect conversion. Correct it?";
+        return "Incorrect unit conversion. Correct it?";
       case SUGGESTION:
         return "Add metric equivalent?";
       case CHECK_UNKNOWN_UNIT:

--- a/languagetool-core/src/main/java/org/languagetool/rules/CommaWhitespaceRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/CommaWhitespaceRule.java
@@ -34,6 +34,7 @@ import static org.languagetool.tools.StringTools.isEmpty;
  * 
  * @author Daniel Naber
  */
+/* need better messages */
 public class CommaWhitespaceRule extends Rule {
 
   private boolean quotesWhitespaceCheck;

--- a/languagetool-core/src/main/resources/org/languagetool/MessagesBundle.properties
+++ b/languagetool-core/src/main/resources/org/languagetool/MessagesBundle.properties
@@ -542,6 +542,7 @@ filler_words_rule_opt_text = Show filler words when more percent per paragraph t
 empty_line_rule_desc = Empty Line
 empty_line_rule_msg = Please delete empty line below and use formatting instead
 
+# key typo
 whitespace_before_parapgraph_end_desc = Space character at the end of paragraph
 whitespace_before_parapgraph_end_msg = Please delete the space character at the end of the paragraph.
 
@@ -553,7 +554,7 @@ repetition_paragraph_beginning_last_msg = Same beginning as last paragraph
 repetition_paragraph_beginning_next_msg = Same beginning as next paragraph
 
 punctuation_mark_paragraph_end_desc = No punctuation mark at the end of paragraph
-punctuation_mark_paragraph_end_msg = Please add a punctuation mark at the end of paragraph.
+punctuation_mark_paragraph_end_msg = Please add a punctuation mark at the end of the paragraph.
 
 guiLookAndFeelMenu = Look & Feel
 


### PR DESCRIPTION
WIP draft for review. Writing up some of my quick thoughts on messages while starting to implement some changes (see also https://forum.languagetool.org/t/en-guidelines-rules-for-messages/5350 from 1 year ago by Mike – if this is a better fit for the forum or the wiki, I can move it there):

1. Straightforward (i.e. simple syntactic structure), concise messages respect users' time.¹ Along with constrained vocabulary (reduce variants like `is deemed as`, `can be regarded as` → `can be considered`), it also makes it easier for non-native (ESL) speakers to understand them.
2. Avoid redundancy (`Consider an alternative.`, `Consider a replacement.`, `Double-check`), especially if we don't have any alternatives to suggest. Deictics (or indexicals) like `here`, or self-reference (e.g. `in formal English` → `in formal writing`, `in formal contexts`), may be unnecessary too.
3. Messages should be perceived as professional, impersonal, and as having been written by native English speakers. We don't want users to see awkward or amateur messages and doubt the competency of the product.
4. Politeness (`Please check whether`, `Please verify`) in messages can sound strange, unnecessary, passive-aggressive, or even rude, since the context is a computer program suggesting writing improvements that it may not have confidence in, rather than an exhortation like "Please enter your email to log in".
5. The `may` construction should be favored over `It seems that`, `You seem to be`, `Make sure that`, `Possibly`, etc. when hedging or noncommital messages are required. The downside of expletive constructions like `It seems that` is that when many messages all start the same way, it's harder for them to become iconic or familiar, since they all blend together.² On the other hand, the message `A pronoun may be missing` gets to the point: it begins with the salient words `A pronoun` rather than the content-free `It seems that`. In general, there's nothing wrong the `It seems that` construction, but the `may` construction may be better: it serves the same purpose of hedging, it makes the topic of the sentence salient, and it is more concise. (NB: we actually have a rule `IT_SEEMS_OR_APPEARS_THAT` that flags these expletives in prose! Maybe we should consider applying the rule to messages themselves?) Also, the construction `may be missing` should be favored over `is probably missing`, regardless of how confident we are, as there can always be false positives.
6. Linguistic jargon need not always be avoided in messages (and indeed the jargon can serve as helpful keywords for users to do further research), but is usually better when paired with an example or explanation. For example, `The genitive ('s or s')` is better than just `The genitive`, and `The determiner 'X'` is better than `The determiner` or `'X'` alone. It also depends on how advanced the jargon is.
7. Avoid implying or attributing mistakes to the user by using the second-person `you` (except for in readily familiar widely-used canned phrases like `Did you mean`). We shouldn't assume that the user is the one who wrote the text: users often check texts that they didn't write themselves, or include quoted or copy-pasted text. Examples: `Did you forget`, `You should probably use`, `You seem to be missing`,`Maybe you need`.
8. It may be good at some point to standardize the format of glosses (`(=blah)` or `(meaning blah)` or `(blah)`) and which quote marks (`'' “”`) to use for mentions (e.g. `Did you mean “it’s” (short for ‘it is’) instead of ‘its’ (possessive pronoun)?` uses several formats in one message).

\____
¹ See also similar standards on StackExchange: [1](https://meta.stackexchange.com/questions/2950/should-hi-thanks-taglines-and-salutations-be-removed-from-posts) [2](https://meta.stackexchange.com/questions/126180/is-it-acceptable-to-write-a-thank-you-in-a-comment) [3](https://meta.stackexchange.com/questions/273252/will-i-really-not-come-off-as-rude-even-if-i-dont-say-thanks-in-comments).
² A similar phenomenon is how we read words by recognizing their overall gestalt or shape, rather than decipher the actual sequence of letters.