### PR TITLE
use rule IDs provided by remote server

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/GRPCRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/GRPCRule.java
@@ -81,13 +81,11 @@ public abstract class GRPCRule extends RemoteRule {
    * Internal rule to create rule matches with IDs based on Match Sub-IDs
    */
   protected class GRPCSubRule extends Rule {
-    private final String subId;
     private final String matchId;
     private final String description;
 
-    GRPCSubRule(String subId, @Nullable String description) {
-      this.subId = subId;
-      this.matchId = GRPCRule.this.getId() + "_" + cleanID(subId);
+    GRPCSubRule(String ruleId, String subId, @Nullable String description) {
+      this.matchId = cleanID(ruleId) + "_" + cleanID(subId);
       if (description == null || description.isEmpty()) {
         this.description = GRPCRule.this.getDescription();
         if (this.description == null || this.description.isEmpty()) {
@@ -238,7 +236,7 @@ public abstract class GRPCRule extends RemoteRule {
       }
       List<RuleMatch> matches = Streams.zip(response.getSentenceMatchesList().stream(), req.sentences.stream(), (matchList, sentence) ->
         matchList.getMatchesList().stream().map(match -> {
-            GRPCSubRule subRule = new GRPCSubRule(match.getSubId(), match.getRuleDescription());
+            GRPCSubRule subRule = new GRPCSubRule(match.getId(), match.getSubId(), match.getRuleDescription());
             String message = match.getMatchDescription();
             String shortMessage = match.getMatchShortDescription();
             if (message == null || message.isEmpty()) {


### PR DESCRIPTION
allow updating rule IDs used in matches without changing server configuration
rule ID from configuration only used for metrics