### PR TITLE
simplify regexes, fixes invalid regex in match

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -1896,10 +1896,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     </unify>
                 </pattern>
                 <message>'\2' et '\5' ne semblent pas bien accordés.</message>
-                <suggestion><match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/>\3 \4 <match no="5" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/></suggestion>
-                <suggestion><match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/>\3 \4 <match no="5" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/></suggestion>
-                <suggestion><match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/>\3 \4 <match no="5" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/></suggestion>
-                <suggestion><match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/>\3 \4 <match no="5" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/></suggestion>
+                <suggestion><match no="2" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/>\3 \4 <match no="5" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/></suggestion>
+                <suggestion><match no="2" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/>\3 \4 <match no="5" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/></suggestion>
+                <suggestion><match no="2" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/>\3 \4 <match no="5" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/></suggestion>
+                <suggestion><match no="2" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/>\3 \4 <match no="5" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/></suggestion>
                 <example correction="pertinent, ni clair|pertinente, ni claire|pertinents, ni clairs|pertinentes, ni claires">Son intervention n'est ni <marker>pertinente, ni clair</marker>.</example>
                 <example correction="frauduleux et ennuyeux|frauduleuse et ennuyeuse|frauduleuses et ennuyeuses">Ce nombre a été rapporté comme <marker>frauduleuse et ennuyeux</marker>.</example>
             </rule>
@@ -1920,10 +1920,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     </unify>
                 </pattern>
                 <message>'\2' et '\5' ne semblent pas bien accordés.</message>
-                <suggestion><match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/>\3 \4 <match no="5" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/></suggestion>
-                <suggestion><match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/>\3 \4 <match no="5" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/></suggestion>
-                <suggestion><match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/>\3 \4 <match no="5" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/></suggestion>
-                <suggestion><match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/>\3 \4 <match no="5" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/></suggestion>
+                <suggestion><match no="2" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/>\3 \4 <match no="5" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/></suggestion>
+                <suggestion><match no="2" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/>\3 \4 <match no="5" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/></suggestion>
+                <suggestion><match no="2" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/>\3 \4 <match no="5" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/></suggestion>
+                <suggestion><match no="2" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/>\3 \4 <match no="5" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/></suggestion>
                 <example correction="direct et indirect|directe et indirecte|directs et indirects|directes et indirectes">Il doit assumer les conséquences <marker>directes et indirect</marker>.</example>
                 <example correction="amusant et divertissant|amusante et divertissante|amusants et divertissants|amusantes et divertissantes">une expérience d'apprentissage <marker>amusante et divertissantes</marker> pour les adolescents.</example>
                 <example correction="concret et facile|concrète et facile|concrets et faciles|concrètes et faciles">avec des exemples <marker>concrets et facile</marker> á mettre en place</example>
@@ -1948,10 +1948,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     </unify>
                 </pattern>
                 <message>'\3' et '\5' ne semblent pas bien accordés.</message>
-                <suggestion><match no="3" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/> \4 <match no="5" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/></suggestion>
-                <suggestion><match no="3" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/> \4 <match no="5" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/></suggestion>
-                <suggestion><match no="3" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/> \4 <match no="5" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/></suggestion>
-                <suggestion><match no="3" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/> \4 <match no="5" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/></suggestion>
+                <suggestion><match no="3" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/> \4 <match no="5" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/></suggestion>
+                <suggestion><match no="3" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/> \4 <match no="5" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/></suggestion>
+                <suggestion><match no="3" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/> \4 <match no="5" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/></suggestion>
+                <suggestion><match no="3" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/> \4 <match no="5" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/></suggestion>
                 <example correction="simple et efficace|simples et efficaces">vous donnent les moyens, <marker>simples et efficace</marker>, de ne pas vous identifier.</example>
                 <example correction="spécifique et certifié|spécifique et certifiée|spécifiques et certifiés|spécifiques et certifiées">satisfaire tous vos attentes, <marker>spécifiques et certifié</marker>.</example>
             </rule>
@@ -1969,10 +1969,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token postag="N.*" postag_regexp="yes"/>
                 </pattern>
                 <message>'\1' et '\2' ne semblent pas bien accordés.</message>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/> <match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/> <match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/> <match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/> <match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/> <match no="2" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/> <match no="2" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/> <match no="2" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/> <match no="2" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/></suggestion>
                 <example correction="méchant petit|méchante petite|méchants petits|méchantes petites">Il était accompagné de <marker>méchants petit</marker> brigands.</example>
                 <example>Ancienne petite amie et ancienne victime de Sydney Carlin.</example>
             </rule>
