### PR TITLE
[pt] rule "PHRASAL VERB RESIDIR EM" disabled and moved to PT-PT

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -9439,46 +9439,7 @@ Isto observa-se quando as forças avaliam mal o cenário.
       <example>…rimeira é eleita por sufrágio universal directo e tem poderes fundamentalmente legislativos, além de fiscalizar…</example>
 	  <example type='correct'>Que mal tem <marker>fazer chichi</marker> na piscina?</example>	
     </rule>
-    <rule id='PHRASAL_VERB_RESIDIR_EM' name='Regência verbal: Residir em'>
-    <!--      Created by Tiago F. Santos, 2018-09-19      -->
-    <!--antipattern>
-          <token regexp='yes'>residentes?|morador(?:es)?</token>
-          <token/>
-          <token regexp='yes'>com|em|n[ao]s?</token>
-      </antipattern-->
-      <antipattern>
-          <token regexp='yes'>residentes?|morad(?:as?|or(?:es)?)</token>
-          <token postag_regexp='yes' postag='A.+'/>
-      </antipattern>
-<!-- MARCOAGPINTO 2020-10-06 + 2020-10-27 (21-OCT-2020+) *START* --> 
-<!-- "No núcleo reside a força imprescindível dos modelos." -->
-      <antipattern>		  
-		  <token regexp="yes">residem?</token>
-		  <token regexp="yes">as?|os?|um|uns|umas?</token>
-		  <token postag='NC[CFM][SP]000|AQ0[CFM][SP]0' postag_regexp='yes'/>
-	  </antipattern>
-<!-- MARCOAGPINTO 2020-10-06 + 2020-10-27 (21-OCT-2020+) *END* -->
-      <pattern>
-          <token inflected='yes' regexp='yes'>residir|morar|residente|morador</token>
-          <token postag_regexp='yes' postag='[DN].+'>
-            <exception postag_regexp='yes' postag='[AP].+'/>
-            <exception postag_regexp='yes' postag='R.+'/>
-            <exception regexp='yes'>com|em|n[ao]s?</exception>
-            <exception scope='next' regexp='yes'>perigos?</exception></token>
-      </pattern>
-      <message>Erro de regência. Dependendo do significado, escolha:</message>
-        <suggestion>\1 em \2</suggestion>
-        <suggestion>\1 com \2</suggestion>
-      <url>https://ciberduvidas.iscte-iul.pt/glossario/erros/251</url>
-      <example correction='Reside em casa|Reside com casa'><marker>Reside casa</marker> da namorada?</example>
-      <example>Lá reside o perigo.</example>
-      <example>…que residentes cubanos nos Estados Unidos…</example>
-      <example>, entre residentes estrangeiros e nacionais no regime fiscal.</example>
-	  <example type='correct'>No núcleo <marker>reside a</marker> força imprescindível dos modelos.</example>
-      <example>Mora alguém nesta casa?</example>
-      <example>Moramos juntos agora.</example>
-    </rule>
-    <rule id='PHRASAL_VERB_SOBREPOR_SOBRE' name='Regência verbal: Sobrepor sobre/a'>
+        <rule id='PHRASAL_VERB_SOBREPOR_SOBRE' name='Regência verbal: Sobrepor sobre/a'>
     <!--      Created by Tiago F. Santos, 2019-09-21      -->
       <pattern>
           <token inflected='yes' regexp='yes'>sobrep[oô]r</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -113,7 +113,46 @@ title="Easy editing stylesheet" ?>
     <!-- Unification rules retrieved from galician grammar.xml - END  -->
 
  <category id="EUROPEAN_PORTUGUESE" name="Português de Portugal">
-     <!-- CHEGAR AO FIM findar/terminar -->
+     <rule id='PHRASAL_VERB_RESIDIR_EM' name='Regência verbal: Residir em' default="off">
+         <!--      Created by Tiago F. Santos, 2018-09-19      -->
+         <!--antipattern>
+               <token regexp='yes'>residentes?|morador(?:es)?</token>
+               <token/>
+               <token regexp='yes'>com|em|n[ao]s?</token>
+           </antipattern-->
+         <antipattern>
+             <token regexp='yes'>residentes?|morad(?:as?|or(?:es)?)</token>
+             <token postag_regexp='yes' postag='A.+'/>
+         </antipattern>
+         <!-- MARCOAGPINTO 2020-10-06 + 2020-10-27 (21-OCT-2020+) *START* -->
+         <!-- "No núcleo reside a força imprescindível dos modelos." -->
+         <antipattern>
+             <token regexp="yes">residem?</token>
+             <token regexp="yes">as?|os?|um|uns|umas?</token>
+             <token postag='NC[CFM][SP]000|AQ0[CFM][SP]0' postag_regexp='yes'/>
+         </antipattern>
+         <!-- MARCOAGPINTO 2020-10-06 + 2020-10-27 (21-OCT-2020+) *END* -->
+         <pattern>
+             <token inflected='yes' regexp='yes'>residir|morar|residente|morador</token>
+             <token postag_regexp='yes' postag='[DN].+'>
+                 <exception postag_regexp='yes' postag='[AP].+'/>
+                 <exception postag_regexp='yes' postag='R.+'/>
+                 <exception regexp='yes'>com|em|n[ao]s?</exception>
+                 <exception scope='next' regexp='yes'>perigos?</exception></token>
+         </pattern>
+         <message>Erro de regência. Dependendo do significado, escolha:</message>
+         <suggestion>\1 em \2</suggestion>
+         <suggestion>\1 com \2</suggestion>
+         <url>https://ciberduvidas.iscte-iul.pt/glossario/erros/251</url>
+         <example correction='Reside em casa|Reside com casa'><marker>Reside casa</marker> da namorada?</example>
+         <example>Lá reside o perigo.</example>
+         <example>…que residentes cubanos nos Estados Unidos…</example>
+         <example>, entre residentes estrangeiros e nacionais no regime fiscal.</example>
+         <example type='correct'>No núcleo <marker>reside a</marker> força imprescindível dos modelos.</example>
+         <example>Mora alguém nesta casa?</example>
+         <example>Moramos juntos agora.</example>
+     </rule>
+
      <rule id='CHEGAR_AO_FIM_FINDAR_TERMINAR' name="Chegar ao fim → findar/terminar/acabar" type="style">
          <!--      Created by Marco A.G.Pinto, Portuguese rule 2022-07-03 (Checked/Enhanced) (5-JUN-2022+)      -->
          <!--


### PR DESCRIPTION
I have talked to our PT collaborator Marco from the LT community, and we agreed to move this rule to PT-PT and disable it for now, as it's been throwing many false alarms and not really correcting anything. @St-ac-y would you mind checking if everything looks okay here?