### PR TITLE
Fr 

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/ignore.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/ignore.txt
@@ -1439,3 +1439,4 @@ Fry #name
 ErbStRG #abk
 Ferranti #name
 FreeSpace #name #eng
+Fr.

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/ignore.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/ignore.txt
@@ -1435,3 +1435,7 @@ eARC #abk
 LBMA #abk
 ETC
 ETCs
+Fry #name
+ErbStRG #abk
+Ferranti #name
+FreeSpace #name #eng

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -54934,9 +54934,5 @@ Zeitraffervideo/S
 Motivwunsch
 Motivwünsche/N
 erbgroßherzoglich/A
-ErbStRG #abk
-Ferranti #name
-Freespace #name #eng
-Fry #name
 erbkonstant/A
 erdhistorisch/A


### PR DESCRIPTION
Im de-DE.dic habe ich jetzt einen Punkt zu `Fr.` hinzugefügt (analog zu `Hr.`); außerdem habe ich `Fr.` wieder zur` ignore.txt` hinzugefügt, um dies nicht mehr als Fehler zu markieren. Im Ergebnis des `Main Tests` scheint es jetzt so zu funktionieren, wie gewünscht: Wenn `Fr` ohne Punkt geschrieben wird, wird es als Fehler markiert und mit Punkt vorgeschlagen (so wie es bei `Hr.` auch schon vorher der Fall war und ist).

![image](https://user-images.githubusercontent.com/115984740/214547472-d4c329b3-e3c0-4ff1-9b46-3d49ece4d3b1.png)

