### PR TITLE
Rechtswale/NS statt Rechtswahle/NS

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
@@ -6694,3 +6694,4 @@ Schönwettwerbereich
 Schönwettwerbereiche
 Schönwettwerbereichen
 Schönwettwerbereichs
+Rechtswale/NS


### PR DESCRIPTION
Die Mehrzahl wird nicht als Fehler erkannt.
Die Einzahl wird erkannt.