### PR TITLE
[es] removed temp_off from rule ex alto cargo

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -12569,7 +12569,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         </rulegroup>
     </category>
     <category id="MISSPELLING" name="Ortografía" type="misspelling">
-        <rule id="EX_ALTO_CARGO" name="exalto cargo (ex alto cargo)" default="temp_off">
+        <rule id="EX_ALTO_CARGO" name="exalto cargo (ex alto cargo)">
             <pattern>
                 <marker>
                     <token regexp="yes">exaltos?</token>


### PR DESCRIPTION
@jaumeortola @maphjo after reviewing the nightly diff, default="temp_off" has been removed from EX_ALTO_CARGO rule