### PR TITLE
[fr] Dictionary changes/additions

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
@@ -1851,4 +1851,4 @@ Sunak;Sunak;Z m s
 Scholz;Scholz;Z m s
 Meloni;Meloni;Z f s
 chapô;chapô;N m s
-chapôs;chapô;N m s
+chapôs;chapô;N m p


### PR DESCRIPTION
correct typo for chapôs (plural)