@@ -1992,10 +1992,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     </unify>
                 </pattern>
                 <message>'\2' et '\4' ne semblent pas bien accordés.</message>
-                <!--<suggestion><match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/> \3 <match no="4" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/></suggestion>
-                <suggestion><match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/> \3 <match no="4" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/></suggestion>-->
-                <suggestion><match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/> \3 <match no="4" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/></suggestion>
-                <suggestion><match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/> \3 <match no="4" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/></suggestion>
+                <!--<suggestion><match no="2" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/> \3 <match no="4" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/></suggestion>
+                <suggestion><match no="2" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/> \3 <match no="4" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/></suggestion>-->
+                <suggestion><match no="2" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/> \3 <match no="4" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/></suggestion>
+                <suggestion><match no="2" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/> \3 <match no="4" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/></suggestion>
                 <example correction="handicapés ou traumatisés|handicapées ou traumatisées">pour les <marker>handicapés ou traumatisée</marker> suite à des accidents divers.</example>
             </rule>
         </rulegroup>
@@ -2027,10 +2027,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     </unify>
                 </pattern>
                 <message>'\1' et '\4' ne semblent pas bien accordés.</message>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/>\2 \3 <match no="4" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/>\2 \3 <match no="4" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/>\2 \3 <match no="4" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/>\2 \3 <match no="4" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/>\2 \3 <match no="4" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/>\2 \3 <match no="4" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/>\2 \3 <match no="4" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/>\2 \3 <match no="4" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/></suggestion>
                 <example correction="direct et indirect|directe et indirecte|directs et indirects|directes et indirectes">Il doit assumer les conséquences <marker>directes et indirect</marker>.</example>
                 <example correction="pertinent, ni clair|pertinente, ni claire|pertinents, ni clairs|pertinentes, ni claires">Son intervention n'est ni <marker>pertinente, ni clair</marker>.</example>
                 <!--<example correction="méchant petit|méchante petite|méchants petits|méchantes petites">Il était accompagné de <marker>méchants petit</marker> brigands.</example>-->
@@ -2052,10 +2052,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     </unify>
                 </pattern>
                 <message>'\1' et '\3' ne semblent pas bien accordés.</message>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/>\2 <match no="3" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/>\2 <match no="3" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/>\2 <match no="3" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/>\2 <match no="3" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/>\2 <match no="3" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/>\2 <match no="3" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/>\2 <match no="3" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/>\2 <match no="3" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/></suggestion>
                 <example correction="direct, indirect|directe, indirecte|directs, indirects|directes, indirectes">Il doit assumer les conséquences <marker>directes, indirect</marker> et...</example>
             </rule>
             <rule>
@@ -2071,10 +2071,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     </unify>
                 </pattern>
                 <message>'\1' et '\2' ne semblent pas bien accordés.</message>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/> <match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/> <match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/> <match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/> <match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/> <match no="2" postag="J" postag_regexp="yes" postag_replace="J [me] sp?"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/> <match no="2" postag="J" postag_regexp="yes" postag_replace="J [fe] sp?"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/> <match no="2" postag="J" postag_regexp="yes" postag_replace="J [me] s?p"/></suggestion>
+                <suggestion><match no="1" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/> <match no="2" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/></suggestion>
                 <example correction="méchant petit|méchante petite|méchants petits|méchantes petites">Il était accompagné de <marker>méchants petit</marker> brigands.</example>
                 <example>Ancienne petite amie et ancienne victime de Sydney Carlin.</example>
             </rule>
@@ -2096,10 +2096,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     </unify>
                 </pattern>
                 <message>'\1' et '\4' ne semblent pas bien accordés.</message>
