### PR TITLE
Add antipatterns to German agreement and verb agreement rules.

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/AgreementRuleAntiPatterns1.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/AgreementRuleAntiPatterns1.java
@@ -1100,6 +1100,10 @@ class AgreementRuleAntiPatterns1 {
     Arrays.asList(
       csToken("BMW"),
       token("ConnectedDrive")
+    ),
+    Arrays.asList( // Die Koalition der Willigen
+      posRegex("ART:DEF:DAT:.+"),
+      token("Willigen")
     ));
 
 }

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/VerbAgreementRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/VerbAgreementRule.java
@@ -359,6 +359,78 @@ public class VerbAgreementRule extends TextLevelRule {
     Arrays.asList( // -Du fühlst dich unsicher?
       tokenRegex("[^a-zäöüß]+du"),
       pos("VER:2:SIN:PRÄ:SFT")
+    ),
+    Arrays.asList( // Mir ist bewusst, dass viele Menschen wie du empfinden.
+      posRegex("PRO:IND.*"),
+      posRegex("SUB:.+:PLU.*"),
+      tokenRegex("wie|als"),
+      posRegex("PRO:PER.+"),
+      posRegex("VER:[1-3]:PLU.*")
+    ),
+    Arrays.asList( //Weniger als du arbeitet keiner.
+      pos("ADV:MOD"),
+      tokenRegex("als"),
+      posRegex("PRO:PER.+"),
+      posRegex("VER:3:SIN.*"),
+      posRegex("PRO:IND:NOM:SIN.*")
+    ),
+    Arrays.asList( //So was wie er könnte ich nicht machen, dich einfach dann zu verlassen
+      posRegex("PRO:IND.*"),
+      tokenRegex("wie"),
+      posRegex("PRO:PER.+"),
+      posRegex("VER:.*:SIN.*"),
+      posRegex("PRO:PER:NOM:SIN.*")
+    ),
+    Arrays.asList( //Kein anderer als du kann mich glücklich machen
+      tokenRegex("kein|keine"),
+      tokenRegex("anderer|andere"),
+      token("als"),
+      tokenRegex("ich|du|er|sie|es"),
+      posRegex("VER:MOD.*:PRÄ")
+    ),
+    Arrays.asList( // Ich will nicht die gleiche Luft wie er einatmen
+      posRegex("ART:DEF.*"),
+      tokenRegex("gleich(e|en)|selb(e|en)"),
+      posRegex("SUB:.+"),
+      token("wie"),
+      posRegex("PRO:PER:NOM:SIN.*"),
+      posRegex("VER:INF.*")
+    ),
+    Arrays.asList( // Was würdest du sagen, wenn du ich wärst?
+      token("wenn"),
+      posRegex("PRO:PER:NOM:SIN.+"),
+      posRegex("PRO:PER:NOM.+"),
+      posRegex("VER:AUX:[1-3]:SIN:KJ2")
+    ),
+    Arrays.asList( // Was würdet ihr sagen, wenn ihr ich wärt?
+      token("wenn"),
+      posRegex("PRO:PER:NOM:PLU.+"),
+      posRegex("PRO:PER:NOM.+"),
+      posRegex("VER:AUX:[1-3]:PLU:KJ2")
+    ),
+    Arrays.asList( //Wenn du gehen willst, dann geh!
+      token("wenn"),
+      token("du"),
+      token("gehen"),
+      token("willst"),
+      token(","),
+      token("dann"),
+      token("geh")
+    ),
+    Arrays.asList( //Ich habe mich noch nicht entschieden, ob ich studieren oder arbeiten gehen soll.
+      token("ob"),
+      token("ich"),
+      posRegex("VER:1.+"),
+      token("oder"),
+      posRegex("VER:1.+"),
+      new PatternTokenBuilder().token("gehen").matchInflectedForms().build(),
+      posRegex("VER:MOD:1.*")
+    ),
+    Arrays.asList( //Mal seh’n, wie’s Wetter wird.
+      token("mal"),
+      token("seh"),
+      tokenRegex("’|'"),
+      token("n")
     )
   );
 

--- a/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/VerbAgreementRuleTest.java
+++ b/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/VerbAgreementRuleTest.java
@@ -72,12 +72,10 @@ public class VerbAgreementRuleTest {
     assertThat(match3.length, is(1));
     assertThat(match3[0].getFromPos(), is(97));
     assertThat(match3[0].getToPos(), is(107));
-    
-    //TODO: This is a FP to be fixed
+
+    //Was a FP, now fixed
     RuleMatch[] match4 = rule.match(lt.analyzeText("Mir ist bewusst, dass viele Menschen wie du empfinden."));
-    assertThat(match4.length, is(1));
-    assertThat(match4[0].getFromPos(), is(41));
-    assertThat(match4[0].getToPos(), is(53));
+    assertThat(match4.length, is(0));
   }
   
   @Test


### PR DESCRIPTION
The antipatterns were tested against the German Tatoeba dataset, as well as ~100k other German sentences to make sure they don't cause any new false negatives.