### PR TITLE
[de] add "Vorfahrtsstraße" to spelling.txt

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -7981,6 +7981,7 @@ Vorfahrin
 Vorfahrinnen
 vorfahrtsregelnd/A
 Vorfahrtsfehler
+Vorfahrtsstraße/N
 Vorfallstyp
 Vorfallstypen
 Vorgabedokument


### PR DESCRIPTION
Alternate form of "Vorfahrtstraße" https://www.duden.de/rechtschreibung/Vorfahrtsstrasze