### PR TITLE
Missing to missing it antipatterns

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/remote-rule-filters.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/remote-rule-filters.xml
@@ -25,7 +25,6 @@
 
 <rules lang="en" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <category name="Machine learning rules" id="AI_RULES">
-        <!-- FIXME: EXAMPLE
         <rulegroup id="AI_HYDRA_LEO_MISSING_TO" name="">
             <rule>
                 <pattern>
@@ -39,6 +38,5 @@
                 <example>I suggest you talk to him and send the email him.</example>
             </rule>
         </rulegroup>
-        -->
     </category>
 </rules>

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/remote-rule-filters.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/remote-rule-filters.xml
@@ -38,5 +38,16 @@
                 <example>I suggest you talk to him and send the email him.</example>
             </rule>
         </rulegroup>
+        <rulegroup id="AI_HYDRA_LEO_MISSING_IT" name="">
+            <rule>
+                <pattern>
+                    <marker>
+                        <token>its</token>
+                    </marker>
+                </pattern>
+                <example correction=""><marker>Its</marker> been a long time and things are coming to their logical end.</example>
+                <example>It's been a long time and things are coming to their logical end.</example>
+            </rule>
+        </rulegroup>
     </category>
 </rules>


### PR DESCRIPTION
Anti-patterns for AI suggestions:

- Uncommenting a previously commented anti-pattern for `MISSING_TO` (send him peace ➡️ send him to peace)
- Writing a new anti-pattern for `MISSING_IT` to never suggest inserting `it` before an `its` (Its been a long time ➡️ It Its been a long time)