### PR TITLE
a more memory-efficient storage for examples and corrections

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/IncorrectExample.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/IncorrectExample.java
@@ -18,7 +18,7 @@
  */
 package org.languagetool.rules;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -27,8 +27,7 @@ import java.util.List;
  * @since 0.9.2
  */
 public final class IncorrectExample extends ExampleSentence {
-
-  private final List<String> corrections;
+  private final Object corrections;
 
   public IncorrectExample(String example) {
     this(example, Collections.emptyList());
@@ -39,19 +38,23 @@ public final class IncorrectExample extends ExampleSentence {
    */
   public IncorrectExample(String example, List<String> corrections) {
     super(example);
-    this.corrections = Collections.unmodifiableList(new ArrayList<>(corrections));
+    this.corrections = corrections.isEmpty() ? null :
+                       corrections.size() == 1 ? corrections.get(0) :
+                       corrections.toArray(new String[0]);
   }
 
   /**
    * Return the possible corrections.
    */
   public List<String> getCorrections() {
-    return corrections;
+    return corrections == null ? Collections.emptyList() :
+           corrections instanceof String ? Collections.singletonList((String) corrections) :
+           Collections.unmodifiableList(Arrays.asList((String[])corrections));
   }
   
   @Override
   public String toString() {
-    return example + " " + corrections;
+    return example + " " + getCorrections();
   }
 
 }

--- a/languagetool-core/src/main/java/org/languagetool/rules/Rule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/Rule.java
@@ -276,7 +276,7 @@ public abstract class Rule {
    * Set the examples that are correct and thus do not trigger the rule.
    */
   public final void setCorrectExamples(List<CorrectExample> correctExamples) {
-    this.correctExamples = Objects.requireNonNull(correctExamples);
+    this.correctExamples = correctExamples.isEmpty() ? null : correctExamples;
   }
 
   /**
@@ -290,7 +290,7 @@ public abstract class Rule {
    * Set the examples that are incorrect and thus do trigger the rule.
    */
   public final void setIncorrectExamples(List<IncorrectExample> incorrectExamples) {
-    this.incorrectExamples = Objects.requireNonNull(incorrectExamples);
+    this.incorrectExamples = incorrectExamples.isEmpty() ? null : incorrectExamples;
   }
 
   /**
@@ -305,7 +305,7 @@ public abstract class Rule {
    * @since 3.5
    */
   public final void setErrorTriggeringExamples(List<ErrorTriggeringExample> examples) {
-    this.errorTriggeringExamples = Objects.requireNonNull(examples);
+    this.errorTriggeringExamples = examples.isEmpty() ? null : examples;
   }
 
   /**


### PR DESCRIPTION
~1MB for en+de languages loaded