### PR TITLE
Remove words already in en_US dictionary (1/3)

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
@@ -28,7 +28,6 @@ abscise
 abscised
 abscises
 abscising
-absents
 abstractive
 Abu Dhabi
 Acadian
@@ -122,7 +121,6 @@ Americanizers
 Amex
 amici curiae
 amicus curiae
-amortizable
 amour propre
 amplexus
 amplexuses
@@ -148,7 +146,6 @@ aneuploid
 aneuploids
 AngelList
 anginal
-angstrom
 ångström
 ångströms
 AngularJS
@@ -363,7 +360,6 @@ Belle Époque
 belles-lettres
 benchmarked
 benchmarking
-benchmarks
 bento
 bentos
 bergère
@@ -764,7 +760,6 @@ coups de grâce
 coups de main
 coups de théâtre
 coups d'état
-cowlings
 coworking
 Craigslist
 crèche
@@ -823,8 +818,6 @@ curveballs
 customer-centric
 customizer
 customizers
-cutout
-cutouts
 cutscene
 cutscenes
 cyanite
@@ -835,9 +828,7 @@ cyberattack
 cyberattacks
 cyberattacker
 cyberattackers
-cyberbullies
 cyberbullied
-cyberbully
 cyberbullying
 cybercafe
 cybercafes
@@ -850,7 +841,6 @@ cyberintrusion
 cyberintrusions
 cyberoperation
 cyberoperations
-cybersex
 cyclogram
 cyclograms
 cyclotomic
@@ -959,8 +949,6 @@ dehumidification
 dehumidifications
 Dei gratia
 déjà vu
-deliverable
-deliverables
 démarche
 démarches
 democratizer
@@ -994,7 +982,6 @@ detailer
 detailers
 détente
 determinantal
-deterministically
 deus ex machina
 développé
 développés
@@ -1242,8 +1229,6 @@ exagrays
 exahenries
 exahenry
 exahertz
-exajoule
-exajoules
 exakatal
 exakatals
 exakelvin
@@ -1517,8 +1502,6 @@ giganewton
 giganewtons
 gigaohm
 gigaohms
-gigapascal
-gigapascals
 gigaradian
 gigaradians
 gigasiemens
@@ -1807,7 +1790,6 @@ inextricability
 infography
 ingénue
 ingénues
-IHU
 Inkscape
 inseverable
 InstaCal
@@ -1818,7 +1800,6 @@ integrable
 integralities
 integrality
 integrations
-intel
 intellectualizer
 intellectualizers
 inter alia
@@ -1878,10 +1859,6 @@ jökulhlaups
 Jong-il
 Jong-un
 Joomla
-josh
-joshed
-joshes
-joshing
 joss
 josses
 journaled
@@ -1927,8 +1904,6 @@ kilobecquerel
 kilobecquerels
 kilocandela
 kilocandelas
-kilocoulomb
-kilocoulombs
 kilofarad
 kilofarads
 kilogray
@@ -1942,8 +1917,6 @@ kilokelvin
 kilokelvins
 kilolumens
 kilolux
-kilonewton
-kilonewtons
 kiloradian
 kiloradians
 kilosiemens
@@ -2195,10 +2168,6 @@ megamole
 megamoles
 meganewton
 meganewtons
-megapascal
-megapascals
-megapixel
-megapixels
 megaradian
 megaradians
 megasiemens
@@ -2226,7 +2195,6 @@ ménages à trois
 mens rea
 mentee
 mentees
-mentorship
 mercerizer
 mercerizers
 Mercutio
@@ -2237,7 +2205,6 @@ mésalliances
 metabolomic
 metabolomics
 metacognitive
-metadata
 metatheatricality
 metathesize
 metathesized
@@ -2386,8 +2353,6 @@ Mohammed
 Mohorovičić discontinuity
 moiré
 moirés
-moisturizer
-moisturizers
 Möller-Barlow disease
 Monégasque
 monensin
@@ -2395,13 +2360,9 @@ Monika
 monochromator
 monochromators
 monopolizable
-monopolizer
-monopolizers
 monoprotic
 monotherapy
 monoxenous
-moralizer
-moralizers
 morphosyntactic
 Mórrígan
 mortiser
@@ -2529,8 +2490,6 @@ neurodiverse
 neurodiversity
 neuroinflammation
 neuropsychiatric
-neutralizer
-neutralizers
 névé
 Neville
 newsfeed
@@ -2565,7 +2524,6 @@ nonillion
 nonillions
 no-nos
 nonpolarizable
