### PR TITLE
optimization for RuleMatch constructor

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/RuleMatch.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RuleMatch.java
@@ -32,7 +32,6 @@ import org.languagetool.tools.StringTools;
 import java.net.URL;
 import java.util.*;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -153,12 +152,18 @@ public class RuleMatch implements Comparable<RuleMatch> {
     this.message = Objects.requireNonNull(message);
     this.shortMessage = shortMessage;
     // extract suggestion from <suggestion>...</suggestion> in message:
-    Matcher matcher = SUGGESTION_PATTERN.matcher(message + suggestionsOutMsg);
-    int pos = 0;
     LinkedHashSet<SuggestedReplacement> replacements = new LinkedHashSet<>();
-    while (matcher.find(pos)) {
-      pos = matcher.end();
-      String replacement = matcher.group(1);
+    String startTag = "<suggestion>";
+    String endTag = "</suggestion>";
+    String suggestion = message + (suggestionsOutMsg != null ? suggestionsOutMsg : "");
+    int pos = suggestion.indexOf(startTag);
+    while (pos != -1) {
+      int end = suggestion.indexOf(endTag, pos);
+      if (end == -1) {
+        break;
+      }
+      String replacement = suggestion.substring(pos + startTag.length(), end);
+      pos = end + endTag.length();
       if (replacement.contains(PatternRuleMatcher.MISTAKE)) {
         continue;
       }
@@ -166,15 +171,9 @@ public class RuleMatch implements Comparable<RuleMatch> {
         replacement = StringTools.uppercaseFirstChar(replacement);
       }
       replacements.add(new SuggestedReplacement(replacement));
-      /*if (getRule() instanceof AbstractPatternRule) {
-        String covered = sentence.getText().substring(fromPos, toPos);
-        if (covered.equals(repl.getReplacement()) && ((AbstractPatternRule) getRule()).getFilter() == null) {
-          // only for development:
-          //System.out.println("WARN: suggestion == covered text for rule " + getRule().getFullId() + ", covered: " + covered + ", " + sentence.getText());
-          System.out.println("WARN: suggestion == covered text for rule " + getRule().getFullId());
-        }
-      }*/
+      pos = suggestion.indexOf(startTag, pos);
     }
+
     this.sentence = sentence;
 
     suggestedReplacements = Suppliers.ofInstance(new ArrayList<>(replacements));

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -23071,9 +23071,8 @@ tokenizer spreadsheet in the forum	     -->
       </pattern>
       <message>Frase-feita. Procure alternativas.</message>
         <suggestion><match no='1' postag='V.+' postag_regexp='yes'>fingir</match> que não <match no='1' postag='V.+' postag_regexp='yes'>ver</match></suggestion>
-        <suggestion>relevar
-egligenciar</suggestion>
-      <example correction='fingi que não vi'><marker>fiz vista grossa</marker>.</example>
+        <suggestion>relevar egligenciar</suggestion>
+      <example correction='fingi que não vi|relevar egligenciar'><marker>fiz vista grossa</marker>.</example>
     </rule>
     <rule id='CLICHE_3103_FINCAR' name='Clichê: Fincar o pé'>
       <pattern>


### PR DESCRIPTION
use indexOf + substrings instead regex to find suggestion tags, ~3-4 times faster
unresponsive servers were stuck in this code according to some thread dumps
