### PR TITLE
fix[core]: match negative numbers in AbstractUnitConversionRule

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractUnitConversionRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractUnitConversionRule.java
@@ -75,9 +75,12 @@ public abstract class AbstractUnitConversionRule extends Rule {
 
   protected static final Unit<Temperature> FAHRENHEIT = CELSIUS.multiply(5.0/9.0).shift(-32);
   // limit size of matched number to (possibly) avoid hangups
+  // we need a different regex for including a word boundary (\b), instead of just prepending that
+  // because otherwise negative numbers aren't correctly recognized
   protected static final String NUMBER_REGEX = "(-?[0-9]{1,32}[0-9,.]{0,32})";
+  protected static final String NUMBER_REGEX_WITH_BOUNDARY = "(-?\\b[0-9]{1,32}[0-9,.]{0,32})";
 
-  protected final Pattern numberRangePart = Pattern.compile("\\b" + NUMBER_REGEX + "$");
+  protected final Pattern numberRangePart = Pattern.compile(NUMBER_REGEX_WITH_BOUNDARY + "$");
   
   private static final double DELTA = 1e-2;
   private static final double ROUNDING_DELTA = 0.05;
@@ -193,7 +196,7 @@ public abstract class AbstractUnitConversionRule extends Rule {
    */
   protected void addUnit(String pattern, Unit base, String symbol, double factor, boolean metric) {
     Unit unit = base.multiply(factor);
-    unitPatterns.put(Pattern.compile("\\b" + NUMBER_REGEX + "[\\s\u00A0]{0," + WHITESPACE_LIMIT + "}" + pattern + "\\b"), unit);
+    unitPatterns.put(Pattern.compile(NUMBER_REGEX_WITH_BOUNDARY + "[\\s\u00A0]{0," + WHITESPACE_LIMIT + "}" + pattern + "\\b"), unit);
     unitSymbols.putIfAbsent(unit, new ArrayList<>());
     unitSymbols.get(unit).add(symbol);
     if (metric && !metricUnits.contains(unit)) {

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/UnitConversionRuleTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/UnitConversionRuleTest.java
@@ -65,6 +65,8 @@ public class UnitConversionRuleTest {
     helper.assertMatches("My new apartment is 500 sq ft.", 1, "46.45 m²", rule, lt);
     helper.assertMatches("It is 100 degrees Fahrenheit outside.", 1, "37.78 °C", rule, lt);
     helper.assertMatches("It is 100 °F outside.", 1, "37.78 °C", rule, lt);
+    helper.assertMatches("It is -22 °F outside.", 1, "-30 °C", rule, lt);
+    helper.assertMatches("It is -22 degrees Fahrenheit outside.", 1, "-30 °C", rule, lt);
 
     // https://github.com/languagetool-org/languagetool/issues/2357
     helper.assertMatches("Millions watched the 1989's Superbowl.", 0, null, rule, lt);


### PR DESCRIPTION
Fix problems with regexes matching negative numbers because of use of the word boundary meta-character
Addresses the problem outlined here: https://forum.languagetool.org/t/temperature/8881