### PR TITLE
[de] add "Vorfahrtsfehler" to spelling.txt

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -7980,6 +7980,7 @@ vorbohrtest
 Vorfahrin
 Vorfahrinnen
 vorfahrtsregelnd/A
+Vorfahrtsfehler
 Vorfallstyp
 Vorfallstypen
 Vorgabedokument


### PR DESCRIPTION
https://www.freiepresse.de/blaulicht-meldungen/neumark-vorfahrtsfehler-hoher-sachschaden-artikel11900801 https://www.ostsee-zeitung.de/lokales/vorpommern-ruegen/ruegen/vorfahrtsfehler-autos-kollidieren-bei-samtens-auf-ruegen-AOFHAO5JXFJI3ETLHMYLODERUU.html https://www.rnd.de/panorama/nach-vorfahrtsfehler-vier-menschen-schwer-verletzt-S3RURW2VKAKK2HHSXHLQULDYSY.html