### PR TITLE
[nl] improved rule EINDE_KOMMA

### DIFF
--- a/languagetool-language-modules/nl/src/main/resources/org/languagetool/rules/nl/grammar.xml
+++ b/languagetool-language-modules/nl/src/main/resources/org/languagetool/rules/nl/grammar.xml
@@ -19113,12 +19113,12 @@ steenwijk;Steenwijk
                 <example correction=" ">Deze zin bevat een dubbele<marker>  </marker>spatie (al valt die wellicht niet op).</example>
             </rule>
         </rulegroup>
-        <rulegroup id="EINDE_KOMMA" name="Einde met (punt)komma" >
+        <rulegroup id="EINDE_KOMMA" name="Einde met puntkomma">
             <rule>
                 <pattern>
-                    <token postag="SENT_END" regexp="yes">[,;]</token>
+                    <token postag="SENT_END" regexp="yes">[;]</token>
                 </pattern>
-                <message>Een zin eindigt meestal niet op een komma of puntkomma. Hebt u per ongeluk een regelovergang gezet of een verkeerd teken gebruikt?</message>
+                <message>Een zin eindigt meestal niet op een puntkomma. Hebt u per ongeluk een regelovergang gezet of een verkeerd teken gebruikt?</message>
                 <example type="incorrect">Deze zin eindigt met een puntkomma<marker>;</marker></example>
             </rule>
         </rulegroup>


### PR DESCRIPTION
Removed the comma from this rule since formal emails often contain comma > new line.