### PR TITLE
[en] Add adverb suggestions to EnglishWordRepeatBeginningRule (#4950)

### DIFF
--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishWordRepeatBeginningRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishWordRepeatBeginningRule.java
@@ -45,6 +45,8 @@ public class EnglishWordRepeatBeginningRule extends WordRepeatBeginningRule {
     return "ENGLISH_WORD_REPEAT_BEGINNING_RULE";
   }
   
+  	//==================== ADVERBS ======================
+  
 	// adverbs used to add to what the previous sentence mentioned
 	private static final Set<String> ADD_ADVERBS = new HashSet<>();
 
@@ -56,7 +58,16 @@ public class EnglishWordRepeatBeginningRule extends WordRepeatBeginningRule {
 
 	// adverbs used to explain what the previous sentence mentioned
 	private static final Set<String> EXPLAIN_ADVERBS = new HashSet<>();
-
+	
+	//==================== EXPRESSIONS ======================
+	// the expressions will be used only as additional suggestions
+	
+	// linking expressions that can be used instead of the ADD_ADVERBS
+	private static final List<String> ADD_EXPRESSIONS = Arrays.asList("In addition", "As well as");
+	
+	// linking expressions that can be used instead of the CONTRAST_ADVERBS
+	private static final List<String> CONTRAST_EXPRESSIONS = Arrays.asList("Even so", "On the other hand");
+	
 	static {
 		// based on https://www.pinterest.com/pin/229542912245527548/
 		ADD_ADVERBS.add("Additionally");
@@ -64,10 +75,8 @@ public class EnglishWordRepeatBeginningRule extends WordRepeatBeginningRule {
 		ADD_ADVERBS.add("Furthermore");
 		ADD_ADVERBS.add("Moreover");
 		ADD_ADVERBS.add("Also");
-		CONTRAST_ADVERBS.add("Unlike");
 		CONTRAST_ADVERBS.add("Nevertheless");
 		CONTRAST_ADVERBS.add("Nonetheless");
-		CONTRAST_ADVERBS.add("Despite");
 		CONTRAST_ADVERBS.add("Alternatively");
 		EMPHASIS_ADVERBS.add("Undoubtedly");
 		EMPHASIS_ADVERBS.add("Indeed");
@@ -103,9 +112,13 @@ public class EnglishWordRepeatBeginningRule extends WordRepeatBeginningRule {
 			return Arrays.asList("Furthermore, " + adaptedToken, "Likewise, " + adaptedToken,
 					"Not only that, but " + adaptedToken);
 		} else if (ADD_ADVERBS.contains(tok)) {
-			return getDifferentAdverbsOfSameCategory(tok, ADD_ADVERBS);
+			List<String> addSuggestions = getDifferentAdverbsOfSameCategory(tok, ADD_ADVERBS);
+			addSuggestions.addAll(ADD_EXPRESSIONS);
+			return addSuggestions;
 		} else if (CONTRAST_ADVERBS.contains(tok)) {
-			return getDifferentAdverbsOfSameCategory(tok, CONTRAST_ADVERBS);
+			List<String> contrastSuggestions = getDifferentAdverbsOfSameCategory(tok, CONTRAST_ADVERBS);
+			contrastSuggestions.addAll(CONTRAST_EXPRESSIONS);
+			return contrastSuggestions;
 		} else if (EMPHASIS_ADVERBS.contains(tok)) {
 			return getDifferentAdverbsOfSameCategory(tok, EMPHASIS_ADVERBS);
 		} else if (EXPLAIN_ADVERBS.contains(tok)) {

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishWordRepeatBeginningRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishWordRepeatBeginningRule.java
@@ -25,6 +25,7 @@ import org.languagetool.rules.WordRepeatBeginningRule;
 import org.languagetool.tools.StringTools;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Adds a list English adverbs to {@link WordRepeatBeginningRule}.
@@ -44,35 +45,84 @@ public class EnglishWordRepeatBeginningRule extends WordRepeatBeginningRule {
     return "ENGLISH_WORD_REPEAT_BEGINNING_RULE";
   }
   
-  private static final Set<String> ADVERBS = new HashSet<>();
-  static {
-    ADVERBS.add("Additionally");
-    ADVERBS.add("Besides");
-    ADVERBS.add("Furthermore");
-    ADVERBS.add("Moreover");
-  }
+	// adverbs used to add to what the previous sentence mentioned
+	private static final Set<String> ADD_ADVERBS = new HashSet<>();
 
-  @Override
-  public boolean isException(String token) {
-    return super.isException(token) || token.equals("The") || token.equals("A") || token.equals("An");
-  }
+	// adverbs used to express contrast to what the previous sentence mentioned
+	private static final Set<String> CONTRAST_ADVERBS = new HashSet<>();
 
-  @Override
-  protected boolean isAdverb(AnalyzedTokenReadings token) {
-    return ADVERBS.contains(token.getToken());
-  }
+	// adverbs used to express emphasis to what the previous sentence mentioned
+	private static final Set<String> EMPHASIS_ADVERBS = new HashSet<>();
 
-  @Override
-  protected List<String> getSuggestions(AnalyzedTokenReadings token) {
-    if (token.hasPosTag("PRP")) {
-      String tok = token.getToken();
-      String adaptedToken = tok.equals("I") ? tok : tok.toLowerCase();
-      return Arrays.asList(
-              "Furthermore, " + adaptedToken,
-              "Likewise, " + adaptedToken,
-              "Not only that, but " + adaptedToken);
-    }
-    return Collections.emptyList();
-  }
+	// adverbs used to explain what the previous sentence mentioned
+	private static final Set<String> EXPLAIN_ADVERBS = new HashSet<>();
 
+	static {
+		// based on https://www.pinterest.com/pin/229542912245527548/
+		ADD_ADVERBS.add("Additionally");
+		ADD_ADVERBS.add("Besides");
+		ADD_ADVERBS.add("Furthermore");
+		ADD_ADVERBS.add("Moreover");
+		ADD_ADVERBS.add("Also");
+		CONTRAST_ADVERBS.add("Unlike");
+		CONTRAST_ADVERBS.add("Nevertheless");
+		CONTRAST_ADVERBS.add("Nonetheless");
+		CONTRAST_ADVERBS.add("Despite");
+		CONTRAST_ADVERBS.add("Alternatively");
+		EMPHASIS_ADVERBS.add("Undoubtedly");
+		EMPHASIS_ADVERBS.add("Indeed");
+		EMPHASIS_ADVERBS.add("Obviously");
+		EMPHASIS_ADVERBS.add("Clearly");
+		EMPHASIS_ADVERBS.add("Importantly");
+		EMPHASIS_ADVERBS.add("Absolutely");
+		EMPHASIS_ADVERBS.add("Definetely");
+		EXPLAIN_ADVERBS.add("Particularly");
+		EXPLAIN_ADVERBS.add("Especially");
+		EXPLAIN_ADVERBS.add("Specifically");
+
+	}
+
+	@Override
+	public boolean isException(String token) {
+		return super.isException(token) || token.equals("The") || token.equals("A") || token.equals("An");
+	}
+
+	@Override
+	protected boolean isAdverb(AnalyzedTokenReadings token) {
+		String tok = token.getToken();
+		return ADD_ADVERBS.contains(tok) || CONTRAST_ADVERBS.contains(tok) || EMPHASIS_ADVERBS.contains(tok)
+				|| EXPLAIN_ADVERBS.contains(tok);
+	}
+
+	@Override
+	protected List<String> getSuggestions(AnalyzedTokenReadings token) {
+		String tok = token.getToken();
+		// the repeated word is a personal pronoun
+		if (token.hasPosTag("PRP")) {
+			String adaptedToken = tok.equals("I") ? tok : tok.toLowerCase();
+			return Arrays.asList("Furthermore, " + adaptedToken, "Likewise, " + adaptedToken,
+					"Not only that, but " + adaptedToken);
+		} else if (ADD_ADVERBS.contains(tok)) {
+			return getDifferentAdverbsOfSameCategory(tok, ADD_ADVERBS);
+		} else if (CONTRAST_ADVERBS.contains(tok)) {
+			return getDifferentAdverbsOfSameCategory(tok, CONTRAST_ADVERBS);
+		} else if (EMPHASIS_ADVERBS.contains(tok)) {
+			return getDifferentAdverbsOfSameCategory(tok, EMPHASIS_ADVERBS);
+		} else if (EXPLAIN_ADVERBS.contains(tok)) {
+			return getDifferentAdverbsOfSameCategory(tok, EXPLAIN_ADVERBS);
+		}
+		return Collections.emptyList();
+	}
+
+	/**
+	 * Gives suggestions to replace the given adverb.
+	 * 
+	 * @param adverb            to get suggestions for
+	 * @param adverbsOfCategory the adverbs of the same category as adverb (adverb
+	 *                          is <b>required</b> to be contained in the Set)
+	 * @return a List of suggested adverbs to replace the given adverb
+	 */
+	private List<String> getDifferentAdverbsOfSameCategory(String adverb, Set<String> adverbsOfCategory) {
+		return adverbsOfCategory.stream().filter(adv -> !adv.equals(adverb)).collect(Collectors.toList());
+	}
 }

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishWordRepeatBeginningRuleTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishWordRepeatBeginningRuleTest.java
@@ -66,6 +66,8 @@ public class EnglishWordRepeatBeginningRuleTest {
     assertTrue(matches3.get(0).getSuggestedReplacements().stream().anyMatch(sugg ->  sugg.equals("Besides")));
     assertTrue(matches3.get(0).getSuggestedReplacements().stream().anyMatch(sugg ->  sugg.equals("Furthermore")));
     assertTrue(matches3.get(0).getSuggestedReplacements().stream().anyMatch(sugg ->  sugg.equals("Moreover")));
+    assertTrue(matches3.get(0).getSuggestedReplacements().stream().anyMatch(sugg ->  sugg.equals("In addition")));
+    assertTrue(matches3.get(0).getSuggestedReplacements().stream().anyMatch(sugg ->  sugg.equals("As well as")));
   }
 
 }

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishWordRepeatBeginningRuleTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishWordRepeatBeginningRuleTest.java
@@ -35,20 +35,37 @@ public class EnglishWordRepeatBeginningRuleTest {
   @Test
   public void testRule() throws IOException {
     JLanguageTool lt = new JLanguageTool(Languages.getLanguageForShortCode("en-US"));
-    // correct sentences:
+    
+    // ================== correct sentences ===================
+    // two successive sentences that start with the same non-adverb word.
     assertEquals(0, lt.check("This is good. This is good, too.").size());
+    // three successive sentences that start with the same exception word ("the").
     assertEquals(0, lt.check("The car. The bicycle. The third sentence with 'the'.").size());
-    // errors:
+
+    // =================== errors =============================
+    // three successive sentences that start with the same non-exception word (personal pronoun "I") 
     List<RuleMatch> matches1 = lt.check("I think so. I have seen that before. I don't like it.");
     assertEquals(1, matches1.size());
+    // check suggestions
     assertThat(matches1.get(0).getSuggestedReplacements().get(0), is("Furthermore, I"));
     assertThat(matches1.get(0).getSuggestedReplacements().get(1), is("Likewise, I"));
     assertThat(matches1.get(0).getSuggestedReplacements().get(2), is("Not only that, but I"));
+    // three successive sentences that start with the same non-exception word (personal pronoun "He")
     List<RuleMatch> matches2 = lt.check("He thinks so. He has seen that before. He doesn't like it.");
     assertEquals(1, matches2.size());
+    // check suggestions
     assertThat(matches2.get(0).getSuggestedReplacements().get(0), is("Furthermore, he"));
     assertThat(matches2.get(0).getSuggestedReplacements().get(1), is("Likewise, he"));
     assertThat(matches2.get(0).getSuggestedReplacements().get(2), is("Not only that, but he"));
+    // two successive sentences that start with one of the saved adverbs ("Also")
+    List<RuleMatch> matches3 = lt.check("Also, I play football. Also, I play basketball.");
+    assertEquals(1, matches3.size());
+    // check suggestions (because the adverbs are contained in a Set it is safer to check if the correct suggestions
+    // are contained in the real suggestions)
+    assertTrue(matches3.get(0).getSuggestedReplacements().stream().anyMatch(sugg ->  sugg.equals("Additionally")));
+    assertTrue(matches3.get(0).getSuggestedReplacements().stream().anyMatch(sugg ->  sugg.equals("Besides")));
+    assertTrue(matches3.get(0).getSuggestedReplacements().stream().anyMatch(sugg ->  sugg.equals("Furthermore")));
+    assertTrue(matches3.get(0).getSuggestedReplacements().stream().anyMatch(sugg ->  sugg.equals("Moreover")));
   }
 
 }


### PR DESCRIPTION
Added feature to suggest different adverbs, when successive sentences start with the same adverb.

*Example*

![image](https://user-images.githubusercontent.com/56915448/116859715-1a3fbd00-ac09-11eb-8998-701d2ca547e7.png)

Also, added a relative test case.