### PR TITLE
[fr] Salammbô Z e s

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
@@ -1925,6 +1925,6 @@ synchise;synchise;N f s
 synchises;synchise;N f p
 synchyse;synchyse;N f s
 synchyses;synchyse;N f p
-Salammbô;Salammbô;Z m s
+Salammbô;Salammbô;Z e s
 quiz;quiz;N m sp
 


### PR DESCRIPTION
After adding Salammbô in dictionary files, nightly diff showed through AGREEMENT_POSTPONED_ADJ that obviously Salammbô is both the name of the book (masculine) _and_ the name of the character (feminine).
This commit makes Salammbô **Z e s** to avoid trouble.