### PR TITLE
Remove spurious "Title" prop

### DIFF
--- a/languagetool-office-extension/src/main/resources/Addons.xcu
+++ b/languagetool-office-extension/src/main/resources/Addons.xcu
@@ -70,9 +70,6 @@
         </node>
         <node oor:name="OfficeToolBar">
             <node oor:name="org.languagetool.openoffice.Main.toolbar" oor:op="replace">
-                <prop oor:name="Title" oor:type="xs:string">
-                    <value>LanguageTool</value>
-                </prop>
                 <node oor:name="T1" oor:op="replace">
                     <prop oor:name="URL" oor:type="xs:string">
                         <value>service:org.languagetool.openoffice.Main?nextError</value>


### PR DESCRIPTION
...which doesn't match the static structure of `officecfg/registry/schema/org/openoffice/Office/Addons.xcs` of OpenOffice.org-based projects and e.g. causes

> warn:configmgr:...:...:configmgr/source/xcuparser.cxx:159: bad set node <prop> member in "file:///.../.config/libreoffice/4/user/uno_packages/cache/uno_packages/....tmp_/LanguageTool-5.6.oxt/Addons.xcu"

on stderr during startup of LibreOffice debug builds