### PR TITLE
Rm69 p v pas corrections

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -38970,7 +38970,7 @@ though, and has since been slightly modified)-->
                     <token postag="A" min="0" skip="1"/>
                     <marker>
                         <token postag="V imp .*" postag_regexp="yes">
-                            <exception postag="V .*" postag_regexp="yes" regexp="yes">^[aêèéeiîouy].*</exception>
+                            <exception postag="V .*" postag_regexp="yes" regexp="yes">[aêèéeiîouy].*</exception>
                             <exception postag="Z.*|R pers.*|V (avoir|etre).*" postag_regexp="yes"/>
                             <exception scope="previous" inflected="yes">ne</exception>
                         </token>
@@ -38988,7 +38988,7 @@ though, and has since been slightly modified)-->
                     <token postag="SENT_START"/>
                     <token postag="A" min="0" skip="1"/>
                     <marker>
-                        <token postag="V imp .*" postag_regexp="yes" regexp="yes">[aâàeéèêioœuyh].*
+                        <token postag="V imp .*" postag_regexp="yes" regexp="yes">[aêèéeiîouy].*
                             <exception postag="Z.*|R pers.*|V (avoir|etre).*" postag_regexp="yes"/>
                             <exception scope="previous" inflected="yes">ne</exception>
                         </token>

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -37775,8 +37775,11 @@ though, and has since been slightly modified)-->
                 <example correction="préférerais">Je <marker>préférerai</marker> ne pas vous voir.</example>
             </rule>
         </rulegroup>
-                <rulegroup id="P_V_PAS" name="négation sans NE">
+        <rulegroup id="P_V_PAS" name="négation sans NE">
             <url>http://www.academie-francaise.fr/ne</url>
+            <antipattern>
+                <token>plus</token>
+            </antipattern>
             <antipattern>
                 <token>
                     <exception postag="V.* (ind|sub|con).*" postag_regexp="yes"/></token>
@@ -37967,7 +37970,7 @@ though, and has since been slightly modified)-->
                 <token>pas</token>
                 <token>cher</token>
             </antipattern>
-            <rule>
+            <rule> <!-- 1 -->
                 <pattern>
                     <marker>
                         <token>j'</token>
@@ -37987,7 +37990,7 @@ though, and has since been slightly modified)-->
                 <example>C'est le dernier message que j'envisage jamais de vous envoyer.</example>
                 <example>J'aime mieux ne pas le dire.</example>
             </rule>
-            <rule>
+            <rule><!-- 2 -->
                 <pattern>
                     <marker>
                         <token>t'
@@ -38009,7 +38012,7 @@ though, and has since been slightly modified)-->
                 <example>Ne t’inquiète pas.</example>
                 <example>Tu t’attends pas te retrouver avec quinze mioches.</example>
             </rule>
-            <rule>
+            <rule><!-- 3 -->
                 <antipattern>
                     <token>vous</token>
                     <token postag="V.* ind pres 2 p" postag_regexp="yes"/>
@@ -38042,7 +38045,7 @@ though, and has since been slightly modified)-->
                 <example>C'est le pire film que j'ai jamais vu.</example>
                 <example>C'est le meilleur repas que j'ai jamais mangé.</example>
             </rule>
-            <rule>
+            <rule><!-- 4 -->
                 <antipattern>
                     <token>vous</token>
                     <token postag="V.* ind pres 2 p" postag_regexp="yes"/>
@@ -38093,7 +38096,7 @@ though, and has since been slightly modified)-->
                 <example>C'est ta mère qui vous laisse pas venir.</example>
                 <example>Pourquoi n'en as-tu reçu aucun avant que nous partions ?</example>
             </rule>
-            <rule>
+            <rule><!-- 5 -->
                 <antipattern>
                     <token postag="Z.*|R pers suj.*" postag_regexp="yes"/>
                     <token postag="R.* obj.*" postag_regexp="yes" regexp="yes">^[àâaêèéeiîoôòóöŌuœäy].*</token>
@@ -38124,7 +38127,7 @@ though, and has since been slightly modified)-->
                 <example>Si Tom y va pas, j’y vais pas.</example>
                 <example>Pensez-vous qu'il me soit jamais possible d'être pris pour un locuteur natif ?</example>
             </rule>
-            <rule>
+            <rule><!-- 6 -->
                 <pattern>
                     <token postag="Z.*|R pers suj.*" postag_regexp="yes"/>
                     <marker>
@@ -38143,7 +38146,7 @@ though, and has since been slightly modified)-->
                 <example correction="ne le lui en a jamais">Il <marker>le lui en a jamais</marker> parlé.</example>
                 <example>Je vous mentionnerai pas mail.</example>
             </rule>
-            <rule>
+            <rule><!-- 7 -->
                 <pattern>
                     <token postag="Z.*|R pers suj.*" postag_regexp="yes">
                         <exception scope="previous" postag="P"/></token>
