### PR TITLE
feat(core): enable filterDictionaryMatches by default

### DIFF
--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -316,7 +316,7 @@ abstract class TextChecker {
     List<String> dictWords = limits.getPremiumUid() != null ?
       getUserDictWords(limits, dictGroups) : Collections.emptyList();
 
-    boolean filterDictionaryMatches = "true".equals(params.get("filterDictionaryMatches"));
+    boolean filterDictionaryMatches = "true".equals(params.getOrDefault("filterDictionaryMatches", "true"));
 
     Long textSessionId = null;
     try {


### PR DESCRIPTION
Make filtering out matches of rules when the matched word is in the dictionary of a user the default behavior.
