### PR TITLE
[WIP] send HTTP code 429 instead of 403 for rate limiting

### DIFF
--- a/languagetool-server/src/main/java/org/languagetool/server/LanguageToolHttpHandler.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/LanguageToolHttpHandler.java
@@ -151,7 +151,7 @@ class LanguageToolHttpHandler implements HttpHandler {
           requestLimiter.checkAccess(remoteAddress, parameters, httpExchange.getRequestHeaders(), userLimits);
         } catch (TooManyRequestsException e) {
           String errorMessage = "Error: Access from " + remoteAddress + " denied: " + e.getMessage();
-          int code = HttpURLConnection.HTTP_FORBIDDEN;
+          int code = 429; // too many requests
           sendError(httpExchange, code, errorMessage);
           // already logged via DatabaseAccessLimitLogEntry
           logError(errorMessage, code, parameters, httpExchange, false);
@@ -164,7 +164,7 @@ class LanguageToolHttpHandler implements HttpHandler {
                 textSizeMessage +
                 " Allowed maximum timeouts: " + errorRequestLimiter.getRequestLimit() +
                 " per " + errorRequestLimiter.getRequestLimitPeriodInSeconds() + " seconds";
-        int code = HttpURLConnection.HTTP_FORBIDDEN;
+        int code = 429; // too many requests
         sendError(httpExchange, code, errorMessage);
         logError(errorMessage, code, parameters, httpExchange);
         return;


### PR DESCRIPTION
Make distinguishing temporarily denied requests (because of limits) and permanently blocked/forbidden requests easier.
Don't merge yet, wait for add-ons to adapt and show the correct error message.