@@ -38163,7 +38166,7 @@ though, and has since been slightly modified)-->
                 <example>Je ne pense pas que je m'exprimerai jamais comme un locuteur natif.</example>
                 <example>Sortir ce que votre appétit pour elle l'est pas un précédent.</example>
             </rule>
-            <rule>
+            <rule><!-- 8 -->
                 <antipattern>
                     <token postag="R pers suj.*" postag_regexp="yes"/>
                     <token>en</token>
@@ -38192,7 +38195,7 @@ though, and has since been slightly modified)-->
                 <example>Je ne l’y ait pas vu.</example>
                 <example>On en va pas en faire des kilomètres.</example>
             </rule>
-            <rule>
+            <rule><!-- 9 -->
                 <pattern>
                     <marker>
                         <token>j'</token>
@@ -38210,7 +38213,7 @@ though, and has since been slightly modified)-->
                 <example>Le meilleur BASIC ayant jamais existé.</example>
                 <example>Je haussais pas les épaules.</example>
             </rule>
-            <rule>
+            <rule><!-- 10 -->
                 <pattern>
                     <marker>
                         <token>t'
@@ -38228,7 +38231,7 @@ though, and has since been slightly modified)-->
                 <example correction="Tu n'en fais pas|Ne t'en fais pas"><marker>T'en fais pas</marker>.</example>
                 <example correction="Tu n'en as pas|Ne t'en as pas"><marker>T'en as pas</marker>.</example>
             </rule>
-            <rule>
+            <rule><!-- 11 -->
                 <antipattern>
                     <token inflected="yes" regexp="yes">ne|n|l</token>
                     <token postag="R pers obj.*|UNKNOWN" postag_regexp="yes" min="0" max="3"/>
@@ -38318,7 +38321,7 @@ though, and has since been slightly modified)-->
                 <example>Nous ne connaissons pas encore celui qui ne ré-ouvrira pas ses portes dans 3 semaines.</example>
                 <example>Je n,ai aucune dualité en moi.</example>
             </rule>
-            <rule>
+            <rule><!-- 12 -->
                 <antipattern>
                     <token regexp="yes">fau[xt]</token>
                     <token regexp="yes">&mots_negation;</token>
@@ -38376,6 +38379,7 @@ though, and has since been slightly modified)-->
                 </antipattern>
                 <pattern>
                     <token>
+                        <exception postag="SENT_START"/>
                         <exception postag="Z.*|R pers.*|V (avoir|etre).*" postag_regexp="yes"/>
                         <exception scope="previous" inflected="yes">ne</exception> </token>
                     <marker>
@@ -38411,7 +38415,7 @@ though, and has since been slightly modified)-->
                 <example>Vous pouvez saisir pas cher ce produit.</example>
                 <example>Mieux vaut pas de cuillère que pas de soupe.</example>
             </rule>
-            <rule>
+            <rule><!-- 13 -->
                 <pattern>
                     <token>
                         <exception postag="Z.*|R pers suj.*" postag_regexp="yes"/>
@@ -38430,7 +38434,7 @@ though, and has since been slightly modified)-->
                 <suggestion>ne \2 \3 \4 \5 \6 \7</suggestion>
                 <example correction="ne le lui en ont jamais">Les enfants <marker>le lui en ont jamais</marker> parlé.</example>
             </rule>
-            <rule>
+            <rule><!-- 14 -->
                 <antipattern>
                     <token>toi</token>
                     <token>t'</token>
@@ -38522,7 +38526,7 @@ though, and has since been slightly modified)-->
                 <example>J'ai remarqué qu'une Yaris III Phase 2 Hybride se garait pas loin.</example>
                 <example>Vous pourrez pas la suite utiliser le code.</example>
             </rule>
-            <rule>
+            <rule><!-- 15 -->
                 <antipattern>
                     <token>toi</token>
                     <token>t'</token>
@@ -38585,7 +38589,7 @@ though, and has since been slightly modified)-->
                 <example>Les frais d'expédition doivent être payés et vous pourrez pas la suite utiliser le code promo.</example>
                 <example>Plus de salles de nous pouvons pas lui demander comment couvrir ses vraies.</example>
             </rule>
-            <rule>
+            <rule><!-- 16 -->
                 <pattern>
                     <marker>
                         <token>vous
@@ -38602,7 +38606,7 @@ though, and has since been slightly modified)-->
                 <example correction="Vous ne bilez pas|Ne vous bilez pas"><marker>Vous bilez pas</marker>.</example>
                 <example correction="Vous ne voulez pas|Ne vous voulez pas"><marker>Vous voulez pas</marker>.</example>
             </rule>
-            <rule>
+            <rule><!-- 17 -->
                 <pattern>
                     <marker>
                         <token>vous
