### PR TITLE
[en] add one simple AP to HYDRA_LEO_ARE_IS as a test

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/remote-rule-filters.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/remote-rule-filters.xml
@@ -27,6 +27,15 @@ To ignore a remote rule match, set the <marker> so that it exactly covers the te
 -->
 <rules lang="en" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/remote-rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <category name="Machine learning rules" id="AI_RULES">
+        <rule id="AI_HYDRA_LEO_CPT_ARE_IS" name="">
+            <pattern>
+                <token>thou</token>
+                <marker>
+                    <token>are</token>
+                </marker>
+            </pattern>
+            <example correction="">Some scholars rely on John 8:57: "thou <marker>are</marker> not yet fifty years old", making the earliest possible year for Jesus's birth c. 18 BC.</example>
+        </rule>
         <rulegroup id="AI_HYDRA_LEO_CP_YOU_YOUR" name="">
             <rule>
                 <pattern>


### PR DESCRIPTION
@udomai 
@s-burst 

I have no clue if I'm doing this correctly, so I'm opening a PR with a super simple test AP.
There were a few disable contexts for 'thou', and even at the threshold that it's currently at, the rule suggests 'is' in this sentence:

> Some scholars rely on John 8:57: "thou are not yet fifty years old", making the earliest possible year for Jesus's birth c. 18 BC.

I have a lot more APs I want to write, one of them being to ignore things in quotes. 
So, this example will be subsumed into that anyway. But it is a test AP for now.

If this looks correct, please merge and I will add the rest. Thanks!