### PR TITLE
[de] moved rule from grammar-premium4 to grammar de-DE-AT OS

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/de-DE-AT/grammar.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/de-DE-AT/grammar.xml
@@ -535,5 +535,26 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         </rule>
       </rulegroup>
     </category>
+
+    <!-- ====================================================================== -->
+    <!-- Zeichensetzung -->
+    <!-- ====================================================================== -->
+
+    <category id="PUNCTUATION" name="Zeichensetzung">
+
+        <rule id="WAEHRUNGSANGABEN_KOMMA" name="Währungsangaben mit Komma statt Punkt, z. B. '45.00 Euro (45,00 Euro)'">
+            <pattern>
+                <token regexp="yes">[0-9].+</token>
+                <token>.</token>
+                <token regexp="yes">[0-9]{2}|–</token>
+                <token regexp="yes" case_sensitive="yes">€|$|AED|Dirham|AFN|Afghani|Puls|ALL|Lek|Qindarka|AMD|Dram|Luma|ANG|Gulden|Cent(s|imos|avos|imes|esimos|esimi) AOA|Kwanza|ARS|AUD|AWG|Florin|AZN|Aserbaidschan-Qäpik|BAM|KonvertibleMark|Fening|BBD|BDT|Taka|Poisha|BGN|Lew|Stotinki|BHD|BIF|BMD|BND|BOB|Boliviano|BOV|Mvdol|BRL|Real|BSD|BTN|Ngultrum|Chetrum|BWP|Pula|Thebe|BYN|Rubel|BZD|CAD|CDF|CHE|CHF|Franken|Rappen|CHW|CLF|UnidaddeFomento|CLP|CNY|RenminbiYuan|Jiao|Fen|COP|COU|UnidaddeValorReal|CRC|Colón|CUC|PesoConvertible|CUP|CVE|Escudo|CZK|Haleru|DJF|DKK|Krone|DOP|DZD|EGP|Piasters|ERN|Nakfa|ETB|Birr|Santim|EUR|Euro|FJD|FKP|GBP|GEL|Lari|Tetri|GHS|GhanaCedi|Pesewas|GIP|Pence|GMD|Dalasi|Bututs|GNF|GTQ|Quetzal|GYD|HKD|HNL|Lempira|HRK|Kuna|Lipa|HTG|Gourde|HUF|Forint|Fillér|IDR|Rupiah|ILS|Schekel|Agorot|INR|Paise|IQD|IRR|Rial|Dinars|ISK|Aurar|JMD|JOD|JPY|Yen|KES|Schilling|KGS|Som|Tyiyn|KHR|Riel|KarakKMF|Franc|KPW|Won|Chon|KRW|KWD|KYD|KZT|Tenge|Tyin|LAK|Laotischer Kip|At|LBP|LKR|LRD|DollarLSL|Loti|Lisente|LYD|MAD|MDL|Leu|MGA|Ariary|Iraimbilanja|MKD|Denar|Deni|MMK|Kyat|Pyas|MNT|Tögrög|Möngö|MOP|Pataca|Avos|MRU|Ouguiya|Khoums|MUR|MVR|Rufiyaa|Laari|MWK|Kwacha|Tambala|MXN|MXV|MYR|Ringgit|Sen|MZN|Metical|NAD|NGN|Naira|Kobo|NIO|CórdobaOro|NOK|Øre|NPR|NZD|OMR|Baizas|PAB|Balboa|PEN|NuevoSol|PGK|Kina|Toea|PHP|PKR|Paisa|PLN|Złoty|Groszy|PYG|Guaraní|QAR|Dirhams|RON|Bani|RSD|Dinar|Para|RUB|RWF|SAR|Riyal|Qirshes|Hallalas|SBD|SCR|Rupie|SDG|Pfund|SEK|Öre|SGD|SHP|SLL|Leone|SOS|SRD|SSP|Piaster|STN|Dobra|SVC|SYP|Piastres|SZL|Lilangeni|THB|Baht|Satang|TJS|Somoni|Diram|TMT|Manat|TND|Millimes|TOP|Paʻanga|Seniti|TRY|Lira|Kuruş|TTD|TWD|TZS|UAH|Hrywnja|Kopeken|UGX|USD|Dime|UYI|Pesos|UYU|Peso|UZS|Soʻm|Tiyin|VES|Céntimos|VND|Đồng|Hào|Xu|VUV|Vatu|WST|Tala|Sene|XAF|CFA|XCD|XOF|XPF|CFP|XSU|SUCRE|YER|Fils|ZAR|Rand|ZMW|Ngwee|ZWL</token>
+            </pattern>
+            <message>Währungsangaben werden im Deutschen in der Regel mit einem Komma geschrieben.</message>
+            <suggestion>\1,\3 \4</suggestion>
+            <url>https://www.typolexikon.de/zahlengliederung/#Waehrungsangaben</url>
+            <example correction="45,00 Euro">Sie erhalten das Produkt für einen Aufpreis von <marker>45.00 Euro</marker>.</example>
+        </rule>
+
+    </category>
 </rules>
 


### PR DESCRIPTION
Regel WAEHRUNGSANGABEN_KOMMA aus grammar-premium4 entfernt und zu grammar de-DE-AT Open Source hinzugefügt, um Konflikte mit WAEHRUNGSANGABEN_CHF in grammar de-CH zu vermeiden. 

