### PR TITLE
[fr] RESOUDRE_OU_SOLUTIONNER

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -20342,7 +20342,7 @@ USA
             <pattern>
                 <token postag="V.*" postag_regexp="yes" inflected="yes">solutionner</token>
             </pattern>
-            <message>Ce terme peut être considéré comme familier. Souhaitez-vous écrire <suggestion><match no="1" postag=".*">résoudre</match></suggestion> employé dans le langage formel ?</message>
+            <message>Ce terme peut être considéré comme familier. Souhaitez-vous écrire <suggestion><match no="1">résoudre</match></suggestion>, plus employé dans le langage formel ?</message>
             <example correction="résoudre">Il a réussi à <marker>solutionner</marker> le problème.</example>
             <example>Il a réussi avec Galinette <marker>Solutionnée</marker> à résoudre le problème.</example>
         </rule>


### PR DESCRIPTION
To fix [[fr]: Bug in CONFUSION_ORTHOGRAPHIQUE[7] (Solutionner)#5592](https://github.com/languagetooler-gmbh/languagetool-premium/issues/5592)

- CONFUSION_ORTHOGRAPHIQUE[7] is now RESOUDRE_OU_SOLUTIONNER in Style file.
- Removing spurious postag=".*" (probable culprit of the apparition of brackets in suggestion box in some cases).
- Slight change of suggestion sentence.