### PR TITLE
Rm6 punctuation on cf

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -38147,7 +38147,20 @@ though, and has since been slightly modified)-->
             <example correction="recherche">Pense à rajouter une <marker>search</marker> pour les deux éléments.</example>
         </rule>
     </category>
-    <category id="CAT_TYPOGRAPHIE" name="Typographie" type="typographical">
+    <category id="CAT_TYPOGRAPHIE" name="Typographie" type="typographical"><rulegroup id="PONCTUATION_SUR_ABREVIATIONS" name="Abréviations" default="temp_off">
+    <rule>
+        <pattern>
+            <marker>
+                <token case_sensitive="yes">cf</token>
+            </marker>
+        <token regexp="yes">[^\.]+</token>
+        </pattern>
+        <message>Si <suggestion>cf.</suggestion> désigne l'abréviation de "confère", il convient d'ajouter un point.</message>
+        <example correction="cf.">Nous avons déjà vu cette notion, <marker>cf</marker> le cours précédent.</example>
+        <example>Nous avons déjà vu cette notion, <marker>cf</marker>. le cours précédent.</example>
+
+    </rule>
+</rulegroup>
         <rulegroup id="FLECHES" name="-&gt; (→)">
             <rule>
                 <pattern>

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -38147,20 +38147,21 @@ though, and has since been slightly modified)-->
             <example correction="recherche">Pense à rajouter une <marker>search</marker> pour les deux éléments.</example>
         </rule>
     </category>
-    <category id="CAT_TYPOGRAPHIE" name="Typographie" type="typographical"><rulegroup id="PONCTUATION_SUR_ABREVIATIONS" name="Abréviations" default="temp_off">
-    <rule>
-        <pattern>
-            <marker>
-                <token case_sensitive="yes">cf</token>
-            </marker>
-        <token regexp="yes">[^\.]+</token>
-        </pattern>
-        <message>Si <suggestion>cf.</suggestion> désigne l'abréviation de "confère", il convient d'ajouter un point.</message>
-        <example correction="cf.">Nous avons déjà vu cette notion, <marker>cf</marker> le cours précédent.</example>
-        <example>Nous avons déjà vu cette notion, <marker>cf</marker>. le cours précédent.</example>
+    <category id="CAT_TYPOGRAPHIE" name="Typographie" type="typographical">
+        <rulegroup id="PONCTUATION_SUR_ABREVIATIONS" name="Abréviations" default="temp_off">
+            <rule>
+                <pattern>
+                    <marker>
+                        <token case_sensitive="yes">cf</token>
+                    </marker>
+                <token regexp="yes">[^\.]+</token>
+                </pattern>
+                <message>Si <suggestion>cf.</suggestion> désigne l'abréviation de "confère", il convient d'ajouter un point.</message>
+                <example correction="cf.">Nous avons déjà vu cette notion, <marker>cf</marker> le cours précédent.</example>
+                <example>Nous avons déjà vu cette notion, <marker>cf</marker>. le cours précédent.</example>
 
-    </rule>
-</rulegroup>
+            </rule>
+        </rulegroup>
         <rulegroup id="FLECHES" name="-&gt; (→)">
             <rule>
                 <pattern>

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -38159,7 +38159,6 @@ though, and has since been slightly modified)-->
                 <message>Si <suggestion>cf.</suggestion> désigne l'abréviation de "confère", il convient d'ajouter un point.</message>
                 <example correction="cf.">Nous avons déjà vu cette notion, <marker>cf</marker> le cours précédent.</example>
                 <example>Nous avons déjà vu cette notion, <marker>cf</marker>. le cours précédent.</example>
-
             </rule>
         </rulegroup>
         <rulegroup id="FLECHES" name="-&gt; (→)">


### PR DESCRIPTION
Because of confusion in branches, this PR replaces this one : [https://github.com/languagetool-org/languagetool/pull/4727](url)

All feedbacks from Udo have been taken into account, except for "CF = Clubo de Futbol", for which I don't find a solution for the moment