### PR TITLE
[fr] remove "éprouvè" from french.dump

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/removed.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/removed.txt
@@ -379,3 +379,4 @@ en-deça	en-deça	N m s
 permis	permis	V ppa m sp
 conduite	conduit	N f s
 conduites	conduit	N f p
+éprouvè	éprouver	V ind pres 1 s


### PR DESCRIPTION
I've seen this error in french.dump that is providing false results in premium diff
Removing this from french.dump, and I'll check tomorrow whether it is the root cause of false results