### PR TITLE
feat(core): added createDefaultJLanguageTool to Language

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/Language.java
+++ b/languagetool-core/src/main/java/org/languagetool/Language.java
@@ -73,6 +73,8 @@ public abstract class Language {
   private static final Pattern APOSTROPHE = Pattern.compile("([\\p{L}\\d-])'([\\p{L}«])",
     Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
 
+  private static final Map<Class<Language>, JLanguageTool> languagetoolInstances = new ConcurrentHashMap<>();
+
   private final UnifierConfiguration unifierConfig = new UnifierConfiguration();
   private final UnifierConfiguration disambiguationUnifierConfig = new UnifierConfiguration();
 
@@ -513,6 +515,18 @@ public abstract class Language {
    */
   public void setPostDisambiguationChunker(Chunker chunker) {
     postDisambiguationChunker = chunker;
+  }
+
+  /**
+   * Create a shared instance of JLanguageTool to use in rules for further processing
+   * Instances are shared by Language
+   * @since 6.1
+   * @return a shared JLanguageTool instance for this language
+   */
+  public JLanguageTool createDefaultJLanguageTool() {
+      Language self = this;
+      Class clazz = this.getClass();
+      return languagetoolInstances.computeIfAbsent(clazz, _class -> new JLanguageTool(self));
   }
 
   /**

--- a/languagetool-standalone/src/test/java/org/languagetool/LanguageTest.java
+++ b/languagetool-standalone/src/test/java/org/languagetool/LanguageTest.java
@@ -81,4 +81,19 @@ public class LanguageTest {
     assertFalse(new English().equalsConsiderVariantsIfSpecified(new German()));
   }
 
+  @Test
+  public void testCreateDefaultJLanguageTool() {
+    Language german = new German();
+    Language germanyGerman = new GermanyGerman();
+    JLanguageTool ltGerman = german.createDefaultJLanguageTool();
+    JLanguageTool ltGerman2 = german.createDefaultJLanguageTool();
+    JLanguageTool ltGermanyGerman = germanyGerman.createDefaultJLanguageTool();
+    JLanguageTool ltEnglish = new English().createDefaultJLanguageTool();
+    assertFalse(ltGermanyGerman == ltGerman);
+    assertTrue(ltGerman2 == ltGerman);
+    assertEquals(ltGerman.getLanguage(), german);
+    assertEquals(ltGermanyGerman.getLanguage(), germanyGerman);
+    assertEquals(ltEnglish.getLanguage(), new English());
+  }
+
 }


### PR DESCRIPTION
Allow using shared JLanguageTool instances from rules for various purposes.

@jaumeortola Can you see if this works for you? And if so, switch the other places where this is already done to use the new method?
