### PR TITLE
fixed thread pool configuration, new options

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -1141,8 +1141,12 @@ public class JLanguageTool {
         } else {
           task = rule.run(analyzedSentences, textSessionID);
         }
-        remoteRuleTasks.add(task);
-        jLanguageToolPool.submit(task);
+
+        try {
+          jLanguageToolPool.submit(task);
+          remoteRuleTasks.add(task);
+        } catch (RejectedExecutionException ignored) {
+        }
       }
     }
   }

--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -1073,7 +1073,7 @@ public class JLanguageTool {
       }
 
       // cancel any remaining tasks (e.g. after interrupt because request timed out)
-      remoteRuleTasks.forEach(t -> t.cancel(true));
+      remoteRuleTasks.stream().filter(Objects::nonNull).forEach(t -> t.cancel(true));
     }
   }
 

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
@@ -248,6 +248,8 @@ public abstract class RemoteRule extends Rule {
             status = RemoteRuleMetrics.RequestResult.TIMEOUT;
             logger.info("Timed out while fetching results for remote rule " + ruleId + ", tried " + (i + 1) + " times, timeout: " + timeout + "ms" , e);
             timeoutTotal.get(ruleId).addAndGet(timeout);
+          } else if (e instanceof RejectedExecutionException) {
+            status = RemoteRuleMetrics.RequestResult.ERROR;
           } else {
             status = RemoteRuleMetrics.RequestResult.ERROR;
             logger.warn("Error while fetching results for remote rule " + ruleId + ", tried " + (i + 1) + " times, timeout: " + timeout + "ms" , e);

--- a/languagetool-core/src/main/java/org/languagetool/tools/LtThreadPoolExecutor.java
+++ b/languagetool-core/src/main/java/org/languagetool/tools/LtThreadPoolExecutor.java
@@ -26,18 +26,31 @@ import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.*;
+import java.util.stream.Stream;
 
 /**
  * ThreadPoolExecutor with some stopping logic for OOM and metrics tracking
- *
  */
 class LtThreadPoolExecutor extends ThreadPoolExecutor {
 
-  private static final Gauge activeThreads = Gauge.build("languagetool_threadpool_active_threads", "Running threads by threadpool")
-      .labelNames("pool").register();
-  private static final Gauge queueSize = Gauge.build("languagetool_threadpool_queue_size", "Queue size by threadpool").labelNames("pool").register();
-  private static final Gauge maxQueueSize = Gauge.build("languagetool_threadpool_max_queue_size", "Queue capacity by threadpool").labelNames("pool").register();
+//  private static final Gauge activeThreads = Gauge.build("languagetool_threadpool_active_threads", "Running threads by threadpool")
+//    .labelNames("pool").register();
+  private static final Gauge queueSize = Gauge.build("languagetool_threadpool_queue_size", "Queue size by threadpool")
+    .labelNames("pool").register();
+  private static final Gauge maxQueueSize = Gauge.build("languagetool_threadpool_max_queue_size", "Queue capacity by threadpool")
+    .labelNames("pool").register();
+  private static final Gauge largestPoolSize = Gauge.build("languagetool_threadpool_largest_queue_size", "The largest number of threads that have ever simultaneously been in the pool")
+    .labelNames("pool").register();
+  private static final Gauge waitingThreads = Gauge.build("languagetool_threadpool_waiting_threads", "Waiting threads by threadpool")
+    .labelNames("pool").register();
+  private static final Gauge timedWaitingThreads = Gauge.build("languagetool_threadpool_timed_waiting_threads", "Timed_Waiting threads by threadpool")
+    .labelNames("pool").register();
+  private static final Gauge blockingThreads = Gauge.build("languagetool_threadpool_blocking_threads", "Blocking threads by threadpool")
+    .labelNames("pool").register();
+  private static final Gauge runningThreads = Gauge.build("languagetool_threadpool_running_threads", "Running threads by threadpool")
+    .labelNames("pool").register();
 
   @Getter
   private final String name;
@@ -66,7 +79,9 @@ class LtThreadPoolExecutor extends ThreadPoolExecutor {
   @Override
   protected void afterExecute(Runnable r, Throwable t) {
     super.afterExecute(r, t);
-    activeThreads.labels(name).dec();
+    updateThreadGauges();
+//    activeThreads.labels(name).dec();
+//    waitingThreads.labels(name).inc();
     queueSize.labels(name).set(queue.size());
     // inherited from removed StoppingThreadPoolExecutor in org.languagetool.server.Server
     if (t != null && t instanceof OutOfMemoryError) {
@@ -80,7 +95,38 @@ class LtThreadPoolExecutor extends ThreadPoolExecutor {
   @Override
   protected void beforeExecute(Thread t, Runnable r) {
     super.beforeExecute(t, r);
-    activeThreads.labels(name).inc();
-    queueSize.labels(name).set(queue.size());
+    updateThreadGauges();
+//    activeThreads.labels(name).inc();
+//    waitingThreads.labels(name).dec();
+  }
+
+  @NotNull
+  @Override
+  public Future<?> submit(@NotNull Runnable runnable) {
+    largestPoolSize.labels(name).set(getLargestPoolSize());
+    return super.submit(runnable);
+  }
+
+  @NotNull
+  @Override
+  public <T> Future<T> submit(@NotNull Runnable runnable, T t) {
+    largestPoolSize.labels(name).set(getLargestPoolSize());
+    return super.submit(runnable, t);
+  }
+
+  @NotNull
+  @Override
+  public <T> Future<T> submit(@NotNull Callable<T> callable) {
+    largestPoolSize.labels(name).set(getLargestPoolSize());
+    return super.submit(callable);
+  }
+
+  private void updateThreadGauges() {
+    Set<Thread> threads = Thread.getAllStackTraces().keySet();
+    Stream<Thread> filtered = threads.stream().filter(thread -> thread.getName().startsWith(name));
+    blockingThreads.labels(name).set(filtered.filter(thread -> thread.getState() == Thread.State.BLOCKED).count());
+    waitingThreads.labels(name).set(filtered.filter(thread -> thread.getState() == Thread.State.WAITING).count());
+    timedWaitingThreads.labels(name).set(filtered.filter(thread -> thread.getState() == Thread.State.TIMED_WAITING).count());
+    runningThreads.labels(name).set(filtered.filter(thread -> thread.getState() == Thread.State.RUNNABLE).count());
   }
 }

--- a/languagetool-core/src/main/java/org/languagetool/tools/LtThreadPoolExecutor.java
+++ b/languagetool-core/src/main/java/org/languagetool/tools/LtThreadPoolExecutor.java
@@ -22,6 +22,7 @@
 package org.languagetool.tools;
 
 import io.prometheus.client.Gauge;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Queue;
@@ -38,6 +39,7 @@ class LtThreadPoolExecutor extends ThreadPoolExecutor {
   private static final Gauge queueSize = Gauge.build("languagetool_threadpool_queue_size", "Queue size by threadpool").labelNames("pool").register();
   private static final Gauge maxQueueSize = Gauge.build("languagetool_threadpool_max_queue_size", "Queue capacity by threadpool").labelNames("pool").register();
 
+  @Getter
   private final String name;
   private final Queue<Runnable> queue;
 

--- a/languagetool-core/src/main/java/org/languagetool/tools/LtThreadPoolExecutor.java
+++ b/languagetool-core/src/main/java/org/languagetool/tools/LtThreadPoolExecutor.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
  */
 class LtThreadPoolExecutor extends ThreadPoolExecutor {
 
-//  private static final Gauge activeThreads = Gauge.build("languagetool_threadpool_active_threads", "Running threads by threadpool")
+  //  private static final Gauge activeThreads = Gauge.build("languagetool_threadpool_active_threads", "Running threads by threadpool")
 //    .labelNames("pool").register();
   private static final Gauge queueSize = Gauge.build("languagetool_threadpool_queue_size", "Queue size by threadpool")
     .labelNames("pool").register();
@@ -123,10 +123,13 @@ class LtThreadPoolExecutor extends ThreadPoolExecutor {
 
   private void updateThreadGauges() {
     Set<Thread> threads = Thread.getAllStackTraces().keySet();
-    Stream<Thread> filtered = threads.stream().filter(thread -> thread.getName().startsWith(name));
-    blockingThreads.labels(name).set(filtered.filter(thread -> thread.getState() == Thread.State.BLOCKED).count());
-    waitingThreads.labels(name).set(filtered.filter(thread -> thread.getState() == Thread.State.WAITING).count());
-    timedWaitingThreads.labels(name).set(filtered.filter(thread -> thread.getState() == Thread.State.TIMED_WAITING).count());
-    runningThreads.labels(name).set(filtered.filter(thread -> thread.getState() == Thread.State.RUNNABLE).count());
+    Stream<Thread> blocked = threads.stream().filter(thread -> thread.getName().startsWith(name) && thread.getState() == Thread.State.BLOCKED);
+    Stream<Thread> waiting = threads.stream().filter(thread -> thread.getName().startsWith(name) && thread.getState() == Thread.State.WAITING);
+    Stream<Thread> waiting_timed = threads.stream().filter(thread -> thread.getName().startsWith(name) && thread.getState() == Thread.State.TIMED_WAITING);
+    Stream<Thread> running = threads.stream().filter(thread -> thread.getName().startsWith(name) && thread.getState() == Thread.State.RUNNABLE);
+    blockingThreads.labels(name).set(blocked.count());
+    waitingThreads.labels(name).set(waiting.count());
+    timedWaitingThreads.labels(name).set(waiting_timed.count());
+    runningThreads.labels(name).set(running.count());
   }
 }

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
@@ -70,6 +70,8 @@ public class HTTPServerConfig {
   protected long maxCheckTimeMillisLoggedIn = -1;
   protected long maxCheckTimeMillisPremium = -1;
   protected int maxCheckThreads = 10;
+  protected int maxTextCheckerThreads; // default to same value as maxCheckThreads
+  protected int textCheckerQueueSize = 8;
   protected Mode mode;
   protected File languageModelDir = null;
   protected File word2vecModelDir = null;
@@ -173,7 +175,7 @@ public class HTTPServerConfig {
   private static final List<String> KNOWN_OPTION_KEYS = Arrays.asList("abTest", "abTestClients", "abTestRollout",
     "beolingusFile", "blockedReferrers", "cacheSize", "cacheTTLSeconds",
     "dbDriver", "dbPassword", "dbUrl", "dbUsername", "disabledRuleIds", "fasttextBinary", "fasttextModel", "grammalectePassword",
-    "grammalecteServer", "grammalecteUser", "ipFingerprintFactor", "languageModel", "maxCheckThreads", "maxCheckTimeMillis",
+    "grammalecteServer", "grammalecteUser", "ipFingerprintFactor", "languageModel", "maxCheckThreads", "maxTextCheckerThreads", "textCheckerQueueSize", "maxCheckTimeMillis",
     "maxCheckTimeWithApiKeyMillis", "maxErrorsPerWordRate", "maxPipelinePoolSize", "maxSpellingSuggestions", "maxTextHardLength",
     "maxTextLength", "maxTextLengthWithApiKey", "maxWorkQueueSize", "neuralNetworkModel", "pipelineCaching",
     "pipelineExpireTimeInSeconds", "pipelinePrewarming", "prometheusMonitoring", "prometheusPort", "remoteRulesFile",
@@ -347,6 +349,16 @@ public class HTTPServerConfig {
         if (maxCheckThreads < 1) {
           throw new IllegalArgumentException("Invalid value for maxCheckThreads, must be >= 1: " + maxCheckThreads);
         }
+        // default value 0 = use maxCheckThreads setting (for compatibility)
+        maxTextCheckerThreads = Integer.parseInt(getOptionalProperty(props, "maxTextCheckerThreads", "0"));
+        if (maxTextCheckerThreads < 0) {
+          throw new IllegalArgumentException("Invalid value for maxTextCheckerThreads, must be >= 1: " + maxTextCheckerThreads);
+        }
+        textCheckerQueueSize = Integer.parseInt(getOptionalProperty(props, "textCheckerQueueSize", "8"));
+        if (textCheckerQueueSize < 0) {
+          throw new IllegalArgumentException("Invalid value for textCheckerQueueSize, must be >= 1: " + textCheckerQueueSize);
+        }
+
         boolean atdMode = getOptionalProperty(props, "mode", "LanguageTool").equalsIgnoreCase("AfterTheDeadline");
         if (atdMode) {
           throw new IllegalArgumentException("The AfterTheDeadline mode is not supported anymore in LanguageTool 3.8 or later");
@@ -832,6 +844,28 @@ public class HTTPServerConfig {
   /** @since 2.7 */
   int getMaxCheckThreads() {
     return maxCheckThreads;
+  }
+
+  /**
+   * @param maxTextCheckerThreads The maximum number of threads in the worker pool processing text checks running at the same time.
+   * @since 5.6
+   */
+  void setMaxTextCheckerThreads(int maxTextCheckerThreads) {
+    this.maxTextCheckerThreads = maxTextCheckerThreads;
+  }
+
+  /** @since 5.6 */
+  int getMaxTextCheckerThreads() {
+    // unset - use maxCheckThreads
+    return maxTextCheckerThreads != 0 ? maxTextCheckerThreads : maxCheckThreads;
+  }
+
+  public int getTextCheckerQueueSize() {
+    return textCheckerQueueSize;
+  }
+
+  public void setTextCheckerQueueSize(int textCheckerQueueSize) {
+    this.textCheckerQueueSize = textCheckerQueueSize;
   }
 
   /**

--- a/languagetool-server/src/main/java/org/languagetool/server/LanguageToolHttpHandler.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/LanguageToolHttpHandler.java
@@ -229,6 +229,9 @@ class LanguageToolHttpHandler implements HttpHandler {
         } else {
           response = "Checking took longer than " + config.getMaxCheckTimeMillisAnonymous() / 1000.0f + " seconds, which is this server's limit. Please make sure you have selected the proper language or consider submitting a shorter text.";
         }
+      } else if (e instanceof UnavailableException) {
+        errorCode = HTTP_UNAVAILABLE;
+        response = e.getMessage();
       } else {
         response = "Internal Error: " + e.getMessage();
         errorCode = HttpURLConnection.HTTP_INTERNAL_ERROR;

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -106,9 +106,9 @@ abstract class TextChecker {
     }
     this.executorService = LtThreadPoolFactory.createFixedThreadPoolExecutor(
       LtThreadPoolFactory.TEXT_CHECKER_POOL,
-      config.maxCheckThreads,
-      config.maxCheckThreads * 4,
-      false, (thread, throwable) -> {
+      config.getMaxTextCheckerThreads(), config.getMaxTextCheckerThreads(),
+      config.getTextCheckerQueueSize(),
+      60L, false, (thread, throwable) -> {
         log.error("Thread: " + thread.getName() + " failed with: " + throwable.getMessage());
       },
       false);
@@ -126,20 +126,16 @@ abstract class TextChecker {
     if (remoteRuleCount > 0) {
       LtThreadPoolFactory.createFixedThreadPoolExecutor(
         LtThreadPoolFactory.REMOTE_RULE_WAITING_POOL,
-        config.getMaxCheckThreads() * remoteRuleCount,
-        config.getMaxCheckThreads() * remoteRuleCount*4,
-        true,
-        (thread, throwable) -> {
+        config.getMaxCheckThreads(), config.getMaxCheckThreads() * remoteRuleCount, 1,
+        60L, true, (thread, throwable) -> {
           log.error("Thread: " + thread.getName() + " failed with: " + throwable.getMessage());
         },
         true
       );
       LtThreadPoolFactory.createFixedThreadPoolExecutor(
         LtThreadPoolFactory.REMOTE_RULE_EXECUTING_POOL,
-        config.getMaxCheckThreads() * remoteRuleCount,
-        config.getMaxCheckThreads() * remoteRuleCount*4,
-        true,
-        (thread, throwable) -> {
+        config.getMaxCheckThreads(), config.getMaxCheckThreads() * remoteRuleCount, 1,
+        60L, true, (thread, throwable) -> {
           log.error("Thread: " + thread.getName() + " failed with: " + throwable.getMessage());
         },
         true

--- a/languagetool-server/src/main/java/org/languagetool/server/UnavailableException.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/UnavailableException.java
@@ -1,0 +1,36 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2014 Daniel Naber (http://www.danielnaber.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.server;
+
+/**
+ * Exception thrown if the server is overloaded, e.g. full queues for TextChecker pool
+ * results in 503 error
+ * @since 5.6
+ */
+class UnavailableException extends RuntimeException {
+
+  UnavailableException(String message) {
+    super(message);
+  }
+
+  UnavailableException(String message, Exception cause) {
+    super(message, cause);
+  }
+  
+}


### PR DESCRIPTION
ThreadPoolExecutor only spawns threads beyond core pool if queue is full;
this never happened with our configuration
added maxTextCheckerThreads, textCheckerQueueSize