### PR TITLE
[en] activate improvements + picky tag

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-US/grammar.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/en-US/grammar.xml
@@ -376,7 +376,7 @@ USA
                     <exception postag="CD" />
                 </token>
             </antipattern>
-            <rule>
+            <rule tags="picky">
                 <pattern>
                     <token>the</token>
                     <token min="0" case_sensitive="yes">United</token>


### PR DESCRIPTION
Old improvements that were never activated:
BE_PART_AGREEMENT_2
SV_AGREEMENT_NEG_QS

US_ONE_ENTITY[1] → picky