### PR TITLE
[core] fix disappearing quotes CommaWhitespaceRule

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/CommaWhitespaceRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/CommaWhitespaceRule.java
@@ -105,7 +105,7 @@ public class CommaWhitespaceRule extends Rule {
         }
       } else if (isWhitespace && isQuote(prevToken) && this.quotesWhitespaceCheck && prevPrevToken.equals(" ")) {
           msg = messages.getString("no_space_around_quotes");
-          suggestionText = "";
+          suggestionText = prevToken;
       } else if (!isWhitespace && prevToken.equals(getCommaCharacter())
           && !isQuote(token)
           && !isHyphenOrComma(token)

--- a/languagetool-core/src/test/java/org/languagetool/rules/CommaWhitespaceRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/CommaWhitespaceRuleTest.java
@@ -95,7 +95,13 @@ public class CommaWhitespaceRuleTest {
     matches = rule.match(lt.getAnalyzedSentence("This , is a test sentence."));
     assertEquals(1, matches.length);
     assertEquals(",", matches[0].getSuggestedReplacements().get(0));
-    
+
+    matches = rule.match(lt.getAnalyzedSentence("You \" fixed\" it."));
+    assertEquals(1, matches.length);
+    assertEquals("\"", matches[0].getSuggestedReplacements().get(0));
+    matches = rule.match(lt.getAnalyzedSentence("You \"fixed \" it."));
+    assertEquals(1, matches.length);
+    assertEquals("\"", matches[0].getSuggestedReplacements().get(0));
 
     assertMatches("Ellipsis . . . as suggested by The Chicago Manual of Style", 3);
     assertMatches("Ellipsis . . . . as suggested by The Chicago Manual of Style", 4);

--- a/languagetool-core/src/test/java/org/languagetool/rules/CommaWhitespaceRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/CommaWhitespaceRuleTest.java
@@ -99,9 +99,13 @@ public class CommaWhitespaceRuleTest {
     matches = rule.match(lt.getAnalyzedSentence("You \" fixed\" it."));
     assertEquals(1, matches.length);
     assertEquals("\"", matches[0].getSuggestedReplacements().get(0));
+    assertEquals(4, matches[0].getFromPos());
+    assertEquals(6, matches[0].getToPos());
     matches = rule.match(lt.getAnalyzedSentence("You \"fixed \" it."));
     assertEquals(1, matches.length);
     assertEquals("\"", matches[0].getSuggestedReplacements().get(0));
+    assertEquals(11, matches[0].getFromPos());
+    assertEquals(13, matches[0].getToPos());
 
     assertMatches("Ellipsis . . . as suggested by The Chicago Manual of Style", 3);
     assertMatches("Ellipsis . . . . as suggested by The Chicago Manual of Style", 4);


### PR DESCRIPTION
Problem:

> The coffee maker doesn't work anymore after you " fixed" it.

CommaWhitespaceRule deletes the quote that has spaces on both sides, as well as the space to its right. (result: `you fixed" it.`)

The change I made in line 108 works for spaces after opening quotes (result: `you "fixed" it.`), but has an undesired outcome for spaces before closing quotes:

> The coffee maker doesn't work anymore after you "fixed " it.

result: `you "fixed "it.`