### PR TITLE
Case sensitive simple replace

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractSimpleReplaceRule2.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractSimpleReplaceRule2.java
@@ -160,7 +160,7 @@ public abstract class AbstractSimpleReplaceRule2 extends Rule {
    */
   public static List<Map<String, SuggestionWithMessage>> simpleReplaceCaseSensitive(String sentence, AnalyzedSentence analyzedSentence)
     throws IOException {
-    // Case sensitive Simple Replace issue link: https://github.com/languagetool-org/languagetool/issues/2288
+    // CS427 Issue Link: https://github.com/languagetool-org/languagetool/issues/2288
 
     List<Map<String, SuggestionWithMessage>> caseSensitiveList = new ArrayList<>();
     // We skip checkingCase check, as we plan to suggest left part before "=" case sensitively if uppercase.

--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractSimpleReplaceRule2.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractSimpleReplaceRule2.java
@@ -123,6 +123,75 @@ public abstract class AbstractSimpleReplaceRule2 extends Rule {
   }
 
   /**
+   * Helper method attached to simpleReplaceCaseSensitive. Suggests case sensitivity on left and right of "="
+   * @param sentence  Sentence to suggest case sensitively
+   * @param sentenceStart Indicates whether token on right part is the start of a sentence
+   * @return List of maps containing error-corrections pairs
+   */
+  private static List<Map<String, SuggestionWithMessage>> suggestCaseSensitive(String sentence, boolean sentenceStart) {
+    List<Map<String, SuggestionWithMessage>> caseSensitiveList = new ArrayList<>();
+    boolean checkCaseSensitive = !sentence.equals(sentence.toLowerCase()); // check if any uppercase
+    String[] wrongForms = sentence.split("\\|"); // Multiple incorrect forms
+    SuggestionWithMessage sugg;
+
+    for (String word : wrongForms) { // Loop only for word count
+      String trimmedWord = word.trim(); // No trailing whitespace (ex. " hi   ")
+      int wordCount = wrongForms.length;
+      for (int i = caseSensitiveList.size(); i < wordCount; i++) {
+        caseSensitiveList.add(new HashMap<>());
+      }
+      // Suggest left part case sensitively
+      if (sentenceStart) {
+        sugg = new SuggestionWithMessage("Marked as start of sentence.");
+        caseSensitiveList.get(wordCount - 1).put(trimmedWord, sugg);
+      } else {
+        sugg = new SuggestionWithMessage("<suggestion> This word is case sensitive. </suggestion>");
+        caseSensitiveList.get(wordCount - 1).put(checkCaseSensitive ? trimmedWord : trimmedWord.toLowerCase(), sugg);
+      }
+    }
+    return caseSensitiveList;
+  }
+  
+   /**
+   * Method that attempts to make Simple Replace partially case-sensitive. Issue linked within method.
+   * @param sentence  Sentence in file
+   * @param analyzedSentence Analyzed version of String sentence
+   * @return  Combined list of maps containing the error-corrections pairs.
+   */
+  public static List<Map<String, SuggestionWithMessage>> simpleReplaceCaseSensitive(String sentence, AnalyzedSentence analyzedSentence)
+    throws IOException {
+    // Case sensitive Simple Replace issue link: https://github.com/languagetool-org/languagetool/issues/2288
+
+    List<Map<String, SuggestionWithMessage>> caseSensitiveList = new ArrayList<>();
+    // We skip checkingCase check, as we plan to suggest left part before "=" case sensitively if uppercase.
+    String[] parts = sentence.split("=");
+    if (parts.length != 2) {
+      throw new IOException("Format error in sentence " + sentence);
+    }
+
+    List<Map<String, SuggestionWithMessage>> caseSensitiveLeftPart = suggestCaseSensitive(parts[0], false);
+    caseSensitiveList.addAll(caseSensitiveLeftPart);
+
+    // Move onto right side of "="
+    AnalyzedTokenReadings[] tokens = analyzedSentence.getTokensWithoutWhitespace();
+    List<Map<String, SuggestionWithMessage>> caseSensitiveRightPart;
+    // If first token is start of sentence, do not suggest case sensitively.
+    if (tokens[0].isSentenceStart()) {
+      caseSensitiveRightPart = suggestCaseSensitive(parts[1], true);
+    } else {
+      caseSensitiveRightPart = suggestCaseSensitive(parts[1], false);
+    }
+    caseSensitiveList.addAll(caseSensitiveRightPart);
+
+    // seal the result (prevent modification from outside this class)
+    List<Map<String,SuggestionWithMessage>> result = new ArrayList<>();
+    for (Map<String, SuggestionWithMessage> map : caseSensitiveList) {
+      result.add(Collections.unmodifiableMap(map));
+    }
+    return Collections.unmodifiableList(result);
+  }
+  
+  /**
    * Load the list of words.
    * Same as {@link AbstractSimpleReplaceRule#loadFromPath} but allows multiple words and a custom message (optional).
    * @param filename the file from classpath to load

--- a/languagetool-core/src/test/java/org/languagetool/rules/AbstractSimpleReplaceRule2Test.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/AbstractSimpleReplaceRule2Test.java
@@ -18,15 +18,11 @@
  */
 package org.languagetool.rules;
 
-import org.apache.commons.io.FileUtils;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.languagetool.JLanguageTool;
 import org.languagetool.Language;
 import org.languagetool.language.Demo;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.*;
 

--- a/languagetool-core/src/test/java/org/languagetool/rules/AbstractSimpleReplaceRule2Test.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/AbstractSimpleReplaceRule2Test.java
@@ -18,21 +18,55 @@
  */
 package org.languagetool.rules;
 
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.languagetool.JLanguageTool;
 import org.languagetool.Language;
 import org.languagetool.language.Demo;
 
+import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.ResourceBundle;
+import java.util.*;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
+import static org.languagetool.rules.AbstractSimpleReplaceRule2.simpleReplaceCaseSensitive;
 
 public class AbstractSimpleReplaceRule2Test {
+
+  // Testing methods created for https://github.com/languagetool-org/languagetool/issues/2288
+  /**
+   * This test aims to ensure that simpleReplaceCaseSensitive works as according to the linked issue above.
+   * This is a standard case, which should not throw any Exceptions.
+   * @throws IOException  In case of errors writing to tempFile
+   */
+  @Test
+  public void caseSensitiveSimpleReplaceNoExceptions() throws IOException {
+    Demo lang = new Demo();
+    JLanguageTool lt = new JLanguageTool(lang);
+    String uppercaseSentence = "UpperCase = Test. Tokens here";
+    String lowercaseSentence = "lowercase = Test tokens here?";
+    List<Map<String, SuggestionWithMessage>> uppercase = simpleReplaceCaseSensitive(uppercaseSentence, lt.getAnalyzedSentence(uppercaseSentence));
+    List<Map<String, SuggestionWithMessage>> lowercase = simpleReplaceCaseSensitive(lowercaseSentence, lt.getAnalyzedSentence(lowercaseSentence));
+    assertEquals(uppercase.size(), 2);
+    assertEquals(lowercase.size(), 2);
+  }
+
+  /**
+   * This simply tests if a sentence of the wrong format is added (no = is present)
+   * @throws IOException  If no = is present in sentence string
+   */
+  @Test
+  public void caseSensitiveSimpleReplaceException() throws IOException {
+    Demo lang = new Demo();
+    JLanguageTool lt = new JLanguageTool(lang);
+    String wrongFormat = "rkjghkrj";
+    assertThrows(IOException.class, () -> {
+      List<Map<String, SuggestionWithMessage>> uppercase = simpleReplaceCaseSensitive(wrongFormat, lt.getAnalyzedSentence(wrongFormat));
+    });
+  }
   
   @Test
   public void testRule() throws IOException {

--- a/languagetool-core/src/test/java/org/languagetool/rules/AbstractSimpleReplaceRule2Test.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/AbstractSimpleReplaceRule2Test.java
@@ -32,7 +32,8 @@ import static org.languagetool.rules.AbstractSimpleReplaceRule2.simpleReplaceCas
 
 public class AbstractSimpleReplaceRule2Test {
 
-  // Testing methods created for https://github.com/languagetool-org/languagetool/issues/2288
+  // CS427 Issue Link: https://github.com/languagetool-org/languagetool/issues/2288
+  // Two tests below correspond to issue linked above
   /**
    * This test aims to ensure that simpleReplaceCaseSensitive works as according to the linked issue above.
    * This is a standard case, which should not throw any Exceptions.


### PR DESCRIPTION
This PR aims to contribute to [issue 2288](https://github.com/languagetool-org/languagetool/issues/2288) regarding making SimpleReplace partly case sensitive. Instead of directly changing the already existing functionality for Simple Replace rule within the AbstractSimpleReplaceRule2 class, I add a separate public method that attempts to follow the partly case sensitive route. This serves only as an idea for the above issue, not a permanent replacement.