### PR TITLE
Add Nicht/Schwimmerbereich

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -32467,5 +32467,4 @@ Zimmerinnen
 Zusammenhaltsgefühl/S
 Schwimmerbereich/S
 Schwimmerbereiche/NS
-Nichtschwimmerbereich/S
-Nichtschwimmerbereiche/NS
+

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -32465,3 +32465,7 @@ Wedemark/S #name
 Zimmerin
 Zimmerinnen
 Zusammenhaltsgefühl/S
+Schwimmerbereich/S
+Schwimmerbereiche/NS
+Nichtschwimmerbereich/S
+Nichtschwimmerbereiche/NS


### PR DESCRIPTION
Schwimmerbereich/S
Schwimmerbereiche/NS

https://github.com/languagetool-org/languagetool/pull/4756
Hier sind falschen Wörter, die akzeptiert werden.