### PR TITLE
suppress misspelled for RemoteRules

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/Language.java
+++ b/languagetool-core/src/main/java/org/languagetool/Language.java
@@ -29,6 +29,7 @@ import org.languagetool.rules.RemoteRuleConfig;
 import org.languagetool.rules.Rule;
 import org.languagetool.rules.neuralnetwork.Word2VecModel;
 import org.languagetool.rules.patterns.*;
+import org.languagetool.rules.spelling.SpellingCheckRule;
 import org.languagetool.synthesis.Synthesizer;
 import org.languagetool.tagging.Tagger;
 import org.languagetool.tagging.disambiguation.Disambiguator;
@@ -259,6 +260,17 @@ public abstract class Language {
    */
   public List<Rule> getRelevantRulesGlobalConfig(ResourceBundle messages, GlobalConfig globalConfig, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) throws IOException {
     return Collections.emptyList();
+  }
+
+  /**
+   * Get the default spelling rule of this language
+   * Useful for rules to implement supression of misspelled suggestions
+   * @since 5.5
+   *
+   */
+  @Nullable
+  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+    return null;
   }
 
   /**

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
@@ -229,7 +229,7 @@ public abstract class RemoteRule extends Rule {
           for (AnalyzedSentence sentence : sentences) {
               List<RuleMatch> sentenceMatches = result.matchesForSentence(sentence);
               if (sentenceMatches != null) {
-                List<RuleMatch> filteredSentenceMatches = suppressMisspelled(sentence, sentenceMatches);
+                List<RuleMatch> filteredSentenceMatches = suppressMisspelled(sentenceMatches);
                 filteredMatches.addAll(filteredSentenceMatches);
               }
           }
@@ -273,7 +273,7 @@ public abstract class RemoteRule extends Rule {
     });
   }
 
-  private List<RuleMatch> suppressMisspelled(AnalyzedSentence sentence, List<RuleMatch> sentenceMatches) throws IOException {
+  private List<RuleMatch> suppressMisspelled(List<RuleMatch> sentenceMatches) {
     List<RuleMatch> result = new ArrayList<>();
     SpellingCheckRule speller = ruleLanguage.getDefaultSpellingRule(messages);
     Predicate<SuggestedReplacement> spelled = (s) -> {
@@ -283,9 +283,11 @@ public abstract class RemoteRule extends Rule {
        throw new RuntimeException(e);
      }
     };
-    if (speller == null && (suppressMisspelledMatch != null || suppressMisspelledSuggestions != null)) {
-      logger.warn("Cannot activate suppression of misspelled matches for rule {}, no spelling rule found for language {}.",
-                  getId(), ruleLanguage.getShortCodeWithCountryAndVariant());
+    if (speller == null) {
+      if (suppressMisspelledMatch != null || suppressMisspelledSuggestions != null) {
+        logger.warn("Cannot activate suppression of misspelled matches for rule {}, no spelling rule found for language {}.",
+          getId(), ruleLanguage.getShortCodeWithCountryAndVariant());
+      }
       return sentenceMatches;
     }
 

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleConfig.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleConfig.java
@@ -144,6 +144,15 @@ public class RemoteRuleConfig {
     return timeoutLimitTotalMilliseconds != null ? timeoutLimitTotalMilliseconds : DEFAULT_TIMEOUT_LIMIT_TOTAL;
   }
 
+  /**
+   *  miscellaneous options for remote rules
+   *  allows implementing additional behavior in subclasses
+   *  some options defined in {@link RemoteRule}:
+   *  fixOffets: boolean - adjust offsets of matches because of discrepancies in string length for some unicode characters between Java and Python
+   *  filterMatches: boolean - enable anti-patterns from remote-rule-filters.xml
+   *  suppressMisspelledMatch: regex - filter out matches with matching rule IDs that have misspelled suggestions
+   *  suppressMisspelledSuggestions: regex - filter out misspelled suggestions from matches with matching rule IDs
+   *  */
   public Map<String, String> getOptions() {
     return options;
   }

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/AustrianGerman.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/AustrianGerman.java
@@ -26,6 +26,7 @@ import org.languagetool.languagemodel.LanguageModel;
 import org.languagetool.rules.Rule;
 import org.languagetool.rules.de.AustrianGermanSpellerRule;
 import org.languagetool.rules.de.GermanCompoundRule;
