### PR TITLE
[gl] Clean-up; category types

### DIFF
--- a/languagetool-language-modules/gl/src/main/resources/org/languagetool/rules/gl/grammar.xml
+++ b/languagetool-language-modules/gl/src/main/resources/org/languagetool/rules/gl/grammar.xml
@@ -5,6 +5,7 @@
   Galician Grammar and Typo Rules for LanguageTool
   Copyright (C) 2006 Marcin Miłkowski
   Copyright (C) 2009 Susana Sotelo Docío
+  Copyright (C) 2021 Xosé Calvo
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -93,7 +94,7 @@
     </equivalence>
   </unification>
 
- <category id="CAT0" name="Gramática::Concordancia">
+ <category id="CAT0" name="Gramática::Concordancia" type="grammar">
 
   <rulegroup id='GENERAL_GENDER_AGREEMENT_ERRORS' name="Concordancia de xénero: Xeral">
     <!--            General gender concordance errors            -->
@@ -525,7 +526,7 @@
       <example>Os rinocerontes serán anestesiados, antes de se remover o chifre.</example>
       <example>Pantalóns, os máis estragados posíbel!</example>
       <example>Os montes Everest, K2 e Kanchenjunga son os máis altos do mundo.</example>
-      <example>As cores son: Ás de Copas vermello, Ás de Ouros vermello, Ás de Paus negro e Ás de Espadas negro.</example>
+      <example>As cores son: Ás de Copas vermello, Ás de Ouros vermello, Ás de Bastos negro e Ás de Espadas negro.</example>
     </rule>
     <rule>
       <antipattern>
@@ -1096,7 +1097,7 @@
                 <token>”</token>
                 <token regexp='yes' spacebefore='no'>\w+</token>
             </pattern>
-            <message>Debe ter espazo despois de pechar comiñas.</message>
+            <message>Debe haber un espazo despois das aspas de peche.</message>
             <suggestion>\1 \2</suggestion>
             <example correction="” dixo">“Bo día, Frank,<marker>”dixo</marker> Hal.</example>
         </rule>
@@ -1188,7 +1189,7 @@
           <token regexp="yes">(?:[khdcmnµfYZEPTGM]|da)?[gmlsJNWCVSFTH](\^)?2</token>
         </marker>
       </pattern>
-      <message>Os expoentes deben estar en superíndice.</message>
+      <message>Os expoñentes deben estar en superíndice.</message>
         <suggestion><match no="2" regexp_match='(.+?)((\^)?)2' regexp_replace='$1²'/></suggestion>
       <example correction="s²">g = 9,8 m/<marker>s2</marker></example>
       <example correction="s²">g = 9,8 m/<marker>s^2</marker></example>
@@ -1200,7 +1201,7 @@
           <token regexp="yes">(?:[khdcmnµfYZEPTGM]|da)?[gmlsJNWCVSFTH](\^)?3</token>
         </marker>
       </pattern>
-      <message>Os expoentes deben estar en superíndice.</message>
+      <message>Os expoñentes deben estar en superíndice.</message>
         <suggestion><match no="2" regexp_match='(.+?)((\^)?)3' regexp_replace='$1³'/></suggestion>
       <example correction="cm³">ρ[H₂O]≈1,0 g/<marker>cm3</marker>.</example>
       <example correction="cm³">ρ[H₂O]≈1,0 g/<marker>cm^3</marker>.</example>
@@ -1465,7 +1466,7 @@
           <token regexp="yes">\d\.\d{3}</token>
         </marker>
       </pattern>
-      <message>En anos os números non deben ser separados.</message>
+      <message>Nos anos os números non deben estar separados.</message>
         <suggestion><match no='2' regexp_match='(\d)(.)(\d{3})' regexp_replace='$1$3'/></suggestion>
       <example correction="1989">É o ano de <marker>1.989</marker>.</example>
     </rule>
@@ -1477,7 +1478,7 @@
           <token regexp="yes">\d{1,2}\.\d{3}</token>
         </marker>
       </pattern>
-      <message>En anos os números non deben ser separados.</message>
+      <message>Nos anos os números non deben estar separados.</message>
         <suggestion><match no='3' regexp_match='(\d{1,2})(.)(\d{3})' regexp_replace='$1$3'/></suggestion>
       <example correction="1989">É decembro de <marker>1.989</marker>.</example>
     </rule>
@@ -1488,7 +1489,7 @@
         </marker>
           <token regexp="yes">aC|dC</token>
       </pattern>
-      <message>En anos os números non deben ser separados.</message>
+      <message>Nos anos os números non deben estar separados.</message>
         <suggestion><match no='1' regexp_match='(\d{1,3})(.)(\d{3})' regexp_replace='$1$3'/></suggestion>
       <example correction="1989">Estamos a <marker>1.989</marker> aC.</example>
     </rule>
@@ -1528,7 +1529,7 @@
             <exception regexp="yes">[.,]</exception></token>
           <token spacebefore="yes" regexp="yes">[%‰‱]</token>
       </pattern>
-      <message>Escriba a porcentaxe sen espazos ( estilo estándar).</message>
+      <message>Escriba a porcentaxe sen espazos (estilo estándar).</message>
         <suggestion>\1\2</suggestion>
     <!--url>https://ciberduvidas.iscte-iul.pt/consultorio/preguntas/centigrados-porcentagem/18011</url TODO localize -->
       <example correction="23,5%">A taxa é de <marker>23,5 %</marker>.</example>
@@ -1553,7 +1554,7 @@
     <rule id="SPACE_INDENTATION" name="Libreoffice: Indentación con espazos" default='off'>
     <!-- Localized from German grammar.xml by Tiago F. Santos,  2017-08-19      -->
       <regexp>^ +</regexp>
-      <message>No LibreOffice, o sangrado é máis precisa se utilizar as ferramentas específicas.</message>
+      <message>No LibreOffice, o sangrado é máis preciso se utilizar as ferramentas específicas.</message>
         <suggestion/>
       <example correction=""><marker> </marker>El saíu de casa.</example>
     </rule>
@@ -1576,7 +1577,7 @@
       </pattern>
       <message>En diálogos e enumeracións debe utilizar trazo longo.</message>
         <suggestion>—</suggestion>
-      <short>Aquí utilice o guión longo.</short>
+      <short>Aquí utilice o trazo longo.</short>
       <example correction='—'><marker>-</marker> Que é iso, mamá?</example>
       <example correction='—'>« <marker>-</marker> Que é iso, mamá?</example>
       <example>— É o teu presente de aniversario, miña filla.</example>
@@ -1597,9 +1598,9 @@
         </marker>
           <token spacebefore="no">,</token>
       </pattern>
-      <message>Termine a frase parentética cun guión longo.</message>
+      <message>Termine a frase parentética cun trazo longo.</message>
         <suggestion>—</suggestion>
-      <short>Aquí utilice o guión longo.</short>
+      <short>Aquí utilice o trazo longo.</short>
       <example correction='—'>como dixen <marker>-</marker>,…</example>
     </rule>
     <rule>
@@ -1616,7 +1617,7 @@
       </pattern>
       <message>Se non pretende unir dúas palabras, debe utilizar trazo longo.</message>
         <suggestion>—</suggestion>
-      <short>Nesta situación debe utilizar trazo longo.</short>
+      <short>Aquí debería utilizar un trazo longo.</short>
       <example correction='—'>Neses establecementos de ensino existían matrículas <marker>-</marker> a maioría de ensino fundamental — e un total de docentes.</example>
       <example correction='—'>Instituto Ricci de Macau <marker>-</marker> Asociación de promoción cultural da Compañía de Xesús en Macau</example>
       <example>Na porción centro-oeste e noroeste presentan maiores elevacións, podendo atinxir 500 metros por enriba do nivel do mar, destacándose a Serra do Tumucumaque e a Serra Lombarda.</example>
@@ -1899,7 +1900,7 @@
       <pattern case_sensitive='yes'>
           <token regexp='yes'>(?:\d+)(?:&tabela_periodica;)+(?:[₁₂₃₄₅₆₇₈₉]+)((&tabela_periodica;)+)?</token>
       </pattern>
-      <message>Os multiplicadores nas fórmulas químicas deben ser separados.</message>
+      <message>Nas fórmulas químicas os multiplicadores deben ser separados.</message>
         <suggestion><match no='1' regexp_match='(\d+)((&tabela_periodica;)+)([₁₂₃₄₅₆₇₈₉₀]+)(((&tabela_periodica;)+)?)' regexp_replace='$1 $2$4$5'/></suggestion>
       <example correction='4 H₂O'><marker>4H₂O</marker></example>
     </rule>
@@ -1909,7 +1910,7 @@
           <token regexp='yes'>(?:\d+)?(?:&tabela_periodica;)+2((?:&tabela_periodica;)+)?
             <exception regexp='yes'>I[CP]2</exception></token>
       </pattern>
-      <message>Os números nas fórmulas químicas deben estar en superíndice.</message>
+      <message>Nas fórmulas químicas os números deben estar en superíndice.</message>
         <suggestion><match no='1' regexp_match='((&tabela_periodica;)+)2(((&tabela_periodica;)+)?)' regexp_replace='$1₂$3'/></suggestion>
       <example correction='O₂'><marker>O2</marker></example>
       <example correction='4H₂O'><marker>4H2O</marker></example>
@@ -1919,7 +1920,7 @@
           <token regexp='yes'>(?:\d+)?(?:&tabela_periodica;)+3((?:&tabela_periodica;)+)?
             <exception regexp='yes'>I[CP]3</exception></token>
       </pattern>
-      <message>Os números nas fórmulas químicas deben estar en superíndice.</message>
+      <message>Nas fórmulas químicas os números deben estar en superíndice.</message>
         <suggestion><match no='1' regexp_match='((&tabela_periodica;)+)3(((&tabela_periodica;)+)?)' regexp_replace='$1₃$3'/></suggestion>
       <example correction='2S₃'><marker>2S3</marker></example>
     </rule>
@@ -1928,7 +1929,7 @@
           <token regexp='yes'>(?:\d+)?(?:&tabela_periodica;)+4((?:&tabela_periodica;)+)?
             <exception regexp='yes'>I[CP]4</exception></token>
       </pattern>
-      <message>Os números nas fórmulas químicas deben estar en superíndice.</message>
+      <message>Nas fórmulas químicas os números deben estar en superíndice.</message>
         <suggestion><match no='1' regexp_match='((&tabela_periodica;)+)4(((&tabela_periodica;)+)?)' regexp_replace='$1₄$3'/></suggestion>
       <example correction='CH₄'><marker>CH4</marker></example>
       <example correction='H₄Si'><marker>H4Si</marker></example>
@@ -1937,7 +1938,7 @@
       <pattern case_sensitive='yes'>
           <token regexp='yes'>(?:\d+)?(?:&tabela_periodica;)+2((?:&tabela_periodica;)+)?2((?:&tabela_periodica;)+)?</token>
       </pattern>
-      <message>Os números nas fórmulas químicas deben estar en superíndice.</message>
+      <message>Nas fórmulas químicas os números deben estar en superíndice.</message>
         <suggestion><match no='1' regexp_match='((&tabela_periodica;)+)2(((&tabela_periodica;)+)?)2(((&tabela_periodica;)+)?)' regexp_replace='$1₂$3₂$6'/></suggestion>
       <example correction='H₂O₂'><marker>H2O2</marker></example>
       <example correction='H₂NO₂Al'><marker>H2NO2Al</marker></example>
@@ -1946,7 +1947,7 @@
       <pattern case_sensitive='yes'>
           <token regexp='yes'>(?:\d+)?(?:&tabela_periodica;)+2((?:&tabela_periodica;)+)?3((?:&tabela_periodica;)+)?</token>
       </pattern>
-      <message>Os números nas fórmulas químicas deben estar en superíndice.</message>
+      <message>Nas fórmulas químicas os números deben estar en superíndice.</message>
         <suggestion><match no='1' regexp_match='((&tabela_periodica;)+)2(((&tabela_periodica;)+)?)3(((&tabela_periodica;)+)?)' regexp_replace='$1₂$3₃$6'/></suggestion>
       <example correction='K₂HPO₃'><marker>K2HPO3</marker></example>
     </rule>
@@ -1954,7 +1955,7 @@
       <pattern case_sensitive='yes'>
           <token regexp='yes'>(?:\d+)?(?:&tabela_periodica;)+3((?:&tabela_periodica;)+)?2((?:&tabela_periodica;)+)?</token>
       </pattern>
-      <message>Os números nas fórmulas químicas deben estar en superíndice.</message>
+      <message>Nas fórmulas químicas os números deben estar en superíndice.</message>
         <suggestion><match no='1' regexp_match='((&tabela_periodica;)+)3(((&tabela_periodica;)+)?)2(((&tabela_periodica;)+)?)' regexp_replace='$1₃$3₂$6'/></suggestion>
       <example correction='CH₃CH₂OH'><marker>CH3CH2OH</marker></example>
     </rule>
@@ -1962,7 +1963,7 @@
       <pattern case_sensitive='yes'>
           <token regexp='yes'>(?:\d+)?(?:&tabela_periodica;)+3((?:&tabela_periodica;)+)?3((?:&tabela_periodica;)+)?</token>
       </pattern>
-      <message>Os números nas fórmulas químicas deben estar en superíndice.</message>
+      <message>Nas fórmulas químicas os números deben estar en superíndice.</message>
         <suggestion><match no='1' regexp_match='((&tabela_periodica;)+)3(((&tabela_periodica;)+)?)3(((&tabela_periodica;)+)?)' regexp_replace='$1₃$3₃$6'/></suggestion>
       <example correction='CH₃CH₃'><marker>CH3CH3</marker></example>
     </rule>
@@ -1970,7 +1971,7 @@
       <pattern case_sensitive='yes'>
           <token regexp='yes'>(?:\d+)?(?:&tabela_periodica;)+2((?:&tabela_periodica;)+)?4((?:&tabela_periodica;)+)?</token>
       </pattern>
-      <message>Os números nas fórmulas químicas deben estar en superíndice.</message>
+      <message>Nas fórmulas químicas os números deben estar en superíndice.</message>
         <suggestion><match no='1' regexp_match='((&tabela_periodica;)+)2(((&tabela_periodica;)+)?)4(((&tabela_periodica;)+)?)' regexp_replace='$1₂$3₄$6'/></suggestion>
       <example correction='H₂SO₄'><marker>H2SO4</marker></example>
     </rule>
@@ -1978,7 +1979,7 @@
       <pattern case_sensitive='yes'>
           <token regexp='yes'>(?:\d+)?(?:&tabela_periodica;)+2((?:&tabela_periodica;)+)?5((?:&tabela_periodica;)+)?</token>
       </pattern>
-      <message>Os números nas fórmulas químicas deben estar en superíndice.</message>
+      <message>Nas fórmulas químicas os números deben estar en superíndice.</message>
         <suggestion><match no='1' regexp_match='((&tabela_periodica;)+)2(((&tabela_periodica;)+)?)5(((&tabela_periodica;)+)?)' regexp_replace='$1₂$3₅$6'/></suggestion>
       <example correction='C₂H₅OH'><marker>C2H5OH</marker></example>
     </rule>
@@ -1986,7 +1987,7 @@
       <pattern case_sensitive='yes'>
           <token regexp='yes'>(?:\d+)?(?:&tabela_periodica;)+2((?:&tabela_periodica;)+)?6((?:&tabela_periodica;)+)?</token>
       </pattern>
-      <message>Os números nas fórmulas químicas deben estar en superíndice.</message>
+      <message>Nas fórmulas químicas os números deben estar en superíndice.</message>
         <suggestion><match no='1' regexp_match='((&tabela_periodica;)+)2(((&tabela_periodica;)+)?)6(((&tabela_periodica;)+)?)' regexp_replace='$1₂$3₆$6'/></suggestion>
       <example correction='C₂H₆'><marker>C2H6</marker></example>
     </rule>
@@ -1996,7 +1997,7 @@
             <exception regexp='yes'>I[CP]7</exception>
             <exception>V7</exception></token>
       </pattern>
-      <message>Os números nas fórmulas químicas deben estar en superíndice.</message>
+      <message>Nas fórmulas químicas os números deben estar en superíndice.</message>
         <suggestion><match no='1' regexp_match='((&tabela_periodica;)+)7(((&tabela_periodica;)+)?)' regexp_replace='$1₇$3'/></suggestion>
       <example correction='C₇H₁₆'><marker>C7H₁₆</marker></example>
     </rule>
@@ -2006,7 +2007,7 @@
             <exception regexp='yes'>I[CP]8</exception>
             <exception>V8</exception></token>
       </pattern>
-      <message>Os números nas fórmulas químicas deben estar en superíndice.</message>
+      <message>Nas fórmulas químicas os números deben estar en superíndice.</message>
         <suggestion><match no='1' regexp_match='((&tabela_periodica;)+)8(((&tabela_periodica;)+)?)' regexp_replace='$1₈$3'/></suggestion>
       <example correction='C₈H₁₈'><marker>C8H₁₈</marker></example>
     </rule>
@@ -2016,7 +2017,7 @@
             <exception regexp='yes'>I[CP]9</exception>
             <exception>V9</exception></token>
       </pattern>
-      <message>Os números nas fórmulas químicas deben estar en superíndice.</message>
+      <message>Nas fórmulas químicas os números deben estar en superíndice.</message>
         <suggestion><match no='1' regexp_match='((&tabela_periodica;)+)9(((&tabela_periodica;)+)?)' regexp_replace='$1₉$3'/></suggestion>
       <example correction='C₉H₂₀'><marker>C9H₂₀</marker></example>
       <example>Lola T70 Chevy V8</example>
