### PR TITLE
[fr] add TIRET_BAS (WORD_CONTAINS_UNDERSCORE)

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -39538,9 +39538,9 @@ though, and has since been slightly modified)-->
                 <token regexp="yes">&comp_mots;+_+&comp_mots;+<exception postag="UNKNOWN" negate_pos="yes"/></token>
             </pattern>
             <message>Un tiret bas (_) à l'intérieur d'un mot est atypique (sauf dans des contextes techniques, les pseudos dans les réseaux sociaux etc.). Veuillez vérifier que le mot '\1' soit correct.</message>
-            <short>Possible faute de frappe</short>
             <suggestion><match no="1" regexp_match="(?iu)(.*)_(.*)" regexp_replace="$1 $2" case_conversion="preserve"/></suggestion>
             <suggestion><match no="1" regexp_match="(?iu)(.*)_(.*)" regexp_replace="$1\-$2" case_conversion="preserve"/></suggestion>
+            <short>Possible faute de frappe</short>
             <example correction="tiret bas|tiret-bas">Ce <marker>tiret_bas</marker> n'est pas correct.</example>
             <example>Le logiciel prévoit ce type de <marker>test-case</marker> en cas de besoin.</example>
             <example correction="un sous-tiret|un-sous-tiret">Appuyez ici pour écrire <marker>un_sous-tiret</marker>.</example>

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -39514,7 +39514,7 @@ though, and has since been slightly modified)-->
                 <token regexp="yes">.*_.*</token>
             </antipattern>
             <antipattern>
-                <token skip="3" regexp="yes">/=|\*|\/|\+|\-|%)_</token>
+                <token skip="3" regexp="yes">(=|\*|\/|\+|\-|%)_</token>
             </antipattern>
             <antipattern>
                 <token skip="3" regexp="yes">.*_.*</token>

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -39494,7 +39494,7 @@ though, and has since been slightly modified)-->
     <category id="CAT_TYPOGRAPHIE" name="Typographie" type="typographical">
         <rule id="TIRET_BAS" name="tiret bas erroné" default="temp_off"><!-- Refer to https://github.com/languagetool-org/languagetool/issues/1204#issuecomment-443842446 -->
             <antipattern><!-- file name: https://github.com/languagetool-org/languagetool/issues/1535 -->
-                <token regexp="yes" spacebefore="no">[a-z-]+</token>
+                <token regexp="yes">[a-z-]+_[a-z-]+</token>
                 <token spacebefore="no">.</token>
                 <token spacebefore="no" regexp="yes">[a-z0-9]{2,7}</token>
             </antipattern>
@@ -39518,7 +39518,7 @@ though, and has since been slightly modified)-->
             </antipattern>
             <antipattern>
                 <token skip="3" regexp="yes">.*_.*</token>
-                <token regexp="yes">=|\*|\/|\+|\-|%</token>
+                <token regexp="yes">=|\*|\/|\+|%</token>
             </antipattern>
             <antipattern>
                 <token regexp="yes">_(=|\*|\/|\+|\-|%)</token>
@@ -39538,12 +39538,12 @@ though, and has since been slightly modified)-->
                 <token regexp="yes">&comp_mots;+_+&comp_mots;+<exception postag="UNKNOWN" negate_pos="yes"/></token>
             </pattern>
             <message>Un tiret bas (_) à l'intérieur d'un mot est atypique (sauf dans des contextes techniques, les pseudos dans les réseaux sociaux etc.). Veuillez vérifier que le mot '\1' soit correct.</message>
-            <suggestion><match no="1" regexp_match="(?iu)(.*)_(.*)" regexp_replace="$1 $2" case_conversion="preserve"/></suggestion>
-            <suggestion><match no="1" regexp_match="(?iu)(.*)_(.*)" regexp_replace="$1\-$2" case_conversion="preserve"/></suggestion>
+            <suggestion><match no="1" regexp_match="(?iu)([a-zàâéèêîôûïëüçœ'-]+)(_+)([a-zàâéèêîôûïëüçœ'-]+)" regexp_replace="$1 $3" case_conversion="preserve"/></suggestion>
+            <suggestion><match no="1" regexp_match="(?iu)([a-zàâéèêîôûïëüçœ'-]+)(_+)([a-zàâéèêîôûïëüçœ'-]+)" regexp_replace="$1\-$3" case_conversion="preserve"/></suggestion>
             <short>Possible faute de frappe</short>
             <example correction="tiret bas|tiret-bas">Ce <marker>tiret_bas</marker> n'est pas correct.</example>
             <example>Le logiciel prévoit ce type de <marker>test-case</marker> en cas de besoin.</example>
