### PR TITLE
[fr] AI_FR_HYDRA_LEO_MISSING_COMMA adding an exception to the filter

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/remote-rule-filters.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/remote-rule-filters.xml
@@ -308,6 +308,16 @@ To ignore a remote rule match, set the <marker> so that it exactly covers the te
                 </pattern>
                 <example correction=""><marker>bleu</marker> ciel.</example>
             </rule>
+            <rule>
+                <pattern>
+                    <marker>
+                        <token>conjonction</token>
+                    </marker>
+                    <token>de</token>
+                    <token regexp="yes">coordination|subordination</token>
+                </pattern>
+                <example correction="">Par son absence volontaire de <marker>conjonction</marker> de coordination.</example>
+            </rule>
         </rulegroup>
         <rulegroup id="AI_FR_HYDRA_LEO_MISSING_PERIOD" name="">
         <rule>

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/remote-rule-filters.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/remote-rule-filters.xml
@@ -311,7 +311,7 @@ To ignore a remote rule match, set the <marker> so that it exactly covers the te
             <rule>
                 <pattern>
                     <marker>
-                        <token>conjonctions?</token>
+                        <token regexp="yes">conjonctions?</token>
                     </marker>
                     <token>de</token>
                     <token regexp="yes">coordination|subordination</token>

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/remote-rule-filters.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/remote-rule-filters.xml
@@ -311,7 +311,7 @@ To ignore a remote rule match, set the <marker> so that it exactly covers the te
             <rule>
                 <pattern>
                     <marker>
-                        <token>conjonction</token>
+                        <token>conjonctions?</token>
                     </marker>
                     <token>de</token>
                     <token regexp="yes">coordination|subordination</token>


### PR DESCRIPTION
As explained in [his issue](https://github.com/languagetooler-gmbh/languagetool-premium/issues/4820), and an exception is added to remote-rule-filters.xml.