### PR TITLE
[de] fix several adverbial usage FPs in DE_AGREEMENT

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/AgreementRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/AgreementRule.java
@@ -1241,6 +1241,18 @@ public class AgreementRule extends Rule {
       token("jeder"),
       posRegex("SUB:(AKK|DAT).*"),
       posRegex("VER.*")
+    ),
+    Arrays.asList( // der fließend Französisch sprechende Trudeau
+      posRegex("(ART|PRO:DEM).*"),
+      posRegex("ADJ:PRD:GRU|PA[12]:PRD:GRU:VER"),
+      posRegex("SUB.*"),
+      posRegex("PA[12].*")
+    ),
+    Arrays.asList( // Spricht dieser fließend Französisch
+      posRegex("VER.*[123].*"),
+      posRegex("(ART|PRO:DEM).*"),
+      posRegex("ADJ:PRD:GRU|PA[12]:PRD:GRU:VER"),
+      posRegex("SUB.*")
     )
   );
 

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/added.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/added.txt
@@ -13700,3 +13700,4 @@ Causae	Causa	SUB:NOM:PLU:FEM
 Causae	Causa	SUB:GEN:PLU:FEM
 Causae	Causa	SUB:DAT:PLU:FEM
 Causae	Causa	SUB:AKK:PLU:FEM
+weniger	weniger	ADV:MOD

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/disambiguation.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/disambiguation.xml
@@ -50,6 +50,17 @@ Copyright © 2013 Markus Brenneis, Daniel Naber, Jan Schreiber
         </equivalence>
     </unification>
 
+    <rule id="LANGE_ZEIT_ADV" name="lange Zeit">
+        <pattern>
+            <token regexp="yes">lange|längere</token>
+            <token>Zeit</token>
+        </pattern>
+        <disambig action="add">
+            <wd pos="ADV:TMP"/>
+            <wd pos="ADV:TMP"/>
+        </disambig>
+    </rule>
+
     <rulegroup id="SUB_INNEN" name="Student*innen">
         <rule>
             <pattern>
@@ -756,14 +767,16 @@ Copyright © 2013 Markus Brenneis, Daniel Naber, Jan Schreiber
     <rule name="NP unify 1b" id="UNIFY_DET_SUB2">
         <antipattern>
             <token postag="ART:.*" postag_regexp="yes" regexp="yes" case_sensitive="yes">[ED].+</token>
-            <token postag="ADJ:.*" postag_regexp="yes"></token>
-            <token postag="SUB:.*" postag_regexp="yes"></token>
+            <token postag="ADJ:.*" postag_regexp="yes"/>
+            <token postag="SUB:.*" postag_regexp="yes"/>
         </antipattern>
          <pattern>
             <unify>
                 <feature id="number"/><feature id="case"/><feature id="gender"/>
                 <!--"beiden Filmen", but: "dass sie Geliebte waren"-->
-                <token postag="(PRO|ART):.*" postag_regexp="yes"><exception>sie</exception></token>
+                <token postag="(PRO|ART):.*" postag_regexp="yes">
+                    <exception>sie</exception>
+                    </token>
                 <token postag="SUB:.*" postag_regexp="yes"><exception postag="ADJ:.*" postag_regexp="yes"/></token>
             </unify>
         </pattern>
@@ -864,17 +877,21 @@ Copyright © 2013 Markus Brenneis, Daniel Naber, Jan Schreiber
             <unify>
                 <feature id="number"/><feature id="case"/><feature id="gender"/>
                 <!-- "Am Strand stehen schöne Häuser"-->
-                <token postag="ADJ:.*" postag_regexp="yes"><exception regexp="yes">lieben?|scheuen?</exception></token>
+                <token postag="ADJ:.*" postag_regexp="yes">
+                    <exception regexp="yes">lieben?|scheuen?</exception>
+                    <exception postag="ADV.*" postag_regexp="yes"/>
+                    </token>
                 <token postag="SUB:.*" postag_regexp="yes">
                     <exception postag="ADJ:.+:SOL" postag_regexp="yes" regexp="yes">[A-Z].+</exception>
                     <exception postag="EIG:.+" postag_regexp="yes" />
-                </token>
+                    </token>
             </unify>
         </pattern>
         <disambig action="unify"/>
         <example type="untouched">Gegen eine schwache Wiener Austria holte das Schlusslicht einen 1:0-Heimerfolg.</example>
         <example type="untouched">Ich liebe Lachs.</example>
         <example type="untouched">Wir lieben Hunde.</example>
+        <example type="untouched">Er war früher Präsident.</example>
     </rule>
 
     <rule name="NP unify 4" id="UNIFY_4">

--- a/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/AgreementRuleTest.java
+++ b/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/AgreementRuleTest.java
@@ -71,6 +71,8 @@ public class AgreementRuleTest {
   @Test
   public void testDetNounRule() throws IOException {
     // correct sentences:
+    assertGood("Der fließend Französisch sprechende Präsident dankt stilvoll ab.");
+    assertGood("Spricht der fließend Französisch?");
     assertGood("Die Einen sagen dies, die Anderen das.");
     assertGood("So ist es in den USA.");
     assertGood("Das ist der Tisch.");


### PR DESCRIPTION
This is an experiment to fix several DE_AGREEMENT FPs of this kind: adjectives used as adverbs

**Die früher Torstraße** genannte Semmelweisstraße verläuft Parallel dazu.
**Der fließend Französisch** sprechende Präsident ist sehr beliebt.
**Der lange Zeit** unbekannte Maler erlangte so Berühmtheit.
Beherrscht **dieser später Englisch**, bekommt er mehr Geld.

see #5470