### PR TITLE
add platform.sh config

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -1,0 +1,18 @@
+name: languagetool
+type: "java:8"
+
+disk: 2048
+
+hooks:
+    build: |
+        mvn clean
+        mvn --projects languagetool-standalone --also-make package -DskipTests
+
+mounts:
+    "ngrams": "shared:files/ngrams"
+
+web:
+    commands:
+        start: |
+            cd languagetool-standalone/target/LanguageTool-5.4-SNAPSHOT/LanguageTool-5.4-SNAPSHOT
+            java -cp languagetool-server.jar org.languagetool.server.HTTPServer --port "$PORT" --allow-origin "*"

--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -1,0 +1,3 @@
+https://{default}/:
+    type: upstream
+    upstream: "languagetool:http"

--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,9 @@
       <lucene.version>5.5.5</lucene.version>
       <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss Z</maven.build.timestamp.format>
   </properties>
-  
+
   <build>
-      
+
       <pluginManagement>
           <plugins>
 
@@ -62,7 +62,7 @@
                       </execution>
                   </executions>
               </plugin>
-              
+
               <plugin>
                   <groupId>pl.project13.maven</groupId>
                   <artifactId>git-commit-id-plugin</artifactId>
@@ -77,11 +77,12 @@
                       </execution>
                   </executions>
                   <configuration>
+                      <failOnNoGitDirectory>false</failOnNoGitDirectory>
                       <generateGitPropertiesFile>true</generateGitPropertiesFile>
                       <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
                   </configuration>
               </plugin>
-              
+
               <plugin>
                   <artifactId>maven-compiler-plugin</artifactId>
                   <version>3.8.1</version>
@@ -146,7 +147,7 @@
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
             <configuration>
-              <useAgent>true</useAgent>  
+              <useAgent>true</useAgent>
             </configuration>
             <executions>
               <execution>
@@ -162,7 +163,7 @@
       </build>
     </profile>
   </profiles>
-    
+
   <modules>
     <module>languagetool-core</module>
     <module>languagetool-language-modules/en</module>


### PR DESCRIPTION
note: it probably doesn't make sense to merge this, but could form the basis for a documentation page.

just wanted to see if I could get languagetool up and running on platform.sh (a PaaS). with this config I got it running. in order to setup ngrams (https://dev.languagetool.org/finding-errors-using-n-gram-data.html) I would need to expand the storage from the default, which I didn't do for now but it should be totally doable of course. and the entire building could be tweaked ..

if you don't push it as master, you will need to adjust the default branch https://docs.platform.sh/guides/general/default-branch.html

one thing to note I had to contact their support to increase the storage space for the git repo :)