### PR TITLE
Improve fehlerhaftes komma allg

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -54882,3 +54882,8 @@ raumfüllenderen
 raumfüllenderem
 Zuliefererkette/N
 Apple Card/S #name
+Kassandraruf/S
+Kassandrarufe/N
+Desk/S #eng
+Tischbräter/S
+Space/S #eng


### PR DESCRIPTION
Modified APs to avoid some of the FNs (https://internal1.languagetool.org/regression-tests/via-http/2023-01-19/de-DE/result_grammar_FEHLERHAFTES_KOMMA_ALLG[1].html)