+import org.languagetool.rules.spelling.SpellingCheckRule;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -52,6 +53,11 @@ public class AustrianGerman extends German {
     List<Rule> rules = new ArrayList<>(super.getRelevantRules(messages, userConfig, motherTongue, altLanguages));
     rules.add(new GermanCompoundRule(messages));
     return rules;
+  }
+
+  @Override
+  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+    return new AustrianGermanSpellerRule(messages, this);
   }
 
   @Override

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/AustrianGerman.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/AustrianGerman.java
@@ -56,7 +56,7 @@ public class AustrianGerman extends German {
   }
 
   @Override
-  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+  public SpellingCheckRule createDefaultSpellingRule(ResourceBundle messages) throws IOException {
     return new AustrianGermanSpellerRule(messages, this);
   }
 

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/GermanyGerman.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/GermanyGerman.java
@@ -56,7 +56,7 @@ public class GermanyGerman extends German {
   }
 
   @Override
-  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+  public SpellingCheckRule createDefaultSpellingRule(ResourceBundle messages) throws IOException {
     return new GermanSpellerRule(messages, this);
   }
 

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/GermanyGerman.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/GermanyGerman.java
@@ -26,6 +26,7 @@ import org.languagetool.languagemodel.LanguageModel;
 import org.languagetool.rules.Rule;
 import org.languagetool.rules.de.GermanCompoundRule;
 import org.languagetool.rules.de.GermanSpellerRule;
+import org.languagetool.rules.spelling.SpellingCheckRule;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -52,6 +53,11 @@ public class GermanyGerman extends German {
     List<Rule> rules = new ArrayList<>(super.getRelevantRules(messages, userConfig, motherTongue, altLanguages));
     rules.add(new GermanCompoundRule(messages));
     return rules;
+  }
+
+  @Override
+  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+    return new GermanSpellerRule(messages, this);
   }
 
   @Override

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/SwissGerman.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/SwissGerman.java
@@ -25,6 +25,7 @@ import org.languagetool.languagemodel.LanguageModel;
 import org.languagetool.rules.Rule;
 import org.languagetool.rules.de.SwissCompoundRule;
 import org.languagetool.rules.de.SwissGermanSpellerRule;
+import org.languagetool.rules.spelling.SpellingCheckRule;
 import org.languagetool.tagging.Tagger;
 import org.languagetool.tagging.de.SwissGermanTagger;
 
@@ -55,6 +56,11 @@ public class SwissGerman extends German {
     List<Rule> rules = new ArrayList<>(super.getRelevantRules(messages, userConfig, motherTongue, altLanguages));
     rules.add(new SwissCompoundRule(messages));
     return rules;
+  }
+
+  @Override
+  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+    return new SwissGermanSpellerRule(messages, this);
   }
 
   @Override

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/SwissGerman.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/SwissGerman.java
@@ -59,7 +59,7 @@ public class SwissGerman extends German {
   }
 
   @Override
-  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+  public SpellingCheckRule createDefaultSpellingRule(ResourceBundle messages) throws IOException {
     return new SwissGermanSpellerRule(messages, this);
   }
 

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/AmericanEnglish.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/AmericanEnglish.java
@@ -28,11 +28,14 @@ import org.languagetool.rules.Rule;
 import org.languagetool.rules.en.AmericanReplaceRule;
 import org.languagetool.rules.en.MorfologikAmericanSpellerRule;
 import org.languagetool.rules.en.UnitConversionRuleUS;
+import org.languagetool.rules.spelling.SpellingCheckRule;
 import org.languagetool.rules.spelling.SymSpellRule;
 import org.languagetool.rules.spelling.suggestions.SuggestionsChanges;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
 
