### PR TITLE
[en] improve PROFANITY

### DIFF
--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/English.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/English.java
@@ -422,6 +422,7 @@ public class English extends Language implements AutoCloseable {
       case "CONFUSION_GONG_GOING":      return 1;   // prefer over I_AM_VB
       case "SEEN_SEEM":                 return 1;   // prefer over PRP_PAST_PART
       case "PROFANITY":                 return 1;   // prefer over spell checker (less prio than EN_COMPOUNDS)
+      case "GOOD_FLUCK":                return 2;   // prefer over PROFANITY
       case "THE_THEM":                  return 1;   // prefer over TO_TWO
       case "THERE_THEIR":               return 1;   // prefer over GO_TO_HOME
       case "IT_IS_DEPENDING_ON":        return 1;   // prefer over PROGRESSIVE_VERBS


### PR DESCRIPTION
- made PROFANITY picky
- added rule GOOD_FLUCK
- added rules for 'retarded' and 'redskin' (part of PROFANITY, so picky as well)
- changed suggestion for [10] from 'Afro-American' (dated, not used anymore) to 'African American'
- turned off rules for 'illegal immigrant', 'bite me', and 'yankee' (they don't really make sense imo, but I didn't consult Grafana)