### PR TITLE
Update dumonts/hunspell to 2.1.1

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/Hunspell.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/Hunspell.java
@@ -1,16 +1,12 @@
 package org.languagetool.rules.spelling.hunspell;
 
-import dumonts.hunspell.bindings.HunspellLibrary;
-import org.bridj.Pointer;
 import org.languagetool.JLanguageTool;
 import org.languagetool.broker.ResourceDataBroker;
 
 import java.io.*;
-import java.nio.charset.Charset;
 import java.nio.file.*;
 import java.util.*;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 public final class Hunspell {
   static class LanguageAndPath {

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <ch.qos.logback.version>1.2.10</ch.qos.logback.version>
 
         <com.carrotsearch.hppc.version>0.8.2</com.carrotsearch.hppc.version>
-        <com.gitlab.dumonts.hunspell.version>1.1.1</com.gitlab.dumonts.hunspell.version>
+        <com.gitlab.dumonts.hunspell.version>2.0.0</com.gitlab.dumonts.hunspell.version>
         <com.github.lucene-gosen.version>6.2.1</com.github.lucene-gosen.version>
         <com.hankcs.aho-corasick-double-array-trie.version>1.2.2</com.hankcs.aho-corasick-double-array-trie.version>
         <com.hankcs.hanlp.version>portable-1.8.2</com.hankcs.hanlp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <ch.qos.logback.version>1.2.10</ch.qos.logback.version>
 
         <com.carrotsearch.hppc.version>0.8.2</com.carrotsearch.hppc.version>
-        <com.gitlab.dumonts.hunspell.version>2.1.0</com.gitlab.dumonts.hunspell.version>
+        <com.gitlab.dumonts.hunspell.version>2.1.1</com.gitlab.dumonts.hunspell.version>
         <com.github.lucene-gosen.version>6.2.1</com.github.lucene-gosen.version>
         <com.hankcs.aho-corasick-double-array-trie.version>1.2.2</com.hankcs.aho-corasick-double-array-trie.version>
         <com.hankcs.hanlp.version>portable-1.8.2</com.hankcs.hanlp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <ch.qos.logback.version>1.2.10</ch.qos.logback.version>
 
         <com.carrotsearch.hppc.version>0.8.2</com.carrotsearch.hppc.version>
-        <com.gitlab.dumonts.hunspell.version>2.0.0</com.gitlab.dumonts.hunspell.version>
+        <com.gitlab.dumonts.hunspell.version>2.1.0</com.gitlab.dumonts.hunspell.version>
         <com.github.lucene-gosen.version>6.2.1</com.github.lucene-gosen.version>
         <com.hankcs.aho-corasick-double-array-trie.version>1.2.2</com.hankcs.aho-corasick-double-array-trie.version>
         <com.hankcs.hanlp.version>portable-1.8.2</com.hankcs.hanlp.version>


### PR DESCRIPTION
Updates the dependency on https://gitlab.com/dumonts/hunspell-java to the newly released 2.0.0
Removes the redundant re-implementation of `spell`, `suggest` and `add` methods.

relates to #7045