### PR TITLE
[en] improve EN_REPEATEDWORDS_NEED

### DIFF
--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishRepeatedWordsRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishRepeatedWordsRule.java
@@ -44,7 +44,7 @@ public class EnglishRepeatedWordsRule extends AbstractRepeatedWordsRule{
 
   private static final List<List<PatternToken>> ANTI_PATTERNS = Arrays.asList(
     Arrays.asList(
-      token("need"),   // "I still need -> require to sign-in"
+      tokenRegex("need(s|ed|ing)?"),   // "I still need -> require to sign-in"
       token("to")
     ));
 

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishRepeatedWordsRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishRepeatedWordsRule.java
@@ -44,7 +44,7 @@ public class EnglishRepeatedWordsRule extends AbstractRepeatedWordsRule{
 
   private static final List<List<PatternToken>> ANTI_PATTERNS = Arrays.asList(
     Arrays.asList(
-      tokenRegex("need"),   // "I still need -> require to sign-in"
+      token("need"),   // "I still need -> require to sign-in"
       token("to")
     ));
 

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishRepeatedWordsRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishRepeatedWordsRule.java
@@ -18,22 +18,44 @@
  */
 package org.languagetool.rules.en;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.function.Supplier;
 
 import org.languagetool.AnalyzedTokenReadings;
 import org.languagetool.language.AmericanEnglish;
 import org.languagetool.rules.AbstractRepeatedWordsRule;
 import org.languagetool.rules.SynonymsData;
+import org.languagetool.rules.patterns.PatternToken;
 import org.languagetool.synthesis.Synthesizer;
 import org.languagetool.synthesis.en.EnglishSynthesizer;
+import org.languagetool.tagging.disambiguation.rules.DisambiguationPatternRule;
+
+import static org.languagetool.rules.patterns.PatternRuleBuilderHelper.token;
+import static org.languagetool.rules.patterns.PatternRuleBuilderHelper.tokenRegex;
 
 public class EnglishRepeatedWordsRule extends AbstractRepeatedWordsRule{
   
   private static final EnglishSynthesizer synth = new EnglishSynthesizer(new AmericanEnglish());
 
+  private final Supplier<List<DisambiguationPatternRule>> antiPatterns;
+
+  private static final List<List<PatternToken>> ANTI_PATTERNS = Arrays.asList(
+    Arrays.asList(
+      tokenRegex("need"),   // "I still need -> require to sign-in"
+      token("to")
+    ));
+
+  @Override
+  public List<DisambiguationPatternRule> getAntiPatterns() {
+    return antiPatterns.get();
+  }
+
   public EnglishRepeatedWordsRule(ResourceBundle messages) {
     super(messages, new AmericanEnglish());
+    antiPatterns = cacheAntiPatterns(new AmericanEnglish(), ANTI_PATTERNS);
     //super.setDefaultTempOff();
   }
   

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishRepeatedWordsRuleTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishRepeatedWordsRuleTest.java
@@ -49,6 +49,7 @@ public class EnglishRepeatedWordsRuleTest {
     assertCorrectText("This is a new experience. Happy New Year!");
     assertCorrectText("This was needed. There is a need to do it.");
     assertCorrectText("It needs to be done. That also needed to be done.");
+    assertCorrectText("I still need to sign-in somewhere. You need to sign-in too.");
     
     assertCorrectText("Asia Global Crossing Ltd. Global Crossing and Asia Global Crossing.");
     assertCorrectText("I suggested that, but he also suggests that.");

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishRepeatedWordsRuleTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishRepeatedWordsRuleTest.java
@@ -47,8 +47,6 @@ public class EnglishRepeatedWordsRuleTest {
   public void testRule() throws IOException {   
     
     assertCorrectText("This is a new experience. Happy New Year!");
-    assertCorrectText("This was needed. There is a need to do it.");
-    assertCorrectText("It needs to be done. That also needed to be done.");
     assertCorrectText("I still need to sign-in somewhere. You need to sign-in too.");
     
     assertCorrectText("Asia Global Crossing Ltd. Global Crossing and Asia Global Crossing.");


### PR DESCRIPTION
Added a first test AP for 'need to', as 'require to' is an odd suggestion:

I still need to sign-in somewhere. You need to sign-in too. →
I still need to sign-in somewhere. You **require** to sign-in too.

However, I couldn't get tokenRegex("need(s|ed|ing)?") or even tokenRegex("need|needs|needed|needing") to work, so it currently only works for VBP.

Questions, comments, concerns, tips?
@jaumeortola @udomai 
