### PR TITLE
Change priority of HydraLEO for FR and ES to be lower of the spellchecker

### DIFF
--- a/languagetool-language-modules/es/src/main/java/org/languagetool/language/Spanish.java
+++ b/languagetool-language-modules/es/src/main/java/org/languagetool/language/Spanish.java
@@ -254,10 +254,7 @@ public class Spanish extends Language implements AutoCloseable {
     }
 
     if (id.startsWith("AI_ES_HYDRA_LEO")) { // prefer more specific rules (also speller)
-      if (id.startsWith("AI_ES_HYDRA_LEO_MISSING_COMMA")) {
-        return -51; // prefer comma style rules.
-      }
-      return -11;
+      return -101;
     }
 
     //STYLE is -50

--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
@@ -352,10 +352,7 @@ public class French extends Language implements AutoCloseable {
     }
 
     if (id.startsWith("AI_FR_HYDRA_LEO")) { // prefer more specific rules (also speller)
-      if (id.startsWith("AI_FR_HYDRA_LEO_MISSING_COMMA")) {
-        return -51; // prefer comma style rules.
-      }
-      return -11;
+      return -101;
     }
 
     return super.getPriorityForId(id);


### PR DESCRIPTION
French and Spanish spellcheckers have a priority of -100 so HydraLEO should have a lower priority.