### PR TITLE
Add ability to prevent PasswordAuthenticator usage while loading rules

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -166,6 +166,8 @@ public class JLanguageTool {
   private static ResourceDataBroker dataBroker = new DefaultResourceDataBroker();
   private static ClassBroker classBroker = new DefaultClassBroker();
 
+  private static volatile boolean useCustomPasswordAuthenticator = true;
+
   private final List<Rule> builtinRules;
   private final List<Rule> userRules = new ArrayList<>(); // rules added via addRule() method
   // rules fetched via getRelevantLanguageModelCapableRules()
@@ -402,6 +404,28 @@ public class JLanguageTool {
    */
   public static synchronized void setClassBrokerBroker(ClassBroker broker) {
     JLanguageTool.classBroker = broker;
+  }
+
+  /**
+   * Whether the {@code Tools.setPasswordAuthenticator()} should be called when loading rules
+   * in rule loader to use {@code PasswordAuthenticator} as default one.
+   *
+   * @return true if {@code PasswordAuthenticator} should be used
+   * @since 5.6
+   */
+  public static boolean isCustomPasswordAuthenticatorUsed() {
+    return JLanguageTool.useCustomPasswordAuthenticator;
+  }
+
+  /**
+   * Whether the {@code Tools.setPasswordAuthenticator()} should be called when loading rules
+   * in rule loader to use {@code PasswordAuthenticator} as default one.
+   *
+   * @param use true if {@code PasswordAuthenticator} should be used
+   * @since 5.6
+   */
+  public static void useCustomPasswordAuthenticator(boolean use) {
+    JLanguageTool.useCustomPasswordAuthenticator = use;
   }
 
   /**

--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleLoader.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleLoader.java
@@ -27,6 +27,7 @@ import java.util.List;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import org.languagetool.JLanguageTool;
 import org.languagetool.tools.Tools;
 import org.xml.sax.helpers.DefaultHandler;
 
@@ -68,7 +69,11 @@ public class PatternRuleLoader extends DefaultHandler {
       handler.setRelaxedMode(relaxedMode);
       SAXParserFactory factory = SAXParserFactory.newInstance();
       SAXParser saxParser = factory.newSAXParser();
-      Tools.setPasswordAuthenticator();
+
+      if (JLanguageTool.isCustomPasswordAuthenticatorUsed()) {
+        Tools.setPasswordAuthenticator();
+      }
+
       saxParser.getXMLReader().setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
       saxParser.parse(is, handler);
       return handler.getRules();

--- a/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/DisambiguationRuleLoader.java
+++ b/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/DisambiguationRuleLoader.java
@@ -18,6 +18,7 @@
  */
 package org.languagetool.tagging.disambiguation.rules;
 
+import org.languagetool.JLanguageTool;
 import org.languagetool.tools.Tools;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -42,7 +43,11 @@ public class DisambiguationRuleLoader extends DefaultHandler {
     DisambiguationRuleHandler handler = new DisambiguationRuleHandler();
     SAXParserFactory factory = SAXParserFactory.newInstance();
     SAXParser saxParser = factory.newSAXParser();
-    Tools.setPasswordAuthenticator();
+
+    if (JLanguageTool.isCustomPasswordAuthenticatorUsed()) {
+      Tools.setPasswordAuthenticator();
+    }
+
     saxParser.parse(stream, handler);
     return handler.getDisambRules();
   }


### PR DESCRIPTION
Custom PasswordAuthenticator [disturbs](https://youtrack.jetbrains.com/issue/IDEA-276949) IntelliJ IDEA proxy authentication process. We need a way to turn it off.