### PR TITLE
[de] rule prio change

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
@@ -381,6 +381,7 @@ public class German extends Language implements AutoCloseable {
       case "OK": return 1; // higher prio than KOMMA_NACH_PARTIKEL_SENT_START[3]
       case "EINE_ORIGINAL_RECHNUNG": return 1; // higher prio than DE_CASE, DE_AGREEMENT and MEIN_KLEIN_HAUS
       case "VALENZ_TEST": return 1; // see if this generates more corpus matches
+      case "WAHERUNGSANGABEN_CHF": return 1; // higher prio than WAHERUNGSANGABEN_KOMMA
       // default is 0
       case "FALSCHES_ANFUEHRUNGSZEICHEN": return -1; // less prio than most grammar rules but higher prio than UNPAIRED_BRACKETS
       case "VER_KOMMA_PRO_RIN": return -1; // prefer WENN_WEN

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
@@ -381,7 +381,7 @@ public class German extends Language implements AutoCloseable {
       case "OK": return 1; // higher prio than KOMMA_NACH_PARTIKEL_SENT_START[3]
       case "EINE_ORIGINAL_RECHNUNG": return 1; // higher prio than DE_CASE, DE_AGREEMENT and MEIN_KLEIN_HAUS
       case "VALENZ_TEST": return 1; // see if this generates more corpus matches
-      case "WAHERUNGSANGABEN_CHF": return 1; // higher prio than WAHERUNGSANGABEN_KOMMA
+      case "WAEHRUNGSANGABEN_CHF": return 1; // higher prio than WAEHRUNGSANGABEN_KOMMA
       // default is 0
       case "FALSCHES_ANFUEHRUNGSZEICHEN": return -1; // less prio than most grammar rules but higher prio than UNPAIRED_BRACKETS
       case "VER_KOMMA_PRO_RIN": return -1; // prefer WENN_WEN

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/de-CH/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/de-CH/grammar.xml
@@ -35,7 +35,7 @@
     <!-- Tippfehler -->
     <!-- ====================================================================== -->
     <category id="TYPOGRAPHY" name="Typografie">
-        <rulegroup id="WAHERUNGSANGABEN_CHF" name="Währungsangaben in CHF mit Punkt statt Komma, z. B. '45,00 CHF (45.00 CHF)'">
+        <rulegroup id="WAEHRUNGSANGABEN_CHF" name="Währungsangaben in CHF mit Punkt statt Komma, z. B. '45,00 CHF (45.00 CHF)'">
             <url>https://www.rotstift-ag.ch/rechtschreibregeln/W/waehrungen.html</url>
             <rule><!--1-->
                 <pattern>


### PR DESCRIPTION
Da grammal.xml de-CH OS ist, sollte die Regel schon beim User sein (wurde gestern activated), im Editor (wenn de-CH eingestellt ist) greift jedoch noch die bestehende Regel WAEHRUNGSANGABEN_KOMMA für de-DE. Daher wurde jetzt die Prio im German.java hochgesetzt für die de-CH Regel.