### PR TITLE
[de] test AP against "jeder" FPs

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/AgreementRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/AgreementRule.java
@@ -1198,6 +1198,11 @@ public class AgreementRule extends Rule {
       token("anderen"),
       posRegex("ADJ.*"),
       posRegex("SUB.*")
+    ),
+    Arrays.asList( // dass jeder LanguageTool benutzen sollte
+      token("jeder"),
+      posRegex("SUB:(AKK|DAT).*"),
+      posRegex("VER.*")
     )
   );
 

--- a/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/AgreementRuleTest.java
+++ b/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/AgreementRuleTest.java
@@ -506,6 +506,7 @@ public class AgreementRuleTest {
     assertGood("Soll das Freude machen?");
     assertGood("Die Trial ist ausgelaufen.");
     assertGood("Ein geworbener Neukunde interagiert zusätzlich mit dem Unternehmen.");
+    assertGood("Ich weiß, dass jeder LanguageTool benutzen sollte.");
     // TODO: not yet detected:
     //assertBad("Erst recht wir fleißiges Arbeiter.");
     //assertBad("Erst recht ich fleißiges Arbeiter.");


### PR DESCRIPTION
Takes care of FPs:

> Warum muss **jeder Englisch** lernen?

Eliminates also TPs where the suggestion makes no sense (suggests plural, should be singular):

> **Jeder Kind** vergisst mal seinen Turnbeutel.

→ Jeder Kinder

Test results: 
[result_java_DE_AGREEMENT.zip](https://github.com/languagetool-org/languagetool/files/7019914/result_java_DE_AGREEMENT.zip)
