### PR TITLE
[gl] fixed capturing acronyms

### DIFF
--- a/languagetool-language-modules/gl/src/main/resources/org/languagetool/rules/gl/grammar.xml
+++ b/languagetool-language-modules/gl/src/main/resources/org/languagetool/rules/gl/grammar.xml
@@ -4759,7 +4759,7 @@
 	<rulegroup id="ACRONYMS_PLURAL" name="Siglas: Plural">
 		<rule>	
 			<pattern>
-				<token regexp="yes">(?:\p{Lu}*)s</token>
+				<token regexp="yes">(?:\p{Lu}{2,})s</token>
 			</pattern>
 			<message>O plural dunha sigla só se marca no artigo ou nalgunha das palabras que a acompañan. Empregue <suggestion><match
 			no="1" regexp_match="(\p{Lu}*)s"


### PR DESCRIPTION
The rule was capturing 'acronyms' with just one uppercase letter, such as 'As', 'Os'. Fixed.