### PR TITLE
[de] is PA1

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -8096,7 +8096,7 @@ Weckmänner/N
 wegdelegiere/N
 wegdelegierend/A
 wegdelegierst
-wegdelegiert/A
+wegdelegiert
 wegdelegiertest
 weggehört
 weggekauft/A

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -42243,7 +42243,6 @@ Keyword Planner/S #name
 IP/S
 Autismusform
 Autismusformen
-zugrundegelegt/A
 desintegrativ/A
 Aktivitätenmuster/SN
 kontaktanalog/A

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -8093,11 +8093,7 @@ Websiteprogrammiersprache/N
 webtauglich/A
 Weckmann/S
 Weckmänner/N
-wegdelegiere/N
-wegdelegierend/A
-wegdelegierst
-wegdelegiert
-wegdelegiertest
+weg_delegieren
 weggehört
 weggekauft/A
 weggeschlagen/A


### PR DESCRIPTION
Wenn Partizipien (wie "wegdelegiert") im spelling.txt als Adjektive deklariert werden, kann es zu vielen FPs bzw. falschen suggestions kommen (wie [hier](https://regression.languagetoolplus.com/via-http/2022-12-05/de-DE/result_grammar-premium2_WORDEN_GEWORDEN_UNTERSCHIED[4].html)) - ist es ok, wenn ich in solchen Fällen einfach das "/A" im spelling entferne? 