### PR TITLE
Typo fix in tagset for DT examples

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/tagset.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/tagset.txt
@@ -4,7 +4,7 @@ For more details, also see https://www.ling.upenn.edu/courses/Fall_2003/ling001/
 
 CC    Coordinating conjunction: and, or, either, if, as, since, once, neither, less
 CD    Cardinal number: one, two, twenty-four
-DT    Determiner: an, an, all, many, much, any, some, this
+DT    Determiner: a, an, all, many, much, any, some, this
 EX    Existential there: there (no other words)
 FW    Foreign word: infinitum, ipso
 IN    Preposition/subordinate conjunction: except, inside, across, on, through, beyond, with, without


### PR DESCRIPTION
Examples for Determiner contain two "an". First one would probably be just "a".