### PR TITLE
Compute Premium only once

### DIFF
--- a/languagetool-server/src/main/java/org/languagetool/server/PipelinePool.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/PipelinePool.java
@@ -258,9 +258,12 @@ class PipelinePool {
       }
       //System.out.println("Enabled " + premiumEnabled + " premium rules, disabled " + otherDisabled + " non-premium rules.");
     } else if (!params.premium && !params.enableHiddenRules) { // compute premium matches locally to use as hidden matches
-      for (Rule rule : lt.getAllActiveRules()) {
-        if (Premium.get().isPremiumRule(rule)) {
-          lt.disableRule(rule.getFullId());
+      Premium premium = Premium.get();
+      if (!(premium instanceof PremiumOff)) {
+        for (Rule rule : lt.getAllActiveRules()) {
+          if (premium.isPremiumRule(rule)) {
+            lt.disableRule(rule.getFullId());
+          }
         }
       }
     }


### PR DESCRIPTION
This PR has two performance improvements:

1. It calls `Premium.get()` only once.
Reflection is extremely slow, and running [this](https://github.com/languagetool-org/languagetool/blob/master/languagetool-core/src/main/java/org/languagetool/Premium.java#L49) when evaluating every single rule is really expensive

```java
      Class<?> aClass = JLanguageTool.getClassBroker().forName(className);
      Constructor<?> constructor = aClass.getConstructor();
      return (Premium)constructor.newInstance();
```
2. If the class is actually an instance of `PremiumOff`, [all rules will be evaluated to false anyway](https://github.com/languagetool-org/languagetool/blob/master/languagetool-core/src/main/java/org/languagetool/PremiumOff.java#L33), so there's no need on evaluating them.

In local testing, this reduces 6 seconds locally every time a pipeline is created (for Catalan)