### PR TITLE
Improve annotated text

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/markup/AnnotatedTextBuilder.java
+++ b/languagetool-core/src/main/java/org/languagetool/markup/AnnotatedTextBuilder.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.StringTokenizer;
 
 /**
  * Use this builder to create input of text with markup for LanguageTool, so that it
@@ -52,6 +53,8 @@ public class AnnotatedTextBuilder {
   private final List<TextPart> parts = new ArrayList<>();
   private final Map<AnnotatedText.MetaDataKey, String> metaData = new HashMap<>();
   private final Map<String, String> customMetaData = new HashMap<>();
+  
+  private final String HiddenChars = "\u00AD\u202D\u202c";
 
   public AnnotatedTextBuilder() {
   }
@@ -82,7 +85,15 @@ public class AnnotatedTextBuilder {
    * {@link org.languagetool.JLanguageTool#check(AnnotatedText)}.
    */
   public AnnotatedTextBuilder addText(String text) {
-    parts.add(new TextPart(text, TextPart.Type.TEXT));
+    StringTokenizer st = new StringTokenizer(text, HiddenChars, true);
+    while (st.hasMoreElements()) {
+      String token = (String) st.nextElement();
+      if (HiddenChars.indexOf(token) < 0) {
+        parts.add(new TextPart(token, TextPart.Type.TEXT));
+      } else {
+        parts.add(new TextPart(token, TextPart.Type.MARKUP));
+      }
+    }
     return this;
   }
 

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/JLanguageToolTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/JLanguageToolTest.java
@@ -111,6 +111,11 @@ public class JLanguageToolTest {
       assertNoError("He explained his errand, but without bothering much to make it plausible, for he felt something well up in him which was the reason he had fled the army.", lt);
       assertNoError("I think it's better, and it's not a big deal.", lt);
 
+      // with hidden characters, separated with annotated text
+      assertNoError("This\u202D\u202C \u202D\u202Cis\u202D\u202C \u202D\u202Ca\u202D\u202C "
+          + "\u202D\u202Ctest\u202D\u202C \u202D\u202Csentence,\u202D\u202C \u202D\u202Cwith"
+          + "\u202D\u202C \u202D\u202Cstrange\u202D\u202C \u202D\u202Chidden\u202D\u202C \u202D\u202Ccharacters.", lt);
+      
       assertOneError("A test test that should give errors.", lt);
       assertOneError("I can give you more a detailed description.", lt);
       assertTrue(lt.getAllRules().size() > 1000);

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/MorfologikAmericanSpellerRuleTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/MorfologikAmericanSpellerRuleTest.java
@@ -206,7 +206,8 @@ public class MorfologikAmericanSpellerRuleTest extends AbstractEnglishSpellerRul
     List<RuleMatch> ruleMatchesWithoutMerge = lt.check("sux\u00AD tainability");
     assertEquals(2, ruleMatchesWithoutMerge.size());
     // make sure we offset correctly for ignored characters
-    assertEquals(Arrays.asList(0, 4), Arrays.asList(ruleMatchesWithoutMerge.get(0).getFromPos(), ruleMatchesWithoutMerge.get(0).getToPos()));
+    // changed 0,4 -> 0,3 after \00AD is handled by annotated text
+    assertEquals(Arrays.asList(0, 3), Arrays.asList(ruleMatchesWithoutMerge.get(0).getFromPos(), ruleMatchesWithoutMerge.get(0).getToPos()));
     assertEquals(Arrays.asList(5, 16), Arrays.asList(ruleMatchesWithoutMerge.get(1).getFromPos(), ruleMatchesWithoutMerge.get(1).getToPos()));
 
     // see issue #1769


### PR DESCRIPTION
Hidden characters \u202d \u202C \u00AD (soft hyphen) are treated as markup. 