### PR TITLE
fix for Wrong sentence splitting #5688

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
@@ -1134,6 +1134,14 @@
 <beforebreak>\bU\.</beforebreak>
 <afterbreak>[SK]\b</afterbreak>
 </rule>
+<rule break="no"><!-- I.S (no dot at end) -->
+<beforebreak>\bI\.</beforebreak>
+<afterbreak>S\b</afterbreak>
+</rule>
+<rule break="no"><!-- M.Z (no dot at end) -->
+<beforebreak>\bM\.</beforebreak>
+<afterbreak>Z\b</afterbreak>
+</rule>
 <rule break="no"><!-- URLs without "www."-->
 <beforebreak>\b(https?|ftp|file|chrome|chromium|android|(chrome|moz)\-extension):///?[A-Za-z0-9\-]+\.</beforebreak>
 <afterbreak>[A-Za-z0-9\-]+(\.|\b)</afterbreak>

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/tokenizers/EnglishSRXSentenceTokenizerTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/tokenizers/EnglishSRXSentenceTokenizerTest.java
@@ -41,6 +41,8 @@ public class EnglishSRXSentenceTokenizerTest {
   @Test
   public void testTokenize() {
     // incomplete sentences, need to work for on-thy-fly checking of texts:
+    testSplit("What is the I.S?");
+    testSplit("Where are the I.S and the M.Z notes? ");
     testSplit("Here's a");
     testSplit("Here's a sentence. ", "And here's one that's not comp");
     testSplit("Or did you install it (i.e. MS Word) yourself?");


### PR DESCRIPTION
ran all the unit test for class EnglishSRXSentenceTokenizerTest.java
Also ran "mvn clean test" on the whole project.

Added logic for explicitly handling rules based on the bug.
Also added unit tests corresponding to the bug reported.