@@ -38621,7 +38625,7 @@ though, and has since been slightly modified)-->
                 <example correction="Vous n'êtes pas|Ne vous êtes pas"><marker>Vous êtes pas</marker> fatigués, vous ?</example>
                 <example correction="Vous n'inquiétez pas|Ne vous inquiétez pas"><marker>Vous inquiétez pas</marker> pour nous.</example>
             </rule>
-            <rule>
+            <rule><!-- 18 -->
                 <pattern>
                     <marker>
                         <token>vous
@@ -38639,7 +38643,7 @@ though, and has since been slightly modified)-->
                 <example correction="Ne vous en faites pas|Vous n'en faites pas"><marker>Vous en faites pas</marker>.</example>
                 <example correction="Ne vous y arrivez pas|Vous n'y arrivez pas"><marker>Vous y arrivez pas</marker>.</example>
             </rule>
-            <rule>
+            <rule><!-- 19 -->
                 <pattern>
                     <marker>
                         <token>j'</token>
@@ -38658,7 +38662,7 @@ though, and has since been slightly modified)-->
                 <example>C'est le dernier message que j'envisage jamais de vous envoyer.</example>
                 <example>J'aime mieux ne pas le dire.</example>
             </rule>
-            <rule>
+            <rule><!-- 20-->
                 <pattern>
                     <marker>
                         <token inflected="yes">ce
@@ -38674,7 +38678,7 @@ though, and has since been slightly modified)-->
                 <example correction="Ce ne serait pas"><marker>Ce serait pas</marker> intéressant d'aller voir le même film trois fois.</example>
                 <example>C'est une bonne chose que cela ne ce soit pas produit.</example>
             </rule>
-            <rule>
+            <rule><!-- 21 -->
                 <pattern>
                     <marker>
                         <token inflected="yes">ce</token>
@@ -38689,7 +38693,7 @@ though, and has since been slightly modified)-->
                 <suggestion>ce n'\2 \3 \4</suggestion>
                 <example correction="Ce n'est pas"><marker>C'est pas</marker> encore arrivé !</example>
             </rule>
-            <rule>
+            <rule><!-- 22 -->
                 <pattern>
                     <token postag="SENT_START|C.*" postag_regexp="yes"/>
                     <marker>
@@ -38705,7 +38709,7 @@ though, and has since been slightly modified)-->
                 <suggestion>elles ne <match no="2" case_conversion="startlower"/> \3 \4</suggestion>
                 <example correction="Ils ne peuvent pas|Elles ne peuvent pas"><marker>Peuvent pas</marker> dormir comme tout le monde !</example>
             </rule>
-            <rule>
+            <rule><!-- 23 -->
                 <pattern>
                     <token postag="SENT_START|C.*" postag_regexp="yes"/>
                     <marker>
@@ -38721,7 +38725,7 @@ though, and has since been slightly modified)-->
                 <suggestion>elles n'<match no="2" case_conversion="startlower"/> \3 \4</suggestion>
                 <example correction="Ils n'arrivent pas|Elles n'arrivent pas"><marker>Arrivent pas</marker> à dormir comme tout le monde !</example>
             </rule>
-            <rule>
+            <rule><!-- 24-->
                 <pattern>
                     <token postag="SENT_START"/>
                     <marker>
@@ -38737,7 +38741,7 @@ though, and has since been slightly modified)-->
                 <suggestion>je ne <match no="2" case_conversion="startlower"/> \3 \4</suggestion>
                 <example correction="Je ne connais pas"><marker>Connais pas</marker>.</example>
             </rule>
-            <rule>
+            <rule><!-- 25 -->
                 <pattern>
                     <token postag="SENT_START"/>
                     <marker>
@@ -38752,7 +38756,7 @@ though, and has since been slightly modified)-->
                 <suggestion>elles n'<match no="2" case_conversion="startlower"/> \3 \4 \5</suggestion>
                 <example correction="Ils n'en sont pas|Elles n'en sont pas"><marker>En sont pas</marker> à l'eau.</example>
             </rule>
-            <rule>
+            <rule><!-- 26 -->
                 <pattern>
                     <token>
                         <exception postag="Z.*|R pers suj.*" postag_regexp="yes"/>
@@ -38772,7 +38776,7 @@ though, and has since been slightly modified)-->
                 <suggestion>n'\4 \5 \6</suggestion>
                 <example correction="tu n'écoute pas|n'écoute pas">Toi <marker>t'écoute pas</marker> la radio.</example>
             </rule>
-            <rule>
+            <rule><!-- 27 -->
                 <antipattern>
                     <token>en</token>
                     <token postag="V.*" postag_regexp="yes"/>
@@ -38798,7 +38802,7 @@ though, and has since been slightly modified)-->
                 <example correction="n'y">Si Tom <marker>y</marker> va pas, je n'y vais pas.</example>
                 <example>Sur l’arrogance, on en va pas en faire des kilomètres.</example>
             </rule>