-                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/>\2 \3 <match no="4" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/>\2 \3 <match no="4" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/>\2 \3 <match no="4" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/>\2 \3 <match no="4" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/></suggestion>
+                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [me] sp?"/>\2 \3 <match no="4" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [me] sp?"/></suggestion>
+                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [fe] sp?"/>\2 \3 <match no="4" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [fe] sp?"/></suggestion>
+                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [me] s?p"/>\2 \3 <match no="4" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [me] s?p"/></suggestion>
+                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [fe] s?p"/>\2 \3 <match no="4" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [fe] s?p"/></suggestion>
                 <example correction="direct et indirect|directe et indirecte|directs et indirects|directes et indirectes">Il doit assumer les conséquences <marker>directes et indirect</marker>.</example>
                 <example correction="pertinent, ni clair|pertinente, ni claire|pertinents, ni clairs|pertinentes, ni claires">Son intervention n'est ni <marker>pertinente, ni clair</marker>.</example>
                 <example>J'aimerais aussi vous demander de faire très attention aux offres venant d'Afrique (Côte d'Ivoire, Bénin et autres…).</example>
@@ -2122,10 +2122,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     </unify>
                 </pattern>
                 <message>'\1' et '\3' ne semblent pas bien accordés.</message>
-                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/>\2 <match no="3" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/>\2 <match no="3" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/>\2 <match no="3" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/>\2 <match no="3" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/></suggestion>
+                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [me] sp?"/>\2 <match no="3" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [me] sp?"/></suggestion>
+                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [fe] sp?"/>\2 <match no="3" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [fe] sp?"/></suggestion>
+                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [me] s?p"/>\2 <match no="3" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [me] s?p"/></suggestion>
+                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [fe] s?p"/>\2 <match no="3" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [fe] s?p"/></suggestion>
                 <example correction="direct, indirect|directe, indirecte|directs, indirects|directes, indirectes">Il doit assumer les conséquences <marker>directes, indirect</marker> et...</example>
             </rule>
             <rule>
@@ -2141,10 +2141,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     </unify>
                 </pattern>
                 <message>'\1' et '\2' ne semblent pas bien accordés.</message>
-                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/> <match no="2" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [me] (s|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/> <match no="2" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (s|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/> <match no="2" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [me] (p|sp)"/></suggestion>
-                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/> <match no="2" postag="(J)(.*)" postag_regexp="yes" postag_replace="$1 [fe] (p|sp)"/></suggestion>
+                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [me] sp?"/> <match no="2" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [me] sp?"/></suggestion>
+                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [fe] sp?"/> <match no="2" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [fe] sp?"/></suggestion>
+                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [me] s?p"/> <match no="2" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [me] s?p"/></suggestion>
+                <suggestion><match no="1" postag="(J|V ppa)(.*)" postag_regexp="yes" postag_replace="J [fe] s?p"/> <match no="2" postag="J" postag_regexp="yes" postag_replace="J [fe] s?p"/></suggestion>
                 <example correction="méchant petit|méchante petite|méchants petits|méchantes petites">Il était accompagné de <marker>méchants petit</marker> brigands.</example>
             </rule>
         </rulegroup>


### PR DESCRIPTION
Changes as suggested by @udomai 
Fixes exceptions seen in nightly diff: https://internal1.languagetool.org/regression-tests/via-http/2021-08-08/fr/result_java_FAKE_RULE.html
Stack trace:
```
Caused by: java.lang.RuntimeException: Error trying to synthesize POS tag (J [fe] (p|sp) (posTagRegExp: true) from token et
#011at org.languagetool.synthesis.BaseSynthesizer.synthesize(BaseSynthesizer.java:196)                                     
#011at org.languagetool.rules.patterns.MatchState.toFinalString(MatchState.java:257)                                       
#011at org.languagetool.rules.patterns.PatternRuleMatcher.concatMatches(PatternRuleMatcher.java:415)                       
#011at org.languagetool.rules.patterns.PatternRuleMatcher.formatMatches(PatternRuleMatcher.java:285)                       
#011at org.languagetool.rules.patterns.PatternRuleMatcher.createRuleMatch(PatternRuleMatcher.java:121)                     
#011at org.languagetool.rules.patterns.PatternRuleMatcher.lambda$match$1(PatternRuleMatcher.java:83)                       
#011at org.languagetool.rules.patterns.AbstractPatternRulePerformer.matchFrom(AbstractPatternRulePerformer.java:157)       
#011at org.languagetool.rules.patterns.AbstractPatternRulePerformer.doMatch(AbstractPatternRulePerformer.java:77)          
#011at org.languagetool.rules.patterns.PatternRuleMatcher.match(PatternRuleMatcher.java:82)                                
#011at org.languagetool.rules.patterns.PatternRule.match(PatternRule.java:215)                                             
#011... 16 more                                                                                                            
Caused by: java.util.regex.PatternSyntaxException: Unclosed group near index 14                                            
(J [fe] (p|sp)                                                                                                             
```