@@ -54,6 +57,11 @@ public class AmericanEnglish extends English {
     rules.add(new AmericanReplaceRule(messages, "/en/en-US/replace.txt"));
     rules.add(new UnitConversionRuleUS(messages));
     return rules;
+  }
+
+  @Override
+  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+      return new MorfologikAmericanSpellerRule(messages, this, null, Collections.emptyList());
   }
 
   @Override

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/AmericanEnglish.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/AmericanEnglish.java
@@ -34,7 +34,6 @@ import org.languagetool.rules.spelling.suggestions.SuggestionsChanges;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -60,7 +59,7 @@ public class AmericanEnglish extends English {
   }
 
   @Override
-  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+  public SpellingCheckRule createDefaultSpellingRule(ResourceBundle messages) throws IOException {
       return new MorfologikAmericanSpellerRule(messages, this, null, Collections.emptyList());
   }
 

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/AustralianEnglish.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/AustralianEnglish.java
@@ -48,7 +48,7 @@ public class AustralianEnglish extends English {
   }
 
   @Override
-  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+  public SpellingCheckRule createDefaultSpellingRule(ResourceBundle messages) throws IOException {
     return new MorfologikAustralianSpellerRule(messages, this, null, Collections.emptyList());
   }
 

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/AustralianEnglish.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/AustralianEnglish.java
@@ -1,6 +1,6 @@
-/* LanguageTool, a natural language style checker 
+/* LanguageTool, a natural language style checker
  * Copyright (C) 2012 Marcin Miłkowski (http://www.languagetool.org)
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -21,6 +21,7 @@ package org.languagetool.language;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
 
@@ -32,6 +33,7 @@ import org.languagetool.languagemodel.LanguageModel;
 import org.languagetool.rules.Rule;
 import org.languagetool.rules.en.MorfologikAustralianSpellerRule;
 import org.languagetool.rules.en.UnitConversionRuleImperial;
+import org.languagetool.rules.spelling.SpellingCheckRule;
 
 public class AustralianEnglish extends English {
 
@@ -43,6 +45,11 @@ public class AustralianEnglish extends English {
   @Override
   public String getName() {
     return "English (Australian)";
+  }
+
+  @Override
+  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+    return new MorfologikAustralianSpellerRule(messages, this, null, Collections.emptyList());
   }
 
   @Override

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/BritishEnglish.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/BritishEnglish.java
@@ -58,7 +58,7 @@ public class BritishEnglish extends English {
   }
 
   @Override
-  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+  public SpellingCheckRule createDefaultSpellingRule(ResourceBundle messages) throws IOException {
     return new MorfologikBritishSpellerRule(messages, this, null, Collections.emptyList());
   }
 

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/BritishEnglish.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/BritishEnglish.java
@@ -21,6 +21,7 @@ package org.languagetool.language;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
 
@@ -33,6 +34,7 @@ import org.languagetool.rules.Rule;
 import org.languagetool.rules.en.BritishReplaceRule;
 import org.languagetool.rules.en.MorfologikBritishSpellerRule;
 import org.languagetool.rules.en.UnitConversionRuleImperial;
+import org.languagetool.rules.spelling.SpellingCheckRule;
 
 public class BritishEnglish extends English {
 
@@ -53,6 +55,11 @@ public class BritishEnglish extends English {
     rules.add(new BritishReplaceRule(messages, "/en/en-GB/replace.txt"));
     rules.add(new UnitConversionRuleImperial(messages));
     return rules;
+  }
+
+  @Override
+  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+    return new MorfologikBritishSpellerRule(messages, this, null, Collections.emptyList());
   }
 
   @Override

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/CanadianEnglish.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/CanadianEnglish.java
@@ -48,7 +48,7 @@ public class CanadianEnglish extends English {
   }
 
   @Override
-  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+  public SpellingCheckRule createDefaultSpellingRule(ResourceBundle messages) throws IOException {
     return new MorfologikCanadianSpellerRule(messages, this, null, Collections.emptyList());
   }
 

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/CanadianEnglish.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/CanadianEnglish.java
@@ -1,6 +1,6 @@
-/* LanguageTool, a natural language style checker 
+/* LanguageTool, a natural language style checker
  * Copyright (C) 2012 Marcin Miłkowski (http://www.languagetool.org)
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -21,6 +21,7 @@ package org.languagetool.language;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
 
@@ -32,6 +33,7 @@ import org.languagetool.languagemodel.LanguageModel;
 import org.languagetool.rules.Rule;
 import org.languagetool.rules.en.MorfologikCanadianSpellerRule;
 import org.languagetool.rules.en.UnitConversionRuleImperial;
+import org.languagetool.rules.spelling.SpellingCheckRule;
 
 public class CanadianEnglish extends English {
 
@@ -43,6 +45,11 @@ public class CanadianEnglish extends English {
   @Override
   public String getName() {
     return "English (Canadian)";
+  }
+
+  @Override
+  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+    return new MorfologikCanadianSpellerRule(messages, this, null, Collections.emptyList());
   }
 
   @Override

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/NewZealandEnglish.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/NewZealandEnglish.java
@@ -1,6 +1,6 @@
-/* LanguageTool, a natural language style checker 
+/* LanguageTool, a natural language style checker
  * Copyright (C) 2012 Marcin Miłkowski (http://www.languagetool.org)
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -21,6 +21,7 @@ package org.languagetool.language;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
 
@@ -33,6 +34,7 @@ import org.languagetool.rules.Rule;
 import org.languagetool.rules.en.MorfologikNewZealandSpellerRule;
 import org.languagetool.rules.en.NewZealandReplaceRule;
 import org.languagetool.rules.en.UnitConversionRuleImperial;
+import org.languagetool.rules.spelling.SpellingCheckRule;
 
 public class NewZealandEnglish extends English {
 
@@ -44,6 +46,11 @@ public class NewZealandEnglish extends English {
   @Override
   public String getName() {
     return "English (New Zealand)";
+  }
+
+  @Override
+  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+    return new MorfologikNewZealandSpellerRule(messages, this, null, Collections.emptyList());
   }
 
   @Override

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/NewZealandEnglish.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/NewZealandEnglish.java
@@ -49,7 +49,7 @@ public class NewZealandEnglish extends English {
   }
 
   @Override
-  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+  public SpellingCheckRule createDefaultSpellingRule(ResourceBundle messages) throws IOException {
     return new MorfologikNewZealandSpellerRule(messages, this, null, Collections.emptyList());
   }
 

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/SouthAfricanEnglish.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/SouthAfricanEnglish.java
@@ -47,7 +47,7 @@ public class SouthAfricanEnglish extends English {
   }
 
   @Override
-  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+  public SpellingCheckRule createDefaultSpellingRule(ResourceBundle messages) throws IOException {
     return new MorfologikSouthAfricanSpellerRule(messages, this, null, Collections.emptyList());
   }
 

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/SouthAfricanEnglish.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/SouthAfricanEnglish.java
@@ -1,6 +1,6 @@
-/* LanguageTool, a natural language style checker 
+/* LanguageTool, a natural language style checker
  * Copyright (C) 2012 Marcin Miłkowski (http://www.languagetool.org)
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -21,6 +21,7 @@ package org.languagetool.language;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
 
@@ -31,6 +32,7 @@ import org.languagetool.UserConfig;
 import org.languagetool.languagemodel.LanguageModel;
 import org.languagetool.rules.Rule;
 import org.languagetool.rules.en.MorfologikSouthAfricanSpellerRule;
+import org.languagetool.rules.spelling.SpellingCheckRule;
 
 public class SouthAfricanEnglish extends English {
 
@@ -42,6 +44,11 @@ public class SouthAfricanEnglish extends English {
   @Override
   public String getName() {
     return "English (South African)";
+  }
+
+  @Override
+  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+    return new MorfologikSouthAfricanSpellerRule(messages, this, null, Collections.emptyList());
   }
 
   @Override

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishRemoteRuleSuppressMisspelledTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishRemoteRuleSuppressMisspelledTest.java
@@ -1,0 +1,128 @@
+/*
+ *  LanguageTool, a natural language style checker
+ *  * Copyright (C) 2021 Fabian Richter
+ *  *
+ *  * This library is free software; you can redistribute it and/or
+ *  * modify it under the terms of the GNU Lesser General Public
+ *  * License as published by the Free Software Foundation; either
+ *  * version 2.1 of the License, or (at your option) any later version.
+ *  *
+ *  * This library is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  * Lesser General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Lesser General Public
+ *  * License along with this library; if not, write to the Free Software
+ *  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ *  * USA
+ *
+ */
+
+package org.languagetool.rules.en;
+
+import org.junit.Test;
+import org.languagetool.AnalyzedSentence;
+import org.languagetool.JLanguageTool;
+import org.languagetool.Language;
+import org.languagetool.language.AmericanEnglish;
+import org.languagetool.rules.RemoteRule;
+import org.languagetool.rules.RemoteRuleConfig;
+import org.languagetool.rules.RemoteRuleResult;
+import org.languagetool.rules.RuleMatch;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EnglishRemoteRuleSuppressMisspelledTest {
+  private static Language testLang = new AmericanEnglish();
+  private static final String TEST_RULE = "TEST_REMOTE_RULE";
+  private static final String TEST_SENTENCE = "This is a test sentence.";
+
+  class TestRule extends RemoteRule {
+
+    TestRule(RemoteRuleConfig config) {
+      super(testLang, JLanguageTool.getMessageBundle(), config, true, TEST_RULE);
+    }
+
+    class TestRequest extends RemoteRequest {
+      List<AnalyzedSentence> sentences;
+    }
+
+    @Override
+    protected RemoteRequest prepareRequest(List<AnalyzedSentence> sentences, Long textSessionId) {
+      TestRequest r = new TestRequest();
+      r.sentences = sentences;
+      return r;
+    }
+
+    @Override
+    protected Callable<RemoteRuleResult> executeRequest(RemoteRequest req, long timeoutMilliseconds)
+        throws TimeoutException {
+      return () -> {
+        List<RuleMatch> matches = new ArrayList<>();
+        TestRequest r = (TestRequest) req;
+        for (AnalyzedSentence s : r.sentences) {
+          RuleMatch m = new RuleMatch(this, s, 0, s.getText().length(), "Test match");
+          m.addSuggestedReplacement("mistake");
+          m.addSuggestedReplacement("mistak");
+          matches.add(m);
+        }
+        return new RemoteRuleResult(true, true, matches, r.sentences);
+      };
+    }
+
+    @Override
+    protected RemoteRuleResult fallbackResults(RemoteRequest r) {
+      return new RemoteRuleResult(false, false, Collections.emptyList(), ((TestRequest) r).sentences);
+    }
+
+    @Override
+    public String getDescription() {
+      return "Test rule";
+    }
+
+  }
+
+  private RemoteRuleConfig withOptions(String... valStrings) {
+    Map<String, String> options = new HashMap<>();
+    for (int i = 0; i < valStrings.length; i+=2) {
+      options.put(valStrings[i], valStrings[i+1]);
+    }
+    RemoteRuleConfig c = new RemoteRuleConfig(TEST_RULE, "", null, null, null, null, null, null, null, null, options);
+    return c;
+  }
+
+  @Test
+  public void test() throws IOException {
+    JLanguageTool lt = new JLanguageTool(testLang);
+    AnalyzedSentence s = lt.getAnalyzedSentence(TEST_SENTENCE);
+
+    TestRule r = new TestRule(withOptions());
+    RuleMatch[] m = r.match(s);
+    assertEquals("Test rule creates match without match suppression", 1, m.length);
+    assertEquals("Test rule creates match with two suggestions", 2, m[0].getSuggestedReplacements().size());
+
+    r = new TestRule(withOptions("suppressMisspelledMatch", TEST_RULE));
+    m = r.match(s);
+    assertEquals("Test rule creates no match with match suppression", 0, m.length);
+
+    r = new TestRule(withOptions("suppressMisspelledSuggestions", TEST_RULE));
+    m = r.match(s);
+    assertEquals("Test rule creates match with suggestion suppression", 1, m.length);
+    assertEquals("Test rule creates match with correctly spelled suggestions", Arrays.asList("mistake"), m[0].getSuggestedReplacements());
+
+    r = new TestRule(withOptions("suppressMisspelledMatch", ".*REMOTE.*"));
+    m = r.match(s);
+    assertEquals("Test rule creates no match with match suppression (regex, full match)", 0, m.length);
+
+    r = new TestRule(withOptions("suppressMisspelledMatch", ".*REMOTE"));
+    m = r.match(s);
+    assertEquals("no match suppression (regex only partial match)", 1, m.length);
+  }
+
+}

