### PR TITLE
getBuildDate: tolerate jars without manifests

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -132,12 +132,12 @@ public class JLanguageTool {
       }
       Object connObj = res.openConnection();
       if (connObj instanceof JarURLConnection) {
-        JarURLConnection conn = (JarURLConnection) connObj;
-        Manifest manifest = conn.getManifest();
-        return manifest.getMainAttributes().getValue("Implementation-Date");
-      } else {
-        return null;
+        Manifest manifest = ((JarURLConnection) connObj).getManifest();
+        if (manifest != null) {
+          return manifest.getMainAttributes().getValue("Implementation-Date");
+        }
       }
+      return null;
     } catch (IOException e) {
       throw new RuntimeException("Could not get build date from JAR", e);
     }


### PR DESCRIPTION
IntelliJ now packs its Grazie plugin together with LanguageTool
and other dependencies into a single fat jar which may have no manifest.
Failing with a NPE in the static initializer isn't the best way to deal with that.