### PR TITLE
Added Galician

### DIFF
--- a/languagetool-office-extension/src/main/resources/description.xml
+++ b/languagetool-office-extension/src/main/resources/description.xml
@@ -44,6 +44,7 @@
 		<name xlink:href="https://www.languagetool.org" lang="en">LanguageTool</name>
 		<name xlink:href="https://www.languagetool.org/es" lang="es">LanguageTool</name>
 		<name xlink:href="https://www.languagetool.org/fr" lang="fr">LanguageTool</name>
+		<name xlink:href="https://www.languagetool.org/gl" lang="gl">LanguageTool</name>
 		<name xlink:href="https://www.languagetool.org/pl" lang="pl">LanguageTool</name>
 		<name xlink:href="https://www.languagetool.org/pt" lang="pt">LanguageTool</name>
 		<name xlink:href="https://www.languagetool.org/ru" lang="ru">LanguageTool</name>


### PR DESCRIPTION
The name, 'LanguageTool', was missing in Galician.