### PR TITLE
[en-US] “the United States” verb agreement

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-US/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-US/grammar.xml
@@ -544,6 +544,117 @@ USA
            <example correction="through">I'm going <marker>thru</marker> hell.</example>
            <example>A thru axle (TA) is a wheel attachment system that secures a wheel on a hub between a pair of dropouts on a bicycle frame or fork.</example>
         </rule>
+        <rulegroup id="US_ONE_ENTITY" name="the United States [are] -> the United States [is] 245 years old" default="temp_off">
+            <rule>
+                <antipattern>
+                    <token>States</token>
+                    <token chunk_re="[IE]-NP-plural">
+                        <exception>need</exception>
+                    </token>
+                </antipattern>
+                <antipattern>
+                    <token postag="IN|RN|TO|V.*" postag_regexp="yes" />
+                    <token min="0">that</token>
+                    <token>the</token>
+                    <token min="0" postag="J.*" postag_regexp="yes" />
+                    <token>United</token>
+                    <token>States</token>
+                </antipattern>
+                <antipattern>
+                    <token postag="NNP" />
+                    <token>and</token>
+                    <token min="0">the</token>
+                    <token min="0" postag="J.*" postag_regexp="yes" />
+                    <token>United</token>
+                    <token>States</token>
+                </antipattern>
+                <antipattern>
+                    <token postag="MD|WRB" postag_regexp="yes" />
+                    <token min="0" postag="V.*" postag_regexp="yes" />
+                    <token min="0" regexp="yes">not|n't</token>
+                    <token>the</token>
+                    <token>United</token>
+                    <token>States</token>
+                    </antipattern>
+                <pattern>
+                    <token>the</token>
+                    <token>United</token>
+                    <token>States</token>
+                        <marker>
+                            <token postag="VB|VBP" postag_regexp="yes">
+                                <exception postag="VBD" />
+                                <exception regexp="yes">must|should|will|would</exception>
+                            </token>
+                        </marker>
+                </pattern>
+                <message>Verb agreement error. Did you mean <suggestion><match no="4" postag="VBZ" /></suggestion>?</message>
+                <example correction="is">The United States <marker>are</marker> 245 years old.</example>
+                <example correction="has">The United States <marker>have</marker> never had a female president.</example>
+                <example correction="does">The United States <marker>do</marker> not need another Trump.</example>
+                <example correction="needs">What the United States <marker>need</marker> is a more competent Congress.</example>
+                <example>United States Copyright Office</example>
+                <example>People in the United States speak English.</example>
+                <example>...offered to help the United States avoid an energy crisis.</example>
+                <example>Germany and the United States are close political allies.</example>
+                <example>The United States fell 6 places to a ranking of only 22...</example>
+                <example>The United States will no longer be able to be the police for the world.</example>
+                <example>Kennedy proposed that the United States accelerate its space program.</example>
+                <example>Should the United States have gotten involved there, too?</example>
+                <example>Why didn't the United States protect the Kurds in Afrin?</example>
+            </rule>
+            <rule>
+                <antipattern>
+                    <token>US</token>
+                    <token chunk_re="[IE]-NP-singular">
+                        <exception>need</exception>
+                    </token>
+                </antipattern>
+                <antipattern>
+                    <token postag="IN|RN|TO|V.*" postag_regexp="yes" />
+                    <token min="0">that</token>
+                    <token>the</token>
+                    <token min="0" postag="J.*" postag_regexp="yes" />
+                    <token>US</token>
+                </antipattern>
+                <antipattern>
+                    <token postag="NNP" />
+                    <token>and</token>
+                    <token min="0">the</token>
+                    <token min="0" postag="J.*" postag_regexp="yes" />
+                    <token>US</token>
+                </antipattern>
+                <antipattern>
+                    <token postag="MD|WRB" postag_regexp="yes" />
+                    <token min="0" postag="V.*" postag_regexp="yes" />
+                    <token min="0" regexp="yes">not|n't</token>
+                    <token>the</token>
+                    <token>US</token>
+                </antipattern>
+                <pattern>
+                    <token>the</token>
+                    <token>US</token>
+                        <marker>
+                            <token postag="VB|VBP" postag_regexp="yes">
+                                <exception postag="VBD" />
+                                <exception regexp="yes">must|people|should|will|would</exception>
+                            </token>
+                        </marker>
+                </pattern>
+                <message>Verb agreement error. Did you mean <suggestion><match no="4" postag="VBZ" /></suggestion>?</message>
+                <example correction="is">The US <marker>are</marker> 245 years old.</example>
+                <example correction="has">The US <marker>have</marker> never had a female president.</example>
+                <example correction="does">The US <marker>do</marker> not need another Trump.</example>
+                <example>US Copyright Office</example>
+                <example>People in the US speak English.</example>
+                <example>...offered to help the US avoid an energy crisis.</example>
+                <example>Germany and the US are close political allies.</example>
+                <example>The US fell 6 places to a ranking of only 22...</example>
+                <example>The US will no longer be able to be the police for the world.</example>
+                <example>Kennedy proposed that the US accelerate its space program.</example>
+                <example>Should the US have gotten involved there, too?</example>
+                <example>Why didn't the US protect the Kurds in Afrin?</example>
+            </rule>
+        </rulegroup>
     </category>
 
 </rules>


### PR DESCRIPTION
For the American English .xml.

Handles phrases that contain either 'the United States' or 'the US' like:

The United States have --> has never had a female president.
The United States are --> is 245 years old.
What the United States need --> needs is a more competent congress.

The US do --> does not need another Trump.
It's crazy that the US do --> does not have tighter gun control laws.

etc...

No FPs with the source checker when using the attached .txt file (grepped for both 'United States' and 'US').
HOWEVER, I got 2 errors (and no warnings) when trying to commit the rule? I'm attaching a screenshot of the errors as well.
[US.txt](https://github.com/languagetool-org/languagetool/files/6232850/US.txt)
![commit_errors](https://user-images.githubusercontent.com/81176099/113070513-9745c580-9177-11eb-872f-d2a576e64a48.png)

