### PR TITLE
Add ability to change Hunspell library in runtime

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/DumontsHunspellDictionary.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/DumontsHunspellDictionary.java
@@ -1,0 +1,100 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2021 Pavel Bakhvalov
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.spelling.hunspell;
+
+import dumonts.hunspell.bindings.HunspellLibrary;
+import org.bridj.Pointer;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DumontsHunspellDictionary implements HunspellDictionary {
+  private final Pointer<HunspellLibrary.Hunhandle> handle;
+  private final Charset charset;
+
+  public DumontsHunspellDictionary(Path dictionary, Path affix) {
+    try {
+      Pointer<Byte> aff = Pointer.pointerToCString(affix.toString());
+      Pointer<Byte> dic = Pointer.pointerToCString(dictionary.toString());
+      handle = HunspellLibrary.Hunspell_create(aff, dic);
+      charset = Charset.forName(HunspellLibrary.Hunspell_get_dic_encoding(handle).getCString());
+      if (this.handle == null) {
+        throw new RuntimeException("Unable to create Hunspell instance");
+      }
+    } catch (UnsatisfiedLinkError e) {
+      throw new RuntimeException("Could not create hunspell instance. Please note that LanguageTool supports only 64-bit platforms " +
+          "(Linux, Windows, Mac) and that it requires a 64-bit JVM (Java).", e);
+    }
+  }
+
+  @Override
+  public boolean spell(String word) {
+    if (handle == null) {
+      throw new RuntimeException("Attempt to use hunspell instance after closing");
+    }
+    @SuppressWarnings("unchecked")
+    Pointer<Byte> str = (Pointer<Byte>) Pointer.pointerToString(word, Pointer.StringType.C, charset);
+    int result = HunspellLibrary.Hunspell_spell(handle, str);
+    return result != 0;
+  }
+
+  @Override
+  public void add(String word) {
+    if (handle == null) {
+      throw new RuntimeException("Attempt to use hunspell instance after closing");
+    }
+    @SuppressWarnings("unchecked")
+    Pointer<Byte> str = (Pointer<Byte>) Pointer.pointerToString(word, Pointer.StringType.C, charset);
+    HunspellLibrary.Hunspell_add(handle, str);
+  }
+
+  @Override
+  public List<String> suggest(String word) {
+    // Create pointer to native string
+    @SuppressWarnings("unchecked")
+    Pointer<Byte> str = (Pointer<Byte>) Pointer.pointerToString(word, Pointer.StringType.C, charset);
+    // Create pointer to native string array
+    Pointer<Pointer<Pointer<Byte>>> nativeSuggestionArray = Pointer.allocatePointerPointer(Byte.class);
+    // Hunspell will allocate the array and fill it with suggestions
+    int suggestionCount = HunspellLibrary.Hunspell_suggest(handle, nativeSuggestionArray, str);
+    if (suggestionCount == 0) {
+      // Return early and don't try to free the array
+      return new ArrayList<>();
+    }
+    // Ask bridj for a `java.util.List` that wraps `nativeSuggestionArray`
+    List<Pointer<Byte>> nativeSuggestionList = nativeSuggestionArray.get().validElements(suggestionCount).asList();
+    // Convert C Strings to java strings
+    List<String> suggestions = nativeSuggestionList.stream().map(p -> p.getStringAtOffset(0, Pointer.StringType.C, charset)).collect(Collectors.toList());
+
+    // We can free the underlying buffer now because Java's `String` owns it's own memory
+    HunspellLibrary.Hunspell_free_list(handle, nativeSuggestionArray, suggestionCount);
+    return suggestions;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (handle != null) {
+      HunspellLibrary.Hunspell_destroy(handle);
+    }
+  }
+}

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellDictionary.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellDictionary.java
@@ -1,0 +1,47 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2021 Pavel Bakhvalov
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.spelling.hunspell;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+public interface HunspellDictionary extends Closeable {
+  /**
+   * Spellcheck the word
+   * @param word the word to check
+   * @return true if the word is spelled correctly
+   */
+  public boolean spell(String word);
+
+  /**
+   * Add word to the run-time dictionary
+   * @param word the word to add
+   */
+  public void add(String word);
+
+  /**
+   * Search suggestions for the word
+   * @param word the word to get suggestions for
+   * @return the list of suggestions
+   */
+  public List<String> suggest(String word);
+}

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
@@ -61,7 +61,7 @@ public class HunspellRule extends SpellingCheckRule {
   protected static final String FILE_EXTENSION = ".dic";
 
   private volatile boolean needsInit = true;
-  protected volatile Hunspell hunspell = null;
+  protected volatile HunspellDictionary hunspell = null;
 
   private static final Logger logger = LoggerFactory.getLogger(HunspellRule.class);
   private static final ConcurrentLinkedQueue<String> activeChecks = new ConcurrentLinkedQueue<>();
@@ -484,13 +484,13 @@ public class HunspellRule extends SpellingCheckRule {
         hunspell = null;
       } else {
         affPath = Paths.get(path + ".aff");
-        hunspell = Hunspell.getInstance(Paths.get(path + ".dic"), affPath);
+        hunspell = Hunspell.getDictionary(Paths.get(path + ".dic"), affPath);
         addIgnoreWords();
       }
     } else if (new File(shortDicPath + ".dic").exists()) {
       // for dynamic languages
       affPath = Paths.get(shortDicPath + ".aff");
-      hunspell = Hunspell.getInstance(Paths.get(shortDicPath + ".dic"), affPath);
+      hunspell = Hunspell.getDictionary(Paths.get(shortDicPath + ".dic"), affPath);
     }
     if (affPath != null) {
       try(Scanner sc = new Scanner(affPath)){

--- a/languagetool-wikipedia/src/main/java/org/languagetool/dev/RareWordsFinder.java
+++ b/languagetool-wikipedia/src/main/java/org/languagetool/dev/RareWordsFinder.java
@@ -19,6 +19,7 @@
 package org.languagetool.dev;
 
 import org.languagetool.rules.spelling.hunspell.Hunspell;
+import org.languagetool.rules.spelling.hunspell.HunspellDictionary;
 import org.languagetool.rules.spelling.morfologik.MorfologikSpeller;
 
 import java.io.File;
@@ -39,10 +40,10 @@ final class RareWordsFinder {
 
   private static final String dictInClassPath = "/en/hunspell/en_US.dict";
   
-  private final Hunspell hunspell;
+  private final HunspellDictionary hunspell;
   
   private RareWordsFinder(String hunspellBase) throws IOException {
-    hunspell = new Hunspell(Paths.get(hunspellBase + ".dic"), Paths.get(hunspellBase + ".aff"));
+    hunspell = Hunspell.getDictionary(Paths.get(hunspellBase + ".dic"), Paths.get(hunspellBase + ".aff"));
   }
   
   private void run(File input, int minimum) throws FileNotFoundException, CharacterCodingException {


### PR DESCRIPTION
Users of IntelliJ IDEA currently have [problems](https://youtrack.jetbrains.com/issue/IDEA-251286) with `dumonts.hunspell.bindings.HunspellLibrary`. I want to introduce the ability of changing the default Hunspell library to a [pure-java version](https://javadoc.io/doc/org.apache.lucene/lucene-analyzers-common/latest/index.html) of Apache Lucene or any other (to support 32-bit platform for example).

Also, I'm not sure about `Hunspell::add` method, it doesn't seem to have been used anywhere.