@@ -2026,13 +2027,13 @@
           <token regexp='yes'>(?:\d+)?(?:&tabela_periodica;)+0((?:&tabela_periodica;)+)?
             <exception>V0</exception></token>
       </pattern>
-      <message>Os números nas fórmulas químicas deben estar en superíndice.</message>
+      <message>Nas fórmulas químicas os números deben estar en superíndice.</message>
         <suggestion><match no='1' regexp_match='((&tabela_periodica;)+)0(((&tabela_periodica;)+)?)' regexp_replace='$1₀$3'/></suggestion>
       <example correction='C₉H₂₀'><marker>C₉H₂0</marker></example>
     </rule>
   </rulegroup>
 
-    <rule id='DEGREE_SYMBOL' name="Matemático: Símbolo de grau (°)">
+    <rule id='DEGREE_SYMBOL' name="Matemático: Símbolo de grao (°)">
     <!--  Localized from Catalan grammar.xml, by Tiago F. Santos, 2017-02-27      -->
       <regexp>(?-i)\s?º\s?([CFNSEW])\b</regexp>
       <message>Se está a indicar graos, utilice o símbolo <suggestion>&#8239;°\1</suggestion>.</message>
@@ -2054,7 +2055,7 @@
           <token regexp="yes">(?:&unidades_de_medida;)s</token>
         </marker>
       </pattern>
-      <message>As abreviaturas de unidades de medida padrão non ten plural.</message>
+      <message>As abreviaturas de unidades de medida estándar non teñen plural.</message>
         <suggestion><match no='2' regexp_match='(&unidades_de_medida;)s' regexp_replace='$1'/></suggestion>
       <example correction="kg">Son 2 <marker>kgs</marker> de maças.</example>
     </rule>
