### PR TITLE
[fr] Word "cryptoactif" gets FP and bad suggestion

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
@@ -1851,3 +1851,5 @@ Scholz;Scholz;Z m s
 Meloni;Meloni;Z f s
 chapô;chapô;N m s
 chapôs;chapô;N m p
+cryptoactif;cryptoactif;N m s
+cryptoactifs;cryptoactif;N m p


### PR DESCRIPTION
Feedback from a user on Twitter shows that "cryptoactif" gets a suggestion → "cryptojuif". 
The word "cryptoactif" is recent (related to all the new vocabulary around cryptocurrencies) and need to be added to the dictionary files.