### PR TITLE
[en] add 'freestanding' to en-GB dict

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling_en-GB.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling_en-GB.txt
@@ -2137,6 +2137,7 @@ franchisor
 franchisors
 fraternized
 fraternizers
+freestanding
 fundraised
 fustianise
 fustianised


### PR DESCRIPTION
Add 'freestanding' to spelling_en-GB.tx for Premium [3489](https://github.com/languagetooler-gmbh/languagetool-premium/issues/3489)