### PR TITLE
[de] 'temp_off' EUERM_EUERN and add euerer/s/m/n euerm euern

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/ignore.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/ignore.txt
@@ -1017,3 +1017,6 @@ Aumühle/S #name
 AWB #abk
 Bohlmann/S #name
 Bottendorf/S #name
+euer/A
+euerm
+euern

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -50161,9 +50161,6 @@ Aufstrom/S
 Aufströme/N
 Liefertermines
 Club-Mate
-euere/A
-euerm
-euern
 Latte macchiato/S
 Serviervorschlag/S
 weinwirtschaftlich/A


### PR DESCRIPTION
@danielnaber: @tiff hatte vorgeschlagen, die Formen in ignore.txt statt in spelling.txt zu ergänzen.  (siehe: https://github.com/languagetool-org/languagetool/commit/f6968dc4ff7c3b97caeaa9c7ea61c40745fa1cc5#r79649970). In der added.txt und do-not-synthesize.txt habe ich sie drin gelassen. Ist das so okay?