### PR TITLE
[en] etc. punctuation

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-US/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-US/grammar.xml
@@ -287,6 +287,26 @@ USA
     </category>
 
     <category id="AMERICAN_ENGLISH_STYLE" name="American English Style" type="style">
+        <rule id="ETC_PERIOD" name="period after abbreviation 'etc.'" default="temp_off">
+            <antipattern>
+                <token>etc</token>
+                <token regexp="yes">/|_|…|:</token>
+            </antipattern>
+            <pattern>
+                <marker>
+                    <token>etc</token>
+                </marker>
+                <token><exception>.</exception></token>
+            </pattern>
+            <message>A period is needed after the abbreviation 'etc.'</message>
+            <suggestion>etc.</suggestion>
+            <example correction="etc.">Tennis, soccer, baseball, <marker>etc</marker> are outdoor games.</example>
+            <example correction="etc.">I use things like Java, Microsoft, Unix, <marker>etc</marker> at work.</example>
+            <example correction="etc.">Make sure you bring your fishing pole, tackle, bait, <marker>etc</marker> as we will not make any stops.</example>
+            <example>Process: 4264 ExecStart=/etc/rc.d/init.d/newrelic-daemon start (code=exited, status=0/SUCCESS)</example>
+            <example>DND_ETC__List1</example>
+            <example>Device Handlers, etc…</example>
+        </rule>
         <rule id="MISSING_COMMA_AFTER_YEAR" name="Potentially missing comma after year">
             <pattern>
                 <token regexp="yes">&months;</token>

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-US/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-US/grammar.xml
@@ -290,11 +290,11 @@ USA
         <rule id="ETC_PERIOD" name="period after abbreviation 'etc.'" default="temp_off">
             <antipattern>
                 <token>etc</token>
-                <token regexp="yes">/|_|…|:</token>
+                <token regexp="yes">/|_|…|#</token>
             </antipattern>
             <pattern>
                 <marker>
-                    <token>etc</token>
+                    <token case_sensitive="yes">etc</token>
                 </marker>
                 <token><exception>.</exception></token>
             </pattern>
@@ -303,9 +303,13 @@ USA
             <example correction="etc.">Tennis, soccer, baseball, <marker>etc</marker> are outdoor games.</example>
             <example correction="etc.">I use things like Java, Microsoft, Unix, <marker>etc</marker> at work.</example>
             <example correction="etc.">Make sure you bring your fishing pole, tackle, bait, <marker>etc</marker> as we will not make any stops.</example>
+            <example correction="etc.">No check engine lights <marker>etc</marker>?</example>
+            <example correction="etc.">Removed the alarm listener and replaced with lights, <marker>etc</marker>, etc.</example>
             <example>Process: 4264 ExecStart=/etc/rc.d/init.d/newrelic-daemon start (code=exited, status=0/SUCCESS)</example>
             <example>DND_ETC__List1</example>
             <example>Device Handlers, etc…</example>
+            <example>root@de1lvapp098p:/etc# ls -l /dev/disk/by-uuid</example>
+            <example>Diversity Dick Liebert reported that questions for the ETC survey are currently being developed.</example>
         </rule>
         <rule id="MISSING_COMMA_AFTER_YEAR" name="Potentially missing comma after year">
             <pattern>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/81176099/115192340-87970e00-a09f-11eb-87e2-7547978ad3cb.png)

Where I come from, 'etc.' needs a period mid-sentence, which LT editor misses. 

However, the rule has a lot of hits; I'll have to look more into the specifics of 'etc.' punctuation but I think most of what the rule detects is accurate.