### PR TITLE
fix off-by-one error in computeOffsetShifts

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
@@ -265,13 +265,13 @@ public abstract class RemoteRule extends Rule {
    *  lookup table, find shifted index for i at shifts[i];
    */
   static int[] computeOffsetShifts(String s) {
-    int len = s.length();
+    int len = s.length() + 1;
     int[] offsets = new int[len];
     int shifted = 0, original = 0;
 
     // go from codepoint to codepoint using shifted
     // offset saved in original will correspond to Java string index shifted
-    while(shifted < len) {
+    while(shifted < s.length()) {
       offsets[original] = shifted;
       shifted = s.offsetByCodePoints(shifted, 1);
       original++;

--- a/languagetool-core/src/test/java/org/languagetool/rules/RemoteRuleOffsetsFixTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/RemoteRuleOffsetsFixTest.java
@@ -44,13 +44,13 @@ public class RemoteRuleOffsetsFixTest {
 
   @Test
   public void testShiftCalculation() {
-    assertEquals(Arrays.asList(0, 2, 3, 4, 5), printShifts("😁foo"));
-    assertEquals(Arrays.asList(0, 1, 2, 3, 4, 6, 7, 8, 9, 10), printShifts("foo 😁 bar"));
-    assertEquals(Arrays.asList(0, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14), printShifts("😁 foo 😁 bar"));
+    assertEquals(Arrays.asList(0, 2, 3, 4, 5, 6), printShifts("😁foo"));
+    assertEquals(Arrays.asList(0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11), printShifts("foo 😁 bar"));
+    assertEquals(Arrays.asList(0, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15), printShifts("😁 foo 😁 bar"));
 
-    assertEquals("1 code point, length 2 / 1", Arrays.asList(0, 2), printShifts("👪"));
-    assertEquals("1 code point for each part, length 4 / 2, displayed as 1", Arrays.asList(0, 2, 4, 5), printShifts("👍🏼"));
-    assertEquals("normal text", Arrays.asList(0), printShifts("a"));
+    assertEquals("1 code point, length 2 / 1", Arrays.asList(0, 2, 3), printShifts("👪"));
+    assertEquals("1 code point for each part, length 4 / 2, displayed as 1", Arrays.asList(0, 2, 4, 5, 6), printShifts("👍🏼"));
+    assertEquals("normal text", Arrays.asList(0, 1), printShifts("a"));
   }
 
   private void testMatch(String text, int from, int to, int fixedFrom, int fixedTo) throws IOException {
@@ -83,6 +83,20 @@ public class RemoteRuleOffsetsFixTest {
     testMatch("😁foo bar", 1, 4, 2, 5);
     testMatch("👪", 0, 1, 0, 2);
     testMatch("👍🏼", 0, 2, 0, 4);
+  }
+
+  @Test
+  public void testException() throws Exception {
+    JLanguageTool lt = new JLanguageTool(new Demo());
+    AnalyzedSentence s = lt.getAnalyzedSentence("abondoned");
+    Rule r = new FakeRule();
+    // multiple matches
+    List<RuleMatch> matches = Arrays.asList(
+      new RuleMatch(r, s, 0, 9, "Match")
+    );
+
+    printShifts("abondoned");
+    RemoteRule.fixMatchOffsets(s, matches);
   }
 
 }


### PR DESCRIPTION
mapping for toPos at end of string wasn't included
raised ArrayIndexOutOfBoundsException