### PR TITLE
Could org.languagetool:languagetool-client-example:2.4 drop off redundant dependencies to loose weight?

### DIFF
--- a/languagetool-client-example/pom.xml
+++ b/languagetool-client-example/pom.xml
@@ -25,6 +25,60 @@
             <groupId>org.languagetool</groupId>
             <artifactId>language-all</artifactId>
             <version>5.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>edu.washington.cs.knowitall</groupId>
+                    <artifactId>opennlp-tokenize-models</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>de.danielnaber</groupId>
+                    <artifactId>german-pos-dict</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.languagetool</groupId>
+                    <artifactId>french-pos-dict</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>edu.washington.cs.knowitall</groupId>
+                    <artifactId>opennlp-postag-models</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.softcatala</groupId>
+                    <artifactId>catalan-pos-dict</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ua.net.nlp</groupId>
+                    <artifactId>morfologik-ukrainian-lt</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>edu.washington.cs.knowitall</groupId>
+                    <artifactId>opennlp-chunk-models</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.github.jimregan</groupId>
+                    <artifactId>languagetool-ga-dicts</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.softcatala</groupId>
+                    <artifactId>spanish-pos-dict</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.ibm.icu</groupId>
+                    <artifactId>icu4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.xml.fastinfoset</groupId>
+                    <artifactId>FastInfoset</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
@udomai Hi, I am a user of project **_org.languagetool:languagetool-client-example:2.4_**. I found that its pom file introduced **_113_** dependencies. However, among them, **_16_** libraries (**_14%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_org.languagetool:languagetool-client-example:2.4_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
edu.washington.cs.knowitall:opennlp-chunk-models:jar:1.5:compile
com.sun.istack:istack-commons-runtime:jar:3.0.5:compile
de.danielnaber:german-pos-dict:jar:1.2.2:compile
org.glassfish.jaxb:jaxb-runtime:jar:2.3.0:compile
org.softcatala:catalan-pos-dict:jar:2.13:compile
com.ibm.icu:icu4j:jar:56.1:compile
org.jvnet.staxex:stax-ex:jar:1.7.8:compile
org.glassfish.jaxb:txw2:jar:2.3.0:compile
org.languagetool:french-pos-dict:jar:0.2:compile
org.softcatala:spanish-pos-dict:jar:0.9:compile
ua.net.nlp:morfologik-ukrainian-lt:jar:5.2.0:compile
io.github.jimregan:languagetool-ga-dicts:jar:0.02:compile
edu.washington.cs.knowitall:opennlp-postag-models:jar:1.5:compile
org.glassfish.jaxb:jaxb-core:jar:2.3.0:compile
edu.washington.cs.knowitall:opennlp-tokenize-models:jar:1.5:compile
com.sun.xml.fastinfoset:FastInfoset:jar:1.2.13:compile
</code></pre>