### PR TITLE
add dependency to languagetool-language-modules/de

### DIFF
--- a/languagetool-language-modules/de/pom.xml
+++ b/languagetool-language-modules/de/pom.xml
@@ -84,6 +84,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.11</version>
+        </dependency>
 
         <dependency>
             <groupId>edu.washington.cs.knowitall</groupId>


### PR DESCRIPTION
build works fine because dependency is already part of other modules,
but gets marked as error in IntelliJ