--- a/languagetool-language-modules/es/src/main/java/org/languagetool/language/Spanish.java
+++ b/languagetool-language-modules/es/src/main/java/org/languagetool/language/Spanish.java
@@ -103,7 +103,7 @@ public class Spanish extends Language implements AutoCloseable {
   }
 
   @Override
-  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+  public SpellingCheckRule createDefaultSpellingRule(ResourceBundle messages) throws IOException {
     return new MorfologikSpanishSpellerRule(messages, this, null, Collections.emptyList());
   }
 

--- a/languagetool-language-modules/es/src/main/java/org/languagetool/language/Spanish.java
+++ b/languagetool-language-modules/es/src/main/java/org/languagetool/language/Spanish.java
@@ -1,6 +1,6 @@
-/* LanguageTool, a natural language style checker 
+/* LanguageTool, a natural language style checker
  * Copyright (C) 2007 Daniel Naber (http://www.danielnaber.de)
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -24,6 +24,7 @@ import org.languagetool.*;
 import org.languagetool.languagemodel.LanguageModel;
 import org.languagetool.rules.*;
 import org.languagetool.rules.es.*;
+import org.languagetool.rules.spelling.SpellingCheckRule;
 import org.languagetool.synthesis.Synthesizer;
 import org.languagetool.synthesis.es.SpanishSynthesizer;
 import org.languagetool.tagging.Tagger;
@@ -99,6 +100,11 @@ public class Spanish extends Language implements AutoCloseable {
             new Contributor("Juan Martorell", "http://languagetool-es.blogspot.com/"),
             new Contributor("Jaume Ortolà")
     };
+  }
+
+  @Override
+  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+    return new MorfologikSpanishSpellerRule(messages, this, null, Collections.emptyList());
   }
 
   @Override

--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
@@ -24,6 +24,7 @@ import org.languagetool.*;
 import org.languagetool.languagemodel.LanguageModel;
 import org.languagetool.rules.*;
 import org.languagetool.rules.fr.*;
+import org.languagetool.rules.spelling.SpellingCheckRule;
 import org.languagetool.synthesis.FrenchSynthesizer;
 import org.languagetool.synthesis.Synthesizer;
 import org.languagetool.tagging.Tagger;
@@ -91,6 +92,12 @@ public class French extends Language implements AutoCloseable {
     return new Contributor[] {
         Contributors.DOMINIQUE_PELLE
     };
+  }
+
+
+  @Override
+  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+    return new MorfologikFrenchSpellerRule(messages, this, null, Collections.emptyList());
   }
 
   @Override

--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
@@ -96,7 +96,7 @@ public class French extends Language implements AutoCloseable {
 
 
   @Override
-  public SpellingCheckRule getDefaultSpellingRule(ResourceBundle messages) throws IOException {
+  public SpellingCheckRule createDefaultSpellingRule(ResourceBundle messages) throws IOException {
     return new MorfologikFrenchSpellerRule(messages, this, null, Collections.emptyList());
   }
 


### PR DESCRIPTION
add options to RemoteRule to filter out matches (`suppressMisspelledMatch`) or suggestions with misspellings (`suppressMisspelledSuggestions`)
allow application to only selected rule IDs via regex
added getDefaultSpellingRule() to Language