### PR TITLE
Correct 'An' for "ho-" + "hour-" words (#4360)

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_an.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_an.txt
@@ -632,7 +632,6 @@
 *ANE
 *ANEC
 *ANEMF
-*ANEMF
 *Anémie
 *ANENA
 *ANESEC
@@ -1199,7 +1198,6 @@
 *EHPAD
 *EHS
 *EI
-*EI
 *EIA
 *EIAJ
 *EIB
@@ -1251,7 +1249,6 @@
 *EMT
 *Emu
 *EMU
-*EN
 *EN
 *EN3S
 *Ena
@@ -1421,7 +1418,6 @@
 *ESEO
 *ESF
 *ESH
-*ESH
 *ESI
 *ESIAB
 *ESIAL
@@ -1450,7 +1446,6 @@
 *ESTAC
 *ESTIA
 *ESTP
-*ET
 *ET
 *ETA
 *ETAM
@@ -2260,7 +2255,6 @@ hourly
 *INPT
 *INR
 *INRA
-*INRA
 *INRETS
 *INRIA
 *INRS
@@ -2268,7 +2262,6 @@ hourly
 *INSA
 *INSAT
 *INSCIR
-*Insee
 *Insee
 *INSERR
 *INSET
@@ -2364,7 +2357,6 @@ hourly
 *IRT
 # *IRU
 *IS
-*IS
 # *ISA
 # *ISAF
 # *ISAM
@@ -2377,7 +2369,6 @@ hourly
 *ISCM
 *ISD
 *ISDA
-*ISDN
 *ISDN
 # *Ise
 # *ISEG
@@ -4032,3 +4023,46 @@ X-rays
 *XXL
 *XXX
 Yttrium
+Yggdrasil
+Ygdrasil
+Ygerne
+Yverdon
+*NTFS
+*NIST
+*NRA
+*SEC
+*XO
+*XOR
+*XFL
+hombre
+hombres
+honesties
+honorability
+honorableness
+honorablenesses
+honoraries
+honorarily
+honoree
+honorees
+honorer
+honoring
+honorless
+honourability
+honourableness
+honourablenesses
+honouraries
+honourarily
+honouree
+honourees
+honourer
+honouring
+honourless
+honours
+hourage
+hourages
+hourglasses
+hourless
+hourlies
+hourplate
+hourplates
+hours


### PR DESCRIPTION
Along with a few other rare ones.

'Y' words found in M-W using:

- \ ē
- \ ˈig

'H' words found in M-W using:

- \ ˈä
- \ ˈō

(Also removed a few duplicates.)