### PR TITLE
remove 'hard coded' from spell checker

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/prohibit.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/prohibit.txt
@@ -283,6 +283,7 @@ many-too-many
 one-too-many
 one-too-one
 PCI-complaint
+hard coded
 up-2-date
 up-to-data
 up-2-data


### PR DESCRIPTION
I feel like I might've done this wrong. 🤔 Please just let me know where I should add it instead if so!

Removes "hard coded" from the spell checker to prevent the 2 step correction.

![image](https://user-images.githubusercontent.com/22801583/145718192-f867e751-14bd-49ad-97ca-7f9eaa7f67c2.png)

![image](https://user-images.githubusercontent.com/22801583/145718199-6e6d9ab0-20f5-466d-9bde-5856f39fbcac.png)
