### PR TITLE
[de] add "löchen" to GermanSpellerRule.java

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanSpellerRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanSpellerRule.java
@@ -1265,6 +1265,7 @@ public class GermanSpellerRule extends CompoundAwareHunspellRule {
     put("Definierung", "Definition");
     put("Definierungen", "Definitionen");
     putRepl("[Üü]bergrifflich(e[mnrs]?)?", "lich", "ig");
+    put("löchen", w -> Arrays.asList("löschen", "löchern", "Köchen"));
   }
 
   private static void putRepl(String wordPattern, String pattern, String replacement) {


### PR DESCRIPTION
 I didn't find a possibility to replace the whole suggestion list with a different list, so I added them to the top of the list instead.