### PR TITLE
allow tab or semicolon in files: multiword.txt, added.txt, removed.txt

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/synthesis/ManualSynthesizer.java
+++ b/languagetool-core/src/main/java/org/languagetool/synthesis/ManualSynthesizer.java
@@ -85,9 +85,9 @@ public final class ManualSynthesizer {
           continue;
         }
         line = line.replaceFirst("#.*", "").trim();
-        String[] parts = line.split("\t");
+        String[] parts = line.split("[\t;]");
         if (parts.length != 3) {
-          throw new IOException("Unknown line format when loading manual synthesizer dictionary: " + line);
+          throw new IOException("Unknown line format when loading manual synthesizer dictionary, expected three tab-separated or semicolon-separated fields: : " + line);
         }
 
         String form = parts[0];

--- a/languagetool-core/src/main/java/org/languagetool/tagging/ManualTagger.java
+++ b/languagetool-core/src/main/java/org/languagetool/tagging/ManualTagger.java
@@ -68,9 +68,9 @@ public class ManualTagger implements WordTagger {
           throw new RuntimeException("Non-breaking space found in line '" + line + "', please remove it");
         }
         line = StringUtils.substringBefore(line, "#").trim();
-        String[] parts = line.split("\t");
+        String[] parts = line.split("[\t;]");
         if (parts.length != 3) {
-          throw new IOException("Unknown line format when loading manual tagger dictionary, expected three tab-separated fields: '" + line + "'");
+          throw new IOException("Unknown line format when loading manual tagger dictionary, expected three tab-separated or semicolon-separated fields: '" + line + "'");
         }
         String form = parts[0];
 

--- a/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/MultiWordChunker.java
+++ b/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/MultiWordChunker.java
@@ -106,10 +106,10 @@ public class MultiWordChunker extends AbstractDisambiguator {
     try (InputStream stream = JLanguageTool.getDataBroker().getFromResourceDirAsStream(filename)) {
       List<String> posTokens = loadWords(stream);
       for (String posToken : posTokens) {
-        String[] tokenAndTag = posToken.split("\t");
+        String[] tokenAndTag = posToken.split("[\t;]");
         if (tokenAndTag.length != 2) {
           throw new RuntimeException(
-              "Invalid format in " + filename + ": '" + posToken + "', expected two tab-separated parts");
+              "Invalid format in " + filename + ": '" + posToken + "', expected two tab-separated or semicolon-separated parts");
         }
         List<String> tokens = new ArrayList<>();
         String originalToken = interner.computeIfAbsent(tokenAndTag[0], Function.identity());

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
@@ -112,4 +112,4 @@ challengée	challenger	V ppa f s
 challengées	challenger	V ppa f p
 challengés	challenger	V ppa m p
 1ʳᵉ	1ᵉʳ	J f s
-start-up	start-up	N f sp
+start-up;start-up;N f sp

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/multiwords.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/multiwords.txt
@@ -1,5 +1,5 @@
 #French multiwords file used for chunking
-n'importe quoi	A
+n'importe quoi;A
 n'importe qui	A
 n'importe quel	A
 noir et blanc	J e sp

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/removed.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/removed.txt
@@ -7,4 +7,4 @@
 environ	environ	N m s
 1ʳᵉ	1ʳᵉ	J f s
 causa	causa	A
-start-up	start-up	N f s
+start-up;start-up;N f s


### PR DESCRIPTION
Editing manually tab-separated files is annoying and frequently a waste of time because of errors and confusions. 
I suggest allowing both tabs and semicolons. It is not "beautiful", but it can be useful. In the future, we can replace all tabs with semicolons in all files. 