-            <example correction="un sous-tiret|un-sous-tiret">Appuyez ici pour écrire <marker>un_sous-tiret</marker>.</example>
+            <example correction="un sous|un-sous">Appuyez ici pour écrire <marker>un_sous</marker>-tiret.</example>
             <example correction="vraiment farfelus|vraiment-farfelus">Certains exemples sont <marker>vraiment______farfelus</marker>.</example><!-- The message does not show all the underscores. -->
             <example>Écrivez votre message ici : <marker>______________________</marker></example>
             <example>Tests de langue<marker>______________________</marker> 37</example>

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -43,6 +43,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
     <!ENTITY unites_de_mesure "(centi|milli|déci|déca|hecto|kilo|atto|exa|mega|giga|tera|peta|zetta|yotta|micro|nano|pico|femto|zepto|yocto)?[mètre|gramme|litre]|degré|[mchkd][wglm]|dag|dal|dam|volt|watt|hz|hertz|bits?|ms|s|cs|cc|dB">
     <!ENTITY departement "Ain|Aisne|Allier|Alpes-de-Haute-Provence|Hautes-Alpes|Alpes-Maritimes|Ardèche|Ardennes|Ariège|Aube|Aude|Aveyron|Bouches-du-Rhône|Calvados|Cantal|Charente|Charente-Maritime|Cher|Corrèze|Corse-du-Sud|Haute-Corse|Côte-d'Or|Côtes d'Armor|Creuse|Dordogne|Doubs|Drôme|Eure|Eure-et-Loir|Finistère|Gars|Haute-Garonne|Gers|Gironde|Hérault|Ille-et-Vilaine|Indre|Indre-et-Loire|Isère|Jura|Landes|Loir-et-Cher|Loire|Haute-Loire|Loire-Atlantique|Loiret|Lot|Lot-et-Garonne|Lozère|Maine-et-Loire|Manche|Marne|Haute-Marne|Mayenne|Meurthe-et-Moselle|Meuse|Morbihan|Moselle|Nièvre|Nord|Oise|Orne|Pas-de-Calais|Puy-de-Dôme|Pyrénées-Atlantiques|Hautes-Pyrénées|Pyrénées-Orientales|Bas-Rhin|Haut-Rhin|Rhône|Haute-Saône|Saône-et-Loire|Sarthe|Savoie|Haute-Savoie|Paris|Seine-Maritime|Seine-et-Marne|Yvelines|Deux-Sèvres|Somme|Tarn|Tarn-et-Garonne|Var|Vaucluse|Vandée|Vienne|Haute-Vienne|Vosges|Yonne|Territoire de Belfort|Essonne|Hauts-de-Seine|Seine-St-Denis|Val-de-Marne|Val-D'Oise|Guadeloupe|Martinique|Guyane|La Réunion|Mayotte">
     <!ENTITY monnaies "afghani|rand|lek|d[ie]nar|euro|kwanza|dollar|florin|riyal|peso|dram|manat|taka|rouble|franc|r(h)?oupie|boliviano|mark|pula|couronne|real|(bulgarian)? lev|riel|peso|escudo|yuan|livre|won|kuna|colon|dirham|birr|dalasi|lari|ghana cedi|quetzal|gourde|lempira|forint|rupiah|rial|yen|tenge|shilling|som|kip|rans|loti|lats|litas|pataca|malagasy|ringgit|kwacha|rufiyaa|ouguija|leu|tugrik|metical|kyat|rand|cordoba|naira|soum|balboa|kina|guarani|(nouveau)? sol|zloty|tala|dobra|leone|lilangeni|somoni|baht|pa'anga|manat|hryvnia|vatu|bolivar|dong|kwacha">
+    <!ENTITY comp_mots "[a-zàâéèêîôûïëüçœ'-]">
 ]>
 <rules lang="fr" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <unification feature="number">
@@ -39491,6 +39492,71 @@ though, and has since been slightly modified)-->
         </rule>
     </category>
     <category id="CAT_TYPOGRAPHIE" name="Typographie" type="typographical">
