### PR TITLE
[pt] rule CONFUSÃO_MAIS_MAS_VÍRGULA improved

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -341,7 +341,7 @@ title="Easy editing stylesheet" ?>
 
 
  <category id='GRAMMAR' name="Gramática Geral" type="grammar">
-     <rule id="CONFUSÃO_MAIS_MAS_VÍRGULA" name="confusao de mais e mas após a vírgula" default="temp_off">
+    <rule id="CONFUSÃO_MAIS_MAS_VÍRGULA" name="confusao de mais e mas após a vírgula" default="temp_off">
         <antipattern>
             <token>,</token>
             <token>mais</token>
@@ -420,7 +420,7 @@ title="Easy editing stylesheet" ?>
              <token postag="C.+|I.+|enfim|opa" postag_regexp="yes"/>
              <token>,</token>
              <token>mais</token>
-             <token regexp='yes' min='0'>'N.+|PD.+|DD.+'</token>
+             <token postag="N.+|PD.+|DD.+" postag_regexp="yes" min='0'/>
              <example>O país é mais desenvolvido e, portanto, mais industrializado.</example>
         </antipattern>
         <antipattern>
@@ -455,8 +455,16 @@ title="Easy editing stylesheet" ?>
             <token>mais</token>
             <token postag='VMP00SM' min='0'/>
             <token regexp='yes'>ainda|cedo|tarde|adiante|abaixo|</token>
-            <token regexp='yes'>\.|,|C.+|SPS00</token>
+            <token regexp='yes'>\.|,</token>
             <example>Já gostava de chocolate - e agora, mais ainda.</example>
+        </antipattern>
+        <antipattern>
+            <token>,</token>
+            <token>mais</token>
+            <token postag='VMP00SM' min='0'/>
+            <token regexp='yes'>ainda|cedo|tarde|adiante|abaixo|</token>
+            <token postag='C.+|SPS00' postag_regexp='yes'/>
+            <example>Ele sentiu muito os efeitos dessa decisão, mais intensamente ainda do que antes.</example>
         </antipattern>
         <pattern>
             <token>,</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -417,11 +417,18 @@ title="Easy editing stylesheet" ?>
             <example>Este grupo, pouco conhecido, mais afasta do que atrai fiéis.</example>
         </antipattern>
         <antipattern>
-             <token postag="C.+|I.+|enfim|opa" postag_regexp="yes"/>
+             <token postag="C.+|I.+" postag_regexp="yes"/>
              <token>,</token>
              <token>mais</token>
              <token postag="N.+|PD.+|DD.+" postag_regexp="yes" min='0'/>
              <example>O país é mais desenvolvido e, portanto, mais industrializado.</example>
+        </antipattern>
+        <antipattern>
+             <token regexp= 'yes'>enfim|opa</token>
+             <token>,</token>
+             <token>mais</token>
+             <token postag="N.+|PD.+|DD.+" postag_regexp="yes" min='0'/>
+             <example>Enfim, mais refrescos para nós.</example>
         </antipattern>
         <antipattern>
              <token>com</token>
@@ -454,7 +461,7 @@ title="Easy editing stylesheet" ?>
             <token>,</token>
             <token>mais</token>
             <token postag='VMP00SM' min='0'/>
-            <token regexp='yes'>ainda|cedo|tarde|adiante|abaixo|</token>
+            <token regexp='yes'>ainda|cedo|tarde|adiante|abaixo</token>
             <token regexp='yes'>\.|,</token>
             <example>Já gostava de chocolate - e agora, mais ainda.</example>
         </antipattern>
@@ -462,7 +469,7 @@ title="Easy editing stylesheet" ?>
             <token>,</token>
             <token>mais</token>
             <token postag='VMP00SM' min='0'/>
-            <token regexp='yes'>ainda|cedo|tarde|adiante|abaixo|</token>
+            <token regexp='yes'>ainda|cedo|tarde|adiante|abaixo</token>
             <token postag='C.+|SPS00' postag_regexp='yes'/>
             <example>Ele sentiu muito os efeitos dessa decisão, mais intensamente ainda do que antes.</example>
         </antipattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -417,18 +417,18 @@ title="Easy editing stylesheet" ?>
             <example>Este grupo, pouco conhecido, mais afasta do que atrai fiéis.</example>
         </antipattern>
         <antipattern>
-             <token regexp='yes'>'C.+|I.+|enfim|opa'</token>
+             <token postag="C.+|I.+|enfim|opa" postag_regexp="yes"/>
              <token>,</token>
              <token>mais</token>
              <token regexp='yes' min='0'>'N.+|PD.+|DD.+'</token>
