### PR TITLE
Add option that rechecks the suggestions 

### DIFF
--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineOptions.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineOptions.java
@@ -60,6 +60,7 @@ public class CommandLineOptions {
   private boolean xmlFiltering = false;
   private boolean lineByLine = false;
   private boolean enableTempOff = false;
+  private boolean recheck = false;
   private JLanguageTool.Level level = JLanguageTool.Level.DEFAULT;
   @Nullable
   private Language language = null;
@@ -131,6 +132,14 @@ public class CommandLineOptions {
 
   public void setEnableTempOff(boolean enableTempOff) {
     this.enableTempOff = enableTempOff;
+  }
+
+  public boolean isRecheck() {
+    return recheck;
+  }
+
+  public void setRecheck(boolean recheck) {
+    this.recheck = recheck;
   }
 
   public boolean isRecursive() {

--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineParser.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineParser.java
@@ -51,6 +51,8 @@ class CommandLineParser {
         options.setLineByLine(true);
       } else if (args[i].equals("--enable-temp-off")) {
         options.setEnableTempOff(true);
+      } else if (args[i].equals("--recheck")) {
+        options.setRecheck(true);
       } else if (args[i].equals("--level")) {
         String level = args[++i];
         try {

--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineTools.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineTools.java
@@ -75,6 +75,10 @@ public final class CommandLineTools {
     return checkText(contents, lt, false, false, -1, 0, 0, StringTools.ApiPrintMode.NORMAL_API, false, DEFAULT, emptyList());
   }
 
+  public static int recheckText(String contents, JLanguageTool lt) throws IOException {
+    return recheckText(contents, lt, false, false, -1, 0, 0, StringTools.ApiPrintMode.NORMAL_API, false, DEFAULT, emptyList());
+  }
+
   public static int checkText(String contents, JLanguageTool lt,
                               boolean isXmlFormat, boolean isJsonFormat, int lineOffset) throws IOException {
     return checkText(contents, lt, isXmlFormat, isJsonFormat, -1, lineOffset, 0, StringTools.ApiPrintMode.NORMAL_API, false, DEFAULT, emptyList());
@@ -158,6 +162,7 @@ public final class CommandLineTools {
     long startTime = System.currentTimeMillis();    
     Map<String, List<RuleMatch>> map = Tools.recheck(contents, lt, level);
     List<RuleMatch> ruleMatches = map.get("valid");
+    List<RuleMatch> invalidMatches = map.get("invalid");
 
     ruleMatches.parallelStream().forEach(r -> {
       // adjust line numbers
@@ -183,7 +188,15 @@ public final class CommandLineTools {
       PrintStream out = new PrintStream(System.out, true, "UTF-8");
       out.print(json);
     } else {
-      printMatches(ruleMatches, prevMatches, contents, contextSize, lt.getLanguage());
+      if (!ruleMatches.isEmpty()) {
+        System.out.println("Valid matches:");
+        printMatches(ruleMatches, prevMatches, contents, contextSize, lt.getLanguage());
+      }
+      if (!invalidMatches.isEmpty()) {
+        // shows the invalid rule matches for debugging
+        System.out.println("Invalid matches:");
+        printMatches(invalidMatches, prevMatches, contents, contextSize, lt.getLanguage());
+      }
     }
 
     //display stats if it's not in a buffered mode

--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/Main.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/Main.java
@@ -20,6 +20,7 @@ package org.languagetool.commandline;
 
 import org.apache.commons.io.ByteOrderMark;
 import org.apache.commons.io.input.BOMInputStream;
+import org.checkerframework.checker.units.qual.s;
 import org.languagetool.*;
 import org.languagetool.bitext.TabBitextReader;
 import org.languagetool.language.AmericanEnglish;
@@ -278,6 +279,9 @@ class Main {
       System.out.print(Tools.correctText(s, lt));
     } else if (profileRules) {
       Tools.profileRulesOnLine(s, lt, currentRule);
+    } else if (options.isRecheck()) {
+      CommandLineTools.recheckText(s, lt, options.isXmlFormat(), options.isJsonFormat(), -1,
+          lineOffset, matches, mode, options.isListUnknown(), level, Collections.emptyList())
     } else if (!options.isTaggerOnly()) {
       CommandLineTools.checkText(s, lt, options.isXmlFormat(), options.isJsonFormat(), -1, 
           lineOffset, matches, mode, options.isListUnknown(), level, Collections.emptyList());

--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/Main.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/Main.java
@@ -281,7 +281,7 @@ class Main {
       Tools.profileRulesOnLine(s, lt, currentRule);
     } else if (options.isRecheck()) {
       CommandLineTools.recheckText(s, lt, options.isXmlFormat(), options.isJsonFormat(), -1,
-          lineOffset, matches, mode, options.isListUnknown(), level, Collections.emptyList())
+          lineOffset, matches, mode, options.isListUnknown(), level, Collections.emptyList());
     } else if (!options.isTaggerOnly()) {
       CommandLineTools.checkText(s, lt, options.isXmlFormat(), options.isJsonFormat(), -1, 
           lineOffset, matches, mode, options.isListUnknown(), level, Collections.emptyList());

--- a/languagetool-commandline/src/test/java/org/languagetool/commandline/MainTest.java
+++ b/languagetool-commandline/src/test/java/org/languagetool/commandline/MainTest.java
@@ -654,6 +654,15 @@ public class MainTest extends AbstractSecurityTestCase {
     assertFalse(output.contains("ENGLISH_WORD_REPEAT_RULE"));
   }
 
+  @Test
+  public void testRecheck() throws Exception {
+    File input = writeToTempFile("This were good for her.");
+    String[] args = {"--line-by-line", "--recheck", input.getAbsolutePath()};
+    Main.main(args);
+    String output = new String(this.out.toByteArray());
+    assertTrue(!output.contains("Invalid"));
+  }
+
   private File writeToTempFile(String content) throws IOException {
     File tempFile = createTempFile();
     try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8))) {

--- a/languagetool-core/src/main/java/org/languagetool/tools/Tools.java
+++ b/languagetool-core/src/main/java/org/languagetool/tools/Tools.java
@@ -213,7 +213,9 @@ public final class Tools {
   /**
    * Rechecks the contents and returns valid and invalid suggestions
    * by checking the corrected text and evaluating the new rule matchs.
-   * Can be slow if 
+   * Can be slow if the number of original rule matchs are too large,
+   * as they are iterated to check if each replacement is valid, i.e. 
+   * doesn't raise any new rule matches.
    * 
    * @param contents String to be checked
    * @param lt Initialized Language Tool object
@@ -238,15 +240,15 @@ public final class Tools {
       // offset adjusment is inspired by correctTextFromMatches() below
       List<String> replacements = match.getSuggestedReplacements();
       Integer offset = match.getToPos() - match.getFromPos() - replacements.get(0).length();
-      Set<Integer[]> otherMatchPosSet = new HashSet<Integer[]>();
+      Set<List<Integer>> otherMatchPosSet = new HashSet<List<Integer>>();
       boolean beforeMatch = true;
       for (RuleMatch rm : ruleMatches) {
         if (rm == match) {
           beforeMatch = false;
           continue;
         }
-        Integer[] offsetPos = beforeMatch ? new Integer[]{rm.getFromPos(), rm.getToPos()} :
-          new Integer[]{rm.getFromPos() - offset, rm.getToPos() - offset};
+        List<Integer> offsetPos = beforeMatch ? Arrays.asList(rm.getFromPos(), rm.getToPos()) :
+          Arrays.asList(rm.getFromPos() - offset, rm.getToPos() - offset);
         otherMatchPosSet.add(offsetPos);
       }
       
@@ -254,7 +256,8 @@ public final class Tools {
       // then the current match is valid, i.e. matches of corrected text are all in the otherMatchSet.
       boolean valid = true;
       for (RuleMatch crm : correctedRuleMatchs) {
-        if (!otherMatchPosSet.contains(new Integer[]{crm.getFromPos(), crm.getToPos()})) {
+        // System.out.println("Corrected RM pos: (" + crm.getFromPos() + ", " + crm.getToPos() + ") ");
+        if (!otherMatchPosSet.contains(Arrays.asList(crm.getFromPos(), crm.getToPos()))) {
           List<RuleMatch> tmp = resultMap.get("invalid");
           tmp.add(match);
           resultMap.put("invalid", tmp);


### PR DESCRIPTION
Recheck the suggestions by applying lt.check() on the corrected texts, and report valid suggestions, i.e. those that don't raise new rule matches, and invalid ones. Option is added for commandline version, and the API can be extended to other versions.