@@ -2110,10 +2111,10 @@
     <rule id='LOOSE_ACCENTS' name="Acentos soltos">
     <!-- Based on Catalan grammar.xml, by Tiago F. Santos on 11-02-2017 -->
       <regexp>[`´]</regexp>
-      <message>Caratere incorreto. Utilice antes o apóstrofe ou revise a acentuación.</message>
+      <message>Carácter incorrecto. Utilice antes o apóstrofe ou revise a acentuación.</message>
         <suggestion>’</suggestion>
         <suggestion/>
-      <short>Caractere incorreto.</short>
+      <short>Carácter incorreto.</short>
       <example correction="’|">Non e<marker>´</marker> común encontrar erros deste tipo.</example>
     </rule>
 
@@ -2137,7 +2138,7 @@
             <exception scope="next">’</exception></token>
           <token regexp='yes'>[«“]</token>
       </pattern>
-      <message>Utilice primeiro comiñas dobres.</message>
+      <message>Utilice primeiro comiñas angulares.</message>
         <suggestion><match no='1' regexp_match='‘' regexp_replace='“' include_skipped='all'/> ‘</suggestion>
       <example correction="“Dixen que ‘"><marker>‘Dixen que “</marker>si”.</example>
       <example>“Dixen que ‘si’”.</example>
@@ -2191,7 +2192,7 @@
           <token>‘</token>
         </marker>
       </pattern>
-      <message>Utilice unha comiña de fecho.</message>
+      <message>Utilice unha comiña de peche.</message>
         <suggestion>’</suggestion>
       <example correction="’">Dixen que ‘si<marker>‘</marker>.</example>
     </rule>
@@ -2203,7 +2204,7 @@
           <token>“</token>
         </marker>
       </pattern>
-      <message>Utilice unha comiña de fecho.</message>
+      <message>Utilice unha comiña de peche.</message>
         <suggestion>”</suggestion>
       <example correction="”">Dixen que “si<marker>“</marker>.</example>
     </rule>
@@ -2222,7 +2223,7 @@
         </marker>
       </pattern>
       <message>Pretende dicir: <suggestion>™</suggestion>?</message>
-      <short>Anotación non padronizada de ™</short>
+      <short>Símbolo estándar de ™</short>
       <example correction='™'>O novo produto é de Escolla Executiva<marker>(TM)</marker> Plus.</example>
     </rule>
     <rule id='SERVICEMARK' name="Tipografia: Servicemark - ℠">
@@ -2235,7 +2236,7 @@
         </marker>
       </pattern>
       <message>Pretende dicir: <suggestion>℠</suggestion>?</message>
-      <short>Anotación non padronizada de ℠</short>
+      <short>Símbolo estándar de ℠</short>
       <example correction='℠'>O novo produto é de Escolla Executiva<marker>(SM)</marker> Plus.</example>
     </rule>
   </rulegroup>
@@ -2270,9 +2271,8 @@
         </marker>
       </pattern>
       <message>Pretende dicir: <suggestion>®</suggestion>?</message>
-      <short>Anotación non padronizada de ®</short>
+      <short>Símbolo estándar de ®</short>
       <example correction='®'>Windows <marker>(R)</marker></example>
-      <example>Estes son Richard Burr (D) e Kay Hagan (R).</example>
     </rule>
 
     <rule id='COPYRIGHT' name="Tipografia: Copyright - ©" type="typographical">
@@ -2297,11 +2297,11 @@
         </marker>
           <token regexp="yes">\d{4}|\p{Lu}\p{Ll}+</token>
       </pattern>
-      <message>Esta anotación non é padronizada, utilice antes o símbolo: <suggestion>©</suggestion></message>
-      <short>Anotación non padronizada de ©</short>
+      <message>Posibelmente sexa máis claro usar o símbolo: <suggestion>©</suggestion></message>
+      <short>Símbolo estándar de ©</short>
       <example correction="©">Copyright <marker>(C)</marker> Joanna Bator, 2012</example>
       <example correction="©">Copyright <marker>(C)</marker> 2010 O Estado da Gramática</example>
-      <example>Isto é unha lista: (a) item, (b) 2 itens, (c) 2014 itens.</example>
+      <example>Isto é unha lista: (a) elemento, (b) 2 elementos, (c) 2014 elementos.</example>
     </rule>
 
   <rulegroup type="locale-violation" id='CURRENCY' name="Posición dos símbolos de moeda: '100£ (£100)">
@@ -2309,7 +2309,7 @@
       <pattern>
           <token regexp="yes">[\d\,\.]+[$£¥\u8371]</token>
       </pattern>
-      <message>O símbolo desta divisa é por norma colocado antes do valor: <suggestion><match no="1" regexp_match="([\d\,\.]+)([$€£¥\u8371])" regexp_replace="$2$1"/></suggestion>.</message>
+      <message>O símbolo desta divisa colócase por norma antes do valor: <suggestion><match no="1" regexp_match="([\d\,\.]+)([$€£¥\u8371])" regexp_replace="$2$1"/></suggestion>.</message>
       <short>Coloque a divisa no inicio</short>
       <example correction="£100">Debe <marker>100£</marker>.</example>
       <example correction="£100.00">Debe <marker>100.00£</marker>.</example>
@@ -2319,7 +2319,7 @@
           <token regexp="yes">[\d\,\.]+</token>
           <token regexp="yes">[$£¥\u8371]</token>
       </pattern>
-      <message>O símbolo desta divisa é por norma colocado antes do valor: <suggestion>\2\1</suggestion>.</message>
+      <message>O símbolo desta divisa colócase por norma antes do valor: <suggestion>\2\1</suggestion>.</message>
       <short>Coloque a divisa no inicio</short>
       <example correction="£100">Debe <marker>100 £</marker>.</example>
       <example correction="£100.00">Debe <marker>100.00 £</marker>.</example>
@@ -2329,7 +2329,7 @@
           <token regexp="yes">[€\u8371]</token>
           <token regexp="yes">\d+(?:[\,\.]\d+)?</token>
       </pattern>
-      <message>O símbolos de euro é colocado despois do valor: <suggestion>\2 \1</suggestion>.</message>
+      <message>O símbolos de euro colócase despois do valor: <suggestion>\2 \1</suggestion>.</message>
       <url>https://gl.wikipedia.org/wiki/Euro</url>
       <short>Coloque a divisa no fin</short>
       <example correction="100 €">Debe <marker>€ 100</marker>.</example>
@@ -2337,22 +2337,22 @@
     </rule>
   </rulegroup>
 
-    <rule type="whitespace" id='CURRENCY_SPACE' name="Símbolos monetários sem espazo en branco: '$ 100' ($100)">
+    <rule type="whitespace" id='CURRENCY_SPACE' name="Símbolos monetarios sen espazo en branco: '$ 100' ($100)">
       <pattern>
           <token regexp="yes">[$£¥\u8371]</token>
           <token regexp="yes" spacebefore="yes">\d+(?:[\,\.]\d+)?</token>
       </pattern>
-      <message>Os símbolos monetarios internacionais non son separados por un espazo: <suggestion>\1\2</suggestion>.</message>
+      <message>Os símbolos monetarios internacionais sepáranse cun espazo: <suggestion>\1\2</suggestion>.</message>
       <url>https://gl.wikipedia.org/wiki/Euro</url>
-      <short>Remover espazo</short>
+      <short>Retirar espazo</short>
       <example correction="$100">Débese <marker>$ 100</marker>.</example>
     </rule>
 
-    <rule type="whitespace" id='CURRENCY_SPACE_2' name="Espazo en branco antes de símbolos monetários: '100,00€' (100,00 €)">
+    <rule type="whitespace" id='CURRENCY_SPACE_2' name="Espazo en branco antes de símbolos monetarios: '100,00€' (100,00 €)">
       <pattern>
           <token regexp="yes">\d+(?:[\,\.]\d+)?[€]</token>
       </pattern>
-      <message>Os símbolos monetarios do euro (€) son separados por un espazo<suggestion><match no="1" regexp_match="(\d+)([€\u8371])" regexp_replace="$1 $2"/></suggestion>.</message>
+      <message>Os símbolos monetarios do euro (€) sepáranse cun espazo<suggestion><match no="1" regexp_match="(\d+)([€\u8371])" regexp_replace="$1 $2"/></suggestion>.</message>
       <url>https://gl.wikipedia.org/wiki/Euro</url>
       <short>Erro tipográfico</short>
       <example correction="100 €">Débese <marker>100€</marker>.</example>
@@ -2445,7 +2445,7 @@
       <pattern>
           <token regexp="yes">[012]?\d[,\.][012345]\d[,\.][012345]\d([,.]\d+)?</token>
       </pattern>
-      <message>En expresións de horas, utilice dous puntos.</message>
+      <message>Para expresar horas, utilice dous puntos.</message>
         <suggestion><match no='1' regexp_match='(\d+)[,\.](\d+)[,\.](.+)' regexp_replace='$1:$2:$3'/></suggestion>
         <suggestion><match no='1' regexp_match='(\d+)[,\.](\d+)[,\.](.+)' regexp_replace='$1&#160;h&#160;$2&#160;min&#160;$3&#160;s'/></suggestion>
       <example correction="10:00:43|10&#160;h&#160;00&#160;min&#160;43&#160;s">Ás <marker>10.00.43</marker>.</example>
@@ -2456,7 +2456,7 @@
           <token regexp="yes">[012]?\d[,\.][012345]\d</token>
           <token regexp="yes">h|horas|hrs|hs|hora</token>
       </pattern>
-      <message>En expresións de horas, utilice dous puntos.</message>
+      <message>Para expresar horas, utilice dous puntos.</message>
         <suggestion><match no='1' regexp_match='(\d+)[,\.](\d+)' regexp_replace='$1:$2'/>&#160;\4</suggestion>
       <example correction="22:50&#160;h">Ás <marker>22.50 h</marker>.</example>
       <example correction="6:05&#160;h">Ás <marker>6,05 h</marker>.</example>
@@ -2468,7 +2468,7 @@
           <token regexp='yes'>ás?|das?</token>
           <token regexp="yes">[012]?\d[,\.][012345]\d</token>
       </pattern>
-      <message>En expresións de horas, utilice dous puntos.</message>
+      <message>Para expresar horas, utilice dous puntos.</message>
         <suggestion>\1 <match no='2' regexp_match='(\d+)[,\.](\d+)' regexp_replace='$1:$2'/></suggestion>
       <example correction="Ás 10:00"><marker>Ás 10.00</marker>.</example>
       <example correction="Da 01:00"><marker>Da 01.00</marker> a as… </example>
@@ -2479,7 +2479,7 @@
           <token regexp="yes" skip="2">[012]?\d[,\.][012345]\d</token>
           <token regexp="yes" inflected="yes">&partes_do_dia;</token>
       </pattern>
-      <message>En expresións de horas, utilice dous puntos.</message>
+      <message>Para expresar horas, utilice dous puntos.</message>
         <suggestion><match no='1' include_skipped='all' regexp_match='(\d+)[,\.](\d+)' regexp_replace='$1:$2'/> <match no='2' include_skipped='all'/></suggestion>
       <example correction="5:00 da mañá">Ás <marker>5.00 da mañá</marker>.</example>
       <example correction="6:05 da tarde">Ás <marker>6.05 da tarde</marker>.</example>
@@ -2590,7 +2590,7 @@
           <token spacebefore="yes"/>
       </pattern>
       <message>Xeralmente, non se coloca punto e vírgula antes de comiñas.</message>
-      <example type="incorrect">“Non me incomode con súa leria infantil<marker>;”</marker> dixen Maria; “eu escribo versos inmortais.”</example>
+      <example type="incorrect">«Non me incomode con súa leria infantil<marker>;»</marker> dixen Maria; «eu escribo versos inmortais.»</example>
     </rule>
 
   <rulegroup id="PARENTESESE_AND_QUOTES_SPACING" name="Espaçamento en volta de comiñas ou paréntesis">
@@ -2620,7 +2620,7 @@
       <example correction="«O"><marker>« O</marker> xardín é verdadeiramente bonito», dixo ela.</example>
       <example correction="«O">Ela dixo: <marker>« O</marker> xardín é verdadeiramente bonito.»</example>
       <example correction="«é">«O xardín», dixo ela, <marker>« é</marker> verdadeiramente bonito.»</example>
-      <example>A galiña di "Quiquiriquiqui" o porco di "Oinc, Oinc," o pato di "Cuá, Cuá" e di que o gato "Miau".</example>
+      <example>A galiña di «Quiquiriquiqui» o porco di «Oinc, Oinc», o pato di «Cuá, Cuá» e o gato «Miau».</example>
     </rule>
     <rule>
       <antipattern>
@@ -2728,7 +2728,7 @@
             <exception postag="SENT_END"/></token>
         </marker>
       </pattern>
-      <message>Debe colocar un espazo despois de '\1'.</message>
+      <message>Debe colocar un espazo despois de «\1».</message>
         <suggestion>\1 \2</suggestion>
       <example correction=": «">El dixo<marker>:«</marker>O xardín é verdadeiramente bonito.»</example>
       <example>A cea estará lista ás 18:30.</example>
@@ -2736,7 +2736,7 @@
 
  </category>
 
- <category id="CAT1" name="Gramática::Verbo">
+ <category id="CAT1" name="Gramática::Verbo" type="grammar">
 
     <rule id="IR_A_INF" name="ir máis infinitivo">
     <!-- Created by Susana Sotelo Docío -->
@@ -2745,7 +2745,7 @@
           <token>a</token>
           <token postag="(VMN0000|VSN0000).*" postag_regexp="yes"/>
       </pattern>
-      <message>A perífrase formada polo verbo &quot;ir&quot; máis un infinitivo constrúese en galego sen preposición: <suggestion>\1 \3</suggestion></message>
+      <message>A perífrase formada polo verbo «ir» máis un infinitivo constrúese sen preposición: <suggestion>\1 \3</suggestion></message>
       <example correction="Vou saltar"><marker>Vou a saltar</marker> con ela.</example>
     </rule>
 
@@ -2760,7 +2760,7 @@
         </marker>
           <token postag="VMN.*|VSN.*|VMP.*|VSP.*|VMG.*|VSG.*" postag_regexp="yes"/>
       </pattern>
-      <message>A palabra &quot;<match no="1"/>&quot; seguida dunha forma non temporal adoita ser do verbo &quot;vir&quot; e, polo tanto, leva til diacrítico para diferenciala da forma homónima do verbo &quot;ver&quot;. Quería vostede dicir <suggestion><match no="1" regexp_match="(?iu)e" regexp_replace="é"/></suggestion>?</message>
+      <message>A palabra «<match no="1"/>» seguida dunha forma non temporal adoita ser do verbo «vir» e, polo tanto, leva til diacrítico para diferenciala da forma homónima do verbo «ver». Quería vostede dicir <suggestion><match no="1" regexp_match="(?iu)e" regexp_replace="é"/></suggestion>?</message>
       <short>Forma incorrecta</short>
       <example correction="vén">O neno <marker>ven</marker> saltando polo camiño.</example>
     </rule>
@@ -2774,8 +2774,8 @@
           <token>de</token>
           <token postag="(VMN0000|VSN0000).*" postag_regexp="yes"/>
       </pattern>
-      <message>A forma &quot;<match no="1"/>&quot; seguida de infinitivo adoita ser do verbo &quot;vir&quot; e, polo tanto, leva til diacrítico para diferenciala da forma homónima do verbo &quot;ver&quot;. Quería vostede dicir <suggestion>vén</suggestion>?</message>
-      <short>Cando é do verbo vir, &quot;ven&quot; leva til</short>
+      <message>A forma «<match no="1"/>» seguida de infinitivo adoita ser do verbo «vir» e, polo tanto, leva til diacrítico para diferenciala da forma homónima do verbo «ver». Quería vostede dicir <suggestion>vén</suggestion>?</message>
+      <short>Cando é do verbo vir, «ven» leva til</short>
       <example correction="vén">A caixa <marker>ven</marker> de sanear a carteira de créditos.</example>
     </rule>
   </rulegroup>
@@ -2791,7 +2791,7 @@
         </marker>
           <token postag="(VMN0000|VSN0000).*" postag_regexp="yes"/>
       </pattern>
-      <message>A forma 'compre', cando é do verbo &quot;cumprir&quot; (ser necesario), leva til para distinguila do verbo 'comprar'. Quería vostede dicir <suggestion>cómpre</suggestion>?</message>
+      <message>A forma «compre», cando é do verbo «cumprir» (ser necesario), leva til para distinguila do verbo «comprar». Quería vostede dicir <suggestion>cómpre</suggestion>?</message>
       <example correction="cómpre">Agora <marker>compre</marker> analizar o proceso de constitución das listas.</example>
     </rule>
     <!-- compre + adverbio + VINF (cómpre agora ignorar a provocación) -->
@@ -2804,7 +2804,7 @@
           <token postag="RG|RN" postag_regexp="yes"/>
           <token postag="(VMN0000|VSN0000).*" postag_regexp="yes"/>
       </pattern>
-      <message>A forma 'compre', cando é do verbo &quot;cumprir&quot; (ser necesario), leva til para distinguila do verbo 'comprar'. Quería vostede dicir <suggestion>cómpre</suggestion>?</message>
+      <message>A forma «compre», cando é do verbo «cumprir» (ser necesario), leva til para distinguila do verbo «comprar». Quería vostede dicir <suggestion>cómpre</suggestion>?</message>
       <example correction="Cómpre"><marker>Compre</marker> agora analizar o proceso de constitución das listas.</example>
     </rule>
     <!-- compre + que -->
@@ -2816,7 +2816,7 @@
         </marker>
           <token>que</token>
       </pattern>
-      <message>A forma 'compre', cando é do verbo &quot;cumprir&quot; (ser necesario), leva til para distinguila do verbo 'comprar'. Quería vostede dicir <suggestion>cómpre</suggestion>?</message>
+      <message>A forma «compre», cando é do verbo «cumprir» (ser necesario), leva til para distinguila do verbo «comprar». Quería vostede dicir <suggestion>cómpre</suggestion>?</message>
       <example correction="Cómpre"><marker>Compre</marker> que a arquitectura das Nacións Unidas se axuste a ese concepto.</example>
     </rule>
   </rulegroup>
@@ -2831,7 +2831,7 @@
             <token postag="V.*" postag_regexp="yes"/>
           </marker>
       </pattern>
-      <message>Os pronomes clíticos non poden ir en galego no inicio da oración. Por favor, empregue o verbo seguido do pronome (por exemplo: 'díxenvolo' no canto de 'volo dixen').</message>
+      <message>Os pronomes clíticos non poden ir en galego no inicio da oración. Por favor, empregue o verbo seguido do pronome (por exemplo: «díxenvolo» no canto de «volo dixen»).</message>
       <short>O pronome debe ir posposto ao verbo</short>
       <example correction=""><marker>Volo dixen</marker> e non me quixestes facer caso.</example>
       <example><marker>Díxenvolo</marker> e non me quixestes facer caso.</example>
@@ -2845,7 +2845,7 @@
       <pattern>
           <token inflected="yes" regexp="yes" postag="V...1S.:PP1.S.*" postag_regexp="yes">casar|morrer|acougar|adormecer|agrelar|acedar|murchar|merar|espertar|quedar|marchar|calar|caer</token>
       </pattern>
-      <message>Algúns verbos en galego non admiten nunca construcións reflexivas. Quería vostede dicir <suggestion><match no="1" postag="(.*):.*" postag_regexp="yes" postag_replace="$1"/></suggestion>?</message>
+      <message>Algúns verbos non admiten nunca construcións reflexivas. Quería vostede dicir <suggestion><match no="1" postag="(.*):.*" postag_regexp="yes" postag_replace="$1"/></suggestion>?</message>
       <example correction="marchei">Finalmente <marker>marcheime</marker> con Alberte.</example>
     </rule>
     <rule>
@@ -2853,7 +2853,7 @@
       <pattern>
           <token inflected="yes" regexp="yes" postag="V...2S.:PP2.S.*" postag_regexp="yes">casar|morrer|acougar|adormecer|agrelar|acedar|murchar|merar|espertar|quedar|marchar|calar|caer</token>
       </pattern>
-      <message>Algúns verbos en galego non admiten nunca construcións reflexivas. Quería vostede dicir <suggestion><match no="1" postag="(.*):.*" postag_regexp="yes" postag_replace="$1"/></suggestion>?</message>
+      <message>Algúns verbos non admiten nunca construcións reflexivas. Quería vostede dicir <suggestion><match no="1" postag="(.*):.*" postag_regexp="yes" postag_replace="$1"/></suggestion>?</message>
       <example correction="marchas">Finalmente <marker>márchaste</marker> con Alberte?</example>
     </rule>
     <rule>
@@ -2861,7 +2861,7 @@
       <pattern>
           <token inflected="yes" regexp="yes" postag="V...3[SP].:PP3.N.*" postag_regexp="yes">casar|morrer|acougar|adormecer|agrelar|acedar|murchar|merar|espertar|quedar|marchar|calar|caer</token>
       </pattern>
-      <message>Algúns verbos en galego non admiten nunca construcións reflexivas. Quería vostede dicir <suggestion><match no="1" postag="(.*):.*" postag_regexp="yes" postag_replace="$1"/></suggestion>?</message>
+      <message>Algúns verbos non admiten nunca construcións reflexivas. Quería vostede dicir <suggestion><match no="1" postag="(.*):.*" postag_regexp="yes" postag_replace="$1"/></suggestion>?</message>
       <example correction="marchou">Finalmente <marker>marchouse</marker> con Alberte.</example>
     </rule>
     <rule>
@@ -2869,7 +2869,7 @@
       <pattern>
           <token inflected="yes" regexp="yes" postag="V...1P.:PP1.P.*" postag_regexp="yes">casar|morrer|acougar|adormecer|agrelar|acedar|murchar|merar|espertar|quedar|marchar|calar|caer</token>
       </pattern>
-      <message>Algúns verbos en galego non admiten nunca construcións reflexivas. Quería vostede dicir <suggestion><match no="1" postag="(.*):.*" postag_regexp="yes" postag_replace="$1"/></suggestion>?</message>
+      <message>Algúns verbos non admiten nunca construcións reflexivas. Quería vostede dicir <suggestion><match no="1" postag="(.*):.*" postag_regexp="yes" postag_replace="$1"/></suggestion>?</message>
       <example correction="marchamos">Finalmente <marker>marchámonos</marker> con Alberte.</example>
     </rule>
     <rule>
@@ -2877,7 +2877,7 @@
       <pattern>
           <token inflected="yes" regexp="yes" postag="V...2P.:PP2.P.*" postag_regexp="yes">casar|morrer|acougar|adormecer|agrelar|acedar|murchar|merar|espertar|quedar|marchar|calar|caer</token>
       </pattern>
-      <message>Algúns verbos en galego non admiten nunca construcións reflexivas. Quería vostede dicir <suggestion><match no="1" postag="(.*):.*" postag_regexp="yes" postag_replace="$1"/></suggestion>?</message>
+      <message>Algúns verbos non admiten nunca construcións reflexivas. Quería vostede dicir <suggestion><match no="1" postag="(.*):.*" postag_regexp="yes" postag_replace="$1"/></suggestion>?</message>
       <example correction="marchades">Finalmente <marker>marchádesvos</marker> con Alberte.</example>
     </rule>
     <!--proclíticos-->
@@ -2898,7 +2898,7 @@
           <token inflected="yes" regexp="yes">casar|morrer|acougar|adormecer|agrelar|acedar|murchar|merar|espertar|quedar|marchar|calar|caer</token>
           </unify>
       </pattern>
-      <message>Algúns verbos en galego non admiten nunca construcións reflexivas. Quería vostede dicir <suggestion>\2</suggestion>?</message>
+      <message>Algúns verbos non admiten nunca construcións reflexivas. Quería vostede dicir <suggestion>\2</suggestion>?</message>
       <example correction="caso">Finalmente non <marker>me caso</marker> con Alberte.</example>
       <example>Finalmente non <marker>caso</marker> con Alberte.</example>
     </rule>
@@ -2915,7 +2915,7 @@
             <exception negate_pos="yes" postag="V.*" postag_regexp="yes"/>
           </token>
       </pattern>
-      <message>A forma 'nos' ao comezo da oración e seguida por un verbo adoita ser un pronome suxeito e leva til. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)o" regexp_replace="ó"/></suggestion>?</message>
+      <message>A forma «nos» ao comezo da oración e seguida por un verbo adoita ser un pronome suxeito e leva til. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)o" regexp_replace="ó"/></suggestion>?</message>
       <short>Acentuación de pronomes suxeito</short>
       <example correction="Nós"><marker>Nos</marker> cremos que a lingua é un tesouro.</example>
     </rule>
@@ -2930,7 +2930,7 @@
             <exception negate_pos="yes" postag="V...2P.*" postag_regexp="yes"/>
           </token>
       </pattern>
-      <message>A forma 'vos' ao comezo da oración e seguida por un verbo adoita ser un pronome suxeito e leva til. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)o" regexp_replace="ó"/></suggestion>?</message>
+      <message>A forma «vos» ao comezo da oración e seguida por un verbo adoita ser un pronome suxeito e leva til. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)o" regexp_replace="ó"/></suggestion>?</message>
       <short>Acentuación de pronomes suxeito</short>
       <example correction="Vós"><marker>Vos</marker> sabedes o que come?</example>
     </rule>
@@ -2950,7 +2950,7 @@
             <exception negate_pos="yes" postag="V.*" postag_regexp="yes"/>informar</token>
           <token>que</token>
       </pattern>
-      <message>O verbo '\1' constrúese normalmente coa preposición 'de'. Quería vostede dicir <suggestion>\1 de \2</suggestion>?</message>
+      <message>O verbo «\1» constrúese normalmente coa preposición «de». Quería vostede dicir <suggestion>\1 de \2</suggestion>?</message>
       <example correction="informaron de que">Os servizos de emerxencia <marker>informaron que</marker> habería fortes ventos na costa.</example>
     </rule>
     <!-- V + en + que: insistir, confiar -->
@@ -2960,7 +2960,7 @@
           <token inflected="yes" regexp="yes">insistir|confiar</token>
           <token>que</token>
       </pattern>
-      <message>O verbo '\1' constrúese normalmente coa preposición 'en'. Quería vostede dicir <suggestion>\1 en \2</suggestion>?</message>
+      <message>O verbo «\1» constrúese normalmente coa preposición «en». Quería vostede dicir <suggestion>\1 en \2</suggestion>?</message>
       <example correction="insistiron en que">Os servizos de emerxencia <marker>insistiron que</marker> habería fortes ventos na costa.</example>
       <example correction="Confío en que"><marker>Confío que</marker> actuarán de xeito consecuente.</example>
     </rule>
@@ -2969,7 +2969,8 @@
  </category>
 
 
- <category id="CAT2" name="Gramática::Outros">
+ <category id="CAT2" name="Gramática::Outros" type="uncategorized">
+ <!-- Inclúe rexime preposicional, acentuación, apócopes, etc. -->
 
   <rulegroup id="FORA_FORA" name="fóra vs. fora">
     <rule name="preposición + fóra (de fóra)">
@@ -2980,7 +2981,7 @@
           <token>fora</token>
         </marker>
       </pattern>
-      <message>A palabra '\2' semella corresponderse neste contexto co adverbio 'fóra', que leva til para diferenciarse das formas dos verbos 'ser' ou 'ir'. Quería vostede dicir <suggestion>fóra</suggestion>?</message>
+      <message>A palabra «\2» semella corresponderse neste contexto co adverbio «fóra», que leva til para diferenciarse das formas dos verbos 'ser' ou 'ir'. Quería vostede dicir <suggestion>fóra</suggestion>?</message>
       <example correction="fóra">O novo profesor é de <marker>fora</marker>.</example>
     </rule>
     <!-- cando os deixaran fora terrible
@@ -3002,7 +3003,7 @@
       <pattern>
           <token>quenes</token>
       </pattern>
-      <message>En galego o pronome 'quen' carece de plural. Empregue mellor <suggestion>quen</suggestion> ou <suggestion>os que</suggestion> segundo o contexto.</message>
+      <message>O pronome «quen» carece de plural. Empregue mellor <suggestion>quen</suggestion> ou <suggestion>os que</suggestion> segundo o contexto.</message>
       <example correction="quen|os que">Non saben <marker>quenes</marker> son os encargados.</example>
       <example>Non saben <marker>quen</marker> son os encargados.</example>
       <example correction="quen|os que">Seguramente <marker>quenes</marker> máis protestan serán os que máis se beneficien.</example>
@@ -3020,7 +3021,7 @@
             <exception regexp="yes">[aeiouáéíóú].*</exception>
           </token>
       </pattern>
-      <message>O adxectivo &quot;grande&quot; vai apocopado cando precede a un substantivo (agás cando este comeza por vogal). Quería vostede dicir <suggestion>gran</suggestion>?</message>
+      <message>O adxectivo «grande» vai apocopado cando precede a un substantivo (agás cando este comeza por vogal). Quería vostede dicir <suggestion>gran</suggestion>?</message>
       <example correction="gran">Resultou ser un <marker>grande</marker> curso.</example>
       <example>Resultou ser un <marker>gran</marker> curso.</example>
     </rule>
@@ -3032,7 +3033,7 @@
         </marker>
           <token postag="NC.S000" postag_regexp="yes" regexp="yes">^[aeiouáéíóú].*</token>
       </pattern>
-      <message>O adxectivo &quot;grande&quot; non vai nunca apocopado cando precede a un substantivo que comeza por vogal. Quería vostede dicir <suggestion>grande</suggestion>?</message>
+      <message>O adxectivo «grande» non vai nunca apocopado cando precede a un substantivo que comeza por vogal. Quería vostede dicir <suggestion>grande</suggestion>?</message>
       <example correction="grande">Resultou ser un <marker>gran</marker> amigo.</example>
       <example>Resultou ser un <marker>grande</marker> amigo.</example>
     </rule>
@@ -3044,7 +3045,7 @@
         </marker>
           <token postag="NCMS000"/>
       </pattern>
-      <message>O adxectivo &quot;malo&quot; vai apocopado cando precede a un substantivo masculino singular. Quería vostede dicir <suggestion>mal</suggestion>?</message>
+      <message>O adxectivo «malo» vai apocopado cando precede a un substantivo masculino singular. Quería vostede dicir <suggestion>mal</suggestion>?</message>
       <example correction="mal">Resultou ser un <marker>malo</marker> ano.</example>
       <example>Resultou ser un <marker>mal</marker> ano.</example>
     </rule>
@@ -3057,9 +3058,9 @@
         </marker>
           <token regexp="yes">^[aeiouáéíóú].*</token>
       </pattern>
-      <message>O adxectivo &quot;santo&quot; non vai apocopado cando precede a palabras que comezan por vogal. Quería vostede dicir <suggestion>santo</suggestion>?</message>
-      <example correction="santo">Foi á romaría de <marker>san</marker> Andrés.</example>
-      <example>Foi á romaría de <marker>santo</marker> Andrés.</example>
+      <message>O adxectivo «santo» non vai apocopado cando precede a palabras que comezan por vogal. Quería vostede dicir <suggestion>santo</suggestion>?</message>
+      <example correction="santo">Foi á romaría de <marker>san</marker> André.</example>
+      <example>Foi á romaría de <marker>santo</marker> André.</example>
     </rule>
     <rule>
     <!-- Created by Susana Sotelo Docío -->
@@ -3069,7 +3070,7 @@
         </marker>
           <token regexp="yes" negate="yes">^[aeiouáéíóú].*</token>
       </pattern>
-      <message>O adxectivo &quot;santo&quot; vai apocopado cando precede a palabras que comezan por consoante. Quería vostede dicir <suggestion>san</suggestion>?</message>
+      <message>O adxectivo «santo» vai apocopado cando precede a palabras que comezan por consoante. Quería vostede dicir <suggestion>san</suggestion>?</message>
       <example correction="san">Foi á romaría de <marker>santo</marker> Domingo.</example>
       <example>Foi á romaría de <marker>san</marker> Domingo.</example>
     </rule>
@@ -3085,7 +3086,7 @@
         </marker>
           <token regexp="yes">[A-ZÁÉÍÓÚ][a-záéíóúüñ].*</token>
       </pattern>
-      <message>A preposición 'cara' vai seguida de 'a' en galego diante dun nome propio. Quería vostede dicir <suggestion><match no="1"/> a</suggestion>?</message>
+      <message>A preposición «cara» vai seguida de «a» diante dun nome propio. Quería vostede dicir <suggestion><match no="1"/> a</suggestion>?</message>
       <short>Forma incorrecta</short>
       <example correction="cara a">A estrada <marker>cara</marker> Noia.</example>
     </rule>
@@ -3100,7 +3101,7 @@
         </marker>
           <token postag="D[ID].*" postag_regexp="yes"/>
       </pattern>
-      <message>A preposición 'cara' vai seguida de 'a' en galego. Quería vostede dicir <suggestion><match no="1"/> a</suggestion>?</message>
+      <message>A preposición «cara» vai seguida de «a». Quería vostede dicir <suggestion><match no="1"/> a</suggestion>?</message>
       <short>Forma incorrecta</short>
       <example correction="Cara a"> <marker>Cara</marker> un novo modelo.</example>
     </rule>
@@ -3115,7 +3116,7 @@
         </marker>
           <token postag="A...P.|NC.P..." postag_regexp="yes"/>
       </pattern>
-      <message>A preposición 'cara' vai seguida de 'a' en galego. Quería vostede dicir <suggestion><match no="1"/> a</suggestion>?</message>
+      <message>A preposición «cara» vai seguida de «a». Quería vostede dicir <suggestion><match no="1"/> a</suggestion>?</message>
       <short>Forma incorrecta</short>
       <example correction="Cara a"> <marker>Cara</marker> novos retos.</example>
     </rule>
@@ -3132,7 +3133,7 @@
           <token regexp="yes">a|as</token>
           <token postag="A...S.|NC.S..." postag_regexp="yes"/>
       </pattern>
-      <message>A preposición 'cara' vai seguida de 'a' en galego. Quería vostede dicir <suggestion><match no="1"/> <match no="2" regexp_match="[aA]" regexp_replace="á"/></suggestion>?</message>
+      <message>A preposición «cara» vai seguida de «a». Quería vostede dicir <suggestion><match no="1"/> <match no="2" regexp_match="[aA]" regexp_replace="á"/></suggestion>?</message>
       <short>Forma incorrecta</short>
       <example correction="Cara á"> <marker>Cara</marker> a nova fase.</example>
       <example> <marker>Cara á</marker> nova fase.</example>
@@ -3148,7 +3149,7 @@
           <token regexp="yes">o|os</token>
           <token postag="A.....|NC....." postag_regexp="yes"/>
       </pattern>
-      <message>A preposición 'cara' vai seguida de 'a' en galego. Quería vostede dicir <suggestion>\1 a\2</suggestion>?</message>
+      <message>A preposición «cara» vai seguida de «a». Quería vostede dicir <suggestion>\1 a\2</suggestion>?</message>
       <short>Forma incorrecta</short>
       <example correction="cara aos">Os independentistas escoceses miran <marker>cara</marker> os liberais para formar goberno.</example>
       <example>Os independentistas escoceses miran <marker>cara aos</marker> liberais para formar goberno.</example>
@@ -3162,7 +3163,7 @@
           <token regexp="yes">até|ata</token>
           <token regexp="yes">aos?|ós?|ás?</token>
       </pattern>
-      <message>A preposición '\1' non vai seguida da preposición 'a'. Quería vostede dicir <suggestion>\1 <match no="2" postag="SPS00:(.*)" postag_replace="$1">o</match></suggestion>?</message>
+      <message>A preposición «\1» non vai seguida da preposición «a». Quería vostede dicir <suggestion>\1 <match no="2" postag="SPS00:(.*)" postag_replace="$1">o</match></suggestion>?</message>
       <short>Forma incorrecta</short>
       <example correction="até a">Xogaron tamén un papel importante <marker>até á</marker> conquista romana.</example>
     </rule>
@@ -3184,7 +3185,7 @@
         </marker>
           <token regexp="yes">\!|\?</token>
       </pattern>
-      <message>En galego non é preciso acentuar as interrogativas directas. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)á" regexp_replace="a"/></suggestion>?</message>
+      <message>Non é preciso acentuar as interrogativas directas. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)á" regexp_replace="a"/></suggestion>?</message>
       <example correction="Cando"><marker>Cándo</marker> chegan teus pais?</example>
     </rule>
     <rule>
@@ -3196,7 +3197,7 @@
         </marker>
           <token regexp="yes">\!|\?</token>
       </pattern>
-      <message>En galego non é preciso acentuar as interrogativas directas. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)á" regexp_replace="a"/></suggestion>?</message>
+      <message>Non é preciso acentuar as interrogativas directas. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)á" regexp_replace="a"/></suggestion>?</message>
       <example correction="Cando">¿<marker>Cándo</marker> chegan teus pais?</example>
     </rule>
     <rule>
@@ -3208,7 +3209,7 @@
         </marker>
           <token regexp="yes">\!|\?</token>
       </pattern>
-      <message>En galego non é preciso acentuar as interrogativas directas. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)ó" regexp_replace="o"/></suggestion>?</message>
+      <message>Non é preciso acentuar as interrogativas directas. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)ó" regexp_replace="o"/></suggestion>?</message>
       <example correction="Onde"><marker>Ónde</marker> está Bretoña?</example>
     </rule>
     <rule>
@@ -3220,7 +3221,7 @@
         </marker>
           <token regexp="yes">\!|\?</token>
       </pattern>
-      <message>En galego non é preciso acentuar as interrogativas directas. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)ó" regexp_replace="o"/></suggestion>?</message>
+      <message>Non é preciso acentuar as interrogativas directas. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)ó" regexp_replace="o"/></suggestion>?</message>
       <example correction="Onde">¿<marker>Ónde</marker> está Bretoña?</example>
     </rule>
     <rule>
@@ -3232,7 +3233,7 @@
         </marker>
           <token regexp="yes">\!|\?</token>
       </pattern>
-      <message>En galego non é preciso acentuar as interrogativas directas. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)é" regexp_replace="e"/></suggestion>?</message>
+      <message>Non é preciso acentuar as interrogativas directas. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)é" regexp_replace="e"/></suggestion>?</message>
       <example correction="Que"><marker>Qué</marker> día chegan teus pais?</example>
     </rule>
     <rule>
@@ -3244,7 +3245,7 @@
         </marker>
           <token regexp="yes">\!|\?</token>
       </pattern>
-      <message>En galego non é preciso acentuar as interrogativas directas. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)é" regexp_replace="e"/></suggestion>?</message>
+      <message>Non é preciso acentuar as interrogativas directas. Quería vostede dicir <suggestion><match no="2" regexp_match="(?iu)é" regexp_replace="e"/></suggestion>?</message>
       <example correction="Que">¿<marker>Qué</marker> día chegan teus pais?</example>
     </rule>
   </rulegroup>
@@ -3259,10 +3260,10 @@
             <exception regexp="yes" scope="previous">(mail|pol|d|n)?[ao]s?</exception>
             <exception regexp="yes" scope="previous">tódolos|tódalas|coa?s?|c?[óá]s?|aos?|e|ou</exception></token>
       </pattern>
-      <message>En galego 'demais' escríbese xunto só cando é pronome, e nese caso vai precedido por un artigo. Polo contexto semella estar vostede empregándoo como adverbio, que indica exceso dunha cantidade, e neste caso vai separado. Quería vostede dicir <suggestion>de máis</suggestion>?</message>
+      <message>«demais» escríbese xunto só cando é pronome, e nese caso vai precedido por un artigo. Polo contexto semella ser o adverbio, que indica exceso dunha cantidade, e neste caso vai separado. Quería vostede dicir <suggestion>de máis</suggestion>?</message>
       <example correction="de máis">Sempre fala <marker>demais</marker>.</example>
       <example>Xaquín e mailos <marker>demais</marker> rapaces.</example>
-      <example>Foi cos <marker>demais</marker> rapaces a xogar.</example>
+      <example>Foi xogar cos <marker>demais</marker> rapaces.</example>
     </rule>
 
     <rule>
@@ -3271,7 +3272,7 @@
           <token>de</token>
           <token>mais</token>
       </pattern>
-      <message>En galego a locución adverbial 'de máis' leva til. Quería vostede dicir <suggestion>de máis</suggestion>?</message>
+      <message>A locución adverbial «de máis» leva til. Quería vostede dicir <suggestion>de máis</suggestion>?</message>
       <example correction="de máis">Sempre fala <marker>de mais</marker>.</example>
     </rule>
   </rulegroup>
@@ -3293,7 +3294,7 @@
           <token>que</token>
         </marker>
       </pattern>
-      <message>Despois dunha partícula negativa, a secuencia 'se non que' é normalmente unha conxunción adversativa e escríbese 'senón que'. Quería vostede dicir <suggestion>senón que</suggestion>?</message>
+      <message>Despois dunha partícula negativa, a secuencia «se non que» é normalmente unha conxunción adversativa e escríbese «senón que». Quería vostede dicir <suggestion>senón que</suggestion>?</message>
       <example correction="senón que">A economía da guerra non se baseaba na empresa libre, <marker>se non que</marker> era o resultado da sectorización do gasto do goberno</example>
     </rule>
     <rule id="SENON_QUE" name="se non que (senón que)">
@@ -3306,7 +3307,7 @@
           <token>que</token>
         </marker>
       </pattern>
-      <message>Despois dunha partícula negativa, a secuencia 'se non que' é normalmente unha conxunción adversativa e escríbese 'senón que'. Quería vostede dicir <suggestion>senón que</suggestion>?</message>
+      <message>Despois dunha partícula negativa, a secuencia «se non que» é normalmente unha conxunción adversativa e escríbese «senón que». Quería vostede dicir <suggestion>senón que</suggestion>?</message>
       <example correction="senón que">O osíxeno non é unha proba de vida, <marker>se non que</marker> é producido polo xeo de auga da superficie de Ganímedes.</example>
     </rule>
   </rulegroup>
@@ -3321,7 +3322,7 @@
             <exception regexp="yes">[oa]s</exception>
           </token>
       </pattern>
-      <message>A forma &quot;<match no="1"/>&quot; require do artigo determinado cando vai diante dun substantivo. Quería vostede dicir <suggestion><match no="1" regexp_match="(?iu)amb([ao])s" regexp_replace="amb$1s $1s"/> \2</suggestion> ou <suggestion><match no="1" regexp_match="(?iu)amb([ao])s" regexp_replace="ámb$1l$1s"/> \2</suggestion>?</message>
+      <message>A forma «<match no="1"/>» require do artigo determinado cando vai diante dun substantivo. Quería vostede dicir <suggestion><match no="1" regexp_match="(?iu)amb([ao])s" regexp_replace="amb$1s $1s"/> \2</suggestion> ou <suggestion><match no="1" regexp_match="(?iu)amb([ao])s" regexp_replace="ámb$1l$1s"/> \2</suggestion>?</message>
       <short>Forma incorrecta</short>
       <example correction="ambas as cidades|ámbalas cidades">Visitou <marker>ambas cidades</marker> este ano.</example>
       <example>Visitou <marker>ámbalas cidades</marker> este ano.</example>
@@ -3336,7 +3337,7 @@
             <exception regexp="yes">[oa]s</exception>
           </token>
       </pattern>
-      <message>A forma &quot;<match no="1"/>&quot; require do artigo determinado cando vai diante dun substantivo. Quería vostede dicir <suggestion><match no="1" regexp_match="(?iu)tod([ao])s" regexp_replace="tod$1s $1s"/></suggestion> ou <suggestion><match no="1" regexp_match="(?iu)tod([ao])s" regexp_replace="tód$1l$1s"/></suggestion>?</message>
+      <message>A forma «<match no="1"/>» require do artigo determinado cando vai diante dun substantivo. Quería vostede dicir <suggestion><match no="1" regexp_match="(?iu)tod([ao])s" regexp_replace="tod$1s $1s"/></suggestion> ou <suggestion><match no="1" regexp_match="(?iu)tod([ao])s" regexp_replace="tód$1l$1s"/></suggestion>?</message>
       <short>Forma incorrecta</short>
       <example correction="todos os|tódolos">De <marker>todos xeitos</marker> non importa moito.</example>
       <example>De <marker>todos os xeitos</marker> non importa moito.</example>
@@ -3353,7 +3354,7 @@
           <token>por</token>
           <token regexp="yes">[oa]s?</token>
       </pattern>
-      <message>A preposición 'por' e o artigo '<match no="2"/>' contraen. Quería vostede dicir <suggestion><match no="1" regexp_match="(?iu)r$" regexp_replace="l"/>\2</suggestion>?</message>
+      <message>A preposición «por» e o artigo «<match no="2"/>» contraen. Quería vostede dicir <suggestion><match no="1" regexp_match="(?iu)r$" regexp_replace="l"/>\2</suggestion>?</message>
       <example correction="Polo"><marker>Por o</marker> mar abaixo vai unha troita de pé.</example>
     </rule>
 
@@ -3364,7 +3365,7 @@
           <token regexp="yes">m[aá]is</token>
           <token regexp="yes">[oa]s?</token>
       </pattern>
-      <message>A conxunción 'e mais' e o artigo '<match no="3"/>' contraen. Quería vostede dicir <suggestion>e mail\3</suggestion>?</message>
+      <message>A conxunción «e mais» e o artigo «<match no="3"/>» contraen. Quería vostede dicir <suggestion>e mail\3</suggestion>?</message>
       <example correction="e maila">Foron ao cine ela <marker>e mais a</marker> súa irmá.</example>
     </rule>
 
@@ -3377,7 +3378,7 @@
           <token regexp="yes">mail[oa]s?</token>
         </marker>
       </pattern>
-      <message>O uso correcto é 'e mais'. Quería vostede dicir <suggestion>e \2</suggestion>?</message>
+      <message>O uso correcto é «e mais». Quería vostede dicir <suggestion>e \2</suggestion>?</message>
       <example correction="e maila">Foron ao cine ela <marker>maila</marker> súa irmá.</example>
     </rule>
   </rulegroup>
@@ -3389,7 +3390,7 @@
           <token>-</token>
           <token regexp='yes'>l[oa]s?</token>
       </pattern>
-      <message>As formas 'e mais', 'ambos', 'entrambos', 'por', 'tras' e 'todos' non marcan a segunda forma do artigo mediante un trazo. Quería vostede dicir <suggestion>\1\3</suggestion>?</message>
+      <message>As formas «e mais», «ambos», «entrambos», «por», «tras» e «todos» non marcan a segunda forma do artigo mediante un trazo. Quería vostede dicir <suggestion>\1\3</suggestion>?</message>
       <example correction="Tódolos"><marker>Tódo-los</marker> días vou mercar á praza.</example>
     </rule>
 
@@ -3421,7 +3422,7 @@
           <token regexp="yes">ou|e</token>
         </marker>
       </pattern>
-      <message>Posíbel incorrección: non se debe usar '\2' despois dunha negación. Empregue mellor <suggestion>nin</suggestion>.</message>
+      <message>Posíbel incorrección: non se debe usar «\2» despois dunha negación. Empregue mellor <suggestion>nin</suggestion>.</message>
       <example correction="nin">Non se pode presentar máis dunha solicitude por persoa <marker>e</marker> grupo.</example>
       <example>Non se pode presentar máis dunha solicitude por persoa <marker>nin</marker> grupo.</example>
     </rule>
@@ -3432,7 +3433,7 @@
           <token>se</token>
           <token>ben</token>
       </pattern>
-      <message>A partícula 'se ben' é un calco do castelán. Empregue mellor <suggestion>aínda que</suggestion>, <suggestion>a pesar de que</suggestion>, <suggestion>pese a que</suggestion> ou <suggestion>malia que</suggestion>.</message>
+      <message>A partícula «se ben» é un calco do castelán. Empregue mellor <suggestion>aínda que</suggestion>, <suggestion>a pesar de que</suggestion>, <suggestion>pese a que</suggestion> ou <suggestion>malia que</suggestion>.</message>
       <example correction="Aínda que|A pesar de que|Pese a que|Malia que"><marker>Se ben</marker> os resultados poden parecer similares, non teñen moito que ver os experimentos.</example>
       <example><marker>Aínda que</marker> os resultados poden parecer similares, non teñen moito que ver os experimentos.</example>
     </rule>
@@ -3448,7 +3449,7 @@
           <token>elo</token>
         </marker>
       </pattern>
-      <message>'Elo' é en galego un substantivo masculino que significa 'aro ou anel dunha cadea'. Quería vostede dicir <suggestion>isto</suggestion> ou <suggestion>iso</suggestion>?</message>
+      <message>«Elo» é un substantivo masculino que significa «aro ou anel dunha cadea». Quería vostede dicir <suggestion>isto</suggestion> ou <suggestion>iso</suggestion>?</message>
       <example correction="isto|iso">Con <marker>elo</marker> conseguimos mellorar o rendemento do proceso.</example>
       <example>Con <marker>iso</marker> conseguimos mellorar o rendemento do proceso.</example>
     </rule>
@@ -3460,7 +3461,7 @@
           <token>elo</token>
         </marker>
       </pattern>
-      <message>'Elo' é en galego un substantivo masculino que significa 'aro ou anel dunha cadea'. Quería vostede dicir <suggestion>isto</suggestion> ou <suggestion>iso</suggestion>?</message>
+      <message>«Elo» é un substantivo masculino que significa «aro ou anel dunha cadea». Quería vostede dicir <suggestion>isto</suggestion> ou <suggestion>iso</suggestion>?</message>
       <example correction="isto|iso">No centro de todo <marker>elo</marker> sitúase o escudo da vila.</example>
       <example>No centro de todo <marker>isto</marker> sitúase o escudo da vila.</example>
     </rule>
@@ -3474,7 +3475,7 @@
           <token regexp="yes">adiante|arredor|arriba|atrás|baixo|cerca|debaixo|dediante|derredor|derriba|detrás|diante|embaixo|encima|enriba|riba</token>
           <token>miña</token>
       </pattern>
-      <message>A expresión '\1 miña' é incorrecta. Empregue mellor <suggestion>\1 de min</suggestion> no seu lugar.</message>
+      <message>A expresión «\1 miña» é incorrecta. Empregue mellor <suggestion>\1 de min</suggestion> no seu lugar.</message>
       <short>Un posesivo non pode complementar un adverbio.</short>
       <example correction="detrás de min">Vén xusto <marker>detrás miña</marker>.</example>
     </rule>
@@ -3484,7 +3485,7 @@
           <token regexp="yes">adiante|arredor|arriba|atrás|baixo|cerca|debaixo|dediante|derredor|derriba|detrás|diante|embaixo|encima|enriba|riba</token>
           <token>túa</token>
       </pattern>
-      <message>A expresión '\1 túa' é incorrecta. Empregue mellor <suggestion>\1 de ti</suggestion> no seu lugar.</message>
+      <message>A expresión «\1 túa» é incorrecta. Empregue mellor <suggestion>\1 de ti</suggestion> no seu lugar.</message>
       <short>Un posesivo non pode complementar un adverbio.</short>
       <example correction="detrás de ti">Mira <marker>detrás túa</marker>, un mono con tres cabezas!</example>
     </rule>
@@ -3494,7 +3495,7 @@
           <token regexp="yes">adiante|arredor|arriba|atrás|baixo|cerca|debaixo|dediante|derredor|derriba|detrás|diante|embaixo|encima|enriba|riba</token>
           <token regexp="yes">nosa|vosa</token>
       </pattern>
-      <message>A expresión '\1 \2' é incorrecta. Empregue mellor <suggestion>\1 de <match no="2" regexp_match="([vn])osa" regexp_replace="$1ós"/></suggestion> no seu lugar.</message>
+      <message>A expresión «\1 \2» é incorrecta. Empregue mellor <suggestion>\1 de <match no="2" regexp_match="([vn])osa" regexp_replace="$1ós"/></suggestion> no seu lugar.</message>
       <short>Un posesivo non pode complementar un adverbio.</short>
       <example correction="detrás de vós">Mirade <marker>detrás vosa</marker>, un mono con tres cabezas!</example>
     </rule>
@@ -3504,7 +3505,7 @@
           <token regexp="yes">adiante|arredor|arriba|atrás|baixo|cerca|debaixo|dediante|derredor|derriba|detrás|diante|embaixo|encima|enriba|riba</token>
           <token>súa</token>
       </pattern>
-      <message>A expresión '\1 súa' é incorrecta. Empregue mellor, dependendo do referente, <suggestion>\1 del</suggestion>, <suggestion>\1 dela</suggestion>, <suggestion>\1 deles</suggestion>, <suggestion>\1 delas</suggestion>, <suggestion>\1 de vostede</suggestion> ou <suggestion>\1 de vostedes</suggestion> no seu lugar.</message>
+      <message>A expresión «\1 súa» é incorrecta. Empregue mellor, dependendo do referente, <suggestion>\1 del</suggestion>, <suggestion>\1 dela</suggestion>, <suggestion>\1 deles</suggestion>, <suggestion>\1 delas</suggestion>, <suggestion>\1 de vostede</suggestion> ou <suggestion>\1 de vostedes</suggestion> no seu lugar.</message>
       <short>Un posesivo non pode complementar un adverbio.</short>
       <example correction="detrás del|detrás dela|detrás deles|detrás delas|detrás de vostede|detrás de vostedes">Ese Presidente da Xunta que leva <marker>detrás súa</marker> a todo o séquito de acólitos coma avésporas chuchonas.</example>
       <example>Ese Presidente da Xunta que leva <marker>detrás del</marker> a todo o séquito de acólitos coma avésporas chuchonas.</example>
@@ -3515,13 +3516,13 @@
 
     <!-- ############################ LEXICAL RULES ############################ -->
 
- <category id="CAT3" name="Léxico::Estranxeirismos (agás castelanismos)">
+ <category id="CAT3" name="Léxico::Estranxeirismos (agás castelanismos)" type="untranslated">
     <rule id="BAFFLE" name="baffle (pantalla acústica)">
     <!-- Created by Susana Sotelo Docío -->
       <pattern>
           <token regexp="yes">baf?fles?</token>
       </pattern>
-      <message>A palabra '<match no="1"/>' é un anglicismo. Empregue mellor <suggestion>pantalla acústica</suggestion>.</message>
+      <message>A palabra «<match no="1"/>» é un anglicismo. Empregue mellor <suggestion>pantalla acústica</suggestion>.</message>
       <example>O aparato ten as <marker>pantallas acústicas</marker> avariadas.</example>
       <example correction="pantalla acústica">O aparato ten os <marker>baffles</marker> avariados.</example>
     </rule>
@@ -3532,7 +3533,7 @@
           <token>compact</token>
           <token>disk</token>
       </pattern>
-      <message>A palabra '\1 \2' é un anglicismo. Empregue mellor <suggestion>disco compacto</suggestion>.</message>
+      <message>A palabra «\1 \2» é un anglicismo. Empregue mellor <suggestion>disco compacto</suggestion>.</message>
       <example correction="disco compacto">Un <marker>compact disk</marker> mercado fóra de España non leva canon da SGAE.</example>
     </rule>
 
@@ -3541,7 +3542,7 @@
       <pattern>
           <token regexp="yes">chefs?</token>
       </pattern>
-      <message>A palabra '<match no="1"/>' é un galicismo. Empregue mellor <suggestion>xefe de cociña</suggestion> ou <suggestion>xefa de cociña</suggestion>.</message>
+      <message>A palabra «<match no="1"/>» é un galicismo. Empregue mellor <suggestion>xefe de cociña</suggestion> ou <suggestion>xefa de cociña</suggestion>.</message>
       <example correction="xefe de cociña|xefa de cociña">Van contratar un novo <marker>chef</marker> no restaurante.</example>
       <example>Van contratar un novo <marker>xefe de cociña</marker> no restaurante.</example>
     </rule>
@@ -3551,7 +3552,7 @@
       <pattern>
           <token regexp="yes">cont[áa]iner(es)?</token>
       </pattern>
-      <message>A palabra '<match no="1"/>' é un anglicismo. Empregue mellor <suggestion>colector</suggestion>.</message>
+      <message>A palabra «<match no="1"/>» é un anglicismo. Empregue mellor <suggestion>colector</suggestion>.</message>
       <example correction="colector">O <marker>container</marker> do lixo apareceu queimado.</example>
     </rule>
 
@@ -3560,7 +3561,7 @@
       <pattern>
           <token regexp="yes">w[aá]ter(es)?</token>
       </pattern>
-      <message>A palabra '<match no="1"/>' é un anglicismo. Empregue mellor <suggestion>váter</suggestion>.</message>
+      <message>A palabra «<match no="1"/>» é un anglicismo. Empregue mellor <suggestion>váter</suggestion>.</message>
       <example correction="váter">O <marker>wáter</marker> estaba limpo.</example>
     </rule>
 
@@ -3569,7 +3570,7 @@
       <pattern>
           <token regexp="yes">playbacks?</token>
       </pattern>
-      <message>A palabra '<match no="1"/>' é un anglicismo. Empregue mellor <suggestion>son pregravado</suggestion> ou <suggestion>son de estudio</suggestion>.</message>
+      <message>A palabra «<match no="1"/>» é un anglicismo. Empregue mellor <suggestion>son pregravado</suggestion> ou <suggestion>son de estudio</suggestion>.</message>
       <example correction="son pregravado|son de estudio">É un <marker>playback</marker>.</example>
       <example>É un <marker>son pregravado</marker>.</example>
     </rule>
@@ -3581,7 +3582,7 @@
           <token>the</token>
           <token regexp="yes">r[eé]cord</token>
       </pattern>
-      <message>A construción '\1 \2 \3' é un anglicismo. Empregue mellor <suggestion>en privado</suggestion>.</message>
+      <message>A expresión «\1 \2 \3» é un anglicismo. Empregue mellor <suggestion>en privado</suggestion>.</message>
       <example correction="en privado">Comunicou a nova <marker>off the record</marker> aos xornalistas.</example>
     </rule>
 
@@ -3590,7 +3591,7 @@
       <pattern>
           <token regexp="yes">(anti)?d[oó]pings?</token>
       </pattern>
-      <message>A palabra '<match no="1"/>' é un anglicismo. Empregue mellor <suggestion><match no="1" regexp_match="[oó]pings?" regexp_replace="opaxe"/></suggestion> (feminino).</message>
+      <message>A palabra «<match no="1"/>» é un anglicismo. Empregue mellor <suggestion><match no="1" regexp_match="[oó]pings?" regexp_replace="opaxe"/></suggestion> (feminino).</message>
       <example correction="dopaxe">O <marker>dóping</marker> é un problema grave no deporte profesional.</example>
       <example>A <marker>dopaxe</marker> é un problema grave no deporte profesional.</example>
     </rule>
@@ -3600,7 +3601,7 @@
       <pattern>
           <token regexp="yes">e?str[eé]ss?</token>
       </pattern>
-      <message>A palabra '<match no="1"/>' é un anglicismo. Empregue mellor <suggestion>tensión</suggestion>.</message>
+      <message>A palabra «<match no="1"/>» é un anglicismo. Empregue mellor <suggestion>tensión</suggestion>.</message>
       <example correction="tensión">O seu é un traballo de moito <marker>stres</marker>.</example>
       <example>O seu é un traballo de moita <marker>tensión</marker>.</example>
     </rule>
@@ -3611,20 +3612,20 @@
           <token regexp="yes">r[eé]cords?
             <exception scope="previous">the</exception></token>
       </pattern>
-      <message>A palabra '<match no="1"/>' é un anglicismo. Empregue mellor <suggestion>marca</suggestion> (feminino).</message>
+      <message>A palabra «<match no="1"/>» é un anglicismo. Empregue mellor <suggestion>marca</suggestion> (feminino).</message>
       <example correction="marca">O atleta non conseguíu bater o <marker>record</marker>.</example>
       <example>O atleta non conseguíu bater a <marker>marca</marker>.</example>
     </rule>
  </category>
 
- <category id="CAT4" name="Léxico::Falsos homónimos">
+ <category id="CAT4" name="Léxico::Falsos homónimos" type="untranslated">
 
     <rule id="RACHA" name="racha (refacho)">
     <!-- Created by Susana Sotelo Docío -->
       <pattern>
           <token regexp="yes">rachas?</token>
       </pattern>
-      <message>Unha racha en galego é unha fenda ou ben un anaco de pedra ou madeira. A forma correcta en galego para facer referencia a un golpe forte de vento é <suggestion>refacho</suggestion> (masculino).</message>
+      <message>Unha racha é unha fenda ou ben un anaco de pedra ou madeira. A forma correcta para facer referencia a un golpe forte de vento é <suggestion>refacho</suggestion> (masculino).</message>
       <short>Posíbel confusión con homónima.</short>
       <example correction="refacho">Había <marker>rachas</marker> de vento na costa.</example>
       <example>Había <marker>refachos</marker> de vento na costa.</example>
@@ -3635,7 +3636,7 @@
       <pattern>
           <token regexp="yes">loros?</token>
       </pattern>
-      <message>Un loro en galego é unha peza do carro. A forma correcta en galego para facer referencia ao paxaro é <suggestion>papagaio</suggestion>.</message>
+      <message>Un loro é unha peza do carro. A forma correcta para facer referencia ao paxaro é <suggestion>papagaio</suggestion>.</message>
       <short>Posíbel castelanismo</short>
       <example correction="papagaio">Ten un <marker>loro</marker> na súa casa.</example>
     </rule>
@@ -3645,7 +3646,7 @@
       <pattern>
           <token inflected="yes">píldora</token>
       </pattern>
-      <message>Unha píldora en galego é unha ave tamén coñecida como &quot;píllara&quot;. A forma correcta en galego para facer referencia ao medicamento é <suggestion>pílula</suggestion>.</message>
+      <message>Unha píldora é unha ave tamén coñecida como «píllara».  A forma correcta para facer referencia ao medicamento é <suggestion>pílula</suggestion>.</message>
       <short>Posíbel castelanismo</short>
       <example correction="pílula">O médico recetoume unhas <marker>píldoras</marker> para a acidez estomacal.</example>
       <example>O médico recetoume unhas <marker>pílulas</marker> para a acidez estomacal.</example>
@@ -3656,7 +3657,7 @@
       <pattern>
           <token inflected="yes">aportar</token>
       </pattern>
-      <message>O verbo &quot;aportar&quot; significa en galego &quot;chegar a porto&quot;. A forma correcta en galego para o sentido de &quot;proporcionar&quot; ou &quot;presentar&quot; é <suggestion><match no="1" postag="(.*)" postag_replace="$1">achegar</match></suggestion> ou <suggestion><match no="1" postag="(.*)" postag_replace="$1">facer</match> unha achega</suggestion>.</message>
+      <message>O verbo «aportar» significa «chegar a porto».  A forma correcta para o sentido de «proporcionar» ou «presentar» é <suggestion><match no="1" postag="(.*)" postag_replace="$1">achegar</match></suggestion> ou <suggestion><match no="1" postag="(.*)" postag_replace="$1">facer</match> unha achega</suggestion>.</message>
       <short>Posíbel castelanismo</short>
       <example correction="achegar|facer unha achega">Eu tamén quero <marker>aportar</marker> algo ao proxecto.</example>
       <example>Eu tamén quero <marker>achegar</marker> algo ao proxecto.</example>
@@ -3667,7 +3668,7 @@
       <pattern>
           <token inflected="yes">beca</token>
       </pattern>
-      <message>A palabra 'beca' significa en galego &quot;vestidura talar de cor negra&quot;. A forma correcta en galego para o sentido de &quot;axuda económica á formación&quot; é <suggestion>bolsa</suggestion>.</message>
+      <message>A palabra «beca» significa «vestidura talar de cor negra».  A forma correcta para o sentido de «axuda económica á formación» é <suggestion>bolsa</suggestion>.</message>
       <short>Posíbel castelanismo</short>
       <example correction="bolsa">Obtivo unha <marker>beca</marker> para o Trinity College.</example>
     </rule>
@@ -3677,7 +3678,7 @@
       <pattern>
           <token inflected="yes">abono</token>
       </pattern>
-      <message>Posíbel castelanismo: &quot;abono&quot; significa en galego &quot;subscrición&quot;. Se vostede alude ás substancias químicas ou orgánicas que aumentan a fertilidade do solo, debe empregar <suggestion>fertilizante</suggestion>; pola contra, se falaba da acción de pagar por un obxecto ou servizo, use <suggestion>pagamento</suggestion> ou <suggestion>pago</suggestion>.</message>
+      <message>Posíbel castelanismo: «abono» significa «subscrición».  Se vostede alude ás substancias químicas ou orgánicas que aumentan a fertilidade do solo, debe empregar <suggestion>fertilizante</suggestion>; pola contra, se falaba da acción de pagar por un obxecto ou servizo, use <suggestion>pagamento</suggestion> ou <suggestion>pago</suggestion>.</message>
       <short>Posíbel castelanismo</short>
       <example correction="fertilizante|pagamento|pago">O estudo analiza o papel dos <marker>abonos</marker> na contaminación das augas subterráneas.</example>
       <example>O estudo analiza o papel dos <marker>fertilizantes</marker> na contaminación das augas subterráneas.</example>
@@ -3690,7 +3691,7 @@
       <pattern>
           <token inflected="yes">grúa</token>
       </pattern>
-      <message>Posíbel castelanismo: o substantivo &quot;grúa&quot; fai referencia a un paxaro. Para denominar ao aparato empregado para mover ou remolcar grandes pesos emprégase preferibelmente <suggestion>guindastre</suggestion> (masculino).</message>
+      <message>Posíbel castelanismo: o substantivo «grúa» fai referencia a un paxaro. Para denominar ao aparato empregado para mover ou remolcar grandes pesos emprégase preferibelmente <suggestion>guindastre</suggestion> (masculino).</message>
       <short>Posíbel forma incorrecta</short>
       <example correction="guindastre">A <marker>grúa</marker> levoulle o automóbil.</example>
       <example>O <marker>guindastre</marker> levoulle o automóbil.</example>
@@ -3701,7 +3702,7 @@
       <pattern>
           <token inflected="yes">fecha</token>
       </pattern>
-      <message>Posíbel castelanismo: o substantivo &quot;fecha&quot; significa en galego &quot;grolo&quot;, &quot;sorbo&quot;. A forma correcta en galego para a indicación de tempo é <suggestion>data</suggestion>.</message>
+      <message>Posíbel castelanismo: o substantivo «fecha» significa «grolo», «sorbo».  A forma correcta para a indicación de tempo é <suggestion>data</suggestion>.</message>
       <short>Posíbel forma incorrecta</short>
       <example correction="data">Xa publicaron a <marker>fecha</marker> do exame de Álxebra.</example>
     </rule>
@@ -3711,7 +3712,7 @@
       <pattern>
           <token inflected="yes">asco</token>
       </pattern>
-      <message>Posíbel castelanismo: &quot;asco&quot; é en galego unha estrutura utricular propia dun tipo de fungo. A forma correcta en galego para indicar repugnancia é <suggestion>noxo</suggestion>.</message>
+      <message>Posíbel castelanismo: «asco» é unha estrutura utricular propia dun tipo de fungo. A forma correcta para indicar repugnancia é <suggestion>noxo</suggestion>.</message>
       <short>Posíbel forma incorrecta</short>
       <example correction="noxo">Esa actitude da xente dá <marker>asco</marker>.</example>
     </rule>
@@ -3721,14 +3722,14 @@
       <pattern>
           <token inflected="yes">rape</token>
       </pattern>
-      <message>Posíbel castelanismo: o substantivo &quot;\1&quot; significa en galego &quot;acción ou efecto de rapar&quot;. A forma correcta en galego para o peixe é <suggestion>rabada</suggestion> (feminino) ou <suggestion>peixe sapo</suggestion>.</message>
+      <message>Posíbel castelanismo: o substantivo «\1» significa «acción ou efecto de rapar».  A forma correcta para o peixe é <suggestion>rabada</suggestion> (feminino) ou <suggestion>peixe sapo</suggestion>.</message>
       <example correction="rabada|peixe sapo">Merquei un par de <marker>rapes</marker> na praza.</example>
       <example>Merquei un par de <marker>rabadas</marker> na praza.</example>
     </rule>
 
  </category>
 
- <category id="CAT5" name="Léxico::Castelanismos léxicos">
+ <category id="CAT5" name="Léxico::Castelanismos léxicos" type="untranslated">
 
     <rule id="MARTINPESCADOR" name="martín pescador (picapeixe)">
     <!-- Created by Susana Sotelo Docío -->
@@ -3736,7 +3737,7 @@
           <token regexp="yes">martín|martiño</token>
           <token regexp="yes">pescador(es)?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1 \2&quot; non existe en galego. Quería vostede dicir <suggestion>picapeixe</suggestion>?</message>
+      <message>Palabra incorrecta: a forma «\1 \2» non existe en galego. Quería vostede dicir <suggestion>picapeixe</suggestion>?</message>
       <example correction="picapeixe">O <marker>martín pescador</marker> non é un paxaro fácil de fotografar.</example>
     </rule>
 
@@ -3745,7 +3746,7 @@
       <pattern>
           <token>alomellor</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>se cadra</suggestion>?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>se cadra</suggestion>?</message>
       <example correction="Se cadra"><marker>Alomellor</marker> non é importante.</example>
     </rule>
 
@@ -3754,7 +3755,7 @@
       <pattern>
           <token regexp="yes">conce(ll|x)a(l|is|es)</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>concelleiro</suggestion>?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>concelleiro</suggestion>?</message>
       <example correction="concelleiro">Mañá será oficial o seu cesamento no cargo de <marker>concellal</marker>.</example>
     </rule>
 
@@ -3763,7 +3764,7 @@
       <pattern>
           <token regexp="yes">deterioros?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>deterioración</suggestion> (feminino)?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>deterioración</suggestion> (feminino)?</message>
       <example correction="deterioración">Denunciamos o <marker>deterioro</marker> da diversificación na oferta educativa.</example>
       <example>Denunciamos a <marker>deterioración</marker> da diversificación na oferta educativa.</example>
     </rule>
@@ -3773,7 +3774,7 @@
       <pattern>
           <token regexp="yes">basuras?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>lixo</suggestion> (masculino)?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>lixo</suggestion> (masculino)?</message>
       <example correction="lixo">Hoxe teño que sacar eu a <marker>basura</marker>.</example>
       <example>Hoxe teño que sacar eu o <marker>lixo</marker>.</example>
     </rule>
@@ -3783,7 +3784,7 @@
       <pattern>
           <token regexp="yes">asignaturas?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>materia</suggestion> ou <suggestion>disciplina</suggestion>?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>materia</suggestion> ou <suggestion>disciplina</suggestion>?</message>
       <example correction="materia|disciplina">Este ano teño só tres <marker>asignaturas</marker>.</example>
       <example>Este ano teño só tres <marker>materias</marker>.</example>
     </rule>
@@ -3793,7 +3794,7 @@
       <pattern>
           <token regexp="yes">veletas?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>catavento</suggestion> (masculino)?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>catavento</suggestion> (masculino)?</message>
       <example correction="catavento">Ten unha <marker>veleta</marker> no pincho da casa.</example>
       <example>Ten un <marker>catavento</marker> no pincho da casa.</example>
     </rule>
@@ -3803,7 +3804,7 @@
       <pattern>
           <token regexp="yes">ventanillas?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>portelo</suggestion> (masculino)?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>portelo</suggestion> (masculino)?</message>
       <example correction="portelo">Abre a <marker>ventanilla</marker> do coche.</example>
       <example>Abre o <marker>portelo</marker> do coche.</example>
     </rule>
@@ -3813,7 +3814,7 @@
       <pattern>
           <token regexp="yes">botiquíns?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>caixa de urxencias</suggestion> (feminino)?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>caixa de urxencias</suggestion> (feminino)?</message>
       <example correction="caixa de urxencias">Hai pílulas para a dor de cabeza no <marker>botiquín</marker>?</example>
       <example>Hai pílulas para a dor de cabeza na <marker>caixa de urxencias</marker>?</example>
     </rule>
@@ -3823,7 +3824,7 @@
       <pattern>
           <token regexp="yes">aforos?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>capacidade</suggestion> (feminino)?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>capacidade</suggestion> (feminino)?</message>
       <example correction="capacidade">No concerto sobrepasouse o <marker>aforo</marker> do recinto.</example>
       <example>No concerto sobrepasouse a <marker>capacidade</marker> do recinto.</example>
     </rule>
@@ -3833,7 +3834,7 @@
       <pattern>
           <token regexp="yes">promedios?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>media</suggestion> (feminino) ou <suggestion>termo medio</suggestion>?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>media</suggestion> (feminino) ou <suggestion>termo medio</suggestion>?</message>
       <example correction="media|termo medio">Precisa pescudar o <marker>promedio</marker> de litros caídos en Santiago durante o ano 2000.</example>
       <example>Precisa pescudar a <marker>media</marker> de litros caídos en Santiago durante o ano 2000.</example>
     </rule>
@@ -3843,7 +3844,7 @@
       <pattern>
           <token regexp="yes">(des)?prevenid[oa]s?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion><match no="1" regexp_match="en" regexp_replace=""/></suggestion>?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion><match no="1" regexp_match="en" regexp_replace=""/></suggestion>?</message>
       <example correction="prevido">Home <marker>prevenido</marker> vale por dous.</example>
     </rule>
 
@@ -3852,7 +3853,7 @@
       <pattern>
           <token regexp="yes">servilletas?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>pano de mesa</suggestion> (masculino)?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>pano de mesa</suggestion> (masculino)?</message>
       <example correction="pano de mesa">Tes que mercar unhas <marker>servilletas</marker> novas.</example>
       <example>Tes que mercar uns <marker>panos de mesa</marker> novos.</example>
     </rule>
@@ -3862,7 +3863,7 @@
       <pattern>
           <token regexp="yes">cupos?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>cota</suggestion> (feminino)?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>cota</suggestion> (feminino)?</message>
       <example correction="cota">Non chegaron ao <marker>cupo</marker> de matriculados.</example>
       <example>Non chegaron á <marker>cota</marker> de matriculados.</example>
     </rule>
@@ -3872,7 +3873,7 @@
       <pattern>
           <token regexp="yes">(callexón|calei?xón)s?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>canella</suggestion> (feminino)?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>canella</suggestion> (feminino)?</message>
       <example correction="canella">A discusión acabou nun <marker>calexón</marker> sen saída.</example>
       <example>A discusión acabou nunha <marker>canella</marker> sen saída.</example>
     </rule>
@@ -3882,7 +3883,7 @@
       <pattern>
           <token regexp="yes">sabañóns?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>frieira</suggestion> (feminino)?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>frieira</suggestion> (feminino)?</message>
       <example correction="frieira">Teño un <marker>sabañón</marker> nunha man.</example>
       <example>Teño unha <marker>frieira</marker> nunha man.</example>
     </rule>
@@ -3892,7 +3893,7 @@
       <pattern>
           <token regexp="yes">rincóns?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>recuncho</suggestion> ou <suggestion>cornello</suggestion>?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>recuncho</suggestion> ou <suggestion>cornello</suggestion>?</message>
       <example correction="recuncho|cornello">Puxo ao neno nun <marker>rincón</marker>.</example>
       <example>Puxo ao neno nun <marker>recuncho</marker>.</example>
     </rule>
@@ -3902,7 +3903,7 @@
       <pattern>
           <token regexp="yes">carcomas?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>caruncho</suggestion> (masculino) ou <suggestion>couza</suggestion>?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>caruncho</suggestion> (masculino) ou <suggestion>couza</suggestion>?</message>
       <example correction="caruncho|couza">O mastro do barco ten <marker>carcoma</marker>.</example>
       <example>O mastro do barco ten <marker>caruncho</marker>.</example>
     </rule>
@@ -3912,7 +3913,7 @@
       <pattern>
           <token regexp="yes">rasgos?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;\1&quot; non existe en galego. Quería vostede dicir <suggestion>trazo</suggestion> (liña trazada ou característica dunha persoa ou cousa) ou <suggestion>risco</suggestion> (liña longa)?</message>
+      <message>Palabra incorrecta: a forma «\1» non existe en galego. Quería vostede dicir <suggestion>trazo</suggestion> (liña trazada ou característica dunha persoa ou cousa) ou <suggestion>risco</suggestion> (liña longa)?</message>
       <example correction="trazo|risco">A ausencia de melanina é un <marker>rasgo</marker> característico do albinismo.</example>
       <example>A ausencia de melanina é un <marker>trazo</marker> característico do albinismo.</example>
     </rule>
@@ -3922,7 +3923,7 @@
       <pattern>
           <token regexp="yes">buzóns?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;<match no="1"/>&quot; non existe en galego. Quería vostede dicir <suggestion><match no="1" regexp_match="buzón(s)?$" regexp_replace="caixa$1 de correos"/></suggestion> (feminino)?</message>
+      <message>Palabra incorrecta: a forma «<match no="1"/>» non existe en galego. Quería vostede dicir <suggestion><match no="1" regexp_match="buzón(s)?$" regexp_replace="caixa$1 de correos"/></suggestion> (feminino)?</message>
       <example correction="caixa de correos">Tiña dúas cartas no <marker>buzón</marker>.</example>
       <example>Tiña dúas cartas na <marker>caixa de correos</marker>.</example>
     </rule>
@@ -3932,7 +3933,7 @@
       <pattern>
           <token regexp="yes">calamar(es)?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;<match no="1"/>&quot; non existe en galego. Quería vostede dicir <suggestion><match no="1" regexp_match="calamare?(s)?$" regexp_replace="lura$1"/></suggestion> (feminino)?</message>
+      <message>Palabra incorrecta: a forma «<match no="1"/>» non existe en galego. Quería vostede dicir <suggestion><match no="1" regexp_match="calamare?(s)?$" regexp_replace="lura$1"/></suggestion> (feminino)?</message>
       <example correction="luras">Traían uns <marker>calamares</marker> do mercado.</example>
       <example>Traían unhas <marker>luras</marker> do mercado.</example>
     </rule>
@@ -3942,7 +3943,7 @@
       <pattern>
           <token regexp="yes">brúxulas?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;<match no="1"/>&quot; non existe en galego. Quería vostede dicir <suggestion>compás</suggestion> (masculino)?</message>
+      <message>Palabra incorrecta: a forma «<match no="1"/>» non existe en galego. Quería vostede dicir <suggestion>compás</suggestion> (masculino)?</message>
       <example correction="compás">Unha <marker>brúxula</marker> sinala sempre ao norte.</example>
       <example>Un <marker>compás</marker> sinala sempre ao norte.</example>
     </rule>
@@ -3952,7 +3953,7 @@
       <pattern>
           <token regexp="yes">corbata?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;<match no="1"/>&quot; non existe en galego. Quería vostede dicir <suggestion>garavata</suggestion> ou <suggestion>gravata</suggestion>?</message>
+      <message>Palabra incorrecta: a forma «<match no="1"/>» non existe en galego. Quería vostede dicir <suggestion>garavata</suggestion> ou <suggestion>gravata</suggestion>?</message>
       <example correction="garavata|gravata">Vai traballar tódolos días vestido de <marker>corbata</marker>.</example>
       <example>Vai traballar tódolos días vestido de <marker>gravata</marker>.</example>
     </rule>
@@ -3962,7 +3963,7 @@
       <pattern>
           <token regexp="yes">contraseñas?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;<match no="1"/>&quot; non existe en galego. Quería vostede dicir <suggestion>contrasinal</suggestion> (masculino)?</message>
+      <message>Palabra incorrecta: a forma «<match no="1"/>» non existe en galego. Quería vostede dicir <suggestion>contrasinal</suggestion> (masculino)?</message>
       <example correction="contrasinal">Tivo que cambiar a súa <marker>contraseña</marker> de entrada.</example>
       <example>Tivo que cambiar o seu <marker>contrasinal</marker> de entrada.</example>
     </rule>
@@ -3972,7 +3973,7 @@
       <pattern>
           <token regexp="yes">grullas?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;<match no="1"/>&quot; non existe en galego. Quería vostede dicir <suggestion>grou</suggestion> (masculino) ou <suggestion>grúa</suggestion>?</message>
+      <message>Palabra incorrecta: a forma «<match no="1"/>» non existe en galego. Quería vostede dicir <suggestion>grou</suggestion> (masculino) ou <suggestion>grúa</suggestion>?</message>
       <example correction="grou|grúa">En novembro é cando as <marker>grullas</marker> inician a súa migración.</example>
       <example>En novembro é cando as <marker>grúas</marker> inician a súa migración.</example>
     </rule>
@@ -3982,7 +3983,7 @@
       <pattern>
           <token regexp="yes">libretas?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;<match no="1"/>&quot; non existe en galego. Quería vostede dicir <suggestion>caderno</suggestion> (masculino)?</message>
+      <message>Palabra incorrecta: a forma «<match no="1"/>» non existe en galego. Quería vostede dicir <suggestion>caderno</suggestion> (masculino)?</message>
       <example correction="caderno">Andrés foi mercar unha <marker>libreta</marker> para a escola.</example>
       <example>Andrés foi mercar un <marker>caderno</marker> para a escola.</example>
     </rule>
@@ -3992,7 +3993,7 @@
       <pattern>
           <token regexp="yes">tizas?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;<match no="1"/>&quot; non existe en galego. Quería vostede dicir <suggestion>xiz</suggestion> (masculino)?</message>
+      <message>Palabra incorrecta: a forma «<match no="1"/>» non existe en galego. Quería vostede dicir <suggestion>xiz</suggestion> (masculino)?</message>
       <example correction="xiz">Na aula do segundo curso non hai <marker>tiza</marker>.</example>
     </rule>
 
@@ -4002,7 +4003,7 @@
       <pattern>
           <token regexp="yes">tragalu(z|ces)</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;<match no="1"/>&quot; non existe en galego. Quería vostede dicir <suggestion>bufarda</suggestion> (feminino)?</message>
+      <message>Palabra incorrecta: a forma «<match no="1"/>» non existe en galego. Quería vostede dicir <suggestion>bufarda</suggestion> (feminino)?</message>
       <example correction="bufarda">Puxo un <marker>tragaluz</marker> na casa.</example>
       <example>Puxo unha <marker>bufarda</marker> na casa.</example>
     </rule>
@@ -4013,7 +4014,7 @@
       <pattern>
           <token regexp="yes">xorobas?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;<match no="1"/>&quot; non existe en galego. Quería vostede dicir <suggestion>chepa</suggestion> ou <suggestion>carrumba</suggestion>?</message>
+      <message>Palabra incorrecta: a forma «<match no="1"/>» non existe en galego. Quería vostede dicir <suggestion>chepa</suggestion> ou <suggestion>carrumba</suggestion>?</message>
       <example correction="chepa|carrumba">O dromedario ten unha única <marker>xoroba</marker>.</example>
       <example>O dromedario ten unha única <marker>chepa</marker>.</example>
     </rule>
@@ -4024,7 +4025,7 @@
       <pattern>
           <token regexp="yes">xarróns?</token>
       </pattern>
-      <message>Palabra incorrecta: a forma &quot;<match no="1"/>&quot; non existe en galego. Quería vostede dicir <suggestion>floreiro</suggestion> ou <suggestion>vaso</suggestion>?</message>
+      <message>Palabra incorrecta: a forma «<match no="1"/>» non existe en galego. Quería vostede dicir <suggestion>floreiro</suggestion> ou <suggestion>vaso</suggestion>?</message>
       <example correction="floreiro|vaso">Rompín o <marker>xarrón</marker> que lle mercara á túa nai.</example>
       <example>Rompín o <marker>floreiro</marker> que lle mercara á túa nai.</example>
     </rule>
@@ -4034,7 +4035,7 @@
       <pattern>
           <token regexp="yes">aport(e|ación)s?</token>
       </pattern>
-      <message>Posíbel castelanismo: o substantivo &quot;<match no="1"/>&quot; non existe en galego. Quería vostede dicir <suggestion>achega</suggestion> ou <suggestion>contribución</suggestion>?</message>
+      <message>Posíbel castelanismo: o substantivo «<match no="1"/>» non existe en galego. Quería vostede dicir <suggestion>achega</suggestion> ou <suggestion>contribución</suggestion>?</message>
       <short>Castelanismo léxico</short>
       <example correction="achega|contribución">Fixo importantes <marker>aportacións</marker> ao proxecto.</example>
       <example>Fixo importantes <marker>achegas</marker> ao proxecto.</example>
@@ -4045,7 +4046,7 @@
       <pattern>
           <token regexp="yes">tiburóns?</token>
       </pattern>
-      <message>Posíbel castelanismo: o substantivo &quot;<match no="1"/>&quot; non existe en galego. Quería vostede dicir <suggestion>quenlla</suggestion> (feminino)?</message>
+      <message>Posíbel castelanismo: o substantivo «<match no="1"/>» non existe en galego. Quería vostede dicir <suggestion>quenlla</suggestion> (feminino)?</message>
       <short>Castelanismo léxico</short>
       <example correction="quenlla">Miraron un <marker>tiburón</marker> dende o barco.</example>
       <example>Miraron unha <marker>quenlla</marker> dende o barco.</example>
@@ -4056,7 +4057,7 @@
       <pattern>
           <token regexp="yes">chequeos?</token>
       </pattern>
-      <message>Posíbel castelanismo: o substantivo &quot;<match no="1"/>&quot; non existe en galego. Quería vostede dicir <suggestion>revisión</suggestion> ou <suggestion>recoñecemento</suggestion>?</message>
+      <message>Posíbel castelanismo: o substantivo «<match no="1"/>» non existe en galego. Quería vostede dicir <suggestion>revisión</suggestion> ou <suggestion>recoñecemento</suggestion>?</message>
       <short>Castelanismo léxico</short>
       <example correction="revisión|recoñecemento">Onte foi facer un <marker>chequeo</marker> médico.</example>
       <example>Onte foi facer un <marker>recoñecemento</marker> médico.</example>
@@ -4067,7 +4068,7 @@
       <pattern>
           <token regexp="yes">turnos?|tandas?</token>
       </pattern>
-      <message>A palabra &quot;<match no="1"/>&quot; é un castelanismo. Empregue no seu sitio <suggestion>quenda</suggestion> ou <suggestion>vez</suggestion> tendo en conta as diferenzas de xénero.</message>
+      <message>A palabra «<match no="1"/>» é un castelanismo. Empregue no seu sitio <suggestion>quenda</suggestion> ou <suggestion>vez</suggestion> tendo en conta as diferenzas de xénero.</message>
       <short>Castelanismo léxico</short>
       <example correction="quenda|vez">Perdín o meu <marker>turno</marker> na lista de agarda.</example>
       <example>Perdín a miña <marker>vez</marker> na lista de agarda.</example>
@@ -4080,7 +4081,7 @@
       <pattern>
           <token regexp="yes">trineos?</token>
       </pattern>
-      <message>A palabra &quot;<match no="1"/>&quot; é un castelanismo. Empregue no seu sitio <suggestion>zorra</suggestion>.</message>
+      <message>A palabra «<match no="1"/>» é un castelanismo. Empregue no seu sitio <suggestion>zorra</suggestion>.</message>
       <short>Castelanismo léxico</short>
       <example correction="zorra">Rebentaban os renos e atuaban o <marker>trineo</marker> na nevada co peso dos seus bandullos.</example>
       <example>Rebentaban os renos e atuaban a <marker>zorra</marker> na nevada co peso dos seus bandullos.</example>
@@ -4091,7 +4092,7 @@
       <pattern>
           <token regexp="yes">grifos?</token>
       </pattern>
-      <message>A palabra &quot;<match no="1"/>&quot; é un castelanismo. Empregue no seu sitio <suggestion>billa</suggestion> (feminino).</message>
+      <message>A palabra «<match no="1"/>» é un castelanismo. Empregue no seu sitio <suggestion>billa</suggestion> (feminino).</message>
       <short>Castelanismo léxico</short>
       <example correction="billa">Non saía auga do <marker>grifo</marker>.</example>
       <example>Non saía auga da <marker>billa</marker>.</example>
@@ -4102,7 +4103,7 @@
       <pattern>
           <token regexp="yes">mordiscos?</token>
       </pattern>
-      <message>A palabra &quot;<match no="1"/>&quot; é un castelanismo. Empregue no seu sitio <suggestion>dentada</suggestion> (feminino).</message>
+      <message>A palabra «<match no="1"/>» é un castelanismo. Empregue no seu sitio <suggestion>dentada</suggestion> (feminino).</message>
       <short>Castelanismo léxico</short>
       <example correction="dentada">Levoulle media orella dun <marker>mordisco</marker>.</example>
       <example>Levoulle media orella dunha <marker>dentada</marker>.</example>
@@ -4113,7 +4114,7 @@
       <pattern>
           <token regexp="yes">andamios?</token>
       </pattern>
-      <message>A palabra &quot;<match no="1"/>&quot; é un castelanismo. Empregue no seu sitio <suggestion>estada</suggestion> (feminino).</message>
+      <message>A palabra «<match no="1"/>» é un castelanismo. Empregue no seu sitio <suggestion>estada</suggestion> (feminino).</message>
       <short>Castelanismo léxico</short>
       <example correction="estada">Un albanel vai vir montar o <marker>andamio</marker> mañá.</example>
       <example>Un albanel vai vir montar a <marker>estada</marker> mañá.</example>
@@ -4124,7 +4125,7 @@
       <pattern>
           <token regexp="yes">andéns?</token>
       </pattern>
-      <message>A palabra &quot;<match no="1"/>&quot; é un castelanismo. Empregue no seu sitio <suggestion>plataforma</suggestion> (feminino).</message>
+      <message>A palabra «<match no="1"/>» é un castelanismo. Empregue no seu sitio <suggestion>plataforma</suggestion> (feminino).</message>
       <short>Castelanismo léxico</short>
       <example correction="plataforma">O tren chegará ao <marker>andén</marker> número tres.</example>
       <example>O tren chegará á <marker>plataforma</marker> número tres.</example>
@@ -4135,7 +4136,7 @@
       <pattern>
           <token regexp="yes">arcéns?</token>
       </pattern>
-      <message>A palabra &quot;<match no="1"/>&quot; é un castelanismo. Empregue no seu sitio <suggestion>beiravía</suggestion> (feminino).</message>
+      <message>A palabra «<match no="1"/>» é un castelanismo. Empregue no seu sitio <suggestion>beiravía</suggestion> (feminino).</message>
       <short>Castelanismo léxico</short>
       <example correction="beiravía">Na bicicleta procuro sempre circular polo <marker>arcén</marker>.</example>
       <example>Na bicicleta procuro sempre circular pola <marker>beiravía</marker>.</example>
@@ -4147,7 +4148,7 @@
       <pattern>
           <token regexp="yes">asequibles?</token>
       </pattern>
-      <message>A palabra &quot;<match no="1"/>&quot; é un castelanismo. Empregue no seu sitio <suggestion>alcanzable</suggestion> ou <suggestion>accesible</suggestion>.</message>
+      <message>A palabra «<match no="1"/>» é un castelanismo. Empregue no seu sitio <suggestion>alcanzable</suggestion> ou <suggestion>accesible</suggestion>.</message>
       <short>Castelanismo léxico</short>
       <example correction="alcanzable|accesible">O prezo actual da vivenda non é <marker>asequible</marker> para moita xente no pais.</example>
       <example>O prezo actual da vivenda non é <marker>accesible</marker> para moita xente no pais.</example>
@@ -4157,7 +4158,7 @@
       <pattern>
           <token regexp="yes">inasequibles?</token>
       </pattern>
-      <message>A palabra &quot;<match no="1"/>&quot; é un castelanismo. Empregue no seu sitio <suggestion>inalcanzable</suggestion> ou <suggestion>inaccesible</suggestion>.</message>
+      <message>A palabra «<match no="1"/>» é un castelanismo. Empregue no seu sitio <suggestion>inalcanzable</suggestion> ou <suggestion>inaccesible</suggestion>.</message>
       <short>Castelanismo léxico</short>
       <example correction="inalcanzable|inaccesible">O prezo actual da vivenda é <marker>inasequible</marker> para moita xente no pais.</example>
       <example>O prezo actual da vivenda é <marker>inaccesible</marker> para moita xente no pais.</example>
@@ -4167,7 +4168,7 @@
       <pattern>
           <token regexp="yes">asequíbe(l|is)</token>
       </pattern>
-      <message>A palabra &quot;<match no="1"/>&quot; é un castelanismo. Empregue no seu sitio <suggestion>alcanzábel</suggestion> ou <suggestion>accesíbel</suggestion>.</message>
+      <message>A palabra «<match no="1"/>» é un castelanismo. Empregue no seu sitio <suggestion>alcanzábel</suggestion> ou <suggestion>accesíbel</suggestion>.</message>
       <short>Castelanismo léxico</short>
       <example correction="alcanzábel|accesíbel">O prezo actual da vivenda non é <marker>asequíbel</marker> para moita xente no pais.</example>
       <example>O prezo actual da vivenda non é <marker>accesíbel</marker> para moita xente no pais.</example>
@@ -4177,7 +4178,7 @@
       <pattern>
           <token regexp="yes">inasequíbe(l|is)</token>
       </pattern>
-      <message>A palabra &quot;<match no="1"/>&quot; é un castelanismo. Empregue no seu sitio <suggestion>inalcanzábel</suggestion> ou <suggestion>inaccesíbel</suggestion>.</message>
+      <message>A palabra «<match no="1"/>» é un castelanismo. Empregue no seu sitio <suggestion>inalcanzábel</suggestion> ou <suggestion>inaccesíbel</suggestion>.</message>
       <short>Castelanismo léxico</short>
       <example correction="inalcanzábel|inaccesíbel">O prezo actual da vivenda é <marker>inasequíbel</marker> para moita xente no pais.</example>
       <example>O prezo actual da vivenda é <marker>inaccesíbel</marker> para moita xente no pais.</example>
@@ -4190,7 +4191,7 @@
       <pattern>
           <token regexp="yes">noraboas?</token>
       </pattern>
-      <message>A palabra &quot;<match no="1"/>&quot; é un castelanismo. Empregue no seu sitio <suggestion>parabén</suggestion> ou <suggestion>parabéns</suggestion>.</message>
+      <message>A palabra «<match no="1"/>» é un castelanismo. Empregue no seu sitio <suggestion>parabén</suggestion> ou <suggestion>parabéns</suggestion>.</message>
       <short>Castelanismo léxico</short>
       <example correction="parabén|parabéns">Moi bo traballo, <marker>noraboa</marker>!</example>
       <example>Moi bo traballo, <marker>parabéns</marker>!</example>
@@ -4202,7 +4203,7 @@
           <token>a</token>
           <token>noraboa</token>
       </pattern>
-      <message>A expresión &quot;<match no="1"/> a noraboa&quot; é un castelanismo. Empregue no seu sitio <suggestion>felicitar</suggestion> ou <suggestion>parabenizar</suggestion>.</message>
+      <message>A expresión «<match no="1"/> a noraboa» é un castelanismo. Empregue no seu sitio <suggestion>felicitar</suggestion> ou <suggestion>parabenizar</suggestion>.</message>
       <short>Castelanismo léxico</short>
       <example correction="felicitar|parabenizar">Quero <marker>dar a noraboa</marker> á miña sobriña Noelia.</example>
       <example>Quero <marker>felicitar</marker> á miña sobriña Noelia.</example>
@@ -4215,7 +4216,7 @@
           <token postag_regexp="yes" postag="DP.FS."/>
           <token>noraboa</token>
       </pattern>
-      <message>A expresión &quot;\1 a \3 noraboa&quot; é un castelanismo. Empregue no seu sitio <suggestion>felicitar</suggestion> ou <suggestion>parabenizar</suggestion>.</message>
+      <message>A expresión «\1 a \3 noraboa» é un castelanismo. Empregue no seu sitio <suggestion>felicitar</suggestion> ou <suggestion>parabenizar</suggestion>.</message>
       <short>Castelanismo léxico</short>
       <example correction="felicitar|parabenizar">Quero <marker>dar a miña noraboa</marker> á miña sobriña Noelia.</example>
       <example>Quero <marker>felicitar</marker> á miña sobriña Noelia.</example>
@@ -4227,7 +4228,7 @@
       <pattern>
           <token regexp="yes">adoquíns?</token>
       </pattern>
-      <message>A palabra &quot;<match no="1"/>&quot; é un castelanismo. Empregue no seu sitio <suggestion>lastra</suggestion> (feminino).</message>
+      <message>A palabra «<match no="1"/>» é un castelanismo. Empregue no seu sitio <suggestion>lastra</suggestion> (feminino).</message>
       <short>Castelanismo léxico</short>
       <example correction="lastra">Usaron <marker>adoquíns</marker> para pavimentar a rúa.</example>
       <example>Usaron <marker>lastras</marker> para pavimentar a rúa.</example>
@@ -4240,7 +4241,7 @@
           <token>sen</token>
           <token>embargo</token>
       </pattern>
-      <message>A conxunción 'sen embargo' é un castelanismo. Empregue no seu sitio <suggestion>porén</suggestion>, <suggestion>mais</suggestion> ou <suggestion>no entanto</suggestion>.</message>
+      <message>A conxunción «sen embargo» é un castelanismo. Empregue no seu sitio <suggestion>porén</suggestion>, <suggestion>mais</suggestion> ou <suggestion>no entanto</suggestion>.</message>
       <short>Castelanismo léxico</short>
       <example correction="Porén|Mais|No entanto"><marker>Sen embargo</marker>, a súa importancia débese a outros factores.</example>
       <example><marker>Porén</marker>, a súa importancia débese a outros factores.</example>
@@ -4250,7 +4251,7 @@
       <pattern>
           <token>nembargantes</token>
       </pattern>
-      <message>A palabra '\1' non existe en galego. Empregue no seu sitio <suggestion>porén</suggestion>, <suggestion>mais</suggestion> ou <suggestion>no entanto</suggestion>.</message>
+      <message>A palabra «\1» non existe en galego. Empregue no seu sitio <suggestion>porén</suggestion>, <suggestion>mais</suggestion> ou <suggestion>no entanto</suggestion>.</message>
       <short>Castelanismo léxico</short>
       <example correction="porén|mais|no entanto">A súa importancia débese <marker>nembargantes</marker> a outros factores.</example>
       <example>A súa importancia débese <marker>porén</marker> a outros factores.</example>
@@ -4266,7 +4267,7 @@
         </marker>
           <token regexp="yes" negate="yes">cerebra(l|is|les)</token>
       </pattern>
-      <message>A palabra '\1' non existe en galego. Empregue no seu sitio <suggestion>codia</suggestion>.</message>
+      <message>A palabra «\1» non existe en galego. Empregue no seu sitio <suggestion>codia</suggestion>.</message>
       <short>Castelanismo léxico</short>
       <example correction="codia">Do pan prefiro comer a <marker>corteza</marker>.</example>
     </rule>
@@ -4276,7 +4277,7 @@
           <token regexp="yes">(corteza|cortiza|codia)s?</token>
           <token regexp="yes">cerebra(l|is|les)</token>
       </pattern>
-      <message>O termo '\1 \2' non é correcto en galego. Empregue no seu sitio <suggestion>córtex \2</suggestion>.</message>
+      <message>O termo «\1 \2» non é correcto en galego. Empregue no seu sitio <suggestion>córtex \2</suggestion>.</message>
       <short>Castelanismo léxico</short>
       <example correction="córtex cerebral">O relator presentou un traballo sobre o comportamento da <marker>corteza cerebral</marker>.</example>
       <example>O relator presentou un traballo sobre o comportamento do <marker>córtex cerebral</marker>.</example>
@@ -4285,13 +4286,13 @@
 
  </category>
 
- <category id="CAT6" name="Léxico::Barbarismos">
+ <category id="CAT6" name="Léxico::Barbarismos" type="untranslated">
     <rule id="ADICAR" name="adicar (dedicar)">
     <!-- Created by Susana Sotelo Docío -->
       <pattern>
           <token inflected="yes">adicar</token>
       </pattern>
-      <message>A palabra '\1' non é aconsellábel en galego. Empregue mellor <suggestion><match no="1" postag="(.*)" postag_replace="$1">dedicar</match></suggestion>.</message>
+      <message>A palabra «\1» non é aconsellábel en galego. Empregue mellor <suggestion><match no="1" postag="(.*)" postag_replace="$1">dedicar</match></suggestion>.</message>
       <short>Barbarismo</short>
       <example correction="dedicar">Acordaron <marker>adicar</marker> máis tempo ás tarefas pendentes.</example>
     </rule>
@@ -4314,7 +4315,7 @@
 
     <!-- ############################ SPELLING RULES ############################ -->
 
- <category id="CAT7" name="Ortografía">
+ <category id="CAT7" name="Ortografía" type="misspelling">
 
   <rulegroup id="ACCESIT" name="accésits (accésit)">
     <rule>
@@ -4322,7 +4323,7 @@
       <pattern>
           <token regexp="yes">acc[eé]sits</token>
       </pattern>
-      <message>A palabra 'accésit' non varía no plural. Empregue mellor <suggestion>accésit</suggestion>.</message>
+      <message>A palabra «accésit» non varía no plural. Empregue mellor <suggestion>accésit</suggestion>.</message>
       <example correction="accésit">Como narrador gaña dous <marker>accésits</marker> do Pedrón de Ouro.</example>
     </rule>
   </rulegroup>
@@ -4335,7 +4336,7 @@
           <token>ven</token>
           <token regexp="yes">com[oa]</token>
       </pattern>
-      <message>A forma 'ben' é probabelmente un adverbio e, por tanto, debe escribirse con 'b'. Quería vostede dicir <suggestion>\1 ben \2</suggestion>?</message>
+      <message>Aquí «ben» probabelmente sexa un adverbio e, por tanto, debe escribirse con «b». Quería vostede dicir <suggestion>\1 ben \2</suggestion>?</message>
       <example correction="tan ben ven">Xoga <marker>tan ven coma</marker> o pai.</example>
       <example>Xoga <marker>tan ben coma</marker> o pai.</example>
     </rule>
@@ -4360,7 +4361,7 @@
           <token regexp="yes">en|de</token>
           <token>seguida</token>
       </pattern>
-      <message>As formas &quot;<match no="1"/>&quot; e &quot;seguida&quot; forman en galego unha locución que se escribe unida. Quería vostede dicir <suggestion>\1\2</suggestion>?</message>
+      <message>As formas «<match no="1"/>» e «seguida» forman en galego unha locución que se escribe unida. Quería vostede dicir <suggestion>\1\2</suggestion>?</message>
       <example correction="enseguida">Deuse conta <marker>en seguida</marker>.</example>
       <example correction="Deseguida"><marker>De seguida</marker> nos percatamos das notas que a constitúen.</example>
     </rule>
@@ -4371,7 +4372,7 @@
           <token>de</token>
           <token regexp="yes">seguido|contado|contino</token>
       </pattern>
-      <message>As formas &quot;de&quot; e &quot;<match no="2"/>&quot; forman en galego unha locución que se escribe unida. Quería vostede dicir <suggestion>\1\2</suggestion>?</message>
+      <message>As formas «de» e «<match no="2"/>» forman en galego unha locución que se escribe unida. Quería vostede dicir <suggestion>\1\2</suggestion>?</message>
       <example correction="deseguido">A masa mestúrase e <marker>de seguido</marker> envásase en recipientes.</example>
       <example correction="decontado">Recoñecera <marker>de contado</marker> os axentes da Stasi.</example>
     </rule>
@@ -4382,7 +4383,7 @@
           <token>tal</token>
           <token>vez</token>
       </pattern>
-      <message>As formas &quot;tal&quot; e &quot;vez&quot; escrébense unidas cando forman unha locución. Quería vostede dicir <suggestion>\1\2</suggestion>?</message>
+      <message>As formas «tal» e «vez» escrébense unidas cando forman unha locución. Quería vostede dicir <suggestion>\1\2</suggestion>?</message>
       <example correction="Talvez"><marker>Tal vez</marker> a maneira máis profusa de ser europeo.</example>
     </rule>
 
@@ -4391,7 +4392,7 @@
       <pattern>
           <token>dacordo</token>
       </pattern>
-      <message>A locución &quot;de acordo&quot; escríbese en galego separada. Quería vostede dicir <suggestion>de acordo</suggestion>?</message>
+      <message>A locución «de acordo» escríbese en galego separada. Quería vostede dicir <suggestion>de acordo</suggestion>?</message>
       <example correction="De acordo"><marker>Dacordo</marker> con iso, será preciso aumentar as inversións.</example>
     </rule>
 
@@ -4401,7 +4402,7 @@
           <token>a</token>
           <token>reo</token>
       </pattern>
-      <message>As formas 'a' e 'reo' normalmente forman en galego unha locución que se escribe preferibelmente unida. Quería vostede dicir <suggestion>\1r\2</suggestion>?</message>
+      <message>As formas «a» e «reo» normalmente forman en galego unha locución que se escribe preferibelmente unida. Quería vostede dicir <suggestion>\1r\2</suggestion>?</message>
       <example correction="arreo">Traballaron <marker>a reo</marker> no proxecto.</example>
     </rule>
 
@@ -4454,7 +4455,7 @@
           <token regexp="yes">de|a</token>
           <token>cotío</token>
       </pattern>
-      <message>Posíbel erro: a locución adverbial &quot;<match no="1"/> cotío&quot; escrébese en galego todo xunto. Quería vostede dicir <suggestion><match no="1"/>cotío</suggestion>?</message>
+      <message>Posíbel erro: a locución adverbial «<match no="1"/> cotío» escrébese todo xunto. Quería vostede dicir <suggestion><match no="1"/>cotío</suggestion>?</message>
       <short>Posíbel forma incorrecta</short>
       <example correction="acotío">Viaxa a Alemaña <marker>a cotío</marker> por razóns de traballo.</example>
     </rule>
@@ -4465,7 +4466,7 @@
           <token>de</token>
           <token regexp="yes">vagar|cote</token>
       </pattern>
-      <message>Posíbel erro: a locución adverbial &quot;de <match no="2"/>&quot; escrébese en galego todo xunto. Quería vostede dicir <suggestion>\1\2</suggestion>?</message>
+      <message>Posíbel erro: a locución adverbial «de <match no="2"/>» escrébese todo xunto. Quería vostede dicir <suggestion>\1\2</suggestion>?</message>
       <short>Posíbel forma incorrecta</short>
       <example correction="devagar">Foi andando <marker>de vagar</marker> pola braña.</example>
       <example correction="decote">Vai <marker>de cote</marker> ao parque.</example>
@@ -4477,7 +4478,7 @@
           <token>a</token>
           <token regexp="yes">modo|modiño|penas</token>
       </pattern>
-      <message>Posíbel erro: a locución adverbial &quot;a <match no="2"/>&quot; escrébese en galego todo xunto. Quería vostede dicir <suggestion>\1\2</suggestion>?</message>
+      <message>Posíbel erro: a locución adverbial «a <match no="2"/>» escrébese todo xunto. Quería vostede dicir <suggestion>\1\2</suggestion>?</message>
       <short>Posíbel forma incorrecta</short>
       <example correction="amodo">Vai <marker>a modo</marker> para non caer.</example>
     </rule>
@@ -4489,7 +4490,7 @@
           <token regexp="yes">[ndc]?un|[nd]?algún|ningún</token>
           <token regexp="yes" postag="NCFS000">h?[aá].*</token>
       </pattern>
-      <message>Posíbel erro: en galego os substantivos femininos que comezan por 'a-' inicial tónico non implican modificacións no determinante que os precede. Quería vostede dicir <suggestion><match no="1" regexp_match="(?iu)(.*)[úu]n" regexp_replace="$1unha"/> \2</suggestion>?</message>
+      <message>Posíbel erro: os substantivos femininos que comezan por «a-» inicial tónico non implican modificacións no determinante que os precede. Quería vostede dicir <suggestion><match no="1" regexp_match="(?iu)(.*)[úu]n" regexp_replace="$1unha"/> \2</suggestion>?</message>
       <example correction="dunha ave">É unha cría <marker>dun ave</marker> rapaz.</example>
       <example>É unha cría <marker>dunha ave</marker> rapaz.</example>
     </rule>
@@ -4500,7 +4501,7 @@
           <token regexp="yes">[nd]?o</token>
           <token regexp="yes" postag="NCFS000">h?[aá].*</token>
       </pattern>
-      <message>Posíbel erro: en galego os substantivos femininos que comezan por 'a-' inicial tónico non implican modificacións no determinante que os precede. Quería vostede dicir <suggestion><match no="1" regexp_match="(?iu)([nd])?o" regexp_replace="$1a"/> \2</suggestion>?</message>
+      <message>Posíbel erro: os substantivos femininos que comezan por «a-» inicial tónico non implican modificacións no determinante que os precede. Quería vostede dicir <suggestion><match no="1" regexp_match="(?iu)([nd])?o" regexp_replace="$1a"/> \2</suggestion>?</message>
       <example correction="na alma">Sentíu unha profunda ferida <marker>no alma</marker>.</example>
       <example>Sentíu unha profunda ferida <marker>na alma</marker>.</example>
     </rule>
@@ -4511,7 +4512,7 @@
           <token>co</token>
           <token regexp="yes" postag="NCFS000">h?[aá].*</token>
       </pattern>
-      <message>Posíbel erro: en galego os substantivos femininos que comezan por 'a-' inicial tónico non implican modificacións no determinante que os precede. Quería vostede dicir <suggestion>coa \2</suggestion>?</message>
+      <message>Posíbel erro: os substantivos femininos que comezan por «a-» inicial tónico non implican modificacións no determinante que os precede. Quería vostede dicir <suggestion>coa \2</suggestion>?</message>
       <example correction="coa arma">Fíxolle unha profunda ferida <marker>co arma</marker>.</example>
       <example>Fíxolle unha profunda ferida <marker>coa arma</marker>.</example>
     </rule>
@@ -4523,13 +4524,13 @@
       <pattern>
           <token regexp="yes">ést?[ea]s?</token>
       </pattern>
-      <message>Posíbel erro: en galego os pronomes demostrativos (este, ese, aquel) non levan til. Quería vostede dicir <suggestion><match no="1" regexp_match="(?iu)é(.*)" regexp_replace="e$1"/></suggestion>?</message>
+      <message>Posíbel erro: os pronomes demostrativos (este, ese, aquel) non levan til. Quería vostede dicir <suggestion><match no="1" regexp_match="(?iu)é(.*)" regexp_replace="e$1"/></suggestion>?</message>
       <example correction="esta">Eles consideran que se lle das confianza á xente <marker>ésta</marker> responderá correctamente.</example>
     </rule>
   </rulegroup>
  </category>
 
- <category id="CAT8" name="Fraseoloxía">
+ <category id="CAT8" name="Fraseoloxía" type="untranslated">
   <rulegroup id="LOCUCIÓNS" name="locucións e frases feitas">
     <rule id="DE_REOLLO" name="de reollo (de esguello)">
     <!-- Created by Susana Sotelo Docío -->
@@ -4537,7 +4538,7 @@
           <token>de</token>
           <token>reollo</token>
       </pattern>
-      <message>A locución &quot;de reollo&quot; é un castelanismo. Empregue no seu sitio <suggestion>de esguello</suggestion>.</message>
+      <message>A locución «de reollo» é un castelanismo. Empregue no seu sitio <suggestion>de esguello</suggestion>.</message>
       <short>Locución incorrecta.</short>
       <example correction="de esguello">Observeina <marker>de reollo</marker>.</example>
     </rule>
@@ -4548,7 +4549,7 @@
           <token>visto</token>
           <token>bo</token>
       </pattern>
-      <message>A locución &quot;visto bo&quot; non é propia do galego. Empregue mellor <suggestion>visto e prace</suggestion>.</message>
+      <message>A locución «visto bo» non é propia do galego. Empregue mellor <suggestion>visto e prace</suggestion>.</message>
       <short>Locución incorrecta.</short>
       <example correction="visto e prace">Patrimonio apraza o seu <marker>visto bo</marker> á recuperación das mámoas de Castiñeiras.</example>
     </rule>
@@ -4560,7 +4561,7 @@
           <token>e</token>
           <token regexp="yes">p(re|er)xu[íi](ci|z)os</token>
       </pattern>
-      <message>A expresión &quot;danos e \3&quot; non é correcta en galego. Empregue mellor <suggestion>danos e perdas</suggestion>.</message>
+      <message>A expresión «danos e \3» non é correcta en galego. Empregue mellor <suggestion>danos e perdas</suggestion>.</message>
       <short>Locución incorrecta.</short>
       <example correction="danos e perdas">Tivo que pagarlle <marker>danos e perxuízos</marker> polo incidente.</example>
     </rule>
@@ -4572,7 +4573,7 @@
           <token>polo</token>
           <token>aro</token>
       </pattern>
-      <message>A expresión &quot;\1 polo aro&quot; non é correcta en galego. Empregue mellor <suggestion><match no="1" postag="(.*)" postag_replace="$1">vir</match> ao rego</suggestion>.</message>
+      <message>A expresión «\1 polo aro» non é correcta en galego. Empregue mellor <suggestion><match no="1" postag="(.*)" postag_replace="$1">vir</match> ao rego</suggestion>.</message>
       <short>Locución incorrecta.</short>
       <example correction="veu ao rego">O alumnado non <marker>pasou polo aro</marker> cando o responsable presentou as súas propostas.</example>
     </rule>
@@ -4584,7 +4585,7 @@
           <token>de</token>
           <token>recibo</token>
       </pattern>
-      <message>A expresión &quot;\1 de recibo&quot; non é correcta en galego. Empregue mellor <suggestion>xustificante de recepción</suggestion>.</message>
+      <message>A expresión «\1 de recibo» non é correcta en galego. Empregue mellor <suggestion>xustificante de recepción</suggestion>.</message>
       <short>Locución incorrecta.</short>
       <example correction="xustificante de recepción">Deberá presentar o <marker>acuse de recibo</marker> cuberto e selado.</example>
     </rule>
@@ -4596,7 +4597,7 @@
           <token regexp="yes">a|unha</token>
           <token>demanda</token>
       </pattern>
-      <message>A expresión &quot;\1 \2 demanda&quot; non é aconsellábel en galego. Empregue mellor <suggestion>admitir \2 demanda</suggestion>.</message>
+      <message>A expresión «\1 \2 demanda» non é aconsellábel en galego. Empregue mellor <suggestion>admitir \2 demanda</suggestion>.</message>
       <short>Locución incorrecta.</short>
       <example correction="admitir a demanda">O xuíz <marker>estimou a demanda</marker> das traballadoras.</example>
       <example>O xuíz <marker>admitiu a demanda</marker> das traballadoras.</example>
@@ -4609,7 +4610,7 @@
           <token>de</token>
           <token>pagos</token>
       </pattern>
-      <message>A expresión &quot;\1 de pagos&quot; non é aconsellábel en galego. Empregue mellor <suggestion>\1 de pagamentos</suggestion>.</message>
+      <message>A expresión «\1 de pagos» non é aconsellábel en galego. Empregue mellor <suggestion>\1 de pagamentos</suggestion>.</message>
       <short>Locución incorrecta.</short>
       <example correction="balanza de pagamentos">A situación actual é de déficit na <marker>balanza de pagos</marker>.</example>
     </rule>
@@ -4621,7 +4622,7 @@
           <token>de</token>
           <token>suxerencias</token>
       </pattern>
-      <message>A expresión &quot;\1 de suxerencias&quot; non é correcta en galego. Empregue mellor <suggestion>caixa de suxestións</suggestion>.</message>
+      <message>A expresión «\1 de suxerencias» non é correcta en galego. Empregue mellor <suggestion>caixa de suxestións</suggestion>.</message>
       <short>Locución incorrecta.</short>
       <example correction="caixa de suxestións">O cliente ten á súa disposición un <marker>buzón de suxerencias</marker>.</example>
       <example>O cliente ten á súa disposición unha <marker>caixa de suxestións</marker>.</example>
@@ -4709,7 +4710,6 @@
       <example>Todo o que eles querían era ficar tranquilos, e ollar e ollar e ollar.</example>
       <example>As instrucións son executadas paso a paso a partir do comezo da lista.</example>
       <example>…integrar o día a día a partir de o…</example>
-      <example>Imos pensar en solucións terra-a-terra.</example>
     </rule>
   </rulegroup>
 
@@ -4762,12 +4762,12 @@
       </pattern>
       <message>Para mellorar o texto, procure variar máis os termos utilizados.</message>
       <!-- url>https://pt.wikiversity.org/wiki/Norma_padrão_de a_lingua_portuguesa/Repeticións_e_elipses</url-->
-      <short>Problema de estilo. Palabra repetida.</short>
+      <short>Problema de estilo: Palabra repetida.</short>
       <example correction="">Saíu de coche despois de coller as chaves do <marker>coche</marker>.</example>
       <!-- example correction="">Principalmente migrantes teñen procurado residencia en Alagoas, estabelecéndose <marker>principalmente</marker> na costa.</example -->
       <example type='incorrect'>As repeticións empobrecen o texto, porque as <marker>repeticións</marker> son aborrecidas de ler.</example>
       <example>Non virá máis.</example>
-      <example>Descoñezo o significado da palabra "imposíbel".</example>
+      <example>Descoñezo o significado da palabra «imposíbel».</example>
       <example>As proteínas son biopolímeros cuxas unidades monoméricas son os aminoácidos.</example>
       <example>…pola posesión do diploma fornecido polas autoridades educativas e…</example>
       <example>Clube Amigos da Chave de Ferrolterra </example>
@@ -4810,12 +4810,12 @@
       </pattern>
       <message>Para mellorar o texto, procure variar máis os termos utilizados.</message>
       <url>https://gl.wikipedia.org/wiki/Figura_estil%C3%ADstica</url>
-      <short>Problema de estilo. Palabra repetida.</short>
-      <example type='incorrect'>A astronomía profesional foi dividido en dous ramos: a astronomía 'observacional' e a <marker>astronomía</marker> teórica.</example>
+      <short>Problema de estilo: Palabra repetida.</short>
+      <example type='incorrect'>A astronomía profesional foi dividido en dous ramos: a astronomía «observacional» e a <marker>astronomía</marker> teórica.</example>
       <example type='incorrect'>Repeticións... as repeticións empobrecen o texto, porque as <marker>repeticións</marker> son aborrecidas de ler.</example>
        <example>Saíu do coche despois de coller as chaves do <marker>coche</marker>.</example>
       <example>Non virá máis.</example>
-      <example>Descoñezo o significado da palabra "imposíbel".</example>
+      <example>Descoñezo o significado da palabra «imposíbel».</example>
       <example>As proteínas son biopolímeros cuxas unidades 'monoméricas' son os aminoácidos.</example>
       <example>…pola posesión do diploma fornecido pola autoridade educacional e…</example>
       <example>Clube da Chave de Ferrolterrao</example>
@@ -4827,7 +4827,7 @@
 
  </category>
 
- <category id="PUNCTUATION" name="Puntuación" default="off">
+ <category id="PUNCTUATION" name="Puntuación" default="off" type="typographical">
 
     <rule id="FINAL_PUNCTUATION" name="Puntuación final ausente">
     <!-- Localized from German grammar.xml by Tiago F. Santos,  2017-08-19      -->
@@ -4872,12 +4872,12 @@
       <pattern>
           <token inflected="yes" regexp='yes'>ser|estar</token>
       </pattern>
-      <message>De acordo coa versión inglesa do E-Prime, evitar formas verbais do verbo 'ser' e 'estar' torna a comunicación máis clara, precisa, e menos dogmática. Tente utilizar un verbo alternativo ou refacer a frase.</message>
+      <message>De acordo coa versión inglesa do E-Prime, evitar formas verbais dos verbos «ser» e «estar» torna a comunicación máis clara, precisa, e menos dogmática. Tente utilizar un verbo alternativo ou refacer a frase.</message>
       <url>https://litemind.com/e-prime/</url>
-      <short>De acordo coa lóxica do E-Prime, debe evitar os verbos 'ser' e 'estar'.</short>
+      <short>Considere evitar os verbos «ser» e «estar».</short>
       <example type="incorrect" correction="">Isto <marker>é</marker> errado…</example>
-      <example>Isto non se <marker>conforma</marker> com o meu coñecemento actual…</example>
-      <example>Os dados non <marker>confirman</marker> esa afirmación…</example>
+      <example>Isto non se <marker>xustifica</marker> co meu coñecemento actual…</example>
+      <example>Os datos non <marker>confirman</marker> esa afirmación…</example>
     </rule>
 
     <!--rule id="E_PRIME_LOOSE" name="E-Prime: 'ser' e 'estar' como verbos princiais" default='off'>


### PR DESCRIPTION
Revision of  \<message\> elements.
Shortening of \<short\> elements.
type for all categories (http://www.w3.org/International/multilingualweb/lt/drafts/its20/its20.html#lqissue-typevalues)
Guillemets («»), instead of (' ").
There are no changes in the rules.
Added myself as contributor.