-nonrepresentational
 norteño
 norteños
 noscitur a sociis
@@ -2619,7 +2577,6 @@ omnivory
 on dit
 on dits
 onanistic
-onscreen
 onus probandi
 Open-Xchange
 opéra bouffe
@@ -2679,7 +2636,6 @@ parklet
 parklets
 Pärnu
 paronym
-parser
 parsers
 #parti pris
 Parti Québécois
@@ -2730,8 +2686,6 @@ petagrays
 petahenries
 petahenry
 petahertz
-petajoule
-petajoules
 petakatal
 petakatals
 petakelvin
@@ -2759,8 +2713,6 @@ petatesla
 petateslas
 petavolt
 petavolts
-petawatt
-petawatts
 petaweber
 petawebers
 Petersburg
@@ -2792,10 +2744,6 @@ Photoshop
 photoshopped
 photoshopping
 photoshops
-photosynthesize
-photosynthesized
-photosynthesizes
-photosynthesizing
 phthalate
 phthalates
 phylogenetic
@@ -2875,8 +2823,6 @@ pliéd
 pliéing
 pliés
 plissé
-plugin
-plugins
 plus ça change
 Pluviose
 Pluviôse
@@ -2958,15 +2904,10 @@ prequalify
 pre-qualify
 prequalifying
 pre-qualifying
-prerecord
 pre-record
-prerecorded
 pre-recorded
-prerecording
 pre-recording
-prerecords
 pre-records
-presidium
 presidiums
 prestress
 prestressed
@@ -2988,7 +2929,6 @@ Pripyat
 Pristina
 Priština
 proactivity
-prob
 probs
 proceduralizations
 procès-verbal
@@ -3039,7 +2979,6 @@ qindarkë
 quadcopter
 quadcopters
 Qualitätswein
-quantitation
 quantizable
 quantum meruit
 quattuordecillion
@@ -3159,7 +3098,6 @@ repowering
 repowers
 reproducibility
 repurpose
-repurposed
 repurposes
 repurposing
 res ipsa loquitor
@@ -3190,7 +3128,6 @@ Rohan
 rollerblade
 rollerbladed
 rollerblades
-rollerblading
 roman à clef
 roman à thèse
 romanèchite
@@ -3204,7 +3141,6 @@ rotorcraft
 roué
 roués
 rRNA
-runtime
 runtimes
 Ryuchuan
 Ryukyuan
@@ -3267,7 +3203,6 @@ scenographers
 scenographic
 scenographical
 scenography
-schadenfreude
 Schematron
 Schiebel
 Schiele
@@ -3306,7 +3241,6 @@ sensorial
 sensorially
 septillion
 septillions
-serializable
 serological
 serologically
 serologist
@@ -3358,7 +3292,6 @@ simped
 Simulink
 sine qua nons
 Sinn Féin
-sizable
 sizableness
 sizably
 sizeable
@@ -3380,7 +3313,6 @@ Snapchat
 socializable
 sociocultural
 socioculturally
-socioeconomic
 sociopathy
 SoftRAN
 soi-disant
@@ -3422,7 +3354,6 @@ spiritualizers
 Spotify
 Sprachgefühl
 Stainton
-standalone
 standardizable
 Stannington
 stare decisis
@@ -3484,8 +3415,6 @@ table d'hôte
 tables d'hôte
 tabula rasa
 Táin Bó Cúailnge
-takeoff
-takeoffs
 Tánaiste
 Tanja
 tannins
@@ -3531,8 +3460,6 @@ teragray
 teragrays
 terahenries
 terahenry
-terajoule
-terajoules
 terakatal
 terakatals
 terakelvin
@@ -3580,18 +3507,12 @@ The Monkees
 theobromine
 theologizer
 theologizers
-thespian
 Tiamat
 tibiofemoral
-timestamp
 timestamping
-timider
-timidest
 Timişoara
 Timorese
 Timor-Leste
-tintype
-tintypes
 tió de Nadal
 Tizzard
 Tobias
@@ -3632,7 +3553,6 @@ Triphammer
 trouvère
 trouvères
 trueing
-trues
 Tuatha Dé Danann
 Tübingen
 tumorigeneses
@@ -3671,7 +3591,6 @@ unclosing
 unconfident
 unconfidently
 uncreative
-uncrowded
 undecillion
 undecillions
 undelete
@@ -3694,7 +3613,6 @@ unital
 universalizations
 universalizability
 unkindnesses of ravens