-            <rule>
+            <rule><!-- 28 -->
                 <pattern>
                     <marker>
                         <token inflected="yes">ce
@@ -38814,7 +38818,7 @@ though, and has since been slightly modified)-->
                 <suggestion>ce n'\2 \3 \4 \5</suggestion>
                 <example correction="Ce n'en est pas"><marker>C'en est pas</marker> une !</example>
             </rule>
-            <rule>
+            <rule><!-- 29 -->
                 <pattern>
                     <marker>
                         <token>t'
@@ -38837,7 +38841,7 @@ though, and has since been slightly modified)-->
                 <example>S'il te plaît, dépose le au courrier si ça ne te t'éloigne pas de ton chemin.</example>
                 <example>Tu t’attends pas te retrouver avec quinze mioches.</example>
             </rule>
-            <rule>
+            <rule><!-- 30 -->
                 <pattern>
                     <marker>
                         <token>j'</token>
@@ -38853,7 +38857,7 @@ though, and has since been slightly modified)-->
                 <suggestion>je n'\2</suggestion>
                 <example correction="Je n'y"><marker>J'y</marker> vais pas.</example>
             </rule>
-            <rule>
+            <rule><!-- 31 -->
                 <antipattern>
                     <token>en</token>
                     <token postag="V.*" postag_regexp="yes"/>
@@ -38921,7 +38925,7 @@ though, and has since been slightly modified)-->
                 <example>Je ne m y connais pas suffisamment.</example>
                 <example>Ils ne délivrent aucun message et n‘en transgressent pas non plus.</example>
             </rule>
-            <rule>
+            <rule><!-- 32 -->
                 <antipattern>
                     <token>en</token>
                     <token postag="V.*" postag_regexp="yes"/>
@@ -38960,22 +38964,42 @@ though, and has since been slightly modified)-->
                 <suggestion>ne</suggestion>
                 <example correction="n'en|ne">Certains <marker>en</marker> sont pas utilisés.</example>
             </rule>
-            <rule default="temp_off">
+            <rule default="temp_off"> <!-- 33 -->
                 <pattern>
                     <token postag="SENT_START"/>
                     <token postag="A" min="0" skip="1"/>
                     <marker>
                         <token postag="V imp .*" postag_regexp="yes">
+                            <exception postag="V .*" postag_regexp="yes" regexp="yes">^[aêèéeiîouy].*</exception>
                             <exception postag="Z.*|R pers.*|V (avoir|etre).*" postag_regexp="yes"/>
                             <exception scope="previous" inflected="yes">ne</exception>
                         </token>
                         <token postag="A" min="0" max="2"/>
-                    <token regexp="yes">&mots_negation;</token>
+                        <token regexp="yes">&mots_negation;</token>
+                    </marker>
+                </pattern>
+                <message>Un adverbe de négation doit être ajouté afin d'obtenir une négation complète.</message>
+                <suggestion>ne <match no="3" include_skipped="all"/> <match no="4" include_skipped="all"/> \5</suggestion>
+                <example correction="ne prenez pas">Surtout, <marker>prenez pas</marker> l'argenterie.</example>
+                <example>Surtout, arrivez pas avant midi.</example>
+            </rule>
+            <rule default="temp_off"> <!-- 34 -->
+                <pattern>
+                    <token postag="SENT_START"/>
+                    <token postag="A" min="0" skip="1"/>
+                    <marker>
+                        <token postag="V imp .*" postag_regexp="yes" regexp="yes">[aâàeéèêioœuyh].*
+                            <exception postag="Z.*|R pers.*|V (avoir|etre).*" postag_regexp="yes"/>
+                            <exception scope="previous" inflected="yes">ne</exception>
+                        </token>
+                        <token postag="A" min="0" max="2"/>
+                        <token regexp="yes">&mots_negation;</token>
                     </marker>
                 </pattern>
                 <message>Un adverbe de négation doit être ajouté afin d'obtenir une négation complète.</message>
                 <suggestion>n'<match no="3" include_skipped="all"/> <match no="4" include_skipped="all"/> \5</suggestion>
                 <example correction="n'arrivez pas">Surtout, <marker>arrivez pas</marker> avant midi.</example>
+                <example>Surtout, prenez pas l'argenterie.</example>
             </rule>
         </rulegroup>
         <rule id="DOUBLE_NEG" name="Double négation">


### PR DESCRIPTION
corrected small details + adding an AP for any use with 'plus' which is confusing, after reviewing today's diff, it appears that 90% of FP results are 'plus' results

- _depuis ce jour, il a plus d'argent_ 
could both mean :
- - _depuis ce jour, il n'a plus du tout d'argent_ 
- - _depuis ce jour, il a encore plus d'argent_ 

