### PR TITLE
Set priority for all HL MCOMMA models

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
@@ -407,7 +407,6 @@ public class German extends Language implements AutoCloseable {
       case "GENDER_NEUTRALITY": return -15;
       case "TYPOGRAPHY": return -15;
       case "ALL_UPPERCASE": return -15;
-      case "AI_HYDRA_LEO_MISSING_COMMA": return -51; // prefer comma style rules.
       case "COMMA_BEHIND_RELATIVE_CLAUSE": return -52; // less prio than AI_HYDRA_LEO
       case "DOPPELUNG_MODALVERB": return -52; // prefer comma rules (DOPPELUNG_MODALVERB, AI)
       case "VER_DOPPELUNG": return -52; // prefer comma rules (including AI)
@@ -423,6 +422,9 @@ public class German extends Language implements AutoCloseable {
       return -1;
     }
     if (id.startsWith("AI_HYDRA_LEO")) { // prefer more specific rules (also speller)
+      if (id.startsWith("AI_HYDRA_LEO_MISSING_COMMA")) {
+        return -51; // prefer comma style rules.
+      }
       if (id.startsWith("AI_HYDRA_LEO_CP")) {
         return 2;
       }


### PR DESCRIPTION
Now there are two HydraLEO missing comma models and they all start with `AI_HYDRA_LEO_MISSING_COMMA` . This PR checks whether the id starts with this string.