### PR TITLE
[pt] New antipattern added to MAIS_MAS rule to fix FAs

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -351,6 +351,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <example>Quanto mais eu durmo, mais sono tenho.</example>
       </antipattern>
       <antipattern>
+        <token regexp='yes'>quanto|quem</token>
+        <token skip="-1">menos</token>
+        <token>mais</token>
+        <example>Quanto menos eu falo, mais penso.</example>
+      </antipattern>
+      <antipattern>
         <token>à</token>
         <token>medida</token>
         <token skip="-1">que</token>
@@ -457,9 +463,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <token>,</token>
         <token>mais</token>
         <token postag='VMP00SM' min='0'/>
-        <token regexp='yes'>ainda|cedo|tarde|adiante|abaixo</token>
+        <token regexp='yes'>ainda|cedo|tarde|adiante|abaixo|multa|multas|taxa|taxas|imposto|impostos</token>
         <token regexp='yes'>\.|,</token>
         <example>Já gostava de chocolate - e agora, mais ainda.</example>
+        <example>O valor final ficou trinta dólares, mais taxas.</example>
       </antipattern>
       <antipattern>
         <token>,</token>


### PR DESCRIPTION
@St-ac-y I have added another antipattern here because the word "menos" wasn't being tagged as an adverb ("RG"), but as a noun, which ended up creating false alarms. Hopefully, this will fix it now.