### PR TITLE
[fr] comment in the tagset.fr file (Marker tag, in MISC).

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/tagset.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/tagset.txt
@@ -34,7 +34,7 @@ _______________________________________________________________________________
     Cardinal number (words):    K
     Abbreviation:               S
     Proper name:                Z
-    Marker                      M
+    Marker                      M <!--contains punctuation: comma, semicolon (M nonfin), and dot (M fin)
     
     
 --  VERBS  --


### PR DESCRIPTION
In the French XML file, some PoS mentions are quite hazy:
- M nonfin
- M fin
These actually refers to tokens tagged with "Marker" PoS, nonfin (non-final) for commas, colon and semicolon, and fin (final) for dots. This commit adds a comment to the tag set file, to avoid confusion.
