### PR TITLE
Correct 'a' for "UHD" + "UHDTV" (#4360)

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_a.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_a.txt
@@ -237,6 +237,8 @@ Ugandan
 *UGU
 *UGX
 *UHCD
+*UHD
+*UHDTV
 *UI
 *UIA
 *UIC


### PR DESCRIPTION
"Ultra High-Definition TV"

- https://en.wikipedia.org/wiki/Ultra-high-definition_television