### PR TITLE
No buffering for fasttext, compute suggestions in correct thread

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/language/FastText.java
+++ b/languagetool-core/src/main/java/org/languagetool/language/FastText.java
@@ -80,7 +80,7 @@ public class FastText {
         logger.warn("More input to read from Fasttext, this should not happen; language detection results might be mixed up");
       }
     }
-    return parseBuffer(buffer, additionalLanguageCodes);
+    return parseBuffer(new String(cbuf), additionalLanguageCodes);
   }
 
   @NotNull

--- a/languagetool-core/src/main/java/org/languagetool/rules/RuleMatch.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RuleMatch.java
@@ -419,6 +419,17 @@ public class RuleMatch implements Comparable<RuleMatch> {
   }
 
   /**
+   * Force computing replacements, e.g. for accurate metrics for computation time and to set timeouts for this process
+   * Used in server use case (i.e. {@link org.languagetool.server.TextChecker})
+   */
+  public void computeLazySuggestedReplacements() {
+    long start = System.nanoTime();
+    suggestedReplacements = Suppliers.ofInstance(suggestedReplacements.get());
+    long delta = System.nanoTime() - start;
+    System.out.printf("Computing replacements for %s took %fms.%n", rule.getId(), delta / 1_000_000f);
+  }
+
+  /**
    * A URL that points to a more detailed error description or {@code null}.
    * Note that the {@link Rule} itself might also have an URL, which is usually
    * a less specific one than this. This one will overwrite the rule's URL in

--- a/languagetool-core/src/main/java/org/languagetool/rules/RuleMatch.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RuleMatch.java
@@ -423,10 +423,7 @@ public class RuleMatch implements Comparable<RuleMatch> {
    * Used in server use case (i.e. {@link org.languagetool.server.TextChecker})
    */
   public void computeLazySuggestedReplacements() {
-    long start = System.nanoTime();
     suggestedReplacements = Suppliers.ofInstance(suggestedReplacements.get());
-    long delta = System.nanoTime() - start;
-    System.out.printf("Computing replacements for %s took %fms.%n", rule.getId(), delta / 1_000_000f);
   }
 
   /**

--- a/languagetool-core/src/test/java/org/languagetool/language/FasttextTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/language/FasttextTest.java
@@ -1,0 +1,81 @@
+package org.languagetool.language;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.After;
+import org.junit.Test;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map.Entry;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * In some cases, it appears that the Fasttext integration can get into a state
+ * where multiple texts are sent in one batch and the responses then wrongly associated
+ * This is a (failed) attempt at reproducing that.
+ * Removing buffering from the communication with fasttext is an attempt at fixing it.
+ */
+public class FasttextTest
+{
+  private static final List<String> languages = Arrays.asList("en", "es", "de", "fr");
+
+  private static final List<Entry<String, String>> TESTED_ENTRIES =
+    Arrays.asList(
+                  new SimpleImmutableEntry<>("en", "This is an English text."),
+                  new SimpleImmutableEntry<>("de", "Dies ist ein deutscher Text.")
+                  );
+
+  private static final int THREAD_COUNT = 11;
+
+  private FastText instance;
+
+  @Before
+  public void setUp() throws IOException {
+    instance = new FastText(new File("lid.176.bin"),
+                            new File("fasttext"));
+  }
+
+  @After
+  public void tearDown() {
+    instance.destroy();
+    instance = null;
+  }
+
+  private Runnable checkLanguage(String text, String expectedLang) {
+    return () -> {
+      while (true) {
+        try {
+          Map<String, Double> detected = instance.runFasttext(text, languages);
+          System.out.printf("Detected '%s' as %s%n", text, detected);
+
+          Entry<String, Double> highest = detected.entrySet().stream().max(Entry.comparingByValue()).get();
+          assertEquals("Expected language correctly detected", expectedLang, highest.getKey());
+          Thread.sleep(1);
+        } catch(IOException | InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+  }
+
+  @Test
+  @Ignore("unable to reproduce bug")
+  public void testConcurrentUse() throws InterruptedException {
+    List<Thread> threads = new ArrayList<>(THREAD_COUNT);
+    for (int i = 0; i < THREAD_COUNT; i++) {
+      Entry<String, String> entry = TESTED_ENTRIES.get(i % TESTED_ENTRIES.size());
+      Thread t = new Thread(checkLanguage(entry.getValue(), entry.getKey()), "fasttext-test-" + i);
+      threads.add(t);
+        System.out.printf("Started thread %d%n", i);
+      t.start();
+    }
+    for (Thread t : threads) {
+      t.join();
+    }
+  }
+}

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -379,8 +379,11 @@ abstract class TextChecker {
         /*if (Math.random() < 0.1) {
           throw new OutOfMemoryError();
         }*/
-        return getRuleMatches(aText, lang, motherTongue, parameters, params, userConfig, detLang, preferredLangs,
+        List<CheckResults> results = getRuleMatches(aText, lang, motherTongue, parameters, params, userConfig, detLang, preferredLangs,
                 preferredVariants, f -> ruleMatchesSoFar.add(new CheckResults(Collections.singletonList(f), Collections.emptyList())));
+        // generate suggestions, otherwise this is not part of the timeout logic and not properly measured in the metrics
+        results.stream().flatMap(r -> r.getRuleMatches().stream()).forEach(RuleMatch::computeLazySuggestedReplacements);
+        return results;
       }
     });
     String incompleteResultReason = null;


### PR DESCRIPTION
Buffering might have led to mix-ups in language detection
Laziness for suggestions can result in ignoring timeouts and incorrect metrics