### PR TITLE
[de] added Leid tun to old spelling

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/alt_neu.csv
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/alt_neu.csv
@@ -848,7 +848,7 @@ kroß braten;krossbraten
 Kumyß;Kumyss
 kurz fassen;kurzfassen
 leerstehen;leer stehen
-leid tun;leidtun
+leid tun|Leid tun;leidtun
 Love-Story;Lovestory
 Short story;Shortstory|Short Story
 Softskill;Soft Skill


### PR DESCRIPTION
"Leid tun" [mit upper case] wurde nicht angemarkert, ist aber wie auch "leid tun" alte Rechtschreibung. => zur `alt_neu.csv` hinzugefügt 

![image](https://user-images.githubusercontent.com/115984740/209308925-5711c77e-5dcc-4e11-b928-ac2eb5ab2201.png)

