### PR TITLE
Fix Genitiv-Form von Bodyguard

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/added.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/added.txt
@@ -5607,7 +5607,7 @@ Hofknickse	Hofknicks	SUB:GEN:PLU:MAS
 Hofknicksen	Hofknicks	SUB:DAT:PLU:MAS
 Hofknickse	Hofknicks	SUB:AKK:PLU:MAS
 Bodyguard	Bodyguard	SUB:NOM:SIN:MAS
-Bodyguard	Bodyguard	SUB:GEN:SIN:MAS
+Bodyguards	Bodyguard	SUB:GEN:SIN:MAS
 Bodyguard	Bodyguard	SUB:DAT:SIN:MAS
 Bodyguard	Bodyguard	SUB:AKK:SIN:MAS
 Bodyguards	Bodyguard	SUB:NOM:PLU:MAS


### PR DESCRIPTION
Genitiv-s bei Bodygas MAS-Form hinzugefügt.