### PR TITLE
[de] prioritize VERWECHSLUNG_MIR_DIR_MIR_DIE over MIR_DIR

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
@@ -294,6 +294,7 @@ public class German extends Language implements AutoCloseable {
       case "DA_DURCH": return 2; // prefer over SUBSTANTIVIERUNG_NACH_DURCH and DURCH_SCHAUEN and DURCH_WACHSEN
       case "BEI_GOOGLE" : return 2;   // prefer over agreement rules and VOR_BEI
       case "EINE_ORIGINAL_RECHNUNG_TEST" : return 2;   // prefer over EINE_ORIGINAL_RECHNUNG
+      case "VERWECHSLUNG_MIR_DIR_MIR_DIE": return 1; // prefer over MIR_DIR
       case "ERNEUERBARE_ENERGIEN": return 1; // prefer over VEREINBAREN
       case "VOR_BEI": return 1; // prefer over BEI_BEHALTEN
       case "VERWANDET_VERWANDTE": return 1; // prefer over DE_CASE


### PR DESCRIPTION
@udomai: Im SentenceSourceChecker schlägt so für "Dazu fehlt mir dir Kraft" nur noch "VERWECHSLUNG_MIR_DIR_MIR_DIE" und nicht mehr "MIR_DIR" und "CONFUSION_RULE_MIR_MIT_NEU" zu. 