### PR TITLE
Luisa cum ex

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -51239,12 +51239,12 @@ Tory-Parteichefin
 Tory-Parteichefinnen
 Tory-Partei/S
 Cashewmus
-Cum-ex-Affäre/N
-Cum-ex-Geschäft/S
-Cum-ex-Geschäfte/N
-Cum-ex-Skandal/S
-Cum-ex-Skandale/N
-Cum-ex
+Cum-Ex-Affäre/N
+Cum-Ex-Geschäft/S
+Cum-Ex-Geschäfte/N
+Cum-Ex-Skandal/S
+Cum-Ex-Skandale/N
+Cum-Ex
 Vorschlagskarte/N
 Teamaccount/S
 Nowa Kachowka/S #name


### PR DESCRIPTION
Entscheidung für "Cum-Ex" basierend auf der gängigeren Schreibweise (z.B. die [Zeit](https://www.zeit.de/politik/deutschland/2022-08/cum-ex-olaf-scholz-ausschuss-faq?utm_referrer=https%3A%2F%2Fwww.google.com%2F), die [Tagesschau ](https://www.tagesschau.de/investigativ/wdr/cum-ex-171.html)und die [Süddeutsche](https://www.sueddeutsche.de/thema/Cum-Ex), der Einschätzung als "Eigenname" und der Häufigkeit der Treffer im Vergleich (https://corpora.uni-leipzig.de/de/res?corpusId=deu_news_2021&word=Cum-Ex). 

Kategorie von Grammatik zu Style geändert. 