### PR TITLE
Change in barbarisms-pt-BR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/barbarisms-pt-BR.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/barbarisms-pt-BR.txt
@@ -175,13 +175,3 @@ water-closet=banheiro
 water-closets=banheiros
 zip=compressão de arquivos
 zips=compressão de arquivos
-#
-# E-MAIL(S) *START*
-e-mail=endereço eletrônico|correio eletrônico|mensagem eletrônica
-e-mails=endereços eletrônicos|correios eletrônicos|mensagens eletrônicas
-email=endereço eletrônico|correio eletrônico|mensagem eletrônica
-emails=endereços eletrônicos|correios eletrônicos|mensagens eletrônicas
-mail=endereço eletrônico|correio eletrônico|mensagem eletrônica
-mails=endereços eletrônicos|correios eletrônicos|mensagens eletrônicas
-# E-MAIL(S) *END*
-#


### PR DESCRIPTION
Removed suggestions of replacing 'e-mail, email' for a translation, as in Brazilian Portuguese the English version of this word is largely used and accepted in all registers.