### PR TITLE
Rename FOLLOW_UP_DE

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/grammar.xml
@@ -16677,7 +16677,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <short>Getrenntschreibung</short>
             <example correction="Des Weiteren"><marker>Desweiteren</marker> werde ich eine Eilmeldung rausschicken.</example>
         </rule>
-        <rulegroup id="FOLLOW_UP_DE" name="Follow up (Follow-up)">
+        <rulegroup id="FOLLOW_UP" name="Follow up (Follow-up)">
             <antipattern case_sensitive="yes">
                 <token regexp="yes">Follow-ups?</token>
             </antipattern>


### PR DESCRIPTION
Rename `FOLLOW_UP_DE` to `FOLLOW_UP`. No need to have unique Rule IDs across languages.