### PR TITLE
[de] rule added

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
@@ -471,6 +471,7 @@ public class German extends Language implements AutoCloseable {
       case "SIE_WOLLTEN_SIND": return -52;
       case "ART_ADJ_SOL": return -52; // prefer comma rules
       case "WURDEN_WORDEN_1": return -52; // prefer comma rules
+      case "WAR_WAHR": return -52; // higher prio than KOMMA_ZWISCHEN_HAUPT_UND_NEBENSATZ
       case "KOMMA_ZWISCHEN_HAUPT_UND_NEBENSATZ": return -53;
       case "VERB_IST": return -53; // less prio than comma rules and spell checker
       case "WAR_WERDEN": return -53; // less prio than comma rules


### PR DESCRIPTION
Ich habe WAR_WAHR höher priorisiert als KOMMA_ZWISCHEN_HAUPT_UND_NEBENSATZ, um derartige Fälle zu vermeiden: 

"Das ist höchst wahrscheinlich **war**."

=> _ist - war_ scheint, als wären 2 Verben im Satz, daher schlägt die Komma-Regel an, sobald _wahr_ korrigiert ist, fällt die Komma-Regel weg (schlägt korrekterweise nicht mehr an), stattdessen schlägt (ebenfalls korrekterweise) HÖCHST_WAHRSCHEINLICH an. 

![image](https://user-images.githubusercontent.com/115984740/208437018-0fd68d65-c27e-460b-9071-37f9959fcd8e.png)