+        <rule id="TIRET_BAS" name="tiret bas erroné" default="temp_off"><!-- Refer to https://github.com/languagetool-org/languagetool/issues/1204#issuecomment-443842446 -->
+            <antipattern><!-- file name: https://github.com/languagetool-org/languagetool/issues/1535 -->
+                <token regexp="yes" spacebefore="no">[a-z-]+</token>
+                <token spacebefore="no">.</token>
+                <token spacebefore="no" regexp="yes">[a-z0-9]{2,7}</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">['‘"“]</token>
+                <token regexp="yes">&comp_mots;+_&comp_mots;+</token>
+                <token regexp="yes" spacebefore="no">['‘"“]</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes" skip="2">['‘"“]</token>
+                <token regexp="yes">&comp_mots;+</token>
+                <token regexp="yes" spacebefore="no">&comp_mots;+</token>
+                <token regexp="yes" spacebefore="no">['‘"“]</token>
+            </antipattern>
+            <antipattern>
+                <token skip="3" regexp="yes">=|\*|\/|\+|\-|%</token>
+                <token regexp="yes">.*_.*</token>
+            </antipattern>
+            <antipattern>
+                <token skip="3" regexp="yes">/=|\*|\/|\+|\-|%)_</token>
+            </antipattern>
+            <antipattern>
+                <token skip="3" regexp="yes">.*_.*</token>
+                <token regexp="yes">=|\*|\/|\+|\-|%</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">_(=|\*|\/|\+|\-|%)</token>
+            </antipattern>
+            <antipattern><!-- https://www.computerhope.com/jargon/p/publicht.htm -->
+                <token>public_html</token>
+            </antipattern>
+            <antipattern><!-- markdown backticks, used for code -->
+                <token>`</token>
+                <token regexp="yes">.*_.*</token>
+                <token>`</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">_(id|token|name)</token>
+            </antipattern>
+            <pattern>
+                <token regexp="yes">&comp_mots;+_+&comp_mots;+<exception postag="UNKNOWN" negate_pos="yes"/></token>
+            </pattern>
+            <message>Un tiret bas (_) à l'intérieur d'un mot est atypique (sauf dans des contextes techniques, les pseudos dans les réseaux sociaux etc.). Veuillez vérifier que le mot '\1' soit correct.</message>
+            <short>Possible faute de frappe</short>
+            <suggestion><match no="1" regexp_match="(?iu)(.*)_(.*)" regexp_replace="$1 $2" case_conversion="preserve"/></suggestion>
+            <suggestion><match no="1" regexp_match="(?iu)(.*)_(.*)" regexp_replace="$1\-$2" case_conversion="preserve"/></suggestion>
+            <example correction="tiret bas|tiret-bas">Ce <marker>tiret_bas</marker> n'est pas correct.</example>
+            <example>Le logiciel prévoit ce type de <marker>test-case</marker> en cas de besoin.</example>
+            <example correction="un sous-tiret|un-sous-tiret">Appuyez ici pour écrire <marker>un_sous-tiret</marker>.</example>
+            <example correction="vraiment farfelus|vraiment-farfelus">Certains exemples sont <marker>vraiment______farfelus</marker>.</example><!-- The message does not show all the underscores. -->
+            <example>Écrivez votre message ici : <marker>______________________</marker></example>
+            <example>Tests de langue<marker>______________________</marker> 37</example>
+            <example>Quelques tests de plus <marker>_</marker> Appendice B</example>
+            <example>Faites seulement ce test <marker>_préliminaire_</marker>.</example>
+            <example>Vérifiez le fichier <marker>country_codes.csv</marker> d'abord…</example>
+            <example>Mais <marker>ceux-ci_</marker> pas comme les autres...</example><!-- TODO -->
+            <example>Voir <marker>_TESTS</marker>' à la page 33.</example><!-- TODO -->
+            <example>Statut "payment_failed"</example>
+            <example>my_variable = x</example>
+            <example>Est-ce que ça vaut la peine d'ajouter `suppress_misspelled` ?</example>
+            <example>Public_html est un dossier qui se trouve sur les serveurs et qui contient des informations HTML.</example>
+        </rule>
         <rule id="OE" name="oe / œ">
             <pattern>
                 <and>


### PR DESCRIPTION
@jaumeortola, when you have a minute (not urgent), could you look at this rule?

I was trying to port the WORD_CONTAINS_UNDERSCORE rule from English to French (TIRET_BAS). The main difference being that the underscore is not a token boundary in French. I thought I had adapted everything, but I'm getting a test failure I can't understand. I've run through a few possible solutions, but I cannot identify the problem.

Do you see what's going wrong? Hopefully I just oversaw something really simple...