### PR TITLE
[nl][LANG_WOORD] Disable rule with many false positives

### DIFF
--- a/languagetool-language-modules/nl/src/main/resources/org/languagetool/rules/nl/grammar.xml
+++ b/languagetool-language-modules/nl/src/main/resources/org/languagetool/rules/nl/grammar.xml
@@ -7379,7 +7379,7 @@ onwaarschijnlijk
 		</rulegroup>
 	</category>
 	<category id="LEESBAARHEID" name="Leesbaarheid" type="style">
-		<rulegroup id="LANG_WOORD" name="Lang woord" tags="picky">
+		<rulegroup id="LANG_WOORD" name="Lang woord" tags="picky" default="off">
 			<rule>
 				<pattern>
 					<token regexp="yes">^\P{M}{20,29}$<exception postag="UNKNOWN"/></token>


### PR DESCRIPTION
As discussed, it makes little to no sense that a simple character count should trigger a rule when Dutch word formation allows for longish compounds.