### PR TITLE
Greek word repeat beginning rule

### DIFF
--- a/languagetool-language-modules/el/src/main/java/org/languagetool/rules/el/GreekWordRepeatBeginningRule.java
+++ b/languagetool-language-modules/el/src/main/java/org/languagetool/rules/el/GreekWordRepeatBeginningRule.java
@@ -72,7 +72,8 @@ public class GreekWordRepeatBeginningRule extends WordRepeatBeginningRule {
   @Override
   public boolean isException(String token) {
     return super.isException(token) || token.equals("Ο") || token.equals("Η") || token.equals("Το") ||
-    	   token.equals("Οι")|| token.equals("Τα");
+    	   token.equals("Οι")|| token.equals("Τα") || token.equals("Ένας") || token.equals("Μία") || 
+		   token.equals("Ένα");
   }
 
   @Override

--- a/languagetool-language-modules/el/src/test/java/org/languagetool/rules/el/GreekWordRepeatBeginningRuleTest.java
+++ b/languagetool-language-modules/el/src/test/java/org/languagetool/rules/el/GreekWordRepeatBeginningRuleTest.java
@@ -40,6 +40,8 @@ public class GreekWordRepeatBeginningRuleTest {
     assertEquals(0, lt.check("Εγώ παίζω ποδόσφαιρο. Εγώ παίζω μπάσκετ").size());
     // three successive sentences that start with the same exception word ("Το").
     assertEquals(0, lt.check("Το αυτοκίνητο είναι καινούργιο. Το ποδήλατο είναι παλιό. Το καράβι είναι καινούργιο.").size());
+    // two successive sentences that start with the same exception word ("Μία").
+    assertEquals(0, lt.check("Μία περίπτωση εξηγήθηκε ήδη. Μία άλλη θα αναλυθεί παρακάτω.").size());
     
     // =================== errors =============================
     // two successive sentences that start with one of the saved adverbs ("Επίσης").


### PR DESCRIPTION
Based on the Greek syntax, two or more successive sentences can start with the same article. Until now, the method isException() in GreekWordRepeatBeginningRule.java takes into consideration only definite articles. Hence, I added all the indefinite articles and a related test case.