-            <example>O país é mais desenvolvido e, portanto, mais industrializado.</example>
+             <example>O país é mais desenvolvido e, portanto, mais industrializado.</example>
         </antipattern>
         <antipattern>
              <token>com</token>
              <token>isso</token>
              <token>,</token>
              <token>mais</token>
-            <example>Com isso, mais pessoas virão.</example>
+             <example>Com isso, mais pessoas virão.</example>
         </antipattern>
         <antipattern>
             <token>sendo</token>
@@ -453,9 +453,9 @@ title="Easy editing stylesheet" ?>
         <antipattern>
             <token>,</token>
             <token>mais</token>
-            <token min='0'>'VMP00SM'</token>
+            <token postag='VMP00SM' min='0'/>
             <token regexp='yes'>ainda|cedo|tarde|adiante|abaixo|</token>
-            <token regexp='yes'>.|,|C.+|SPS00</token>
+            <token regexp='yes'>\.|,|C.+|SPS00</token>
             <example>Já gostava de chocolate - e agora, mais ainda.</example>
         </antipattern>
         <pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -341,7 +341,7 @@ title="Easy editing stylesheet" ?>
 
 
  <category id='GRAMMAR' name="Gramática Geral" type="grammar">
-     <rule id="CONFUSION_OF_MAS_MAIS_COMMA" name="confusion of mais and mas after comma" default="temp_off">
+     <rule id="CONFUSÃO_MAIS_MAS_VÍRGULA" name="confusao de mais e mas após a vírgula" default="temp_off">
         <antipattern>
             <token>,</token>
             <token>mais</token>
@@ -391,7 +391,7 @@ title="Easy editing stylesheet" ?>
         <antipattern>
             <token>,</token>
             <token>mais</token>
-            <token regexp='no' min='0'>de</token>
+            <token min='0'>de</token>
             <token postag='Z.+' postag_regexp='yes'/>
             <example>Foram seis dias de folga, mais dois com o fim de semana.</example>
         </antipattern>
@@ -405,14 +405,14 @@ title="Easy editing stylesheet" ?>
         <antipattern>
             <token>,</token>
             <token skip="-1">mais</token>
-            <token regexp='no' min='0'>ou</token>
+            <token min='0'>ou</token>
             <token>menos</token>
             <example>Ele vai ganhar, mais voto ou menos voto.</example>
         </antipattern>
         <antipattern>
-            <token regexp='no' min='0'>ainda</token>
+            <token min='0'>ainda</token>
             <token skip="-1">mais</token>
-            <token regexp='no' min='0'>do</token>
+            <token min='0'>do</token>
             <token>que</token>
             <example>Este grupo, pouco conhecido, mais afasta do que atrai fiéis.</example>
         </antipattern>
@@ -453,15 +453,9 @@ title="Easy editing stylesheet" ?>
         <antipattern>
             <token>,</token>
             <token>mais</token>
-            <token regexp='no' min='0'>'VMP00SM'</token>
+            <token min='0'>'VMP00SM'</token>
             <token regexp='yes'>ainda|cedo|tarde|adiante|abaixo|</token>
             <token regexp='yes'>.|,|C.+|SPS00</token>
-            <example>Já gostava de chocolate - e agora, mais ainda.</example>
-        </antipattern>
-        <antipattern>
-            <token>,</token>
-            <token>mais</token>
-            <token regexp='yes'>esperança|</token>
             <example>Já gostava de chocolate - e agora, mais ainda.</example>
         </antipattern>
         <pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -341,17 +341,25 @@ title="Easy editing stylesheet" ?>
 
 
  <category id='GRAMMAR' name="Gramática Geral" type="grammar">
-     <rule id="CONFUSION_OF_MAS_MAIS" name="confusion of mais and mas" default="temp_off">
+     <rule id="CONFUSION_OF_MAS_MAIS_COMMA" name="confusion of mais and mas after comma" default="temp_off">
         <antipattern>
+            <token>,</token>
             <token>mais</token>
             <token postag='AQ.+' postag_regexp='yes'/>
             <example>Stefani Joanne, mais conhecida como Lady Gaga, é uma cantora estadunidense.</example>
         </antipattern>
         <antipattern>
             <token regexp='yes'>quanto|quem</token>
-            <token skip="-1">mais</token>
+            <token skip="-1" postag='RG|AQ0CS0' postag_regexp='yes'/>
             <token>mais</token>
             <example>Quanto mais eu durmo, mais sono tenho.</example>
+        </antipattern>
+        <antipattern>
+            <token>à</token>
+            <token>medida</token>
+            <token skip="-1">que</token>
+            <token>mais</token>
+            <example>À medida que o tempo passa, mais esperança tenho.</example>
         </antipattern>
         <antipattern>
             <token skip="-1">mais</token>
