### PR TITLE
[de] rule suggestion: ENUM_SUB_UND_VER

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -21579,6 +21579,22 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <message>Verdoppelung: meinten Sie <suggestion>\1</suggestion> oder <suggestion>\2</suggestion>?</message>
             <example correction='kein|ein'>Da steht <marker>kein ein</marker> Fahrrad.</example>
         </rule>
+        <rule id="ENUM_SUB_UND_VER" name="TODO">
+            <pattern>
+                <token>,</token>
+                <token postag="SUB.*" postag_regexp="yes"/>
+                <marker>
+                    <token>und</token>
+                    <token postag="VER.*" postag_regexp="yes">
+                        <!-- TODO: Ich möchte ALLE Tokens, die nicht eindeutig Verben sind, ausnehmen. -->
+                        <exception postag="(SUB|ADV).*" postag_regexp="yes"></exception>
+                    </token>
+                </marker>
+            </pattern>
+            <message>Haben Sie hier ein Wort vergessen?</message>
+            <example correction="">Äpfel, Birnen <marker>und kann</marker> man dort kaufen.</example>
+            <example correction="">Darüber hinausgehende Informationen, Kontaktstellen <marker>und finden</marker> Betroffene hier.</example>
+        </rule>
     </category>
 
     <!-- ====================================================================== -->

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -21586,8 +21586,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token postag="SUB.*" postag_regexp="yes"/>
                     <token>und</token>
                     <token postag="VER.*" postag_regexp="yes">
-                        <!-- TODO: Ich möchte ALLE Tokens, die nicht eindeutig Verben sind, ausnehmen. -->
-                        <exception postag="(SUB|ADV).*" postag_regexp="yes"></exception>
+                        <exception postag='VER.*' postag_regexp='yes' negate_pos='yes'></exception>
                     </token>
                 </marker>
             </pattern>

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -21581,9 +21581,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         </rule>
         <rule id="ENUM_SUB_UND_VER" name="TODO">
             <pattern>
-                <token>,</token>
-                <token postag="SUB.*" postag_regexp="yes"/>
                 <marker>
+                    <token>,</token>
+                    <token postag="SUB.*" postag_regexp="yes"/>
                     <token>und</token>
                     <token postag="VER.*" postag_regexp="yes">
                         <!-- TODO: Ich möchte ALLE Tokens, die nicht eindeutig Verben sind, ausnehmen. -->
@@ -21592,8 +21592,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 </marker>
             </pattern>
             <message>Haben Sie hier ein Wort vergessen?</message>
-            <example correction="">Äpfel, Birnen <marker>und kann</marker> man dort kaufen.</example>
-            <example correction="">Darüber hinausgehende Informationen, Kontaktstellen <marker>und finden</marker> Betroffene hier.</example>
+            <suggestion>und \2 \4</suggestion>
+            <example correction="und Birnen kann">Äpfel<marker>, Birnen und kann</marker> man dort kaufen.</example>
+            <example correction="und Kontaktstellen finden">Weitere Informationen<marker>, Kontaktstellen und finden</marker> Betroffene hier.</example>
         </rule>
     </category>
 

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -21579,7 +21579,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <message>Verdoppelung: meinten Sie <suggestion>\1</suggestion> oder <suggestion>\2</suggestion>?</message>
             <example correction='kein|ein'>Da steht <marker>kein ein</marker> Fahrrad.</example>
         </rule>
-        <rule id="AUFZAEHLUNG_EXTRA_UND" name="Pferde, Kühe und (?) sind Tiere">
+        <rule id="AUFZAEHLUNG_EXTRA_UND" default="temp_off" name="Pferde, Kühe und (?) sind Tiere">
             <antipattern>
                 <token skip="-1" postag="SENT_START"/>
                 <token skip="-1" postag="VER.*:[123]:.*" postag_regexp="yes"/>

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -21580,6 +21580,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example correction='kein|ein'>Da steht <marker>kein ein</marker> Fahrrad.</example>
         </rule>
         <rule id="ENUM_SUB_UND_VER" name="TODO">
+            <antipattern>
+                <token skip="-1" postag="SENT_START"/>
+                <token skip="-1" postag="VER.*:[123]:.*" postag_regexp="yes"/>
+                <token>und</token>
+            </antipattern>
             <pattern>
                 <marker>
                     <token>,</token>
@@ -21594,6 +21599,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <suggestion>und \2 \4</suggestion>
             <example correction="und Birnen kann">Äpfel<marker>, Birnen und kann</marker> man dort kaufen.</example>
             <example correction="und Kontaktstellen finden">Weitere Informationen<marker>, Kontaktstellen und finden</marker> Betroffene hier.</example>
+            <example>Als Sänger agiert er in musikalischen Komödien, Musicals, Shows und gibt Konzerte.</example>
         </rule>
     </category>
 

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -21579,7 +21579,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <message>Verdoppelung: meinten Sie <suggestion>\1</suggestion> oder <suggestion>\2</suggestion>?</message>
             <example correction='kein|ein'>Da steht <marker>kein ein</marker> Fahrrad.</example>
         </rule>
-        <rule id="ENUM_SUB_UND_VER" name="TODO">
+        <rule id="AUFZAEHLUNG_EXTRA_UND" name="Pferde, Kühe und (?) sind Tiere">
             <antipattern>
                 <token skip="-1" postag="SENT_START"/>
                 <token skip="-1" postag="VER.*:[123]:.*" postag_regexp="yes"/>
@@ -21595,7 +21595,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     </token>
                 </marker>
             </pattern>
-            <message>Haben Sie hier ein Wort vergessen?</message>
+            <message>Hier scheint der letzte Teil einer Aufzählung zu fehlen.</message>
             <suggestion>und \2 \4</suggestion>
             <example correction="und Birnen kann">Äpfel<marker>, Birnen und kann</marker> man dort kaufen.</example>
             <example correction="und Kontaktstellen finden">Weitere Informationen<marker>, Kontaktstellen und finden</marker> Betroffene hier.</example>


### PR DESCRIPTION
Die neue Regel soll Fehler wie diesen erkennen:
> Weitere Informationen, Kontaktstellen und finden Betroffene hier.

In den Commits "v1" und "v2" habe ich den Marker unterschiedlich gesetzt, denn ich bin mir in diesem Fall nicht sicher, ob die Angabe einer `suggestion` sinnvoll ist.

Insbesondere bei der Kategorisierung, `id` und `name` bitte ich um Unterstützung, da ich noch nicht so vertraut mit dem „Regelwerk“ bin.