### PR TITLE
[fr] add AVERER

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -4500,6 +4500,7 @@ though, and has since been slightly modified)-->
             <suggestion>cirrhose</suggestion>
             <example correction="cirrhose"><marker>cirrhose du foie</marker></example>
         </rule>
+<!-- SAVERER_FAUX, SAVERER_VRAI , AVERE(premium1) have been merged in AVERER
         <rule id="SAVERER_VRAI" name="s’avérer vrai">
             <pattern>
                 <token inflected="yes" skip="2">avérer</token>
@@ -4509,6 +4510,7 @@ though, and has since been slightly modified)-->
             <suggestion>\1 exact</suggestion>
             <example correction="avérer exact">s’<marker>avérer vrai</marker></example>
         </rule>
+-->
         <rule id="ABOLIR_ENTIEREMENT" name="abolir entièrement">
             <pattern>
                 <token inflected="yes" skip="4">abolir</token>
@@ -59192,6 +59194,36 @@ though, and has since been slightly modified)-->
         </rule>
     </category>
     <category id="CAT_TOURS_CRITIQUES" name="Tours critiqués divers (barbarismes, impropriétés, solécismes, etc.)">
+        <rulegroup id="AVERER" name="identique que(à)" default="temp_off">
+             <rule>
+                <pattern>
+                    <marker>
+                        <token regexp="yes" min="0">[tsmn]'</token>
+                        <token postag="V etre .*" postag_regexp="yes"/>
+                        <token postag="V .*" postag_regexp="yes" inflected="yes" skip="1">avérer</token>
+                    </marker>
+                    <token inflected="yes">faux<|erroné|incorrect|injuste|inexact</token>
+                </pattern>
+                <message>Cette expression est un oxymore, 'avérer' signifie 'reconnaître comme vrai'.</message>
+                <suggestion><match no="1" regexp_match="([tsm])'" regexp_replace="$1e"/> <match no="2" postag="V.*" postag_regexp="yes">révéler</match></suggestion>
+                <example correction="révélée">Sa conclusion s'est <marker>avérée</marker> fausse.</example>
+                <example correction="se révèle">Sa conclusion <marker>s'avère</marker> fausse.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <marker>
+                        <token regexp="yes" min="0">[tsm]'</token>
+                        <token postag="V .*" postag_regexp="yes" inflected="yes" skip="1">avérer</token>
+                        <token inflected="yes" regexp="yes">vrai|exact|juste|authentique</token>
+                    </marker>
+                </pattern>
+                <message>Cette expression est un pléonasme, 'avérer' signifie déjà 'reconnaître comme vrai'.</message>
+                <suggestion><match no="1" regexp_match="([tsm])'" regexp_replace="$1e"/> <match no="2" postag="V.*" postag_regexp="yes">révéler</match> \3</suggestion>
+                <suggestion>\1\2</suggestion>
+                <example correction="révélée vraie|avérée">Sa conclusion s'est <marker>avérée vraie</marker>.</example>
+                <example correction="se révèle vraie|s'avère">Sa conclusion <marker>s'avère vraie</marker>.</example>
+            </rule>
+        </rulegroup>
         <rulegroup id="NEGATION_NULLE_PART" name="négation nulle part" default="temp_off">
              <rule>
             <antipattern>
@@ -64056,6 +64088,7 @@ though, and has since been slightly modified)-->
                 <example correction="pis-aller"><marker>pire-aller</marker></example>
             </rule>
         </rulegroup>
+<!-- SAVERER_FAUX, SAVERER_VRAI , AVERE(premium1) have been merged in AVERER
         <rule id="SAVERER_FAUX" name="s’avérer faux">
             <pattern>
                 <marker>
@@ -64067,6 +64100,7 @@ though, and has since been slightly modified)-->
             <suggestion><match no="1" postag="(V.*)" postag_regexp="yes" postag_replace="$1">révéler</match></suggestion>
             <example correction="révélée">Sa conclusion s'est <marker>avérée</marker> fausse.</example>
         </rule>
+-->
         <rulegroup id="SACCAPARER_DE" name="s’accaparer de">
             <rule>
                 <pattern>

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/grammar.xml
@@ -59199,10 +59199,9 @@ though, and has since been slightly modified)-->
                 <pattern>
                     <marker>
                         <token regexp="yes" min="0">[tsmn]'</token>
-                        <token postag="V etre .*" postag_regexp="yes"/>
                         <token postag="V .*" postag_regexp="yes" inflected="yes" skip="1">avérer</token>
                     </marker>
-                    <token inflected="yes">faux<|erroné|incorrect|injuste|inexact</token>
+                    <token inflected="yes" regexp="yes">faux|erroné|incorrect|injuste|inexact</token>
                 </pattern>
                 <message>Cette expression est un oxymore, 'avérer' signifie 'reconnaître comme vrai'.</message>
                 <suggestion><match no="1" regexp_match="([tsm])'" regexp_replace="$1e"/> <match no="2" postag="V.*" postag_regexp="yes">révéler</match></suggestion>


### PR DESCRIPTION
I've seen that the app was correcting some uses of "avérer" with AVERE(premium1) instead of SAVERER_FAUX(open source), and some cases were not covered
I commented SAVERER_FAUX(os), SAVERER_VRAI(os) , AVERE(premium1) until the new merged rulegroup has been confirmed by night diff