### PR TITLE
[nl] add spelling

### DIFF
--- a/languagetool-language-modules/nl/src/main/resources/org/languagetool/resource/nl/disambiguation.xml
+++ b/languagetool-language-modules/nl/src/main/resources/org/languagetool/resource/nl/disambiguation.xml
@@ -1522,4 +1522,11 @@ Copyright (C) 2008-2018 Ruud Baars, TaalTik
 		</pattern>
 	   <disambig action="remove" postag="[^E]"/>
 	</rule>
+
+	<rule id="IGNORE_SPELLING_OF_100K" name="ignore spelling of '100k' and '2022b'">
+		<pattern>
+			<token regexp="yes">\d+[a-z]</token>
+		</pattern>
+		<disambig action="ignore_spelling"/>
+	</rule>
 </rules>

--- a/languagetool-language-modules/nl/src/main/resources/org/languagetool/resource/nl/spelling/ignore.txt
+++ b/languagetool-language-modules/nl/src/main/resources/org/languagetool/resource/nl/spelling/ignore.txt
@@ -2279,4 +2279,5 @@ sjiek
 M&M's
 Leve
 Gelieve
-Scribbr
+Scribbr #name
+MyParcel #name

--- a/languagetool-language-modules/nl/src/main/resources/org/languagetool/resource/nl/spelling/spelling.txt
+++ b/languagetool-language-modules/nl/src/main/resources/org/languagetool/resource/nl/spelling/spelling.txt
@@ -11569,3 +11569,45 @@ Eye relief
 kopi loewak
 Kopi loewak
 herstel
+admin
+admins
+boosting
+backlink
+backlinks
+Employer Branding
+Rijkerswoerdse Plassen #name
+altcoin
+altcoins
+stablecoin
+stablecoins
+backlog
+backlogs
+bloglink
+bloglinks
+linkbuilding
+DevOps
+insight
+insights
+call-to-action
+analytics
+funnel
+funnels
+benefit
+benefits
+Brits-Indië
+API's
+API’s
+KPI's
+KPI’s
+ID's
+ID’s
+USP’s
+USP's
+esports
+hypocentrum
+hypocentra
+STAP-budget
+blacklist
+blacklists
+whitelist
+whitelists


### PR DESCRIPTION
* I added a generic disambiguation rule that allows spelling of numbers that are followed by a letter (e.g., 2022b or 100k)
* I went through the most common words that our Dutch users add to their dictionaries, mostly anglicisms used in marketing and dev speech – I guess the Dutch are using a lot of English terms like we Germans

Please check and confirm @LanguageTool-AS