-unlikeliness
 unlink
 unlinking
 unlinks
@@ -3710,7 +3628,6 @@ unrepealable
 unrufflable
 unruffleable
 unsated
-untenanted
 ununbium
 ununhexium
 ununium
@@ -3788,12 +3705,9 @@ voxels
 VR
 vulcanizer
 vulcanizers
-vulgarizer
-vulgarizers
 Wachovia
 walkable
 Wanderjahr
-wanner
 watchkeeper
 watchkeepers
 waveguide
@@ -3806,8 +3720,6 @@ weblink
 weblinks
 Wechsler
 Weebly
-weeknight
-weeknights
 Wellingtonian
 Wellingtonians
 Weltanschauung
@@ -3830,9 +3742,6 @@ workpiece
 workpieces
 Worrall
 Wotton
-wracked
-wracking
-wracks
 wunderkinder
 Würzburg
 wüstite
@@ -4626,8 +4535,6 @@ CPUs
 Cristian
 crypto
 cryptos
-dataset
-datasets
 Deepak
 DevOps
 dropdown
@@ -4739,13 +4646,11 @@ SSN
 SSNs
 TeamViewer
 Tenerife
-transactional
 UAT
 UATs
 Ubisoft
 UID
 uncheck
-unchecked
 unchecking
 unchecks
 unmerge
@@ -4753,7 +4658,6 @@ unmerged
 unmerges
 unmerging
 unpair
-unpaired
 unpairing
 unpairs
 UPC
@@ -4779,14 +4683,10 @@ Zack
 Zuckerberg
 programmatically
 allelomorph
-teleport
 teleports
 teleporting
 teleported
-cum
-cums
 cummed
-cumming
 Basecamp
 Statista
 Americano
@@ -4853,8 +4753,6 @@ CEOs
 Sinan
 Holodomor
 foosball
-hoverboard
-hoverboards
 borderless
 celadon
 celadons
@@ -5062,7 +4960,6 @@ Duramax
 Bellevue
 CIO
 CIOs
-clickbait
 clickbaits
 DM
 DMs
@@ -5102,9 +4999,7 @@ ConnectedDrive
 IMAP
 stimulator
 stimulators
-reconfigure
 reconfigures
-reconfigured
 reconfiguring
 Ashraf
 IPs
@@ -5129,7 +5024,6 @@ quaternaries
 Snowden
 triages
 triaging
-triaged
 Aon
 Davidoff
 Bergmann
@@ -5154,8 +5048,6 @@ autocorrected
 exocytosis
 exocytoses
 hypertonic
-hypotactic
-hypotaxis
 hypotonic
 isotonic
 PDFs
@@ -5341,7 +5233,6 @@ colobus
 colobuses
 Arnaud
 advisor # variant of "adviser"
-advisors
 Allahyar
 passé
 MQTT
@@ -5406,7 +5297,6 @@ toastie
 Baghdadi
 al-Baghdadi
 pickaxe
-pickaxes
 Amato
 Deepawali
 FaceTime
@@ -5456,7 +5346,6 @@ purées
 iframe
 iframes
 pre-emptively
-preemptively
 Vettel
 MPs
 Katya
@@ -5496,7 +5385,6 @@ RFQ
 Sonos
 SSC
 Transsmart
-tech
 Suraj
 Unger
 Yoda
@@ -5559,21 +5447,16 @@ Chamorro
 Chamorros
 charette
 charettes
-bussed
-bussing
-busses
 Artur
 SMEs
 Shubham
 ribosome
 ribosomes
-reticulum
 reticulums
 OOP
 Michaela
 Medtronic
 lysosome
-lysosomes
 Lleida
 LLP
 ketosis
@@ -5604,7 +5487,6 @@ Grafana
 OAuth
 IFTTT
 Netgear
-downtime
 downtimes
 uptime
 uptimes
@@ -5759,8 +5641,6 @@ vinting
 Sophos
 Yovanovitch
 Charlottenburg
-hoodie
-hoodies
 probiotic
 probiotics
 selectable
@@ -5850,8 +5730,6 @@ panino
 panini
 paraben
 parabens
-paratactic
-parataxis
 Pringles
 Payson
 RDC
@@ -5859,8 +5737,6 @@ McCollum
 Sennheiser
 Werner
 Zhou
-tenement
-tenements
 Tata Motors
 Tata Steel
 EasyJet
@@ -5868,7 +5744,6 @@ Jeb
 Lakers
 MongoDB
 pattie
-patties
 Targaryen
 TUI
 Shaylin
