### PR TITLE
treat remote rule filters rule IDs as regexps

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/rules/remote-rules.xsd
+++ b/languagetool-core/src/main/resources/org/languagetool/rules/remote-rules.xsd
@@ -83,7 +83,7 @@
 				</xs:simpleType>
 			</xs:attribute>
 			<xs:attribute name="name" use="required" type="xs:string"/>
-			<xs:attribute name="id" type="xs:ID" use="required" />
+			<xs:attribute name="id" type="xs:string" use="required" />
 			<xs:attribute name="tags"/>
 		</xs:complexType>
 	</xs:element>
@@ -114,7 +114,7 @@
 				</xs:simpleType>
 			</xs:attribute>
 			<xs:attribute name="name" type="xs:string"/>
-			<xs:attribute name="id" type="xs:ID"/>
+			<xs:attribute name="id" type="xs:string"/>
 			<xs:attribute name="tags"/>
 		</xs:complexType>
 	</xs:element>

--- a/languagetool-core/src/test/java/org/languagetool/rules/RemoteRuleFiltersTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/RemoteRuleFiltersTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.*;
 
@@ -132,5 +133,30 @@ public class RemoteRuleFiltersTest {
     assertTrue("Filter applies, antipattern did not match", RemoteRuleFilters.filterMatches(testLang, s,
       Arrays.asList(matchSubstring(ruleId, s, "best bar"))
     ).isEmpty());
+  }
+
+  @Test
+  public void testIDRegexFilter() throws IOException, ExecutionException {
+    String ruleId = "TEST_ID_REGEX";
+    JLanguageTool lt = new JLanguageTool(testLang);
+    AnalyzedSentence s = lt.getAnalyzedSentence("This is a foo.");
+
+    assertFalse("Regex doesn't match", RemoteRuleFilters.filterMatches(testLang, s,
+      Arrays.asList(matchSubstring(ruleId, s, "foo"))
+      ).isEmpty());
+
+    assertTrue("Regex matches 1", RemoteRuleFilters.filterMatches(testLang, s,
+      Arrays.asList(matchSubstring(ruleId + "1", s, "foo"))
+      ).isEmpty());
+    assertTrue("Regex matches 2", RemoteRuleFilters.filterMatches(testLang, s,
+      Arrays.asList(matchSubstring(ruleId + "2", s, "foo"))
+      ).isEmpty());
+    assertTrue("Regex matches 3", RemoteRuleFilters.filterMatches(testLang, s,
+      Arrays.asList(matchSubstring(ruleId + "99", s, "foo"))
+      ).isEmpty());
+
+    assertFalse("Regex must match complete string", RemoteRuleFilters.filterMatches(testLang, s,
+      Arrays.asList(matchSubstring(ruleId + "100", s, "foo"))
+      ).isEmpty());
   }
 }

--- a/languagetool-core/src/test/resources/org/languagetool/rules/xx/remote-rule-filters.xml
+++ b/languagetool-core/src/test/resources/org/languagetool/rules/xx/remote-rule-filters.xml
@@ -62,5 +62,12 @@
             <example correction="">I went to the <marker>best bar</marker>.</example>
             <example>I went to the test bar.</example>
         </rule>
+        <rule id="TEST_ID_REGEX[0-9]{1,2}" name="">
+            <pattern>
+                <token>foo</token>
+            </pattern>
+            <example correction="">Lorem ipsum <marker>foo</marker>.</example>
+            <example>I went to the test bar.</example>
+        </rule>
     </category>
 </rules>


### PR DESCRIPTION
Allow remote rule filters to match multiple rule IDs by treating their IDs as regular expressions