### PR TITLE
(zh-CN) Hanlp v1.8.2 upgrade

### DIFF
--- a/languagetool-language-modules/zh/pom.xml
+++ b/languagetool-language-modules/zh/pom.xml
@@ -57,11 +57,6 @@
             <version>${com.hankcs.hanlp.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.code</groupId>
-            <artifactId>cjftransform</artifactId>
-            <version>${com.google.code.cjftransform.version}</version>
-        </dependency>
-        <dependency>
             <!-- see http://stackoverflow.com/questions/174560/sharing-test-code-in-maven#174670 -->
             <groupId>org.languagetool</groupId>
             <artifactId>languagetool-core</artifactId>

--- a/languagetool-language-modules/zh/src/main/java/org/languagetool/tokenizers/zh/ChineseWordTokenizer.java
+++ b/languagetool-language-modules/zh/src/main/java/org/languagetool/tokenizers/zh/ChineseWordTokenizer.java
@@ -18,38 +18,26 @@
  */
 package org.languagetool.tokenizers.zh;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import com.hankcs.hanlp.HanLP;
+import com.hankcs.hanlp.seg.Segment;
 import org.languagetool.tokenizers.Tokenizer;
 
 import com.hankcs.hanlp.seg.common.Term;
-import com.hankcs.hanlp.tokenizer.BasicTokenizer;
-import cn.com.cjf.CJFBeanFactory;
-import cn.com.cjf.ChineseJF;
 
 public class ChineseWordTokenizer implements Tokenizer {
 
-  private ChineseJF chinesdJF;
-
-  private void init() {
-    if (chinesdJF == null) {
-      chinesdJF = CJFBeanFactory.getChineseJF();
-    }
-  }
+  private static final Segment SEGMENT = HanLP.newSegment()
+    .enableAllNamedEntityRecognize(false)
+    .enableCustomDictionary(false)
+    .enablePartOfSpeechTagging(true);
 
   @Override
   public List<String> tokenize(String text) {
-    init();
-    try {
-      List<Term> termList = BasicTokenizer.segment(text);
-      List<String> words = new ArrayList<>(termList.size());
-      for (Term term : termList) {
-        words.add(term.toString());
-      }
-      return words;
-    } catch (Exception e) {
-      return new ArrayList<>(0);
-    }
+    List<Term> termList = SEGMENT.seg(text);
+
+    return termList.stream().map(Term::toString).collect(Collectors.toList());
   }
 }

--- a/languagetool-language-modules/zh/src/main/resources/org/languagetool/rules/zh/grammar.xml
+++ b/languagetool-language-modules/zh/src/main/resources/org/languagetool/rules/zh/grammar.xml
@@ -1851,7 +1851,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 		</rule>
 		<rule id="SHI1_SHI2" name="释/失">
 			<pattern>
-				<token>爱</token><token>不</token><token>失</token><token>手</token>
+				<token>爱</token><token>不</token><token>失手</token>
 			</pattern>
 			<message>您的意思是"<suggestion>爱不释手</suggestion>"？</message>
 			<short>成语错误</short>
@@ -2787,7 +2787,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 		</rulegroup>
 		<rule id="ZHI5_ZHI6" name="指/直">
 			<pattern>
-				<token>令</token><token>人</token><token>发</token><token>直</token>
+				<token>令人</token><token>发</token><token>直</token>
 			</pattern>
 			<message>您的意思是"<suggestion>令人发指</suggestion>"？</message>
 			<short>成语错误</short>
@@ -3957,7 +3957,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 		</rulegroup>
 		<rule id="LV3_LV4" name="膂/旅">
 			<pattern>
-				<token>旅</token><token>力</token><token>过</token><token>人</token>
+				<token>旅</token><token>力</token><token>过人</token>
 			</pattern>
 			<message>您的意思是"<suggestion>膂力过人</suggestion>"？</message>
 			<short>成语错误</short>
@@ -4532,7 +4532,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 		<rulegroup id="XUAN3_XUAN4" name="眩/炫">
 			<rule>
 				<pattern>
-					<token>令</token><token>人</token><token>目</token><token>炫</token>
+					<token>令人</token><token>目</token><token>炫</token>
 				</pattern>
 				<message>您的意思是"<suggestion>令人目眩</suggestion>"？</message>
 				<short>词语错误</short>
@@ -5909,7 +5909,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 		</rule>
 		<rule id="ZE1_ZE2" name="咋/乍">
 			<pattern>
-				<token>令</token><token>人</token><token>乍</token><token>舌</token>
+				<token>令人</token><token>乍</token><token>舌</token>
 			</pattern>
 			<message>您的意思是"<suggestion>令人咋舌</suggestion>"？</message>
 			<short>成语错误</short>
@@ -6620,7 +6620,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 		</rulegroup>
 		<rule id="XIAO5_XIAO6" name="潇/萧">
 			<pattern>
-				<token>风雨</token><token>萧萧</token>
+				<token>风雨</token><token>萧</token><token>萧</token>
 			</pattern>
 			<message>您的意思是"<suggestion>风雨潇潇</suggestion>"？</message>
 			<short>词语错误</short>
@@ -7605,7 +7605,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 		<rulegroup id="BAO3_BAO4" name="抱/报">
 			<rule>
 				<pattern>
-					<token>远大</token><token>报</token><token>负</token>
+					<token>远</token><token>大报</token><token>负</token>
 				</pattern>
 				<message>您的意思是"<suggestion>远大抱负</suggestion>"？</message>
 				<short>词语错误</short>
@@ -8500,7 +8500,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 		</rule>
 		<rule id="ZHI1_PAO2" name="掷/抛">
 			<pattern>
-				<token>抛</token><token>地</token><token>有</token><token>声</token>
+				<token>抛</token><token>地</token><token>有声</token>
 			</pattern>
 			<message>您的意思是"<suggestion>掷地有声</suggestion>"？</message>
 			<short>成语错误</short>
@@ -8661,7 +8661,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 			<example correction="诅咒">杰克<marker>咀咒</marker>了一声。</example>
 			<example>杰克诅咒了一声。</example>
 		</rule>
-			<rule id="XIAO1_RAO2" name="骁/饶">
+		<rule id="XIAO1_RAO2" name="骁/饶">
 			<pattern>
 				<token>饶</token><token>勇</token><token>善战</token>
 			</pattern>
@@ -8713,7 +8713,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 		<rulegroup id="RENGONGZHINENG" name="人工智能">
 			<rule>
 				<pattern>
-					<token>人工</token><token>只</token><token>能</token>
+					<token>人工</token><token>只能</token>
 				</pattern>
 				<message>您的意思是"<suggestion>人工智能</suggestion>"？</message>
 				<short>成语错误</short>
@@ -8721,7 +8721,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 				<example>很多人钻牛角尖，迷失在模式确认，电脑指标，人工智能，甚至是绝望的灵魂研究占星术之中。</example>
 			</rule>
 		</rulegroup>
-		
+
 		<rulegroup id="BU" name="不">
 			<rule>
 				<antipattern>
@@ -9114,7 +9114,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 					<marker>
 						<token>宵</token>
 					</marker>
-					<token postag="j">汉</token>
+					<token postag="tg">汉</token>
 				</pattern>
 				<message>您的意思是“<suggestion>霄</suggestion>\2”？</message>
 				<short>词语错误</short>
@@ -9334,7 +9334,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 			</rule>
 			<rule>
 				<pattern>
-						<token>洲</token><token>郡</token>
+					<token>洲</token><token>郡</token>
 				</pattern>
 				<message>您的意思是“<suggestion>州郡</suggestion>”？</message>
 				<short>词语错误</short>
@@ -12349,7 +12349,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 					<marker>
 						<token>义</token>
 					</marker>
-					<token regexp="yes" postag="v">思|念|下|用|识</token>
+					<token regexp="yes">思|念|下|用|识</token>
 				</pattern>
 				<message>您的意思是“<suggestion>意</suggestion>\2”吗？</message>
 				<short>词语错误</short>
@@ -12742,7 +12742,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 					<marker>
 						<token>黏</token>
 					</marker>
-					<token>上去</token>
+					<token>上</token>
+					<token>去</token>
 				</pattern>
 				<message>您的意思是"<suggestion>粘</suggestion>\2"吗？</message>
 				<short>词语错误</short>
@@ -13760,7 +13761,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 					<marker>
 						<token>瞻</token>
 					</marker>
-					<token postag="v">养</token>
+					<token postag="vn">养老</token>
 				</pattern>
 				<message>您的意思是“<suggestion>赡</suggestion>养”吗？</message>
 				<short>词语错误</short>
@@ -14932,7 +14933,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 					<marker>
 						<token>代</token>
 					</marker>
-					<token regexp="yes" postag="v">木|树</token>
+					<token regexp="yes" postag="n">木|树</token>
 				</pattern>
 				<message>您的意思是“<suggestion>伐</suggestion>\2”吗？</message>
 				<short>词语错误</short>
@@ -15506,7 +15507,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 			</rule>
 			<rule>
 				<pattern>
-					<token>妄</token><token>费心</token><token>机</token>
+					<token>妄</token><token>费</token><token>心机</token>
 				</pattern>
 				<message>您的意思是"<suggestion>枉费心机</suggestion>"？</message>
 				<short>成语错误</short>
@@ -16476,7 +16477,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 			</rule>
 			<rule>
 				<pattern>
-					<token>忠贞</token><token>不</token><token regexp="yes">逾|遇</token>
+					<token>忠</token><token>贞</token><token>不</token><token regexp="yes">逾|遇</token>
 				</pattern>
 				<message>您的意思是"<suggestion>忠贞不渝</suggestion>"？</message>
 				<short>成语错误</short>
@@ -19196,7 +19197,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 		<rule id="ZH2" name="必需\必须">
 			<pattern>
 				<token>必需</token>
-				<token postag='v'/>
+				<token postag='vn'/>
 			</pattern>
 			<message>"\1"后面不应接动词，您的意思是"<suggestion>必须</suggestion>"吗？</message>
 			<short>词语错误</short>
@@ -19574,7 +19575,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 			<rule>
 				<pattern>
 					<token postag="p" skip="2">给</token>
-					<token postag="u">所</token>
+					<token postag="n">所</token>
 				</pattern>
 				<message>搭配错误： “给” “所” 不一起使用，请去掉 “所” ，或改为 “被...所” 句式。</message>
 				<short>介词的误用</short>

--- a/languagetool-language-modules/zh/src/test/java/org/languagetool/tagging/zh/ChineseTaggerTest.java
+++ b/languagetool-language-modules/zh/src/test/java/org/languagetool/tagging/zh/ChineseTaggerTest.java
@@ -1,6 +1,6 @@
-/* LanguageTool, a natural language style checker 
+/* LanguageTool, a natural language style checker
  * Copyright (C) 2005 Daniel Naber (http://www.danielnaber.de)
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -28,7 +28,7 @@ import java.io.IOException;
 
 /**
  * The test of ChineseTagger.
- * 
+ *
  * @author Minshan Chen
  * @author Xiaohui Wu
  * @author Jiamin Zheng
@@ -49,43 +49,43 @@ public class ChineseTaggerTest {
   public void testTagger() throws IOException {
 
     TestTools.myAssert(
-            "主任强调指出错误的地方。",
-            "主任/[null]n -- 强调/[null]v -- 指出/[null]v -- 错误/[null]n -- 的/[null]uj -- 地方/[null]n -- 。/[null]w",
-            tokenizer, tagger);
+      "主任强调指出错误的地方。",
+      "主任/[null]n -- 强调/[null]v -- 指出/[null]v -- 错误/[null]n -- 的/[null]uj -- 地方/[null]n -- 。/[null]w",
+      tokenizer, tagger);
 
     TestTools.myAssert(
-            "她胸前挂着一块碧绿的玉。",
-            "她/[null]r -- 胸前/[null]s -- 挂/[null]v -- 着/[null]uz -- 一块/[null]s -- 碧绿/[null]z -- 的/[null]uj -- 玉/[null]n -- 。/[null]w",
-            tokenizer, tagger);
+      "她胸前挂着一块碧绿的玉。",
+      "她/[null]r -- 胸前/[null]s -- 挂/[null]v -- 着/[null]uz -- 一块/[null]s -- 碧绿/[null]z -- 的/[null]uj -- 玉/[null]n -- 。/[null]w",
+      tokenizer, tagger);
 
     TestTools.myAssert(
-            "“鲯鳅”的研究结果有什么奥妙？",
-            "“/[null]w -- 鲯/[null]n -- 鳅/[null]x -- ”/[null]w -- 的/[null]uj -- 研究/[null]vn -- 结果/[null]n -- 有/[null]v -- 什么/[null]r -- 奥妙/[null]n -- ？/[null]w",
-            tokenizer, tagger);
+      "“鲯鳅”的研究结果有什么奥妙？",
+      "“/[null]w -- 鲯/[null]n -- 鳅/[null]x -- ”/[null]w -- 的/[null]uj -- 研究/[null]vn -- 结果/[null]n -- 有/[null]v -- 什么/[null]r -- 奥妙/[null]n -- ？/[null]w",
+      tokenizer, tagger);
 
     TestTools.myAssert(
-            "我们的女组长真是尺竿头更进一步。",
-            "我们/[null]r -- 的/[null]uj -- 女/[null]b -- 组长/[null]n -- 真是/[null]d -- 尺/[null]q -- 竿/[null]ng -- 头/[null]n -- 更进一步/[null]l -- 。/[null]w",
-            tokenizer, tagger);
+      "我们的女组长真是尺竿头更进一步。",
+      "我们/[null]r -- 的/[null]uj -- 女/[null]b -- 组长/[null]n -- 真是/[null]d -- 尺/[null]q -- 竿/[null]ng -- 头/[null]n -- 更进一步/[null]l -- 。/[null]w",
+      tokenizer, tagger);
 
     TestTools.myAssert(
-            "国务院，非国家工作人员不能随便进去的地方。",
-            "国务院/[null]nt -- ，/[null]w -- 非/[null]h -- 国家/[null]n -- 工作/[null]vn -- 人员/[null]n -- 不能/[null]v -- 随便/[null]ad -- 进去/[null]v -- 的/[null]uj -- 地方/[null]n -- 。/[null]w",
-            tokenizer, tagger);
+      "国务院，非国家工作人员不能随便进去的地方。",
+      "国务院/[null]nt -- ，/[null]w -- 非/[null]h -- 国家/[null]n -- 工作/[null]vn -- 人员/[null]n -- 不能/[null]v -- 随便/[null]ad -- 进去/[null]v -- 的/[null]uj -- 地方/[null]n -- 。/[null]w",
+      tokenizer, tagger);
 
     TestTools.myAssert(
-            "“哇……”珠海北师大操场上的师生大吃一惊！",
-            "“/[null]w -- 哇/[null]y -- ……/[null]w -- ”/[null]w -- 珠海/[null]ns -- 北师大/[null]j -- 操场/[null]n -- 上/[null]f -- 的/[null]uj -- 师生/[null]n -- 大吃一惊/[null]l -- ！/[null]w",
-            tokenizer, tagger);
+      "“哇……”珠海北师大操场上的师生大吃一惊！",
+      "“/[null]w -- 哇/[null]o -- ……/[null]w -- ”/[null]w -- 珠海/[null]ns -- 北师大/[null]j -- 操场/[null]n -- 上/[null]f -- 的/[null]uj -- 师生/[null]n -- 大吃一惊/[null]l -- ！/[null]w",
+      tokenizer, tagger);
 
     TestTools.myAssert(
-            "在炎热的暑假里，我和其他同学们参加了姜老师的一个项目。",
-            "在/[null]p -- 炎热/[null]a -- 的/[null]uj -- 暑假/[null]t -- 里/[null]f -- ，/[null]w -- 我/[null]r -- 和/[null]c -- 其他/[null]r -- 同学/[null]n -- 们/[null]k -- 参加/[null]v -- 了/[null]ul -- 姜/[null]n -- 老师/[null]n -- 的/[null]uj -- 一个/[null]mq -- 项目/[null]n -- 。/[null]w",
-            tokenizer, tagger);
+      "在炎热的暑假里，我和其他同学们参加了姜老师的一个项目。",
+      "在/[null]p -- 炎热/[null]a -- 的/[null]uj -- 暑假/[null]t -- 里/[null]f -- ，/[null]w -- 我/[null]r -- 和/[null]c -- 其他/[null]r -- 同学/[null]n -- 们/[null]k -- 参加/[null]v -- 了/[null]ul -- 姜/[null]n -- 老师/[null]n -- 的/[null]uj -- 一个/[null]mq -- 项目/[null]n -- 。/[null]w",
+      tokenizer, tagger);
 
     TestTools.myAssert(
-            "“咕咚，”一台联想ThinkPad T系列电脑从关羽的宿舍飞了下来。",
-            "“/[null]w -- 咕咚/[null]o -- ，/[null]w -- ”/[null]w -- 一/[null]m -- 台/[null]q -- 联想/[null]nz -- ThinkPad/[null]nx --  /[null]w -- T/[null]nx -- 系列/[null]q -- 电脑/[null]n -- 从/[null]p -- 关/[null]v -- 羽/[null]q -- 的/[null]uj -- 宿舍/[null]n -- 飞/[null]v -- 了/[null]ul -- 下来/[null]v -- 。/[null]w",
-            tokenizer, tagger);
+      "“咕咚，”一台联想ThinkPad T系列电脑从关羽的宿舍飞了下来。",
+      "“/[null]w -- 咕咚/[null]o -- ，/[null]w -- ”/[null]w -- 一/[null]m -- 台/[null]q -- 联想/[null]nz -- ThinkPad/[null]nx --  /[null]w -- T/[null]nx -- 系列/[null]q -- 电脑/[null]n -- 从/[null]p -- 关/[null]v -- 羽/[null]q -- 的/[null]uj -- 宿舍/[null]n -- 飞/[null]v -- 了/[null]ul -- 下来/[null]v -- 。/[null]w",
+      tokenizer, tagger);
   }
 }

--- a/languagetool-language-modules/zh/src/test/java/org/languagetool/tokenizers/zh/ChineseWordTokenizerTest.java
+++ b/languagetool-language-modules/zh/src/test/java/org/languagetool/tokenizers/zh/ChineseWordTokenizerTest.java
@@ -1,6 +1,6 @@
-/* LanguageTool, a natural language style checker 
+/* LanguageTool, a natural language style checker
  * Copyright (C) 2005 Daniel Naber (http://www.danielnaber.de)
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -43,50 +43,50 @@ public class ChineseWordTokenizerTest {
     List<String> tokens = wordTokenizer.tokenize("主任强调指出错误的地方。");
     assertEquals(7, tokens.size());
     assertEquals("[主任/n, 强调/v, 指出/v, 错误/n, 的/uj, 地方/n, 。/w]",
-            tokens.toString());
+      tokens.toString());
 
     List<String> tokens2 = wordTokenizer.tokenize("她胸前挂着一块碧绿的玉。");
     assertEquals(9, tokens2.size());
     assertEquals("[她/r, 胸前/s, 挂/v, 着/uz, 一块/s, 碧绿/z, 的/uj, 玉/n, 。/w]",
-            tokens2.toString());
+      tokens2.toString());
 
     List<String> tokens3 = wordTokenizer.tokenize("“鲯鳅”的研究结果有什么奥妙？");
     assertEquals(11, tokens3.size());
     assertEquals(
-            "[“/w, 鲯/n, 鳅/x, ”/w, 的/uj, 研究/vn, 结果/n, 有/v, 什么/r, 奥妙/n, ？/w]",
-            tokens3.toString());
+      "[“/w, 鲯/n, 鳅/x, ”/w, 的/uj, 研究/vn, 结果/n, 有/v, 什么/r, 奥妙/n, ？/w]",
+      tokens3.toString());
 
     List<String> tokens4 = wordTokenizer.tokenize("我们的女组长真是尺竿头更进一步。");
     assertEquals(10, tokens4.size());
     assertEquals(
-            "[我们/r, 的/uj, 女/b, 组长/n, 真是/d, 尺/q, 竿/ng, 头/n, 更进一步/l, 。/w]",
-            tokens4.toString());
+      "[我们/r, 的/uj, 女/b, 组长/n, 真是/d, 尺/q, 竿/ng, 头/n, 更进一步/l, 。/w]",
+      tokens4.toString());
 
     List<String> tokens5 = wordTokenizer.tokenize("国务院，非国家工作人员不能随便进去的地方。");
     assertEquals(12, tokens5.size());
     assertEquals(
-            "[国务院/nt, ，/w, 非/h, 国家/n, 工作/vn, 人员/n, 不能/v, 随便/ad, 进去/v, 的/uj, 地方/n, 。/w]",
-            tokens5.toString());
+      "[国务院/nt, ，/w, 非/h, 国家/n, 工作/vn, 人员/n, 不能/v, 随便/ad, 进去/v, 的/uj, 地方/n, 。/w]",
+      tokens5.toString());
 
     List<String> tokens6 = wordTokenizer.tokenize("“哇……”珠海北师大操场上的师生大吃一惊！");
     assertEquals(12, tokens6.size());
     assertEquals(
-            "[“/w, 哇/y, ……/w, ”/w, 珠海/ns, 北师大/j, 操场/n, 上/f, 的/uj, 师生/n, 大吃一惊/l, ！/w]",
-            tokens6.toString());
+      "[“/w, 哇/o, ……/w, ”/w, 珠海/ns, 北师大/j, 操场/n, 上/f, 的/uj, 师生/n, 大吃一惊/l, ！/w]",
+      tokens6.toString());
 
     List<String> tokens7 = wordTokenizer
-            .tokenize("在炎热的暑假里，我和其他同学们参加了姜老师的一个项目。");
+      .tokenize("在炎热的暑假里，我和其他同学们参加了姜老师的一个项目。");
     assertEquals(19, tokens7.size());
     assertEquals(
-            "[在/p, 炎热/a, 的/uj, 暑假/t, 里/f, ，/w, 我/r, 和/c, 其他/r, 同学/n, 们/k, 参加/v, 了/ul, 姜/n, 老师/n, 的/uj, 一个/mq, 项目/n, 。/w]",
-            tokens7.toString());
+      "[在/p, 炎热/a, 的/uj, 暑假/t, 里/f, ，/w, 我/r, 和/c, 其他/r, 同学/n, 们/k, 参加/v, 了/ul, 姜/n, 老师/n, 的/uj, 一个/mq, 项目/n, 。/w]",
+      tokens7.toString());
 
     List<String> tokens8 = wordTokenizer
-            .tokenize("“咕咚，”一台联想ThinkPad T系列电脑从关羽的宿舍飞了下来。");
+      .tokenize("“咕咚，”一台联想ThinkPad T系列电脑从关羽的宿舍飞了下来。");
     assertEquals(21, tokens8.size());
     assertEquals(
-            "[“/w, 咕咚/o, ，/w, ”/w, 一/m, 台/q, 联想/nz, ThinkPad/nx,  /w, T/nx, 系列/q, 电脑/n, 从/p, 关/v, 羽/q, 的/uj, 宿舍/n, 飞/v, 了/ul, 下来/v, 。/w]",
-            tokens8.toString());
+      "[“/w, 咕咚/o, ，/w, ”/w, 一/m, 台/q, 联想/nz, ThinkPad/nx,  /w, T/nx, 系列/q, 电脑/n, 从/p, 关/v, 羽/q, 的/uj, 宿舍/n, 飞/v, 了/ul, 下来/v, 。/w]",
+      tokens8.toString());
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -88,9 +88,8 @@
         <com.carrotsearch.hppc.version>0.8.2</com.carrotsearch.hppc.version>
         <com.gitlab.dumonts.hunspell.version>1.1.1</com.gitlab.dumonts.hunspell.version>
         <com.github.lucene-gosen.version>6.2.1</com.github.lucene-gosen.version>
-        <com.google.code.cjftransform.version>1.0.1</com.google.code.cjftransform.version>
         <com.hankcs.aho-corasick-double-array-trie.version>1.2.2</com.hankcs.aho-corasick-double-array-trie.version>
-        <com.hankcs.hanlp.version>portable-1.7.8</com.hankcs.hanlp.version>
+        <com.hankcs.hanlp.version>portable-1.8.2</com.hankcs.hanlp.version>
         <com.vdurmont.emoji-java.version>5.1.1</com.vdurmont.emoji-java.version>
         <com.sparkjava.version>2.9.3</com.sparkjava.version>
 


### PR DESCRIPTION
1. Upgrade HanLP to version 1.8.2
2. Enable POS tagging function to get more accurate result.
3. Updated test cases.