### PR TITLE
Randau statt Radau

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/prohibit.txt
@@ -6722,3 +6722,4 @@ Glomärulär/A
 Brodkörbchen/S
 Brodkorb/S
 Brodkörbe/N
+Randau


### PR DESCRIPTION
Die richtige Schreibweise: https://www.duden.de/rechtschreibung/Radau