### PR TITLE
fix some errors and logging for remote rules

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleFilters.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleFilters.java
@@ -202,6 +202,11 @@ public final class RemoteRuleFilters {
 
   @NotNull
   static String getFilename(Language lang) {
+      // we don't support language variants in AI rules / remote rule filters at the moment;
+      // this is another kind of variant, treat it as German
+      if (lang.getShortCode().equals("de-DE-x-simple-language")) {
+        lang = Languages.getLanguageForShortCode("de-DE");
+      }
       return lang.getShortCode() + "/" + RULE_FILE;
   }
 }


### PR DESCRIPTION
load remote rule filters for SimpleGerman from .../de/remote-rule-filters.xml
track remote rule timeouts as timeouts in metrics