@@ -5931,7 +5806,6 @@ Avichai
 Barnsley
 chromatid
 chromatids
-downtown
 freezy
 FTE
 FTEs
@@ -6060,8 +5934,6 @@ invalidators
 Jinping
 Fuelcell
 Gulfport
-swatch
-swatches
 swatched
 swatching
 e-cig
@@ -6216,14 +6088,12 @@ Tariq
 pathophysiology
 pathophysiologies
 eyewitnessed
-eyewitness
 x-ray
 x-rays
 x-rayed
 x-raying
 composable
 Trimble
-whoa
 woah
 Hayabusa
 Andrey
@@ -6271,7 +6141,6 @@ Ndrangheta
 preinstall
 preinstalling
 preinstalls
-preinstalled
 Tomochichi
 Musgrove
 Yamacraw
@@ -6326,10 +6195,6 @@ nootropics
 Phuket
 polypeptide
 polypeptides
-prep
-preps
-prepped
-prepping
 redox
 SCOTUS
 stoichiometries
@@ -6420,7 +6285,6 @@ chit-chatted
 homeschool
 homeschools
 homeschooled
-homeschooling
 YouTuber
 YouTubers
 screenshotted
@@ -6499,8 +6363,6 @@ Airtel
 Aiden
 Antonietta
 Atos
-blockchain
-blockchains
 backlink
 backlinks
 B&B
@@ -6565,9 +6427,6 @@ tetradic
 tetrad
 tetrads
 USB-C
-crosscut
-crosscutting
-crosscuts
 cross-cut
 cross-cutting
 cross-cuts
@@ -6636,9 +6495,7 @@ uprate
 uprating
 uprates
 uprated
-crutch
 crutched
-crutches
 crutching
 Fridericus
 Byton
@@ -6676,7 +6533,6 @@ compressions
 Daliyah
 cmd
 caddy
-caddies
 Daytona
 Dinesh
 Echosmith
@@ -6857,16 +6713,7 @@ rsvps
 rsvped
 rsvp'd
 rsvping
-courier
-couriered
-couriering
-theme
-themed
 theming
-themes
-toughed
-toughs
-toughing
 FedExed
 FedExes
 FedExing
@@ -6985,7 +6832,6 @@ voice-overing
 voice-overs
 Des Moines
 Brevard
-chariots
 charioted
 charioting
 intercommunal
@@ -7081,11 +6927,9 @@ DHCP
 fontina
 fontinas
 grassroot
-grassroots
 Héctor
 Hussain
 Ibrahima
-intersectionality
 intersectionalities
 IXL
 Julieta
@@ -7481,7 +7325,6 @@ dry-docks
 dry-docked
 dry-docking
 Nathanael
-helms
 helmed
 helming
 Crowninshield
@@ -7491,9 +7334,6 @@ duralumin
 measurer
 measurers
 Fremantle
-wet
-wets
-wetting
 wetted
 clubroom
 clubrooms
@@ -7531,8 +7371,6 @@ sulfonating
 sulfonated
 Lausanne
 dystopic
-coronavirus
-coronaviruses
 genomic
 kilobase
 kilobases
@@ -7552,7 +7390,6 @@ monocistronic
 polyprotein
 polyproteins
 protease
-nucleotide
 nucleotides
 epizootic
 epizootics
@@ -7593,12 +7430,9 @@ microtubules
 Mitsuki
 plugger
 pluggers
-raccoons
 Radley
 Templeton
 work-life
-copper
-coppers
 coppered
 coppering
 recourses
@@ -7614,7 +7448,6 @@ dead-end
 dead-ends
 dead-ended
 dead-ending
-unset
 unsets
 unsetted
 unsetting
@@ -7724,7 +7557,6 @@ drop-shipped
 digester
 digesters
 Fayette
-formative
 formatives
 Hillview
 Belo Horizonte
@@ -7920,14 +7752,11 @@ Santino
 statist
 statists
 stressor
-stressors
 Supriya
 telescreen
 telescreens
 transferor
 transferors
-transphobic
-transphobia
 videography
 videographies
 Xfinity
@@ -7996,7 +7825,6 @@ Roselle
 Nikola
 Gabriele
 Easton
-ontology
 ontologies
 Milano
 Roma
@@ -8031,7 +7859,6 @@ springers
 cuttle
 cuttles
 Torino
-activation
 activations
 Volker
 Scarsdale
@@ -8082,7 +7909,6 @@ cheerlead
 cheerleads
 cheerleaded
 cheerleading
