### PR TITLE
make PatternToken.getExceptionList non-nullable and public

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternToken.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternToken.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ObjectArrays;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.VisibleForTesting;
 import org.languagetool.AnalyzedToken;
 import org.languagetool.AnalyzedTokenReadings;
 import org.languagetool.JLanguageTool;
@@ -672,11 +671,10 @@ public class PatternToken implements Cloneable {
    * @return A List of Exceptions. Used for testing.
    * @since 1.0.0
    */
-  @Nullable
-  @VisibleForTesting
+  @NotNull
   public List<PatternToken> getExceptionList() {
     PatternToken[] array = rareFields == null ? EMPTY_ARRAY : rareFields.currentAndNextExceptions;
-    return array.length == 0 ? null : Arrays.asList(array);
+    return array.length == 0 ? Collections.emptyList() : Arrays.asList(array);
   }
 
   @ApiStatus.Internal
@@ -771,7 +769,7 @@ public class PatternToken implements Cloneable {
       sb.append(chunkTag);
     }
     List<PatternToken> exceptionList = getExceptionList();
-    if (exceptionList != null) {
+    if (!exceptionList.isEmpty()) {
       sb.append("/exceptions=");
       sb.append(exceptionList);
     }

--- a/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternTestTools.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/patterns/PatternTestTools.java
@@ -18,15 +18,11 @@
  */
 package org.languagetool.rules.patterns;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import org.languagetool.Language;
+
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.languagetool.Language;
 
 import static org.junit.Assert.fail;
 
@@ -115,7 +111,7 @@ public final class PatternTestTools {
               i);
 
       List<PatternToken> exceptionPatternTokens = new ArrayList<>();
-      if (pToken.getExceptionList() != null) {
+      if (!pToken.getExceptionList().isEmpty()) {
         for (PatternToken exception: pToken.getExceptionList()) {
           // Detect useless exception or missing skip="...". I.e. things like this:
           // <token postag="..."><exception scope="next">foo</exception</token>


### PR DESCRIPTION
This is needed for IntelliJ that now inspects the pattern rules to see whether they need chunk tags. IntelliJ disables the chunker for English for being too expensive for an IDE, and it performs this analysis to avoid introducing false positives as a result.