### PR TITLE
[es] removed rule NO_SEPARADO

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -13361,17 +13361,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 <example correction="antirruso"><marker>anti ruso</marker></example>
                 <example correction="antirrusas"><marker>anti-rusas</marker></example>
             </rule>
-            <rule default="temp_off">
-                <pattern>
-                    <token>contra</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">..+</token>
-                </pattern>
-                <message suppress_misspelled="yes">Probablemente se escribe junto.</message>
-                <suggestion><match no="3" regexp_match="(.+)" regexp_replace="contra$1"/></suggestion>
-                <suggestion><match no="3" regexp_match="(.+)" regexp_replace="contrar$1"/></suggestion>
-                <example correction="contrarrotación">La <marker>contra-rotación</marker>.</example>
-            </rule>
             <rule>
                 <pattern>
                     <token>ciber</token>


### PR DESCRIPTION
@jaumeortola the rule has been removed from the OS repository (grammar.xml)