### PR TITLE
[de] add "E-Ink" to spelling.txt

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -48921,3 +48921,4 @@ stadtklimatisch/A
 Erzählinstanz
 Erzählinstanzen
 weg_feiern
+E-Ink


### PR DESCRIPTION
Commonly used word describing products that are using electronic paper, especially when it's possible to write on it.
https://www.google.com/search?q=%22E-Ink%22+site%3A*.de
https://de.wikipedia.org/wiki/Elektronisches_Papier