### PR TITLE
Add mapping for Chinese to SRX rules

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
@@ -6624,6 +6624,7 @@
 <languagemap languagepattern="(BE|be).*" languagerulename="Belarusian"></languagemap>
 <languagemap languagepattern="(GL|gl).*" languagerulename="Galician"></languagemap>
 <languagemap languagepattern="(JA|ja).*" languagerulename="Ideographic"></languagemap>
+<languagemap languagepattern="(ZH|zh).*" languagerulename="Ideographic"></languagemap>
 <languagemap languagepattern="(BR|br).*" languagerulename="Breton"></languagemap>
 <languagemap languagepattern="(PT|pt).*" languagerulename="Portuguese"></languagemap>
 <languagemap languagepattern="(IT|it).*" languagerulename="Italian"></languagemap>

--- a/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
@@ -4288,7 +4288,7 @@
 <rule break="no">
 <beforebreak>\b(бульв|г|д|доп|др|е|зам|Зам|и|им|инд|исп|Исп)\.\s</beforebreak>
 <afterbreak></afterbreak>
-</rule>    
+</rule>
 <rule break="no">
 <beforebreak>\b(англ|в|вв|га|гг|гл|гос|грн|дм|долл|е|ед)\.\s</beforebreak>
 <afterbreak>\p{Ll}</afterbreak>
@@ -4896,7 +4896,7 @@
 <afterbreak>(und|oder|bis)\s</afterbreak>
 </rule>
 <!-- einige deutsche Monate, vor denen eine Zahl erscheinen kann,
-         ohne dass eine Satzgrenze erkannt wird 
+         ohne dass eine Satzgrenze erkannt wird
          (z.B. "am 13. Dezember" -> keine Satzgrenze) -->
 <rule break="no">
 <beforebreak>\d+\.\s</beforebreak>

--- a/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
@@ -5827,7 +5827,7 @@
 <afterbreak>['"«¡¿\p{Ps}\p{Pi}]?\p{Lu}\p{Ll}*</afterbreak>
 </rule>
 </languagerule>
-<languagerule languagerulename="Japanese">
+<languagerule languagerulename="Ideographic">
 <rule break="no">
 <beforebreak>[:]+[\p{Pe}\p{Pf}\p{Po}"-[\u002C\u003A\u003B\u055D\u060C\u061B\u0703\u0704\u0705\u0706\u0707\u0708\u0709\u07F8\u1363\u1364\u1365\u1366\u1802\u1804\u1808\u204F\u205D\u3001\uA60D\uFE10\uFE11\uFE13\uFE14\uFE50\uFE51\uFE54\uFE55\uFF0C\uFF1A\uFF1B\uFF64]]*</beforebreak>
 <afterbreak>\s+\P{Lu}</afterbreak>
@@ -6623,7 +6623,7 @@
 <languagemap languagepattern="(UK|uk).*" languagerulename="Ukrainian"></languagemap>
 <languagemap languagepattern="(BE|be).*" languagerulename="Belarusian"></languagemap>
 <languagemap languagepattern="(GL|gl).*" languagerulename="Galician"></languagemap>
-<languagemap languagepattern="(JA|ja).*" languagerulename="Japanese"></languagemap>
+<languagemap languagepattern="(JA|ja).*" languagerulename="Ideographic"></languagemap>
 <languagemap languagepattern="(BR|br).*" languagerulename="Breton"></languagemap>
 <languagemap languagepattern="(PT|pt).*" languagerulename="Portuguese"></languagemap>
 <languagemap languagepattern="(IT|it).*" languagerulename="Italian"></languagemap>


### PR DESCRIPTION
I use the LanguageTool SRX rules in a separate project, [srx-languagetool-ruby](https://github.com/amake/srx-languagetool-ruby). Thanks for providing such a comprehensive resource.

One point I find lacking about the existing rules is that there is no entry for Chinese. However the existing Japanese rules work perfectly well for both languages, so I would like to propose this small tweak to the mapping rules.

(I surmise that LanguageTool uses something different to segment Chinese, so I understand if you don't want to add a bunch of data that you don't need. But I figured this is small enough to be acceptable.)