### PR TITLE
don't compute expensive historical readings during feature unification

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/Unifier.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/Unifier.java
@@ -19,12 +19,12 @@
 
 package org.languagetool.rules.patterns;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.jetbrains.annotations.Nullable;
 import org.languagetool.AnalyzedToken;
 import org.languagetool.AnalyzedTokenReadings;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Implements unification of features over tokens.
@@ -156,7 +156,7 @@ public class Unifier {
           equivList.add(equivalencesMatched.get(tokCnt));
           tokSequenceEquivalences.add(equivList);
         } else {
-          tokSequence.get(0).addReading(aToken, "Unifier");
+          tokSequence.get(0).addReading(aToken, "");
           tokSequenceEquivalences.get(0).add(equivalencesMatched.get(tokCnt));
         }
         tokCnt++;
@@ -217,7 +217,7 @@ public class Unifier {
           tokSequenceEquivalences.add(equivList);
         } else {
           if (readingsCounter < tokSequence.size()) {
-            tokSequence.get(readingsCounter).addReading(aToken, "Unifier");
+            tokSequence.get(readingsCounter).addReading(aToken, "");
             tokSequenceEquivalences.get(readingsCounter).add(equivalencesMatchedHere);
           } else {
             anyFeatUnified = false;
@@ -374,7 +374,7 @@ public class Unifier {
       AnalyzedTokenReadings tmpATR = new AnalyzedTokenReadings(token, 0);
       tokenSequence.add(tmpATR);
     } else {
-      tokenSequence.get(pos).addReading(token, "Unifier");
+      tokenSequence.get(pos).addReading(token, "");
     }
   }
 


### PR DESCRIPTION
This speeds up `Main -l de` for me by ~10%