### PR TITLE
Grammalecte

### DIFF
--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/rules/fr/GrammalecteRule.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/rules/fr/GrammalecteRule.java
@@ -420,6 +420,7 @@ public class GrammalecteRule extends Rule {
     "g2__conf_a_à_verbe__b7_a1_1",
     "g2__conf_a_à_verbe__b8_a1_1",
     "g3__gn_la_3m__b1_a1_1"
+    "gv1__imp_verbe_groupe3_d__b2"//rule is generating FP and a loop(https://github.com/languagetooler-gmbh/languagetool-premium/issues/5220)
   ));
 
   public GrammalecteRule(ResourceBundle messages, GlobalConfig globalConfig) {

--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/rules/fr/GrammalecteRule.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/rules/fr/GrammalecteRule.java
@@ -419,7 +419,7 @@ public class GrammalecteRule extends Rule {
     "g2__conf_a_à_verbe__b4_a1_1",
     "g2__conf_a_à_verbe__b7_a1_1",
     "g2__conf_a_à_verbe__b8_a1_1",
-    "g3__gn_la_3m__b1_a1_1"
+    "g3__gn_la_3m__b1_a1_1",
     "gv1__imp_verbe_groupe3_d__b2"//rule is generating FP and a loop(https://github.com/languagetooler-gmbh/languagetool-premium/issues/5220)
   ));
 


### PR DESCRIPTION
To fix the FR part of https://github.com/languagetooler-gmbh/languagetool-premium/issues/5220
The rule shows **grammalecte_gv1__imp_verbe_groupe3_d__b2_** in Editor and Grafana but "grammalecte" at the beginning never appears in this file (looks like a prefix).
@jaumeortola please advise if something is wrong here, thanks!