### PR TITLE
discard lazy suggestions when timeout is reached

### DIFF
--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -478,6 +478,10 @@ abstract class TextChecker {
       }
     }
 
+    // no lazy computation at later points (outside of timeout enforcement)
+    // e.g. ruleMatchesSoFar can have matches without computeLazySuggestedReplacements called yet
+    res.forEach(checkResults -> checkResults.getRuleMatches().forEach(RuleMatch::discardLazySuggestedReplacements));
+
     setHeaders(httpExchange);
 
     List<RuleMatch> hiddenMatches = new ArrayList<>();


### PR DESCRIPTION
computation of suggestions from ruleMatchesSoFar with allowIncompleteResults=true took place in server thread
with no timeout set; could lead to all server threads being blocked causing http timeouts of all requests