-checkbox
 checkboxes
 Bram
 plaintext
@@ -8140,11 +7966,9 @@ Freiburg
 Gaulle
 Charles de Gaulle
 Corbett
-brine
 brines
 brined
 brining
-replenishment
 replenishments
 Plainfield
 Kilgore
@@ -8212,7 +8036,6 @@ agnatic
 stackable
 Pomeroy
 Orson
-functor
 functors
 Derry
 Cuthbert
@@ -8260,7 +8083,6 @@ Maastricht
 Lathrop
 Fulcher
 forecasted
-forecasting
 entropic
 entropically
 Cinque
@@ -8279,7 +8101,6 @@ Grosvenor
 errorless
 environ
 environed
-environs
 environing
 entrainment
 entrainments
@@ -8304,7 +8125,6 @@ Lucie
 Liana
 histone
 histones
-haptic
 haptics
 fenugreek
 employability
@@ -8331,13 +8151,11 @@ plasmid
 plasmids
 omeprazole
 omeprazoles
-ketogenic
 Feldman
 brushless
 acidification
 acidifications
 Umberto
-topology
 topologies
 Silvio
 scrollable
@@ -8354,7 +8172,6 @@ Hwang
 fundraise
 fundraises
 fundraised
-fundraising
 fibrillar
 fibrillary
 Dunlop
@@ -8439,8 +8256,6 @@ suer
 suers
 seater
 seaters
-pathfinder
-pathfinders
 pathfinding
 Newell
 mobilities
@@ -8464,7 +8279,6 @@ stator
 stators
 Seamus
 Rowley
-recruitment
 recruitments
 Pacifica
 Niki
@@ -8527,7 +8341,6 @@ carbonylations
 arriver
 Antoni
 Vasily
-usurpation
 usurpations
 uplink
 uplinks
@@ -8564,7 +8377,6 @@ Fontana
 dramaturgical
 dramaturgically
 didactics
-delimitation
 delimitations
 Cristiano
 corticosteroid
@@ -8594,8 +8406,6 @@ Rodd
 resistive
 recency
 recencies
-orangutan
-orangutans
 neurodevelopmental
 Meaghan
 Lovato
@@ -8648,7 +8458,6 @@ McGraw
 lipoprotein
 lipoproteins
 Gottfried
-ether
 ethers
 dysregulation
 Dolomites
@@ -8663,7 +8472,6 @@ antifungals
 Zermatt
 Turkmen
 tornados
-tornadoes
 subsequence
 subsequences
 spectrophotometer
@@ -8696,7 +8504,6 @@ Holbrook
 Hodgson
 Hatcher
 Françoise
-exacerbation
 exacerbations
 Ellicott
 Edelman
@@ -8723,7 +8530,6 @@ allocators
 Alfons
 Achilleas
 Yousuf
-wearable
 wearables
 upskill
 upskills
@@ -8822,14 +8628,12 @@ spectrographic
 spectrographical
 somatostatin
 somatostatins
-solicitude
 solicitudes
 sexualities
 reverification
 reverifications
 Ravenna
 Rashida
-proliferation
 proliferations
 pricer
 phlebotomist
@@ -8871,7 +8675,6 @@ Brookline
 Byrne
 Bluffton
 Bastrop
-assignee
 assignees
 aspirational
 aspirationally
@@ -8899,7 +8702,6 @@ recordable
 recirculation
 recirculations
 Quarles
-prosthetic
 prosthetically
 Selangor
 Paddington
@@ -8921,7 +8723,6 @@ Iverson
 illuminance
 illuminances
 Horst
-executable
 executables
 Edmonds
 Edmonson
@@ -8989,9 +8790,7 @@ racquets
 praxis
 praxes
 Planta
-phenol
 phenols
-pedagogy
 pedagogies
 patellar
 Painesville
@@ -9026,13 +8825,10 @@ Kath
 Jorgensen
 interpretability
 interpretabilities
-integrator
 integrators
-inquietude
 inquietudes
 incompressible
 homogenous
-homogeneously
 hagfish
 hagfishes
 Greenbrier
@@ -9121,7 +8917,6 @@ preimage
 preimages
 polyamide
 polyamides
-neuroscience
 neurosciences
 neuromuscular
 Ndebele
@@ -9131,7 +8926,6 @@ Minden Hills
 Haliburton
 Margaux
 localizations
-limestone
 limestones
 Lethbridge
 Leoni
@@ -9162,9 +8956,7 @@ flitters
 flittered
 flittering
 Falmouth
