### PR TITLE
[fr] Creating replace_picky file

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/replace_anglicism.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/replace_anglicism.txt
@@ -1,5 +1,5 @@
 # French anglicism rule
-# To add excpetion to this rule: immunize or ignore spelling in disambiguation.xml or add to multiwords.txt as proper noun (Z)  
+# To add exception to this rule: immunize or ignore spelling in disambiguation.xml or add to multiwords.txt as proper noun (Z)
 because=parce que|à cause de
 screenshot|screen shot=capture d'écran
 screenshots|screeen shots=captures d'écran

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/replace_picky.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/replace_picky.txt
@@ -1,0 +1,7 @@
+# General replacement rules, used by org.languagetool.rules.en.SimpleReplaceRule
+# Format: UTF-8, one entry per line in format: phrase=replacement
+# 'phrase' is what the text is searched for. 'replacement' is the suggestion shown to the user.
+# 'phrase' is searched for case-insensitively.
+# Both 'phrase' and 'replacement' can contain more than one value when separated by '|'.
+# Example:
+# incorrect=suggestion one|suggestion two


### PR DESCRIPTION
Quite many words in [replace_anglisicm.txt](C:\Users\steib\IdeaProjects\languagetool\languagetool-language-modules\fr\src\main\resources\org\languagetool\rules\fr\replace_anglicism.txt) and[ replace.txt](C:\Users\steib\IdeaProjects\languagetool\languagetool-language-modules\fr\src\main\resources\org\languagetool\rules\fr\replace.txt) are to be considered picky. To do so, a new file is needed, created in this pull request.