@@ -360,10 +368,101 @@ title="Easy editing stylesheet" ?>
             <example>Este mercado tem mais ofertas, mais opções e mais economia.</example>
         </antipattern>
         <antipattern>
+            <token>mais</token>
+            <token>e</token>
+            <token>mais</token>
+            <example>Quando penso nos motivos, mais e mais compreendo.</example>
+        </antipattern>
+        <antipattern>
+            <token>,</token>
+            <token skip="-1">mais</token>
+            <token>e</token>
+            <token postag='N.+' postag_regexp='yes'/>
+            <example>Eram três quartos, mais sala de jantar e escritório.</example>
+        </antipattern>
+        <antipattern>
+            <token>menos</token>
+            <token postag='N.+' postag_regexp='yes'/>
+            <token>,</token>
+            <token>mais</token>
+            <token postag='N.+' postag_regexp='yes'/>
+            <example>Menos conversa, mais ação.</example>
+        </antipattern>
+        <antipattern>
+            <token>,</token>
+            <token>mais</token>
+            <token regexp='no' min='0'>de</token>
+            <token postag='Z.+' postag_regexp='yes'/>
+            <example>Foram seis dias de folga, mais dois com o fim de semana.</example>
+        </antipattern>
+        <antipattern>
+            <token>a</token>
+            <token>cada</token>
+            <token skip="-1">,</token>
+            <token>mais</token>
+            <example>A cada garfada, mais feliz ficava.</example>
+        </antipattern>
+        <antipattern>
+            <token>,</token>
+            <token skip="-1">mais</token>
+            <token regexp='no' min='0'>ou</token>
+            <token>menos</token>
+            <example>Ele vai ganhar, mais voto ou menos voto.</example>
+        </antipattern>
+        <antipattern>
+            <token regexp='no' min='0'>ainda</token>
+            <token skip="-1">mais</token>
+            <token regexp='no' min='0'>do</token>
+            <token>que</token>
+            <example>Este grupo, pouco conhecido, mais afasta do que atrai fiéis.</example>
+        </antipattern>
+        <antipattern>
+             <token regexp='yes'>'C.+|I.+|enfim|opa'</token>
              <token>,</token>
              <token>mais</token>
-            <token regexp='yes'>cedo|tarde|à|adiante|nada|ou|devagar|rápido|um|uma|algum|alguma|poderes|poder</token>
+             <token regexp='yes' min='0'>'N.+|PD.+|DD.+'</token>
+            <example>O país é mais desenvolvido e, portanto, mais industrializado.</example>
+        </antipattern>
+        <antipattern>
+             <token>com</token>
+             <token>isso</token>
+             <token>,</token>
+             <token>mais</token>
+            <example>Com isso, mais pessoas virão.</example>
+        </antipattern>
+        <antipattern>
+            <token>sendo</token>
+            <token>assim</token>
+            <token>,</token>
+            <token>mais</token>
+            <example>Sendo assim, mais pessoas virão.</example>
+        </antipattern>
+        <antipattern>
+            <token>,</token>
+            <token>mais</token>
+            <token>do</token>
+            <token>mesmo</token>
+            <example>É sempre assim, mais do mesmo.</example>
+        </antipattern>
+        <antipattern>
+            <token>,</token>
+            <token>mais</token>
+            <token regexp='yes'>cedo|tarde|à|precisamente|frequentemente|recentemente|detalhadamente|adiante|acima|abaixo|atrás|ao|para|vale|nada|ou|devagar|rápido|um|uma|algum|alguma</token>
             <example>O local é perto do shopping, mais adiante.</example>
+        </antipattern>
+        <antipattern>
+            <token>,</token>
+            <token>mais</token>
+            <token regexp='no' min='0'>'VMP00SM'</token>
+            <token regexp='yes'>ainda|cedo|tarde|adiante|abaixo|</token>
+            <token regexp='yes'>.|,|C.+|SPS00</token>
+            <example>Já gostava de chocolate - e agora, mais ainda.</example>
+        </antipattern>
+        <antipattern>
+            <token>,</token>
+            <token>mais</token>
+            <token regexp='yes'>esperança|</token>
+            <example>Já gostava de chocolate - e agora, mais ainda.</example>
         </antipattern>
         <pattern>
             <token>,</token>


### PR DESCRIPTION
Hi all @St-ac-y @marcoagpinto 

I have improved the mais/mas confusion rule to fix some false alarms that were showing up. Please note that a big portion of the examples shown [here](https://internal1.languagetool.org/regression-tests/via-http/2022-07-06/pt-PT/result_grammar_CONFUSION_OF_MAS_MAIS[1].html) are valid corrections for the rule. I have added antipatterns for the ones that do not apply :)

If anyone wants to take a look at it, please let me know your thoughts.