-expiration
 expirations
-entailment
 entailments
 encyclopaedia
 Drummond
@@ -9189,7 +8981,6 @@ animatics
 anaphylactic
 actioning
 Zeeland
-waveform
 waveforms
 updatable
 unforgiven
@@ -9235,8 +9026,6 @@ Pelham
 Piero
 operon
 operons
-esophagus
-esophagi
 esophaguses
 Vin Diesel
 Hang Seng
@@ -9267,8 +9056,6 @@ bioweapons
 radiological
 radiologic
 radiologically
-outfitter
-outfitters
 DeStefano
 Northup
 Benvolio
@@ -9365,7 +9152,6 @@ inviters
 inserter
 inserters
 Ingersoll
-indivisible
 indivisibles
 hydrophobicity
 hydrophobicities
@@ -9391,8 +9177,6 @@ fishman
 fishmen
 Farnsworth
 faired
-fairing
-fairs
 evolutionism
 essentialist
 essentialists
@@ -9413,7 +9197,6 @@ coprocessor
 coprocessors
 continuer
 continuers
-contactless
 Comstock
 combinable
 carpaccio
@@ -9431,7 +9214,6 @@ biopharmaceuticals
 benzoate
 benzoates
 basidiomycota
-backdoor
 backdoors
 auditable
 asserter
@@ -9440,7 +9222,6 @@ Arvin
 antipyretic
 alpinist
 alpinists
-accreditation
 accreditations
 zirconia
 zirconias
@@ -9458,13 +9239,11 @@ underspend
 underspending
 underspent
 uncompromised
-truancy
 truancies
 Tilly
 Tierney
 tandoor
 tandoors
-tandoori
 swishy
 swishier
 swishiest
@@ -9493,7 +9272,6 @@ Northumberland
 physiographic
 physiographical
 physiographically
-sandstone
 sandstones
 stratigraphic
 stratigraphical
@@ -9520,7 +9298,6 @@ pronate
 pronated
 pronates
 pronating
-predication
 predications
 pollutions
 pneumatics
@@ -9543,7 +9320,6 @@ Masjid
 literatures
 lipase
 lipases
-invective
 invectives
 integumentary
 innovational
@@ -9582,11 +9358,8 @@ follicularly
 focusable
 Finney
 Farrah
-expense
 expensed
-expenses
 expensing
-elliptical
 ellipticals
 electroconvulsive
 effectuation
@@ -9599,11 +9372,7 @@ diphenhydramines
 Denpasar
 dematerializations
 degressive
-cue
-cued
-cues
 cueing
-counterfactual
 counterfactuals
 convertor
 convertors
@@ -9675,10 +9444,7 @@ psychotherapeutists
 psychotherapeutics
 psilocybin
 psilocybins
-prototype
-prototypes
 prototyped
-prototyping
 primavera
 precess
 precesses
@@ -9721,7 +9487,6 @@ Kendal
 Kendall
 isomorphically
 Iredell
-intersectional
 hypotonia
 hypotonias
 Humber
@@ -9768,14 +9533,12 @@ contactors
 Colossians
 Cockburn
 chuff
-chuffed
 chuffs
 chuffing
 chromate
 chromates
 chlorella
 chlorellas
-celestial
 celestials
 carboxylic
 Cappadocia
@@ -9844,7 +9607,6 @@ unbans
 unbanned
 unbanning
 tweezer
-tweezers
 Turnbull
 Tilbury
 Thurston
@@ -9859,15 +9621,11 @@ stealer
 stealable
 sociogram
 sociograms
-slurry
 slurries
 Skagit
 Silverstone
 Silverstein
 Shadwell
-scaffold
-scaffolding
-scaffolds
 scaffolded
 safelight
 safelights
@@ -9878,7 +9636,6 @@ rhizospheres
 Reith
 redfish
 redfishes
-reclamation
 reclamations
 ptyalin
 ptyalins
@@ -9905,8 +9662,6 @@ pervier
 perviest
 Pawtucket
 pathologic
-pathological
-pathologically
 Parton
 Otero
 ostinato
@@ -9941,8 +9696,6 @@ OpenCL
 LLVM
 SPARQL
 SurveyMonkey
-polyhedron
-polyhedrons
 polyhedra
 AppleScript
 mannitol


### PR DESCRIPTION
Tested against:

- Hunspell en_US (2020.12.07)

by using:

- http://app.aspell.net/lookup

Removed anything with a "YES" in the "In en_US" column.