### PR TITLE
[fr] CAT_ANGLICISMES_Reorganized

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -5052,7 +5052,7 @@ USA
             <example correction="jour férié">C'est un <marker>congé férié</marker>.</example>
         </rule>
     </category>
-    <category id="CAT_ANGLICISMES" name="Anglicismes (calques, emprunts directs, etc.)" type="style">
+    <category id="CAT_ANGLICISMES_FOREIGN_TERMS" name="Anglicismes non adaptés" type="style">
         <rulegroup id="FOCUS" name="focus (concentration)">
             <rule>
                 <pattern>
@@ -5208,6 +5208,6303 @@ USA
                 <example correction="concentres">En vrai, tu te <marker>focus</marker> mieux dans sa chambre.</example>
             </rule>
         </rulegroup>
+        <rulegroup id="PHOTO-FINISH" name="photo-finish">
+            <rule>
+                <pattern>
+                    <token regexp="yes">photos?</token>
+                    <token regexp="yes">finishs?|finishes</token>
+                </pattern>
+                <message>« Photo-finish » peut être considéré comme un anglicisme.</message>
+                <suggestion>photo d'arrivée</suggestion>
+                <example correction="photo d'arrivée"><marker>photo finish</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">photos?-?finishe?s?</token>
+                </pattern>
+                <message>« Photo-finish » peut être considéré comme un anglicisme.</message>
+                <suggestion>photo d'arrivée</suggestion>
+                <example correction="photo d'arrivée"><marker>photo-finish</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="VISE-GRIP" name="vise-grip">
+            <rule>
+                <pattern>
+                    <token regexp="yes">vi[sc]es?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">grips?|grippes?</token>
+                </pattern>
+                <message>« Vise-grip » peut être considéré comme un anglicisme.</message>
+                <suggestion>pince-étau</suggestion>
+                <example correction="pince-étau"><marker>vise grip</marker></example>
+                <example correction="pince-étau"><marker>vise-grip</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="PACKAGE_DEAL" name="package deal">
+            <rule>
+                <pattern>
+                    <token regexp="yes">packages?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">deals?</token>
+                </pattern>
+                <message>« Package deal » peut être considéré comme un anglicisme.</message>
+                <suggestion>accord global</suggestion>
+                <suggestion>entente globale</suggestion>
+                <example correction="accord global|entente globale"><marker>package deal</marker></example>
+                <example correction="accord global|entente globale"><marker>package-deal</marker></example>
+                <example><marker>accord global</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="QUEEN_SIZE" name="queen size">
+            <rule>
+                <pattern>
+                    <token regexp="yes">queens?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">sizes?</token>
+                </pattern>
+                <message>« Queen size » peut être considéré comme un anglicisme. Employez <suggestion>grand format</suggestion> (lit), <suggestion>longue</suggestion> (cigarette).</message>
+                <example correction="grand format|longue">lit <marker>queen size</marker></example>
+                <example correction="grand format|longue">lit <marker>queen-size</marker></example>
+                <example>lit <marker>grand format</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="MELTING-POT" name="melting-pot" default="off">
+            <rule>
+                <pattern>
+                    <token regexp="yes">meltings?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">pots?</token>
+                </pattern>
+                <message>« Melting pot » peut être considéré comme un anglicisme.</message>
+                <suggestion>creuset</suggestion>
+                <example correction="creuset"><marker>melting pot</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">melting-pots?</token>
+                </pattern>
+                <message>« Melting pot » peut être considéré comme un anglicisme.</message>
+                <suggestion>creuset</suggestion>
+                <example correction="creuset"><marker>melting-pot</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="MILK-SHAKE" name="milk-shake" default="off">
+            <!-- deactivated : widespread usage -->
+            <rule>
+                <pattern>
+                    <token regexp="yes">milks?</token>
+                    <token regexp="yes">shakes?</token>
+                </pattern>
+                <message>« Milk-shake » peut être considéré comme un anglicisme.</message>
+                <suggestion>lait fouetté</suggestion>
+                <example correction="lait fouetté"><marker>milk shake</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">milk-?shakes?</token>
+                </pattern>
+                <message>« Milk-shake » peut être considéré comme un anglicisme.</message>
+                <suggestion>lait fouetté</suggestion>
+                <example correction="lait fouetté"><marker>milk-shake</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="KING_SIZE" name="king size">
+            <pattern>
+                <token regexp="yes">king?</token>
+                <token regexp="yes">sizes?</token>
+            </pattern>
+            <message>« King size » peut être considéré comme un anglicisme. Employez <suggestion>très grand format</suggestion> (lit), <suggestion>longue</suggestion> (cigarette).</message>
+            <example correction="très grand format|longue">lit <marker>king size</marker></example>
+            <example>lit <marker>très grand format</marker></example>
+        </rule>
+        <rule id="EXTRA_LARGE" name="extra large" default="off">
+            <!-- deactivated : widespread usage -->
+            <pattern>
+                <token regexp="yes">extras?</token>
+                <token regexp="yes">larges?</token>
+            </pattern>
+            <message>« Extra large » peut être considéré comme un anglicisme.</message>
+            <suggestion>très grand</suggestion>
+            <example correction="très grand"><marker>extra large</marker></example>
+        </rule>
+        <rule id="POLL" name="poll">
+            <pattern>
+                <token regexp="yes">polls?
+                    <exception scope="previous">-</exception></token>
+            </pattern>
+            <message>« Poll » peut être considéré comme un anglicisme.</message>
+            <suggestion>bureau de vote</suggestion>
+            <suggestion>bureau de scrutin</suggestion>
+            <example correction="bureau de vote|bureau de scrutin"><marker>poll</marker></example>
+            <example><marker>bureau de vote</marker></example>
+        </rule>
+        <rule id="POLE_POSITION" name="pole position" default="off">
+            <!-- deactivated : widespread usage -->
+            <pattern>
+                <token regexp="yes">poles?</token>
+                <token regexp="yes">positions?</token>
+            </pattern>
+            <message>« Pole position » peut être considéré comme un anglicisme.</message>
+            <suggestion>position de tête</suggestion>
+            <example correction="position de tête"><marker>pole position</marker></example>
+        </rule>
+        <rule id="OFF" name="off">
+            <antipattern>
+                <token skip="5">on</token>
+                <token>off</token>
+            </antipattern>
+            <pattern>
+                <token regexp="yes">offs?
+                    <exception scope="previous">-</exception>
+                    <exception scope="next">-</exception></token>
+            </pattern>
+            <message>« Off » peut être considéré comme un anglicisme. Employez <suggestion>hors champ</suggestion>, <suggestion>libre</suggestion> (journée), <suggestion>de congé</suggestion> (journée), <suggestion>en congé</suggestion> (ne pas travailler), <suggestion>arrêt</suggestion> (appareil électrique), <suggestion>fermé</suggestion> (robinet).</message>
+            <example correction="hors champ|libre|de congé|en congé|arrêt|fermé"><marker>off</marker></example>
+            <example><marker>hors champ</marker></example>
+        </rule>
+        <rule id="PATCH" name="patch" default="off">
+            <pattern>
+                <token regexp="yes"> patch|patches|patchs
+                    <exception case_sensitive="yes">PATCH</exception><!-- HTTP Method --></token>
+            </pattern>
+            <message>'Patch' peut être considéré comme un anglicisme. Employez <suggestion><match no="1" regexp_match="(?i)patche?" regexp_replace="pièce"/></suggestion> (chambre à air, ballon, morceau de tissu), <suggestion><match no="1" regexp_match="(?i)patche?" regexp_replace="timbre"/> <match no="1" regexp_match="(?i)patche?" regexp_replace="cutané"/></suggestion>, <suggestion><match no="1" regexp_match="(?i)patche?" regexp_replace="correctif"/></suggestion> (informatique), <suggestion><match no="1" regexp_match="(?i)patche?" regexp_replace="retouche"/></suggestion> (informatique), <suggestion><match no="1" regexp_match="(?i)patche?" regexp_replace="solution"/> temporaire</suggestion>.</message>
+            <example correction="pièce|timbre cutané|correctif|retouche|solution temporaire"><marker>patch</marker></example>
+            <example correction="pièces|timbres cutanés|correctifs|retouches|solutions temporaire"><marker>patches</marker></example>
+            <example><marker>rustine</marker></example>
+        </rule>
+        <rule id="MUFFLER" name="muffler">
+            <pattern>
+                <token regexp="yes">mufflers?</token>
+            </pattern>
+            <message>« Muffler » peut être considéré comme un anglicisme. Employez <suggestion>tuyau d'échappement</suggestion>, <suggestion>silencieux</suggestion> (langue technique), <suggestion>pot d'échappement</suggestion>, <suggestion>pot</suggestion> (courant), <suggestion>système d'échappement</suggestion>, <suggestion>échappement</suggestion> (courant).</message>
+            <example correction="tuyau d'échappement|silencieux|pot d'échappement|pot|système d'échappement|échappement"><marker>muffler</marker></example>
+            <example><marker>tuyau d’échappement</marker></example>
+        </rule>
+        <rule id="NIL" name="nil">
+            <pattern case_sensitive="yes">
+                <token regexp="yes">nils?</token>
+            </pattern>
+            <message>« nil » peut être considéré comme un anglicisme.</message>
+            <suggestion>néant</suggestion>
+            <suggestion>sans objet</suggestion>
+            <suggestion>s. o.</suggestion>
+            <example correction="néant|sans objet|s. o."><marker>nil</marker></example>
+            <example><marker>sans objet</marker></example>
+            <example><marker>Le Nil est un fleuve d’Afrique.</marker></example>
+        </rule>
+        <rule id="NURSING" name="nursing">
+            <pattern>
+                <token regexp="yes">nursings?</token>
+            </pattern>
+            <message>« Nursing » peut être considéré comme un anglicisme.</message>
+            <suggestion>profession d'infirmier</suggestion>
+            <suggestion>études d'infirmier</suggestion>
+            <suggestion>formation en soins infirmiers</suggestion>
+            <suggestion>soins infirmiers</suggestion>
+            <example correction="profession d'infirmier|études d'infirmier|formation en soins infirmiers|soins infirmiers"><marker>nursing</marker></example>
+            <example><marker>soins infirmiers</marker></example>
+        </rule>
+        <rulegroup id="MUST" name="must">
+            <antipattern>
+                <token>must</token>
+                <token>du</token>
+                <token>must</token>
+            </antipattern>
+            <rule>
+                <pattern>
+                    <token postag="D . s" postag_regexp="yes">
+                        <exception regexp="yes">le|la</exception></token>
+                    <marker>
+                        <token>must
+                            <exception scope="next" regexp="yes">-|have|"|see|read</exception></token>
+                    </marker>
+                </pattern>
+                <message>Cette expression peut être considérée comme un anglicisme.</message>
+                <suggestion>incontournable</suggestion>
+                <suggestion>indispensable</suggestion>
+                <example correction="incontournable|indispensable">C'est un <marker>must</marker> en cette saison.</example>
+                <example><marker>incontournable</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="D . p" postag_regexp="yes"/>
+                    <marker>
+                        <token>must
+                            <exception scope="next" regexp="yes">-|have|"|see|read</exception></token>
+                    </marker>
+                </pattern>
+                <message>Cette expression peut être considérée comme un anglicisme.</message>
+                <suggestion>incontournables</suggestion>
+                <suggestion>indispensables</suggestion>
+                <example correction="incontournables|indispensables">Ce sont les <marker>must</marker> en cette saison.</example>
+                <example><marker>incontournable</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <marker>
+                        <token>le</token>
+                        <token>must
+                            <exception scope="next" regexp="yes">-|have|"|see|read</exception></token>
+                    </marker>
+                </pattern>
+                <message>Cette expression peut être considérée comme un anglicisme.</message>
+                <suggestion>l'incontournable</suggestion>
+                <suggestion>l'indispensable</suggestion>
+                <suggestion>le meilleur</suggestion>
+                <suggestion>le mieux</suggestion>
+                <example correction="l'incontournable|l'indispensable|le meilleur|le mieux">C'est <marker>le must</marker> en cette saison.</example>
+                <example><marker>incontournable</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="D . s" postag_regexp="yes">
+                        <exception regexp="yes">le|la</exception></token>
+                    <marker>
+                        <token>must</token>
+                        <token>have</token>
+                    </marker>
+                </pattern>
+                <message>Cette expression peut être considérée comme un anglicisme.</message>
+                <suggestion>incontournable</suggestion>
+                <suggestion>indispensable</suggestion>
+                <example correction="incontournable|indispensable">C'est un <marker>must have</marker> en cette saison.</example>
+                <example><marker>incontournable</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="D . p" postag_regexp="yes">
+                        <exception regexp="yes">le|la</exception></token>
+                    <marker>
+                        <token>must</token>
+                        <token>have</token>
+                    </marker>
+                </pattern>
+                <message>Cette expression peut être considérée comme un anglicisme.</message>
+                <suggestion>incontournables</suggestion>
+                <suggestion>indispensables</suggestion>
+                <example correction="incontournables|indispensables">Ce sont des <marker>must have</marker> en cette saison.</example>
+                <example><marker>incontournable</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <marker>
+                        <token regexp="yes">le|la</token>
+                        <token>must</token>
+                        <token>have</token>
+                    </marker>
+                </pattern>
+                <message>Cette expression peut être considérée comme un anglicisme.</message>
+                <suggestion>l'incontournable</suggestion>
+                <suggestion>l'indispensable</suggestion>
+                <example correction="l'incontournable|l'indispensable">C'est <marker>le must have</marker> en cette saison.</example>
+                <example><marker>incontournable</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">aux|des</token>
+                    <marker>
+                        <token>must
+                            <exception scope="next" regexp="yes">-|have|"|see|read</exception></token>
+                    </marker>
+                </pattern>
+                <message>Cette expression peut être considérée comme un anglicisme.</message>
+                <suggestion>incontournables</suggestion>
+                <suggestion>indispensables</suggestion>
+                <example correction="incontournables|indispensables">C'est un des <marker>must</marker> en cette saison.</example>
+                <example><marker>incontournable</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <marker>
+                        <token regexp="yes">de|du</token>
+                        <token>must
+                            <exception scope="next" regexp="yes">-|have|"|see|read</exception></token>
+                    </marker>
+                </pattern>
+                <message>Cette expression peut être considérée comme un anglicisme.</message>
+                <suggestion>de l'incontournable</suggestion>
+                <suggestion>de l'indispensable</suggestion>
+                <example correction="de l'incontournable|de l'indispensable">C'est <marker>du must</marker> en cette saison.</example>
+                <example><marker>incontournable</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="[PD].*" postag_regexp="yes">
+                        <exception postag="D . s" postag_regexp="yes"/></token>
+                    <marker>
+                        <token>must</token>
+                        <token>have</token>
+                    </marker>
+                </pattern>
+                <message>Cette expression peut être considérée comme un anglicisme.</message>
+                <suggestion>incontournables</suggestion>
+                <suggestion>indispensables</suggestion>
+                <example correction="incontournables|indispensables">Ce sont des <marker>must have</marker> en cette saison.</example>
+                <example><marker>incontournable</marker></example>
+            </rule>
+        </rulegroup>
+        <rule default="off" id="PARKING" name="parking">
+            <pattern>
+                <token regexp="yes">parkings?</token>
+            </pattern>
+            <message>« Parking » peut être considéré comme un anglicisme. Employez <suggestion>stationnement</suggestion> (action), <suggestion>parc de stationnement</suggestion> (lieu), <suggestion>parc à voitures</suggestion> (lieu), <suggestion>parc-autos</suggestion> (lieu), <suggestion>parc à autos</suggestion> (lieu), <suggestion>parcage</suggestion> (action), <suggestion>garage</suggestion> (action ou lieu couvert). Note : « Stationnement » est un régionalisme (Québec) au sens de « parc de stationnement ».</message>
+            <example correction="stationnement|parc de stationnement|parc à voitures|parc-autos|parc à autos|parcage|garage"><marker>parking</marker></example>
+            <example><marker>parc de stationnement</marker></example>
+        </rule>
+        <rule id="MEMBERSHIP" name="membership">
+            <pattern>
+                <token regexp="yes">memberships?</token>
+            </pattern>
+            <message>« Membership » peut être considéré comme un anglicisme.</message>
+            <suggestion>effectif</suggestion>
+            <suggestion>nombre de membres</suggestion>
+            <example correction="effectif|nombre de membres"><marker>membership</marker></example>
+            <example><marker>effectif</marker></example>
+        </rule>
+        <rule id="MEDLEY" name="medley" default="off">
+            <pattern>
+                <token regexp="yes">medleys?</token>
+            </pattern>
+            <message>« Medley » peut être considéré comme un anglicisme.</message>
+            <suggestion>pot-pourri</suggestion>
+            <example correction="pot-pourri"><marker>medley</marker></example>
+        </rule>
+        <rule id="METER" name="meter">
+            <pattern>
+                <token regexp="yes">meters?
+                    <exception scope="previous">hour</exception></token>
+            </pattern>
+            <message>« Meter » peut être considéré comme un anglicisme.</message>
+            <suggestion>compteur</suggestion>
+            <example correction="compteur"><marker>meter</marker></example>
+        </rule>
+        <rule id="MEETING" name="meeting">
+            <antipattern>
+                <token>Meeting</token>
+                <token>ID</token>
+            </antipattern>
+            <pattern>
+                <token regexp="yes">meetings?</token>
+            </pattern>
+            <message>« Meeting » peut être considéré comme un anglicisme.</message>
+            <suggestion><match no="1" regexp_match="(?i)meeting?" regexp_replace="réunion"/></suggestion>
+            <suggestion>rencontre</suggestion>
+            <example correction="réunion|rencontre"><marker>meeting</marker></example>
+            <example><marker>réunion</marker></example>
+        </rule>
+        <rule id="LOADER" name="loader">
+            <pattern>
+                <token regexp="yes">loaders?</token>
+            </pattern>
+            <message>« Loader » peut être considéré comme un anglicisme. Employez <suggestion>chargeuse</suggestion> (véhicule).</message>
+            <example correction="chargeuse"><marker>loader</marker></example>
+        </rule>
+        <rule id="LIVE" name="live" tags="picky">
+            <antipattern>
+                <token>black</token>
+                <token regexp="yes">lives?</token>
+                <token regexp="yes">matters?</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">xbox|ableton|facebook|quizlet</token>
+                <token>live</token>
+            </antipattern>
+            <antipattern>
+                <token>live</token>
+                <token>nation</token>
+            </antipattern>
+            <antipattern>
+                <token postag="V.*" postag_regexp="yes" inflected="yes">partir</token>
+                <token>en</token>
+                <token>live</token>
+            </antipattern>
+            <pattern>
+                <token>en</token>
+                <token>live
+                    <exception scope="next" regexp="yes">streaming|shows?|-</exception></token>
+            </pattern>
+            <message>« Live » peut être considéré comme un anglicisme. Employez <suggestion>\1 <match no="2" regexp_match="live" regexp_replace="direct" case_conversion="preserve"/></suggestion>.</message>
+            <example correction="en direct">Nous sommes <marker>en live</marker> depuis notre studio.</example>
+            <example><marker>en direct</marker></example>
+            <example>Black Lives Matter</example>
+        </rule>
+        <rule id="LISTING" name="listing">
+            <pattern>
+                <token regexp="yes">listings?</token>
+            </pattern>
+            <message>« Listing » peut être considéré comme un anglicisme. Employez <suggestion>listage</suggestion> (informatique).</message>
+            <example correction="listage"><marker>listing</marker></example>
+        </rule>
+        <rule id="LIFT" name="lift">
+            <pattern>
+                <token regexp="yes">lifts?</token>
+            </pattern>
+            <message>« Lift » peut être considéré comme un anglicisme. Employez <suggestion>monte-charge</suggestion> (ascenseur pour objets), <suggestion>pont élévateur</suggestion> (garage), <suggestion>chariot élévateur</suggestion> (véhicule pour soulever des charges), <suggestion>prendre en voiture</suggestion>, <suggestion>voiturer</suggestion> (familier), <suggestion>reconduire</suggestion>, <suggestion>ramener</suggestion>, <suggestion>déposer</suggestion>.</message>
+            <example correction="monte-charge|pont élévateur|chariot élévateur|prendre en voiture|voiturer|reconduire|ramener|déposer"><marker>lift</marker></example>
+            <example><marker>monte-charge</marker></example>
+        </rule>
+        <rule id="HOSE" name="hose">
+            <pattern>
+                <token regexp="yes">hoses?</token>
+            </pattern>
+            <message>« Hose » peut être considéré comme un anglicisme.</message>
+            <suggestion>tuyau d'arrosage</suggestion>
+            <suggestion>tuyau</suggestion>
+            <example correction="tuyau d'arrosage|tuyau"><marker>hose</marker></example>
+            <example><marker>tuyau</marker></example>
+        </rule>
+        <rule id="FULL" name="full">
+            <antipattern>
+                <token>full</token>
+                <token regexp="yes">HD|House</token>
+            </antipattern>
+            <pattern>
+                <token regexp="yes">fulls?
+                    <exception scope="next" postag="UNKNOWN"/>
+                    <exception scope="next" regexp="yes">(?-i)[A-Z].*|-</exception></token>
+            </pattern>
+            <message>« Full » peut être considéré comme un anglicisme. Employez <suggestion>main pleine</suggestion> (cartes), <suggestion>plein</suggestion>, <suggestion>beaucoup</suggestion>.</message>
+            <example correction="main pleine|plein|beaucoup"><marker>full</marker></example>
+            <example><marker>plein</marker></example>
+        </rule>
+        <rulegroup id="FUN" name="fun">
+            <rule>
+                <antipattern>
+                    <token>fun</token>
+                    <token regexp="yes">facts?</token>
+                </antipattern>
+                <pattern>
+                    <token regexp="yes" case_sensitive="yes">funs?
+                        <exception scope="next" regexp="yes">radio|day|brothers|["»]|boxe?s?</exception>
+                        <exception scope="previous" regexp="yes">having|sur</exception></token>
+                </pattern>
+                <message>« Fun » peut être considéré comme un anglicisme.</message>
+                <suggestion><match no="1" regexp_match="fun(?iu)" regexp_replace="plaisir"/></suggestion>
+                <suggestion><match no="1" regexp_match="fun(?iu)" regexp_replace="sympa"/></suggestion>
+                <suggestion><match no="1" regexp_match="fun(?iu)" regexp_replace="drôle"/></suggestion>
+                <example correction="plaisir|sympa|drôle"><marker>fun</marker></example>
+                <example><marker>plaisir</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="INTERCOM" name="intercom">
+            <pattern>
+                <token regexp="yes">intercoms?</token>
+            </pattern>
+            <message>« Intercom » peut être considéré comme un anglicisme.</message>
+            <suggestion>interphone</suggestion>
+            <example correction="interphone"><marker>intercom</marker></example>
+        </rule>
+        <rule id="FILIBUSTER" name="filibuster">
+            <pattern>
+                <token regexp="yes">filibusters?</token>
+            </pattern>
+            <message>« Filibuster » peut être considéré comme un anglicisme.</message>
+            <suggestion>obstruction systématique</suggestion>
+            <example correction="obstruction systématique"><marker>filibuster</marker></example>
+        </rule>
+        <rule id="ENTREPRENEURSHIP" name="entrepreneurship">
+            <pattern>
+                <token regexp="yes">entrepreneurships?</token>
+            </pattern>
+            <message>« Entrepreneurship » peut être considéré comme un anglicisme.</message>
+            <suggestion>esprit d'entreprise</suggestion>
+            <suggestion>entrepreneuriat</suggestion>
+            <example correction="esprit d'entreprise|entrepreneuriat"><marker>entrepreneurship</marker></example>
+            <example><marker>esprit d’entreprise</marker></example>
+        </rule>
+        <rule id="ESCALATOR" name="escalator" default="off">
+            <!-- deactivated : widespread usage -->
+            <pattern>
+                <token regexp="yes">escalators?</token>
+            </pattern>
+            <message>« Escalator » peut être considéré comme un anglicisme.</message>
+            <suggestion>escalier mécanique</suggestion>
+            <example correction="escalier mécanique"><marker>escalator</marker></example>
+        </rule>
+        <rule id="DUMP" name="dump">
+            <pattern>
+                <token regexp="yes">dumps?</token>
+            </pattern>
+            <message>« Dump » peut être considéré comme un anglicisme. Employez <suggestion>décharge</suggestion>, <suggestion>dépotoir</suggestion>, <suggestion>dépôt d'ordures</suggestion>, <suggestion>terril</suggestion> (résidus d’extraction minière).</message>
+            <example correction="décharge|dépotoir|dépôt d'ordures|terril"><marker>dump</marker></example>
+            <example><marker>décharge</marker></example>
+        </rule>
+        <rule id="ENCRYPTION" name="encryption">
+            <pattern>
+                <token regexp="yes">encryptions?</token>
+            </pattern>
+            <message>« Encryption » peut être considéré comme un anglicisme.</message>
+            <suggestion>cryptage</suggestion>
+            <suggestion>chiffrement</suggestion>
+            <example correction="cryptage|chiffrement"><marker>encryption</marker></example>
+            <example><marker>cryptage</marker></example>
+        </rule>
+        <rule id="COOKIE" name="cookie" default="off">
+            <!-- picky -->
+            <pattern>
+                <token regexp="yes">cookies?</token>
+            </pattern>
+            <message>« Cookie » peut être considéré comme un anglicisme.</message>
+            <suggestion><match no="1" regexp_match="(?i)cookie" regexp_replace="biscuit"/></suggestion>
+            <suggestion><match no="1" regexp_match="(?i)cookie" regexp_replace="témoin"/> de connexion</suggestion>
+            <suggestion><match no="1" regexp_match="(?i)cookie" regexp_replace="témoin"/></suggestion>
+            <example correction="biscuit|témoin de connexion|témoin"><marker>cookie</marker></example>
+            <example><marker>témoin de connexion</marker></example>
+        </rule>
+        <rule id="CORDUROY" name="corduroy">
+            <pattern>
+                <token regexp="yes">corduroys?</token>
+            </pattern>
+            <message>« Corduroy » peut être considéré comme un anglicisme.</message>
+            <suggestion>velours côtelé</suggestion>
+            <example correction="velours côtelé"><marker>corduroy</marker></example>
+        </rule>
+        <rule id="CONTAINER" name="container">
+            <pattern>
+                <token regexp="yes">containers?</token>
+            </pattern>
+            <message>« Container » peut être considéré comme un anglicisme.</message>
+            <suggestion>conteneur</suggestion>
+            <example correction="conteneur"><marker>container</marker></example>
+        </rule>
+        <rule id="BRANDING" name="branding">
+            <pattern>
+                <token regexp="yes">branding|bradings</token>
+            </pattern>
+            <message>« Branding » peut être considéré comme un anglicisme. Employez <suggestion>stratégie de marque</suggestion>, <suggestion>valorisation de la marque</suggestion>, <suggestion>image de marque</suggestion>, <suggestion>pouvoir de la marque</suggestion>, <suggestion>notoriété</suggestion> (figuré).</message>
+            <example correction="stratégie de marque|valorisation de la marque|image de marque|pouvoir de la marque|notoriété"><marker>branding</marker></example>
+            <example><marker>stratégie de marque</marker></example>
+        </rule>
+        <rulegroup id="CHUM" name="chum">
+            <rule>
+                <pattern>
+                    <token postag="D.*|J m s" postag_regexp="yes"/>
+                    <marker>
+                        <token case_sensitive="yes">chum</token>
+                    </marker>
+                </pattern>
+                <message>« Chum » peut être considéré comme un anglicisme.</message>
+                <suggestion>ami</suggestion>
+                <suggestion>copain</suggestion>
+                <suggestion>camarade</suggestion>
+                <suggestion>collègue</suggestion>
+                <suggestion>petit ami</suggestion>
+                <suggestion>compagnon</suggestion>
+                <suggestion>conjoint</suggestion>
+                <example correction="ami|copain|camarade|collègue|petit ami|compagnon|conjoint">Un <marker>chum</marker></example>
+                <example><marker>ami</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="D.*|J m p" postag_regexp="yes"/>
+                    <marker>
+                        <token case_sensitive="yes">chums</token>
+                    </marker>
+                </pattern>
+                <message>« Chum » peut être considéré comme un anglicisme.</message>
+                <suggestion>amis</suggestion>
+                <suggestion>copains</suggestion>
+                <suggestion>camarades</suggestion>
+                <suggestion>collègues</suggestion>
+                <suggestion>petits amis</suggestion>
+                <suggestion>compagnons</suggestion>
+                <suggestion>conjoints</suggestion>
+                <example correction="amis|copains|camarades|collègues|petits amis|compagnons|conjoints">Des <marker>chums</marker></example>
+                <example><marker>ami</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="CHEAP" name="cheap">
+            <rule>
+                <antipattern>
+                    <token regexp="yes">order|price|be|by|amazing|not|after|great|beautiful</token>
+                    <token>cheap</token>
+                </antipattern>
+                <pattern>
+                    <token case_sensitive="yes">cheap
+                        <exception scope="next" regexp="yes">awesome|under|labour|jordans|nikes|that|beautiful|beats|nike|perfect|ordinary|price|best</exception></token>
+                </pattern>
+                <message>« Cheap » peut être considéré comme un anglicisme. Employez <suggestion>ordinaire</suggestion>, <suggestion>bon marché</suggestion> ou <suggestion>abordable</suggestion>.</message>
+                <example correction="ordinaire|bon marché|abordable"><marker>cheap</marker></example>
+                <example><marker>bon marché</marker></example>
+                <example>Order cheap 240 mg buy online dosage.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>de</token>
+                    <token regexp="yes" case_sensitive="yes">cheaps?
+                        <exception scope="next" regexp="yes">awesome|labour|beautiful|beats|nike|perfect|ordinary|price|best</exception></token>
+                </pattern>
+                <message>« Cheap » peut être considéré comme un anglicisme. Employez <suggestion>d'ordinaire</suggestion>, <suggestion>de bon marché</suggestion> ou <suggestion>d'abordable</suggestion>.</message>
+                <example correction="d'ordinaire|de bon marché|d'abordable"><marker>de cheap</marker></example>
+                <example><marker>bon marché</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BUILDING" name="building">
+            <rule>
+                <pattern>
+                    <token postag="D . s" postag_regexp="yes"/>
+                    <marker>
+                        <token>building</token>
+                    </marker>
+                </pattern>
+                <message>« Building » peut être considéré comme un anglicisme.</message>
+                <suggestion>édifice</suggestion>
+                <suggestion>gratte-ciel</suggestion>
+                <suggestion>immeuble</suggestion>
+                <example correction="édifice|gratte-ciel|immeuble">Un <marker>building</marker></example>
+                <example><marker>édifice</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="D . p" postag_regexp="yes"/>
+                    <marker>
+                        <token>buildings</token>
+                    </marker>
+                </pattern>
+                <message>« Building » peut être considéré comme un anglicisme.</message>
+                <suggestion>édifices</suggestion>
+                <suggestion>gratte-ciel</suggestion>
+                <suggestion>gratte-ciels</suggestion>
+                <suggestion>immeubles</suggestion>
+                <example correction="édifices|gratte-ciel|gratte-ciels|immeubles">Des <marker>buildings</marker></example>
+                <example><marker>édifice</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="CASTING" name="casting">
+            <pattern>
+                <token regexp="yes">castings?</token>
+            </pattern>
+            <message>« Casting » peut être considéré comme un anglicisme.</message>
+            <suggestion>distribution</suggestion>
+            <suggestion>distribution artistique</suggestion>
+            <example correction="distribution|distribution artistique"><marker>casting</marker></example>
+            <example><marker>distribution</marker></example>
+        </rule>
+        <rule id="CART" name="cart">
+            <pattern>
+                <token regexp="yes">carts?</token>
+            </pattern>
+            <message>« Cart » peut être considéré comme un anglicisme.</message>
+            <suggestion>voiturette</suggestion>
+            <suggestion>voiturette électrique</suggestion>
+            <example correction="voiturette|voiturette électrique"><marker>cart</marker></example>
+            <example><marker>voiturette</marker></example>
+        </rule>
+        <rule id="CANCELLATION" name="cancellation">
+            <pattern>
+                <token regexp="yes">cancellations?</token>
+            </pattern>
+            <message>« Cancellation » peut être considéré comme un anglicisme.</message>
+            <suggestion>annulation</suggestion>
+            <example correction="annulation"><marker>cancellation</marker></example>
+        </rule>
+        <rule id="CASHEW" name="cashew">
+            <pattern>
+                <token regexp="yes">cashews?</token>
+            </pattern>
+            <message>« Cashew » peut être considéré comme un anglicisme.</message>
+            <suggestion>cajou</suggestion>
+            <suggestion>noix de cajou</suggestion>
+            <example correction="cajou|noix de cajou"><marker>cashew</marker></example>
+            <example><marker>cajou</marker></example>
+        </rule>
+        <rule id="CLUTCH" name="clutch">
+            <pattern>
+                <token regexp="yes">clutchs?|clutches</token>
+            </pattern>
+            <message>« Clutch » peut être considéré comme un anglicisme.</message>
+            <suggestion>embrayage</suggestion>
+            <suggestion>pédale d'embrayage</suggestion>
+            <example correction="embrayage|pédale d'embrayage"><marker>clutch</marker></example>
+            <example><marker>embrayage</marker></example>
+        </rule>
+        <rule id="BVLD" name="bvld">
+            <pattern>
+                <token>bvld</token>
+            </pattern>
+            <message>« Bvld. » peut être considéré comme un anglicisme.</message>
+            <suggestion>boul.</suggestion>
+            <suggestion>bd.</suggestion>
+            <example correction="boul.|bd."><marker>bvld</marker></example>
+            <example><marker>boul.</marker></example>
+        </rule>
+        <rule id="BOUNCER" name="bouncer">
+            <pattern>
+                <token regexp="yes">bouncers?</token>
+            </pattern>
+            <message>« Bouncer » peut être considéré comme un anglicisme.</message>
+            <suggestion>videur</suggestion>
+            <suggestion>homme de main</suggestion>
+            <example correction="videur|homme de main"><marker>bouncer</marker></example>
+            <example><marker>homme de main</marker></example>
+        </rule>
+        <rulegroup id="BOSS" name="boss">
+            <antipattern>
+                <token>hugo</token>
+                <token>boss</token>
+            </antipattern>
+            <antipattern>
+                <token>
+                    <exception postag="D.*" postag_regexp="yes"/></token>
+                <token regexp="yes" case_sensitive="yes">Boss|BOSS</token>
+            </antipattern>
+            <rule>
+                <pattern>
+                    <token>boss
+                        <exception scope="previous" regexp="yes">des|big|-|aux|l[ea]|de</exception>
+                        <exception scope="previous" postag="D . p" postag_regexp="yes"/></token>
+                </pattern>
+                <message>« Boss » peut être considéré comme un anglicisme.</message>
+                <suggestion>patron</suggestion>
+                <suggestion>superviseur</suggestion>
+                <suggestion>supérieur</suggestion>
+                <suggestion>expert</suggestion>
+                <suggestion>directeur</suggestion>
+                <example correction="patron|superviseur|supérieur|expert|directeur"><marker>boss</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>le</token>
+                    <token>boss</token>
+                </pattern>
+                <message>« Boss » peut être considéré comme un anglicisme.</message>
+                <suggestion>le patron</suggestion>
+                <suggestion>le superviseur</suggestion>
+                <suggestion>le supérieur</suggestion>
+                <suggestion>l'expert</suggestion>
+                <suggestion>le directeur</suggestion>
+                <example correction="le patron|le superviseur|le supérieur|l'expert|le directeur">C'est lui <marker>le boss</marker>.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">de|du</token>
+                    <token>boss</token>
+                </pattern>
+                <message>« Boss » peut être considéré comme un anglicisme.</message>
+                <suggestion>\1 patron</suggestion>
+                <suggestion>\1 superviseur</suggestion>
+                <suggestion>\1 supérieur</suggestion>
+                <suggestion>de l'expert</suggestion>
+                <suggestion>\1 directeur</suggestion>
+                <example correction="du patron|du superviseur|du supérieur|de l'expert|du directeur">Il faut que je te parle <marker>du boss</marker>.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <or>
+                        <token postag="D . p|J . p" postag_regexp="yes"/>
+                        <token regexp="yes">aux|des</token>
+                    </or>
+                    <marker>
+                        <token case_sensitive="yes">boss</token>
+                    </marker>
+                </pattern>
+                <message>« Boss » peut être considéré comme un anglicisme.</message>
+                <suggestion>patrons</suggestion>
+                <suggestion>experts</suggestion>
+                <suggestion>supérieurs</suggestion>
+                <suggestion>chefs</suggestion>
+                <suggestion>directeurs</suggestion>
+                <example correction="patrons|experts|supérieurs|chefs|directeurs">Les <marker>boss</marker> arrivent.</example>
+            </rule>
+        </rulegroup>
+        <rule id="BREAKER" name="breaker">
+            <pattern>
+                <token regexp="yes">breakers?</token>
+            </pattern>
+            <message>« Breaker » peut être considéré comme un anglicisme. Employez <suggestion>disjoncteur</suggestion> (plusieurs circuits), <suggestion>coupe-circuit</suggestion> (un circuit).</message>
+            <example correction="disjoncteur|coupe-circuit"><marker>breaker</marker></example>
+            <example><marker>disjoncteur</marker></example>
+        </rule>
+        <rule id="REFILL" name="refill">
+            <pattern>
+                <token regexp="yes">refills?</token>
+            </pattern>
+            <message>« Refill » peut être considéré comme un anglicisme. Employez <suggestion>recharge</suggestion> (pour un stylo ou un briquet ou en général), <suggestion>nouvelle cartouche</suggestion> (stylo), <suggestion>cartouche</suggestion> (stylo), <suggestion>mine de rechange</suggestion> (stylomine), <suggestion>feuilles de rechange</suggestion> (calepin), <suggestion>deuxième verre</suggestion> (bar), <suggestion>la même chose</suggestion> (bar).</message>
+            <example correction="recharge|nouvelle cartouche|cartouche|mine de rechange|feuilles de rechange|deuxième verre|la même chose"><marker>refill</marker></example>
+            <example><marker>recharge</marker></example>
+        </rule>
+        <rule id="SMILE" name="smile">
+            <pattern>
+                <token regexp="yes" case_sensitive="yes">smiles?</token>
+            </pattern>
+            <message>« Smile » peut être considéré comme un anglicisme.</message>
+            <suggestion><match no="1" regexp_match="smile" regexp_replace="sourire"/></suggestion>
+            <example correction="sourire"><marker>smile</marker></example>
+        </rule>
+        <rule id="FLANNELETTE" name="flannelette">
+            <pattern>
+                <token regexp="yes">flann?ell?ettes?</token>
+            </pattern>
+            <message>« Flannelette » peut être considéré comme un anglicisme.</message>
+            <suggestion>finette</suggestion>
+            <suggestion>pilou</suggestion>
+            <suggestion>flanelle de coton</suggestion>
+            <example correction="finette|pilou|flanelle de coton"><marker>flannelette</marker></example>
+            <example><marker>finette</marker></example>
+        </rule>
+        <rule default="off" id="FAN" name="fan">
+            <pattern>
+                <token regexp="yes">fans?</token>
+            </pattern>
+            <message>« Fan » peut être considéré comme un anglicisme. Employez <suggestion>admirateur</suggestion>, <suggestion>partisan</suggestion>, <suggestion>adepte</suggestion>, <suggestion>ventilateur</suggestion> (maison, appartement, atelier, moteur), <suggestion>hotte</suggestion> (cuisinière).</message>
+            <example correction="admirateur|partisan|adepte|ventilateur|hotte"><marker>fan</marker></example>
+            <example><marker>admirateur</marker></example>
+        </rule>
+        <rule id="FEELING" name="feeling">
+            <pattern>
+                <token regexp="yes">feelings?</token>
+            </pattern>
+            <message>« Feeling » peut être considéré comme un anglicisme.</message>
+            <suggestion>sentiment</suggestion>
+            <suggestion>impression</suggestion>
+            <example correction="sentiment|impression"><marker>feeling</marker></example>
+            <example><marker>impression</marker></example>
+        </rule>
+        <rule default="off" id="FAX" name="fax">
+            <pattern>
+                <token regexp="yes">faxs?|faxes</token>
+            </pattern>
+            <message>« Fax » peut être considéré comme un anglicisme.</message>
+            <suggestion>télécopie</suggestion>
+            <suggestion>télécopieur</suggestion>
+            <example correction="télécopie|télécopieur"><marker>fax</marker></example>
+            <example><marker>télécopieur</marker></example>
+        </rule>
+        <rule id="MOMENTUM" name="momentum">
+            <pattern>
+                <token regexp="yes">momentums?</token>
+            </pattern>
+            <message>« Momentum » peut être considéré comme un anglicisme. Employez <suggestion>élan</suggestion>, <suggestion>initiative</suggestion>, <suggestion>impulsion du moment</suggestion>, <suggestion>vitesse acquise</suggestion>, <suggestion>lancée</suggestion>, <suggestion>dynamisme</suggestion>, <suggestion>dynamique</suggestion> (substantif), <suggestion>circonstances favorables</suggestion>, <suggestion>conjoncture favorable</suggestion>, <suggestion>force</suggestion>, <suggestion>avoir le vent en poupe</suggestion> (personne ; familier).</message>
+            <example correction="élan|initiative|impulsion du moment|vitesse acquise|lancée|dynamisme|dynamique|circonstances favorables|conjoncture favorable|force|avoir le vent en poupe"><marker>momentum</marker></example>
+            <example><marker>élan</marker></example>
+        </rule>
+        <rule id="BLENDER" name="blender" default="off">
+            <pattern>
+                <token regexp="yes">blenders?</token>
+            </pattern>
+            <message>« Blender » peut être considéré comme un anglicisme.</message>
+            <suggestion>mélangeur</suggestion>
+            <example correction="mélangeur"><marker>blender</marker></example>
+        </rule>
+        <rulegroup id="MINIVAN" name="minivan">
+            <rule>
+                <pattern>
+                    <token regexp="yes">mini-?vans?</token>
+                </pattern>
+                <message>« Minivan » peut être considéré comme un anglicisme. Employez <suggestion>monospace</suggestion>. Ce mot se prononce à la française.</message>
+                <example correction="monospace"><marker>minivan</marker></example>
+                <example>Le <marker>monospace</marker>.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">minis?</token>
+                    <token regexp="yes">vans?</token>
+                </pattern>
+                <message>« Minivan » peut être considéré comme un anglicisme. Employez <suggestion>monospace</suggestion>. Ce mot se prononce à la française.</message>
+                <example correction="monospace"><marker>mini van</marker></example>
+                <example>Le <marker>monospace</marker>.</example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="MAKING_OF" name="making of">
+            <rule>
+                <pattern>
+                    <token regexp="yes">makings?
+                        <exception scope="previous">the</exception></token>
+                    <token min="0">-</token>
+                    <token regexp="yes">of|off|ofs|offs</token>
+                </pattern>
+                <message>« Making of » peut être considéré comme un anglicisme.</message>
+                <suggestion>coulisses</suggestion>
+                <suggestion>genèse</suggestion>
+                <suggestion>réalisation</suggestion>
+                <suggestion>tournage</suggestion>
+                <suggestion>secrets de tournage</suggestion>
+                <example correction="coulisses|genèse|réalisation|tournage|secrets de tournage"><marker>making of</marker></example>
+                <example correction="coulisses|genèse|réalisation|tournage|secrets de tournage"><marker>making-of</marker></example>
+                <example>les <marker>coulisses</marker></example>
+                <example>Robert E. Kapsis, Hitchcock : The Making of a Reputation, University of Chicago Press, 1992.</example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="HAS_BEEN" name="has been">
+            <rule>
+                <pattern>
+                    <token>has</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">beens?</token>
+                </pattern>
+                <message>« Has been » peut être considéré comme un anglicisme. Employez <suggestion>qui a fait son temps</suggestion>, <suggestion>dépassé</suggestion>, <suggestion>démodé</suggestion> (familier).</message>
+                <example correction="qui a fait son temps|dépassé|démodé"><marker>has been</marker></example>
+                <example correction="qui a fait son temps|dépassé|démodé"><marker>has-been</marker></example>
+                <example>Les <marker>dépassés</marker>.</example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="MASS_MEDIA" name="mass media">
+            <rule>
+                <pattern>
+                    <token regexp="yes">mass|masses</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">média|media|medias|médias</token>
+                </pattern>
+                <message>« Mass media » peut être considéré comme un anglicisme.</message>
+                <suggestion>média de masse</suggestion>
+                <example correction="média de masse"><marker>mass media</marker></example>
+                <example correction="média de masse"><marker>mass-media</marker></example>
+                <example>les <marker>média de masse</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="LAZY-BOY" name="lazy-boy">
+            <rule>
+                <pattern>
+                    <token regexp="yes">lazys?|lazies</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">boys?</token>
+                </pattern>
+                <message>« Lazy-boy » peut être considéré comme un anglicisme.</message>
+                <suggestion>fauteuil de repos</suggestion>
+                <example correction="fauteuil de repos"><marker>lazy boy</marker></example>
+                <example correction="fauteuil de repos"><marker>lazy-boy</marker></example>
+                <example>les <marker>fauteuils de repos</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="HATCHBACK" name="hatchback">
+            <rule>
+                <pattern>
+                    <token regexp="yes">hatchbacks?</token>
+                </pattern>
+                <message>« Hatchback » peut être considéré comme un anglicisme. Employez <suggestion>hayon</suggestion> (partie mobile de la voiture), <suggestion>coupé avec hayon</suggestion>, <suggestion>berline avec hayon</suggestion>, <suggestion>trois portes</suggestion>, <suggestion>cinq portes</suggestion>. Un « coupé » possède deux portes latérales ; une « berline » en possède quatre.</message>
+                <example correction="hayon|coupé avec hayon|berline avec hayon|trois portes|cinq portes"><marker>hatchback</marker></example>
+                <example>les <marker>hayons</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">hatchs?|hatches</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">backs?</token>
+                </pattern>
+                <message>« Hatchback » peut être considéré comme un anglicisme. Employez <suggestion>hayon</suggestion> (partie mobile de la voiture), <suggestion>coupé avec hayon</suggestion>, <suggestion>berline avec hayon</suggestion>, <suggestion>trois portes</suggestion>, <suggestion>cinq portes</suggestion>. Un « coupé » possède deux portes latérales ; une « berline » en possède quatre.</message>
+                <example correction="hayon|coupé avec hayon|berline avec hayon|trois portes|cinq portes"><marker>hatch back</marker></example>
+                <example>les <marker>hayons</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="MARSHMALLOW" name="marshmallow">
+            <rule>
+                <pattern>
+                    <token regexp="yes">marshs?|marshes</token>
+                    <token regexp="yes">mallows?</token>
+                </pattern>
+                <message>« Marshmallow » peut être considéré comme un anglicisme.</message>
+                <suggestion>guimauve</suggestion>
+                <example correction="guimauve"><marker>marsh mallow</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="HAPPY-FEW" name="happy-few">
+            <rule>
+                <pattern>
+                    <token regexp="yes">happys?|happies</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">fews?</token>
+                </pattern>
+                <message>« Happy-few » peut être considéré comme un anglicisme. Employez <suggestion>privilégiés</suggestion>, <suggestion>l'élite</suggestion>, <suggestion>la crème</suggestion> (familier).</message>
+                <example correction="privilégiés|l'élite|la crème"><marker>happy few</marker></example>
+                <example correction="privilégiés|l'élite|la crème"><marker>happy-few</marker></example>
+                <example>les <marker>privilégiés</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="HIGH-TECH" name="high-tech" default="off">
+            <rule>
+                <pattern>
+                    <token regexp="yes">high-?techs?</token>
+                </pattern>
+                <message>« High-tech » peut être considéré comme un anglicisme. Employez <suggestion>haute technologie</suggestion> (substantif), <suggestion>de pointe</suggestion> (locution adjectivale).</message>
+                <example correction="haute technologie|de pointe"><marker>hightech</marker></example>
+                <example correction="haute technologie|de pointe"><marker>high-tech</marker></example>
+                <example><marker>haute technologie</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">highs?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">techs?</token>
+                </pattern>
+                <message>« High-tech » peut être considéré comme un anglicisme. Employez <suggestion>haute technologie</suggestion> (substantif), <suggestion>de pointe</suggestion> (locution adjectivale).</message>
+                <example correction="haute technologie|de pointe"><marker>high tech</marker></example>
+                <example><marker>haute technologie</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="FOURSOME" name="foursome">
+            <rule>
+                <pattern>
+                    <token regexp="yes">foursome|four-some|foursomes|four-somes</token>
+                </pattern>
+                <message>« Foursome » peut être considéré comme un anglicisme. Employez <suggestion>quatuor</suggestion> (général), <suggestion>double</suggestion> (golf).</message>
+                <example correction="quatuor|double"><marker>foursome</marker></example>
+                <example><marker>double</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">fours?</token>
+                    <token regexp="yes">somes?</token>
+                </pattern>
+                <message>« Foursome » peut être considéré comme un anglicisme. Employez <suggestion>quatuor</suggestion> (général), <suggestion>double</suggestion> (golf).</message>
+                <example correction="quatuor|double"><marker>four some</marker></example>
+                <example><marker>double</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="FULL_PIN" name="full pin">
+            <rule>
+                <pattern>
+                    <token regexp="yes">fullpins?</token>
+                </pattern>
+                <message>« Full pin » peut être considéré comme un anglicisme. Employez <suggestion>un max</suggestion> (familier ; degré d’intensité), <suggestion>à pleins tubes</suggestion> (familier ; volume), <suggestion>à plein régime</suggestion> (vitesse), <suggestion>à toute allure</suggestion> (vitesse), <suggestion>à fond de train</suggestion> (familier ; vitesse), <suggestion>à fond la caisse</suggestion> (familier ; vitesse), <suggestion>à toute vapeur</suggestion> (familier ; vitesse), <suggestion>à toute pompe</suggestion> (familier ; vitesse), <suggestion>à pleine gomme</suggestion> (familier ; vitesse).</message>
+                <example correction="un max|à pleins tubes|à plein régime|à toute allure|à fond de train|à fond la caisse|à toute vapeur|à toute pompe|à pleine gomme"><marker>fullpin</marker></example>
+                <example><marker>à plein régime</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">fulls?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">pins?</token>
+                </pattern>
+                <message>« Full pin » peut être considéré comme un anglicisme. Employez <suggestion>un max</suggestion> (familier ; degré d’intensité), <suggestion>à plein tubes</suggestion> (familier ; volume), <suggestion>à plein régime</suggestion> (vitesse), <suggestion>à toute allure</suggestion> (vitesse), <suggestion>à fond de train</suggestion> (familier ; vitesse), <suggestion>à fond la caisse</suggestion> (familier ; vitesse), <suggestion>à toute vapeur</suggestion> (familier ; vitesse), <suggestion>à toute pompe</suggestion> (familier ; vitesse), <suggestion>à pleine gomme</suggestion> (familier ; vitesse).</message>
+                <example correction="un max|à plein tubes|à plein régime|à toute allure|à fond de train|à fond la caisse|à toute vapeur|à toute pompe|à pleine gomme"><marker>full pin</marker></example>
+                <example><marker>à plein régime</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="FAIRWAY" name="fairway">
+            <rule>
+                <pattern>
+                    <token regexp="yes" case_sensitive="yes">fair-?ways?</token>
+                </pattern>
+                <message>« Fairway » peut être considéré comme un anglicisme. Employez <suggestion>allée</suggestion> (golf).</message>
+                <example correction="allée"><marker>fairway</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes" case_sensitive="yes">fairs?</token>
+                    <token regexp="yes">ways?</token>
+                </pattern>
+                <message>« Fairway » peut être considéré comme un anglicisme. Employez <suggestion>allée</suggestion> (golf).</message>
+                <example correction="allée"><marker>fair way</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="FAIR-PLAY" name="fair-play">
+            <rule>
+                <pattern>
+                    <token regexp="yes">fair-?plays?</token>
+                </pattern>
+                <message>« Fair-play » peut être considéré comme un anglicisme. Employez <suggestion>franc-jeu</suggestion> (substantif), <suggestion>loyal</suggestion> (adjectif), <suggestion>régulier</suggestion> (adjectif).</message>
+                <example correction="franc-jeu|loyal|régulier"><marker>fair-play</marker></example>
+                <example><marker>franc-jeu</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">fairs?</token>
+                    <token regexp="yes">plays?</token>
+                </pattern>
+                <message>« Fair-play » peut être considéré comme un anglicisme. Employez <suggestion>franc-jeu</suggestion> (substantif), <suggestion>loyal</suggestion> (adjectif), <suggestion>régulier</suggestion> (adjectif).</message>
+                <example correction="franc-jeu|loyal|régulier"><marker>fair play</marker></example>
+                <example><marker>franc-jeu</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="EGG_ROLL" name="egg roll">
+            <rule>
+                <pattern>
+                    <token regexp="yes">eggs?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">rolls?</token>
+                </pattern>
+                <message>« Egg roll » peut être considéré comme un anglicisme.</message>
+                <suggestion>rouleau de printemps</suggestion>
+                <suggestion>pâté impérial</suggestion>
+                <example correction="rouleau de printemps|pâté impérial"><marker>egg roll</marker></example>
+                <example><marker>rouleau impérial</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">eggrolls?</token>
+                </pattern>
+                <message>« Egg roll » peut être considéré comme un anglicisme.</message>
+                <suggestion>rouleau de printemps</suggestion>
+                <suggestion>pâté impérial</suggestion>
+                <example correction="rouleau de printemps|pâté impérial"><marker>eggroll</marker></example>
+                <example><marker>rouleau impérial</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="CLAM_CHOWDER" name="clam chowder">
+            <rule>
+                <pattern>
+                    <token regexp="yes">clams?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">chowders?</token>
+                </pattern>
+                <message>« Clam chowder » peut être considéré comme un anglicisme.</message>
+                <suggestion>chaudrée de palourde</suggestion>
+                <example correction="chaudrée de palourde"><marker>clam chowder</marker></example>
+                <example><marker>chaudrée de palourdes</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">clamchowders?</token>
+                </pattern>
+                <message>« Clam chowder » peut être considéré comme un anglicisme.</message>
+                <suggestion>chaudrée de palourde</suggestion>
+                <example correction="chaudrée de palourde"><marker>clamchowder</marker></example>
+                <example><marker>chaudrée de palourdes</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="CROWBAR" name="crowbar">
+            <rule>
+                <pattern>
+                    <token regexp="yes">crows?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">bars?|barres?</token>
+                </pattern>
+                <message>« Crowbar » peut être considéré comme un anglicisme. Employez <suggestion>pied-de-biche</suggestion>, <suggestion>pince-monseigneur</suggestion>, <suggestion>pince à levier</suggestion>, <suggestion>barre à mine</suggestion> (pour creuser, essoucher).</message>
+                <example correction="pied-de-biche|pince-monseigneur|pince à levier|barre à mine"><marker>crow bar</marker></example>
+                <example><marker>pied-de-biche</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">crowbars?|crowbarres?</token>
+                </pattern>
+                <message>« Crowbar » peut être considéré comme un anglicisme. Employez <suggestion>pied-de-biche</suggestion>, <suggestion>pince-monseigneur</suggestion>, <suggestion>pince à levier</suggestion>, <suggestion>barre à mine</suggestion> (pour creuser, essoucher).</message>
+                <example correction="pied-de-biche|pince-monseigneur|pince à levier|barre à mine"><marker>crowbar</marker></example>
+                <example><marker>pied-de-biche</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="GAZEBO" name="Gazebo">
+            <pattern>
+                <token regexp="yes">gazebos?</token>
+            </pattern>
+            <message>« Gazebo » peut être considéré comme un anglicisme.</message>
+            <suggestion>pavillon</suggestion>
+            <suggestion>tonnelle</suggestion>
+            <suggestion>kiosque de jardin</suggestion>
+            <suggestion>gloriette</suggestion>
+            <example correction="pavillon|tonnelle|kiosque de jardin|gloriette"><marker>gazebo</marker></example>
+            <example><marker>pavillon</marker></example>
+        </rule>
+        <rule id="PAD" name="pad">
+            <pattern>
+                <token regexp="yes">pads?|paddes?
+                    <exception scope="previous">-</exception></token>
+            </pattern>
+            <message>« Pad » peut être considéré comme un anglicisme. Employez <suggestion>épaulette</suggestion>, <suggestion>bloc-notes</suggestion>, <suggestion>nuque longue</suggestion> (coupe de cheveux), <suggestion>clavier</suggestion> (informatique), <suggestion>pavé numérique</suggestion> (informatique), <suggestion>coussin chauffant</suggestion>, <suggestion>coussinet</suggestion>, <suggestion>tampon encreur</suggestion> (article de bureau).</message>
+            <example correction="épaulette|bloc-notes|nuque longue|clavier|pavé numérique|coussin chauffant|coussinet|tampon encreur"><marker>pad</marker></example>
+            <example><marker>nuque longue</marker></example>
+        </rule>
+        <rule id="EXHIBIT" name="exhibit">
+            <pattern>
+                <token regexp="yes">exhibits?</token>
+            </pattern>
+            <message>« Exhibit » peut être considéré comme un anglicisme. Employez <suggestion>pièce à conviction</suggestion> (droit), <suggestion>pièce</suggestion> (droit), <suggestion>objet exposé</suggestion> (exposition), <suggestion>pièce d'exposition</suggestion> (exposition), <suggestion>pièce exposée</suggestion> (exposition), <suggestion>produit</suggestion> (foire agricole).</message>
+            <example correction="pièce à conviction|pièce|objet exposé|pièce d'exposition|pièce exposée|produit"><marker>exhibit</marker></example>
+            <example><marker>pièce à conviction</marker></example>
+        </rule>
+        <rulegroup id="EX-OFFICIO" name="ex officio">
+            <rule>
+                <pattern>
+                    <token>ex</token>
+                    <token min="0">-</token>
+                    <token>officio</token>
+                </pattern>
+                <message>« Ex officio » peut être considéré comme un anglicisme.</message>
+                <suggestion>d'office</suggestion>
+                <suggestion>de droit</suggestion>
+                <example correction="d'office|de droit"><marker>ex officio</marker></example>
+                <example correction="d'office|de droit"><marker>ex-officio</marker></example>
+                <example><marker>d’office</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="EYE-LINER" name="eye-liner" default="off">
+            <!-- deactivated : widespread usage -->
+            <rule>
+                <pattern>
+                    <token regexp="yes">eyes?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">liners?</token>
+                </pattern>
+                <message>« Eye liner » peut être considéré comme un anglicisme.</message>
+                <suggestion>crayon</suggestion>
+                <example correction="crayon"><marker>eye liner</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">eyes?-?liners?</token>
+                </pattern>
+                <message>« Eye-liner » peut être considéré comme un anglicisme.</message>
+                <suggestion>crayon</suggestion>
+                <example correction="crayon"><marker>eyeliner</marker></example>
+                <example correction="crayon"><marker>eye-liner</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="CRUISE_CONTROL" name="cruise control">
+            <rule>
+                <pattern>
+                    <token regexp="yes">cruises?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">controls?</token>
+                </pattern>
+                <message>« Cruise control » peut être considéré comme un anglicisme.</message>
+                <suggestion>régulateur de vitesse</suggestion>
+                <example correction="régulateur de vitesse"><marker>cruise control</marker></example>
+                <example correction="régulateur de vitesse"><marker>cruise-control</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">cruisecontrols?</token>
+                </pattern>
+                <message>« Cruise control » peut être considéré comme un anglicisme.</message>
+                <suggestion>régulateur de vitesse</suggestion>
+                <example correction="régulateur de vitesse"><marker>cruisecontrol</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="CLAPBOARD" name="clapboard">
+            <rule>
+                <pattern>
+                    <token regexp="yes">claps?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">boards?</token>
+                </pattern>
+                <message>« Clapboard » peut être considéré comme un anglicisme.</message>
+                <suggestion>clin d'aluminium</suggestion>
+                <example correction="clin d'aluminium"><marker>clap board</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">clapboards?</token>
+                </pattern>
+                <message>« Clapboard » peut être considéré comme un anglicisme.</message>
+                <suggestion>clin d'aluminium</suggestion>
+                <example correction="clin d'aluminium"><marker>clapboard</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup default="off" id="FAST_FOOD" name="fast food">
+            <rule>
+                <pattern>
+                    <token regexp="yes">fasts?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">foods?</token>
+                </pattern>
+                <message>« Fast food » peut être considéré comme un anglicisme.</message>
+                <suggestion>repas-minute</suggestion>
+                <suggestion>restaurant-minute</suggestion>
+                <suggestion>cuisine-minute</suggestion>
+                <suggestion>plat-minute</suggestion>
+                <suggestion>prêt-à-manger</suggestion>
+                <suggestion>restauration-minute</suggestion>
+                <example correction="repas-minute|restaurant-minute|cuisine-minute|plat-minute|prêt-à-manger|restauration-minute"><marker>fast food</marker></example>
+                <example><marker>repas-minute</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">fastfoods?</token>
+                </pattern>
+                <message>« Fast food » peut être considéré comme un anglicisme.</message>
+                <suggestion>repas-minute</suggestion>
+                <suggestion>restaurant-minute</suggestion>
+                <suggestion>cuisine-minute</suggestion>
+                <suggestion>plat-minute</suggestion>
+                <suggestion>prêt-à-manger</suggestion>
+                <suggestion>restauration-minute</suggestion>
+                <example correction="repas-minute|restaurant-minute|cuisine-minute|plat-minute|prêt-à-manger|restauration-minute"><marker>fastfood</marker></example>
+                <example><marker>repas-minute</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BURNOUT" name="burnout" tags="picky">
+            <rule>
+                <pattern>
+                    <token regexp="yes">burns?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">outs?</token>
+                </pattern>
+                <message>« Burnout » peut être considéré comme un anglicisme.</message>
+                <suggestion>surmenage</suggestion>
+                <suggestion>épuisement professionnel</suggestion>
+                <example correction="surmenage|épuisement professionnel"><marker>burn out</marker></example>
+                <example><marker>surmenage</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">burnouts?</token>
+                </pattern>
+                <message>« Burnout » peut être considéré comme un anglicisme.</message>
+                <suggestion>surmenage</suggestion>
+                <suggestion>épuisement professionnel</suggestion>
+                <example correction="surmenage|épuisement professionnel"><marker>burnout</marker></example>
+                <example><marker>surmenage</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BED_AND_BREAKFAST" name="bed and breakfast" default="off">
+            <rule>
+                <pattern>
+                    <token regexp="yes">beds?</token>
+                    <token min="0">-</token>
+                    <token>and</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">breakfasts?</token>
+                </pattern>
+                <message>« Bed and breakfast » peut être considéré comme un anglicisme.</message>
+                <suggestion>chambre d'hôte</suggestion>
+                <suggestion>maison d'hôte</suggestion>
+                <example correction="chambre d'hôte|maison d'hôte"><marker>bed and breakfast</marker></example>
+                <example correction="chambre d'hôte|maison d'hôte"><marker>bed-and-breakfast</marker></example>
+                <example><marker>chambre d’hôte</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BOW-WINDOW" name="bow-window" tags="picky">
+            <rule>
+                <pattern>
+                    <token regexp="yes">bows?</token>
+                    <token regexp="yes">windows?</token>
+                </pattern>
+                <message>« Bow-window » peut être considéré comme un anglicisme.</message>
+                <suggestion>fenêtre arquée</suggestion>
+                <suggestion>fenêtre en saillie</suggestion>
+                <example correction="fenêtre arquée|fenêtre en saillie"><marker>bow window</marker></example>
+                <example><marker>fenêtre arquée</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">bow-?windows?</token>
+                </pattern>
+                <message>« Bow-window » peut être considéré comme un anglicisme.</message>
+                <suggestion>fenêtre arquée</suggestion>
+                <suggestion>fenêtre en saillie</suggestion>
+                <example correction="fenêtre arquée|fenêtre en saillie"><marker>bow-window</marker></example>
+                <example><marker>fenêtre arquée</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BRAINSTORMING" name="brainstorming">
+            <rule>
+                <pattern>
+                    <token regexp="yes">brains?</token>
+                    <token regexp="yes">stormings?</token>
+                </pattern>
+                <message>« Brainstorming » peut être considéré comme un anglicisme.</message>
+                <suggestion>remue-méninges</suggestion>
+                <example correction="remue-méninges"><marker>brain storming</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">brain-?stormings?</token>
+                </pattern>
+                <message>« Brainstorming » peut être considéré comme un anglicisme.</message>
+                <suggestion>remue-méninges</suggestion>
+                <example correction="remue-méninges"><marker>brainstorming</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BELLBOY" name="bellboy">
+            <rule>
+                <pattern>
+                    <token regexp="yes">bells?</token>
+                    <token regexp="yes">boys?</token>
+                </pattern>
+                <message>« Bellboy » peut être considéré comme un anglicisme.</message>
+                <suggestion>chasseur</suggestion>
+                <example correction="chasseur"><marker>bell boy</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">bell-?boys?</token>
+                </pattern>
+                <message>« Bellboy » peut être considéré comme un anglicisme.</message>
+                <suggestion>chasseur</suggestion>
+                <example correction="chasseur"><marker>bellboy</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BLOCK_HEATER" name="block heater">
+            <rule>
+                <pattern>
+                    <token regexp="yes">blocks?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">heaters?</token>
+                </pattern>
+                <message>« Block heater » peut être considéré comme un anglicisme.</message>
+                <suggestion>chauffe-moteur</suggestion>
+                <example correction="chauffe-moteur"><marker>block heater</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">blocks?heaters?</token>
+                </pattern>
+                <message>« Block heater » peut être considéré comme un anglicisme.</message>
+                <suggestion>chauffe-moteur</suggestion>
+                <example correction="chauffe-moteur"><marker>blockheater</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BACKUP" name="backup">
+            <rule>
+                <pattern>
+                    <token case_sensitive="yes">back
+                        <exception scope="previous" regexp="yes">database</exception></token>
+                    <token min="0">-</token>
+                    <token>up
+                        <exception scope="next" regexp="yes">camera|system|story</exception></token>
+                </pattern>
+                <message>« Backup » peut être considéré comme un anglicisme.</message>
+                <suggestion>copie</suggestion>
+                <suggestion>sauvegarde informatique</suggestion>
+                <suggestion>fichier de sauvegarde</suggestion>
+                <suggestion>renfort</suggestion>
+                <example correction="copie|sauvegarde informatique|fichier de sauvegarde|renfort"><marker>back up</marker></example>
+                <example><marker>fichier de sauvegarde</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token case_sensitive="yes">back
+                        <exception scope="previous">database</exception></token>
+                    <token min="0">-</token>
+                    <token regexp="yes">ups?
+                        <exception scope="next" regexp="yes">managers?|restore|["]|system|camera</exception></token>
+                </pattern>
+                <message>« Backup » peut être considéré comme un anglicisme.</message>
+                <suggestion>copies</suggestion>
+                <suggestion>sauvegardes informatiques</suggestion>
+                <suggestion>fichiers de sauvegarde</suggestion>
+                <suggestion>renforts</suggestion>
+                <example correction="copies|sauvegardes informatiques|fichiers de sauvegarde|renforts"><marker>back up</marker></example>
+                <example><marker>fichier de sauvegarde</marker></example>
+            </rule>
+            <rule>
+                <antipattern>
+                    <token>database</token>
+                    <token case_sensitive="yes">backup</token>
+                </antipattern>
+                <pattern>
+                    <token case_sensitive="yes">backup
+                        <exception scope="previous" postag="D . p" postag_regexp="yes"/>
+                        <exception scope="next" regexp="yes">managers?|restore|["]|system|camera</exception></token>
+                </pattern>
+                <message>« Backup » peut être considéré comme un anglicisme.</message>
+                <suggestion>copie</suggestion>
+                <suggestion>sauvegarde informatique</suggestion>
+                <suggestion>fichier de sauvegarde</suggestion>
+                <suggestion>renfort</suggestion>
+                <example correction="copie|sauvegarde informatique|fichier de sauvegarde|renfort"><marker>backup</marker></example>
+                <example><marker>fichier de sauvegarde</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="D . p|P.*" postag_regexp="yes"/>
+                    <marker>
+                        <token case_sensitive="yes" regexp="yes">backups?</token>
+                    </marker>
+                </pattern>
+                <message>« Backup » peut être considéré comme un anglicisme.</message>
+                <suggestion>copies</suggestion>
+                <suggestion>sauvegardes informatiques</suggestion>
+                <suggestion>fichiers de sauvegarde</suggestion>
+                <suggestion>renforts</suggestion>
+                <example correction="copies|sauvegardes informatiques|fichiers de sauvegarde|renforts">Les <marker>backups</marker></example>
+                <example><marker>fichier de sauvegarde</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="ALL_DRESSED" name="all dressed">
+            <rule>
+                <pattern>
+                    <token>all</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">dressed|dress</token>
+                </pattern>
+                <message>« All dressed » peut être considéré comme un anglicisme. Employez <suggestion>garnie</suggestion> (pizza).</message>
+                <example correction="garnie"><marker>all dressed</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">alldressed|alldress</token>
+                </pattern>
+                <message>« All dressed » peut être considéré comme un anglicisme. Employez <suggestion>garnie</suggestion> (pizza).</message>
+                <example correction="garnie"><marker>alldressed</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="COACH" name="coach" default="off">
+            <!-- very low apply rate -->
+            <pattern>
+                <token regexp="yes">coach|coaches|coachs</token>
+            </pattern>
+            <message>« Coach » est considéré comme un anglicisme. En voici des alternatives : <suggestion>entraîneur</suggestion> (sport), <suggestion>accompagnateur</suggestion> (entreprise, etc.), (un) <suggestion>coupé</suggestion> (automobile à deux portes et quatre places).</message>
+            <example correction="entraîneur|accompagnateur|coupé"><marker>coach</marker></example>
+            <example><marker>entraîneur</marker></example>
+        </rule>
+        <rule id="BAND" name="band">
+            <pattern>
+                <token postag="[PD].*" postag_regexp="yes"/>
+                <marker>
+                    <token regexp="yes" case_sensitive="yes">bands?</token>
+                </marker>
+            </pattern>
+            <message>« Band » peut être considéré comme un anglicisme.</message>
+            <suggestion>groupe</suggestion>
+            <suggestion>formation</suggestion>
+            <suggestion>ensemble</suggestion>
+            <suggestion>orchestre</suggestion>
+            <example correction="groupe|formation|ensemble|orchestre">Un <marker>band</marker></example>
+            <example><marker>group</marker></example>
+        </rule>
+        <rule id="SPLIT" name="split">
+            <pattern>
+                <token regexp="yes">splits?
+                    <exception scope="previous">-</exception></token>
+            </pattern>
+            <message>« Split » peut être considéré comme un anglicisme. Employez <suggestion>grand écart</suggestion> (figure de gymnastique), <suggestion>maison à deux niveaux</suggestion> (bâtiment).</message>
+            <example correction="grand écart|maison à deux niveaux"><marker>split</marker></example>
+            <example><marker>grand écart</marker></example>
+        </rule>
+        <rule id="SMOKE" name="smoke">
+            <pattern>
+                <token regexp="yes">smokes?</token>
+            </pattern>
+            <message>« Smoke » peut être considéré comme un anglicisme. Employez <suggestion>bille</suggestion> (jeu pour enfants).</message>
+            <example correction="bille"><marker>smoke</marker></example>
+        </rule>
+        <rule id="SMELTER" name="smelter">
+            <pattern>
+                <token regexp="yes">smelters?</token>
+            </pattern>
+            <message>« Smelter » peut être considéré comme un anglicisme.</message>
+            <suggestion>haut-fourneau</suggestion>
+            <suggestion>fonderie</suggestion>
+            <example correction="haut-fourneau|fonderie"><marker>smelter</marker></example>
+            <example><marker>fonderie</marker></example>
+        </rule>
+        <rule id="SMOOTH" name="smooth">
+            <pattern>
+                <token regexp="yes">smooths?</token>
+            </pattern>
+            <message>« Smooth » peut être considéré comme un anglicisme. Employez <suggestion>doux</suggestion>, <suggestion>calme</suggestion>, <suggestion>pénard</suggestion> (familier).</message>
+            <example correction="doux|calme|pénard"><marker>smooth</marker></example>
+            <example><marker>doux</marker></example>
+        </rule>
+        <rule id="TOO_BAD" name="too bad">
+            <pattern>
+                <token>too</token>
+                <token>bad</token>
+            </pattern>
+            <message>« Too bad » peut être considéré comme un anglicisme.</message>
+            <suggestion>c'est quand même incroyable !</suggestion>
+            <suggestion>quel dommage !</suggestion>
+            <suggestion>tant pis !</suggestion>
+            <example correction="c'est quand même incroyable !|quel dommage !|tant pis !"><marker>too bad</marker></example>
+            <example><marker>tant pis !</marker></example>
+        </rule>
+        <rule id="PER_CAPITA" name="per capita">
+            <pattern>
+                <token>per</token>
+                <token regexp="yes">capp?itas?</token>
+            </pattern>
+            <message>« Per capita » peut être considéré comme un anglicisme. Employez <suggestion>par personne</suggestion>, <suggestion>par habitant</suggestion>, <suggestion>par tête</suggestion>, <suggestion>par tête de pipe</suggestion> (familier).</message>
+            <example correction="par personne|par habitant|par tête|par tête de pipe"><marker>per capita</marker></example>
+            <example><marker>par tête</marker></example>
+        </rule>
+        <rule id="FIXTURE" name="fixture">
+            <pattern>
+                <token regexp="yes">fixtures?</token>
+            </pattern>
+            <message>« Fixture » peut être considéré comme un anglicisme. Employez <suggestion>installations sanitaires</suggestion> (salle de bain), <suggestion>plomberie</suggestion>, <suggestion>tuyauterie</suggestion>, <suggestion>appareillage électrique</suggestion>, <suggestion>appareils électriques</suggestion>, <suggestion>luminaire</suggestion>, <suggestion>applique</suggestion>, <suggestion>plafonnier</suggestion>, <suggestion>suspension</suggestion>, <suggestion>appareil d'éclairage</suggestion>, <suggestion>installation électrique</suggestion>, <suggestion>accessoire fixe</suggestion>.</message>
+            <example correction="installations sanitaires|plomberie|tuyauterie|appareillage électrique|appareils électriques|luminaire|applique|plafonnier|suspension|appareil d'éclairage|installation électrique|accessoire fixe"><marker>fixture</marker></example>
+            <example><marker>plomberie</marker></example>
+        </rule>
+        <rule id="PLASTER" name="plaster">
+            <pattern>
+                <token regexp="yes">plasters?</token>
+            </pattern>
+            <message>« Plaster » peut être considéré comme un anglicisme.</message>
+            <suggestion>pansement</suggestion>
+            <example correction="pansement"><marker>plaster</marker></example>
+        </rule>
+        <rule id="PLUG" name="plug">
+            <pattern>
+                <token regexp="yes">plugs?</token>
+            </pattern>
+            <message>« Plug » peut être considéré comme un anglicisme.</message>
+            <suggestion>prise de courant</suggestion>
+            <suggestion>prise électrique</suggestion>
+            <suggestion>fiche</suggestion>
+            <suggestion>publicité gratuite</suggestion>
+            <suggestion>publicité dissimulée</suggestion>
+            <example correction="prise de courant|prise électrique|fiche|publicité gratuite|publicité dissimulée"><marker>plug</marker></example>
+            <example><marker>prise de courant</marker></example>
+        </rule>
+        <rulegroup id="LOOK" name="look">
+            <antipattern>
+                <token>
+                    <exception postag="SENT_START"/></token>
+                <token case_sensitive="yes" regexp="yes">Looks?</token>
+            </antipattern>
+            <rule>
+                <pattern>
+                    <token postag="D m s">
+                        <exception regexp="yes">le|ce</exception></token>
+                    <token>look</token>
+                </pattern>
+                <message>« Look » est un considéré comme un anglicisme. En voici quelques alternatives :</message>
+                <suggestion><match no="1" postag="(D) (m) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> allure</suggestion>
+                <suggestion><match no="1" postag="(D) (m) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> apparence</suggestion>
+                <suggestion>\1 style</suggestion>
+                <suggestion>\1 aspect</suggestion>
+                <example correction="une allure|une apparence|un style|un aspect"><marker>un look</marker></example>
+                <example><marker>allure</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>ce</token>
+                    <token>look</token>
+                </pattern>
+                <message>« Look » est un considéré comme un anglicisme. En voici quelques alternatives :</message>
+                <suggestion>cette allure</suggestion>
+                <suggestion>cette apparence</suggestion>
+                <suggestion>ce style</suggestion>
+                <suggestion>cet aspect</suggestion>
+                <example correction="cette allure|cette apparence|ce style|cet aspect"><marker>ce look</marker></example>
+                <example><marker>allure</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">[dl]e</token>
+                    <token>look</token>
+                </pattern>
+                <message>« Look » est un considéré comme un anglicisme. En voici quelques alternatives :</message>
+                <suggestion><match no="1" regexp_match="(?iu)e" regexp_replace="'"/>allure</suggestion>
+                <suggestion><match no="1" regexp_match="(?iu)e" regexp_replace="'"/>apparence</suggestion>
+                <suggestion>\1 style</suggestion>
+                <suggestion><match no="1" regexp_match="(?iu)e" regexp_replace="'"/>aspect</suggestion>
+                <example correction="l'allure|l'apparence|le style|l'aspect"><marker>le look</marker></example>
+                <example><marker>allure</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">looks?
+                        <exception scope="previous" regexp="yes">de|it</exception>
+                        <exception scope="previous" postag="D m s"/></token>
+                </pattern>
+                <message>« Look » est un considéré comme un anglicisme. En voici quelques alternatives :</message>
+                <suggestion><match no="1" regexp_match="look(?iu)" regexp_replace="allure"/></suggestion>
+                <suggestion><match no="1" regexp_match="look(?iu)" regexp_replace="apparence"/></suggestion>
+                <suggestion><match no="1" regexp_match="look(?iu)" regexp_replace="style"/></suggestion>
+                <suggestion><match no="1" regexp_match="look(?iu)" regexp_replace="aspect"/></suggestion>
+                <example correction="allures|apparences|styles|aspects">des <marker>looks</marker></example>
+                <example><marker>allure</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>de</token>
+                    <token>looks</token>
+                </pattern>
+                <message>« Look » est un considéré comme un anglicisme. En voici quelques alternatives :</message>
+                <suggestion><match no="1" regexp_match="(?iu)e" regexp_replace="'"/>allures</suggestion>
+                <suggestion><match no="1" regexp_match="(?iu)e" regexp_replace="'"/>apparences</suggestion>
+                <suggestion>\1 styles</suggestion>
+                <suggestion><match no="1" regexp_match="(?iu)e" regexp_replace="'"/>aspects</suggestion>
+                <example correction="d'allures|d'apparences|de styles|d'aspects"><marker>de looks</marker></example>
+                <example><marker>allure</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="SMOOTHY" name="smoothy">
+            <pattern>
+                <token regexp="yes">smoothys?|smoothies</token>
+            </pattern>
+            <message>« Smoothy » peut être considéré comme un anglicisme.</message>
+            <suggestion>onctueux</suggestion>
+            <suggestion>crémeux</suggestion>
+            <suggestion>baratté</suggestion>
+            <example correction="onctueux|crémeux|baratté"><marker>smoothy</marker></example>
+            <example><marker>baratté</marker></example>
+        </rule>
+        <rule id="PER_DIEM" name="per diem">
+            <pattern>
+                <token>per</token>
+                <token regexp="yes">diems?</token>
+            </pattern>
+            <message>« Per diem » peut être considéré comme un anglicisme.</message>
+            <suggestion>allocation journalière</suggestion>
+            <suggestion>indemnité journalière</suggestion>
+            <example correction="allocation journalière|indemnité journalière"><marker>per diem</marker></example>
+            <example><marker>allocation journalière</marker></example>
+        </rule>
+        <rule id="JUNKIE" name="junk(ie)">
+            <pattern>
+                <token regexp="yes">junkie|junky|junkies|junkys|junk|junks</token>
+            </pattern>
+            <message>« Junk(ie) » peut être considéré comme un anglicisme.</message>
+            <suggestion>toxicomane</suggestion>
+            <suggestion>drogué</suggestion>
+            <example correction="toxicomane|drogué"><marker>junkie</marker></example>
+            <example><marker>drogué</marker></example>
+        </rule>
+        <rule id="SPEECH" name="speech">
+            <pattern>
+                <token regexp="yes">speechs?|speeches</token>
+            </pattern>
+            <message>« Speech » peut être considéré comme un anglicisme.</message>
+            <suggestion>allocution</suggestion>
+            <suggestion>discours</suggestion>
+            <suggestion>sermon</suggestion>
+            <suggestion>remontrances</suggestion>
+            <example correction="allocution|discours|sermon|remontrances"><marker>speech</marker></example>
+            <example><marker>discours</marker></example>
+        </rule>
+        <rule id="PATTERN" name="pattern">
+            <pattern>
+                <token regexp="yes">patterns?</token>
+            </pattern>
+            <message>« Pattern » peut être considéré comme un anglicisme.</message>
+            <suggestion>modèle</suggestion>
+            <suggestion>schéma</suggestion>
+            <suggestion>structure</suggestion>
+            <suggestion>déroulement</suggestion>
+            <suggestion>cheminement</suggestion>
+            <suggestion>processus</suggestion>
+            <suggestion>configuration</suggestion>
+            <suggestion>type</suggestion>
+            <suggestion>patron</suggestion>
+            <suggestion>trame</suggestion>
+            <suggestion>motif</suggestion>
+            <suggestion>configuration</suggestion>
+            <example correction="modèle|schéma|structure|déroulement|cheminement|processus|configuration|type|patron|trame|motif"><marker>pattern</marker></example>
+            <example><marker>modèle</marker></example>
+        </rule>
+        <rule id="DRILL" name="drill">
+            <pattern>
+                <token regexp="yes">drills?</token>
+            </pattern>
+            <message>« Drill » peut être considéré comme un anglicisme. Employez <suggestion>perceuse</suggestion> (bois, métal), <suggestion>foreuse</suggestion> (pierre), <suggestion>roulette</suggestion> (dentiste), <suggestion>exercice militaire</suggestion> (armée), <suggestion>exercice d'apprentissage</suggestion> (enseignement).</message>
+            <example correction="perceuse|foreuse|roulette|exercice militaire|exercice d'apprentissage"><marker>drill</marker></example>
+            <example><marker>perceuse</marker></example>
+        </rule>
+        <rule id="DRUMMER" name="drummer">
+            <pattern>
+                <token regexp="yes">drummers?</token>
+            </pattern>
+            <message>« Drummer » peut être considéré comme un anglicisme.</message>
+            <suggestion>batteur</suggestion>
+            <suggestion>percussionniste</suggestion>
+            <example correction="batteur|percussionniste"><marker>drummer</marker></example>
+            <example><marker>batteur</marker></example>
+        </rule>
+        <rule id="PEELING" name="peeling">
+            <pattern>
+                <token regexp="yes">peelings?</token>
+            </pattern>
+            <message>« Peeling » peut être considéré comme un anglicisme.</message>
+            <suggestion>dermabrasion</suggestion>
+            <example correction="dermabrasion"><marker>peeling</marker></example>
+        </rule>
+        <rulegroup id="DRIVING_RANGE" name="driving range">
+            <rule>
+                <pattern>
+                    <token regexp="yes">drivings?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">ranges?</token>
+                </pattern>
+                <message>« Driving range » peut être considéré comme un anglicisme.</message>
+                <suggestion>terrain d'exercice</suggestion>
+                <example correction="terrain d'exercice"><marker>driving range</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="SPLIT-LEVEL" name="split-level">
+            <rule>
+                <pattern>
+                    <token regexp="yes">splitlevels?</token>
+                </pattern>
+                <message>« Split-level » peut être considéré comme un anglicisme.</message>
+                <suggestion>maison sur deux niveaux</suggestion>
+                <suggestion>maison à deux niveaux</suggestion>
+                <example correction="maison sur deux niveaux|maison à deux niveaux"><marker>splitlevel</marker></example>
+                <example><marker>maison sur deux niveaux</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">splits?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">levels?</token>
+                </pattern>
+                <message>« Split-level » peut être considéré comme un anglicisme.</message>
+                <suggestion>maison sur deux niveaux</suggestion>
+                <suggestion>maison à deux niveaux</suggestion>
+                <example correction="maison sur deux niveaux|maison à deux niveaux"><marker>split level</marker></example>
+                <example><marker>maison sur deux niveaux</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="PUSH-UP" name="push-up" default="off">
+            <rule>
+                <pattern>
+                    <token regexp="yes">pushups?</token>
+                </pattern>
+                <message>« Push-up » peut être considéré comme un anglicisme.</message>
+                <suggestion>traction</suggestion>
+                <suggestion>pompe</suggestion>
+                <example correction="traction|pompe"><marker>pushup</marker></example>
+                <example><marker>pompe</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">pushs?|pushes</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">ups?</token>
+                </pattern>
+                <message>« Push-up » peut être considéré comme un anglicisme.</message>
+                <suggestion>traction</suggestion>
+                <suggestion>pompe</suggestion>
+                <example correction="traction|pompe"><marker>push up</marker></example>
+                <example><marker>pompe</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="DRIVEWAY" name="driveway">
+            <rule>
+                <pattern>
+                    <token regexp="yes">driveway|drive-way|drive-ways|driveways</token>
+                </pattern>
+                <message>« Driveway » peut être considéré comme un anglicisme.</message>
+                <suggestion>allée</suggestion>
+                <suggestion>passage</suggestion>
+                <suggestion>entrée de garage</suggestion>
+                <suggestion>entrée de maison</suggestion>
+                <example correction="allée|passage|entrée de garage|entrée de maison"><marker>driveway</marker></example>
+                <example><marker>passage</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">drives?</token>
+                    <token regexp="yes">ways?</token>
+                </pattern>
+                <message>« Driveway » peut être considéré comme un anglicisme.</message>
+                <suggestion>allée</suggestion>
+                <suggestion>passage</suggestion>
+                <suggestion>entrée de garage</suggestion>
+                <suggestion>entrée de maison</suggestion>
+                <example correction="allée|passage|entrée de garage|entrée de maison"><marker>drive way</marker></example>
+                <example><marker>passage</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="SPEED_BUMP" name="speed bump">
+            <rule>
+                <pattern>
+                    <token regexp="yes">speedbumps?</token>
+                </pattern>
+                <message>« Speed bump » peut être considéré comme un anglicisme.</message>
+                <suggestion>ralentisseur</suggestion>
+                <example correction="ralentisseur"><marker>speedbump</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">speeds?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">bumps?</token>
+                </pattern>
+                <message>« Speed bump » peut être considéré comme un anglicisme.</message>
+                <suggestion>ralentisseur</suggestion>
+                <example correction="ralentisseur"><marker>speed bump</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="STAND-BY" name="stand-by">
+            <rule>
+                <pattern>
+                    <token regexp="yes">stand-by|stand-bys|standby|standbys|standbies|stand-bies</token>
+                </pattern>
+                <message>« Stand-by » peut être considéré comme un anglicisme.</message>
+                <suggestion>en attente</suggestion>
+                <suggestion>attente</suggestion>
+                <suggestion>liste d'attente</suggestion>
+                <suggestion>passage en attente</suggestion>
+                <suggestion>vol sur attente</suggestion>
+                <example correction="en attente|attente|liste d'attente|passage en attente|vol sur attente"><marker>stand-by</marker></example>
+                <example><marker>attente</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">stand|stands</token>
+                    <token regexp="yes">bies|by|bys</token>
+                </pattern>
+                <message>« Stand-by » peut être considéré comme un anglicisme.</message>
+                <suggestion>en attente</suggestion>
+                <suggestion>attente</suggestion>
+                <suggestion>liste d'attente</suggestion>
+                <suggestion>passage en attente</suggestion>
+                <suggestion>vol sur attente</suggestion>
+                <example correction="en attente|attente|liste d'attente|passage en attente|vol sur attente"><marker>stand by</marker></example>
+                <example><marker>attente</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="JUNK_BOND" name="junk bond">
+            <rule>
+                <pattern>
+                    <token regexp="yes">junkbou?nds?</token>
+                </pattern>
+                <message>« Junk bond » peut être considéré comme un anglicisme.</message>
+                <suggestion>obligation spéculative</suggestion>
+                <suggestion>obligation pourrie</suggestion>
+                <example correction="obligation spéculative|obligation pourrie"><marker>junkbond</marker></example>
+                <example><marker>obligation spéculative</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">junk|junks</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">bond|bonds|bounds|bound</token>
+                </pattern>
+                <message>« Junk bond » peut être considéré comme un anglicisme.</message>
+                <suggestion>obligation spéculative</suggestion>
+                <suggestion>obligation pourrie</suggestion>
+                <example correction="obligation spéculative|obligation pourrie"><marker>junk bond</marker></example>
+                <example><marker>obligation spéculative</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="JUMP_SUIT" name="jump suit">
+            <rule>
+                <pattern>
+                    <token regexp="yes">jumpsuit|jumpsuits</token>
+                </pattern>
+                <message>« Jump suit » peut être considéré comme un anglicisme.</message>
+                <suggestion>combinaison-pantalon</suggestion>
+                <suggestion>combinaison</suggestion>
+                <example correction="combinaison-pantalon|combinaison"><marker>jumpsuit</marker></example>
+                <example><marker>combinaison</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">jump|jumps</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">suit|suits</token>
+                </pattern>
+                <message>« Jump suit » peut être considéré comme un anglicisme.</message>
+                <suggestion>combinaison-pantalon</suggestion>
+                <suggestion>combinaison</suggestion>
+                <example correction="combinaison-pantalon|combinaison"><marker>jump suit</marker></example>
+                <example><marker>combinaison</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="JUNK_FOOD" name="junk food">
+            <rule>
+                <pattern>
+                    <token regexp="yes">junkfood|junkfoods</token>
+                </pattern>
+                <message>« Junk food » peut être considéré comme un anglicisme.</message>
+                <suggestion>malbouffe</suggestion>
+                <suggestion>camelote</suggestion>
+                <suggestion>saloperies</suggestion>
+                <!--(familier)-->
+                <suggestion>aliment vide</suggestion>
+                <example correction="malbouffe|camelote|saloperies|aliment vide"><marker>junkfood</marker></example>
+                <example><marker>camelote</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">junk|junks</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">food|foods</token>
+                </pattern>
+                <message>« Junk food » peut être considéré comme un anglicisme.</message>
+                <suggestion>malbouffe</suggestion>
+                <suggestion>camelote</suggestion>
+                <suggestion>saloperies</suggestion>
+                <!--(familier)-->
+                <suggestion>aliment vide</suggestion>
+                <example correction="malbouffe|camelote|saloperies|aliment vide"><marker>junk food</marker></example>
+                <example><marker>camelote</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="JUNK_MAIL" name="junk mail">
+            <rule>
+                <pattern>
+                    <token regexp="yes">junkmail|junkmails</token>
+                </pattern>
+                <message>« Junk mail » peut être considéré comme un anglicisme.</message>
+                <suggestion>pourriel</suggestion>
+                <suggestion>courrier-poubelle</suggestion>
+                <suggestion>courriel-rebut</suggestion>
+                <suggestion>polluriel</suggestion>
+                <suggestion>courrier publicitaire importun</suggestion>
+                <example correction="pourriel|courrier-poubelle|courriel-rebut|polluriel|courrier publicitaire importun"><marker>junkmail</marker></example>
+                <example><marker>pourriel</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">junk|junks</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">mail|mails</token>
+                </pattern>
+                <message>« Junk mail » peut être considéré comme un anglicisme.</message>
+                <suggestion>pourriel</suggestion>
+                <suggestion>courrier-poubelle</suggestion>
+                <suggestion>courriel-rebut</suggestion>
+                <suggestion>polluriel</suggestion>
+                <suggestion>courrier publicitaire importun</suggestion>
+                <example correction="pourriel|courrier-poubelle|courriel-rebut|polluriel|courrier publicitaire importun"><marker>junk mail</marker></example>
+                <example><marker>pourriel</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="LIFTING" name="lifting" default="off">
+            <pattern>
+                <token regexp="yes">lifting|liftings</token>
+            </pattern>
+            <message>« Lifting » peut être considéré comme un anglicisme.</message>
+            <suggestion>lissage</suggestion>
+            <suggestion>remodelage</suggestion>
+            <example correction="lissage|remodelage"><marker>lifting</marker></example>
+            <example><marker>remodelage</marker></example>
+        </rule>
+        <rulegroup id="JOB" name="job" tags="picky">
+            <antipattern>
+                <token regexp="yes">jobs?</token>
+                <token regexp="yes">recrui?ting|dating|-|sharing|design</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes">dating|blow|inside|good|"|steve|-|great|fantastic|your|enjoy|[\#]|loub|bullshit</token>
+                <token regexp="yes">jobs?</token>
+            </antipattern>
+            <antipattern>
+                <token>
+                    <exception postag="SENT_START"/></token>
+                <token regexp="yes">(?-i)Jobs?|(?-i)JOBS?</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes" skip="1">(?-i)Jobs?|(?-i)JOBS?</token>
+                <token regexp="yes">(?-i)[A-Z].*</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes" skip="1">(?-i)Jobs?|(?-i)JOBS?</token>
+                <token postag="[YK]" postag_regexp="yes"/>
+            </antipattern>
+            <rule>
+                <pattern>
+                    <marker>
+                        <token postag="D . s" postag_regexp="yes">
+                            <exception postag="D f s"/>
+                            <exception regexp="yes">le|ce</exception></token>
+                        <token case_sensitive="yes">job</token>
+                    </marker>
+                </pattern>
+                <message>« Job » peut être considéré comme un anglicisme.</message>
+                <suggestion>\1 emploi</suggestion>
+                <suggestion>\1 boulot</suggestion>
+                <suggestion>\1 travail</suggestion>
+                <example correction="mon emploi|mon boulot|mon travail">J'apprécie <marker>mon job</marker>.</example>
+                <example><marker>boulot</marker></example>
+                <example>Steve <marker>Jobs</marker>, le pionnier de l’ordinateur conçu comme une prison cool, mise au point pour supprimer leur liberté aux idiots, est mort.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <marker>
+                        <token>le</token>
+                        <token regexp="yes" case_sensitive="yes">job|jobs
+                            <exception scope="previous">Steve</exception></token>
+                    </marker>
+                </pattern>
+                <message>« Job » peut être considéré comme un anglicisme.</message>
+                <suggestion>l'<match no="2" regexp_match="(?i)job" regexp_replace="emploi"/></suggestion>
+                <suggestion>le <match no="2" regexp_match="(?i)job" regexp_replace="boulot"/></suggestion>
+                <suggestion>la <match no="2" regexp_match="(?i)job" regexp_replace="tâche"/></suggestion>
+                <suggestion>le <match no="2" regexp_match="(?i)job" regexp_replace="travail"/></suggestion>
+                <example correction="l'emploi|le boulot|la tâche|le travail">J'apprécie <marker>le job</marker>.</example>
+                <example><marker>boulot</marker></example>
+                <example>Steve <marker>Jobs</marker>, le pionnier de l’ordinateur conçu comme une prison cool, mise au point pour supprimer leur liberté aux idiots, est mort.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <marker>
+                        <token>de</token>
+                        <token case_sensitive="yes">job
+                            <exception scope="previous">Steve</exception></token>
+                    </marker>
+                </pattern>
+                <message>« Job » peut être considéré comme un anglicisme.</message>
+                <suggestion>d'<match no="2" regexp_match="job(?iu)" regexp_replace="emploi"/></suggestion>
+                <suggestion>de <match no="2" regexp_match="job(?iu)" regexp_replace="boulot"/></suggestion>
+                <suggestion>de <match no="2" regexp_match="job(?iu)" regexp_replace="tâche"/></suggestion>
+                <suggestion>de <match no="2" regexp_match="job(?iu)" regexp_replace="travail"/></suggestion>
+                <example correction="d'emploi|de boulot|de tâche|de travail">Tu dois changer <marker>de job</marker>.</example>
+                <example><marker>boulot</marker></example>
+                <example>Steve <marker>Jobs</marker>, le pionnier de l’ordinateur conçu comme une prison cool, mise au point pour supprimer leur liberté aux idiots, est mort.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <marker>
+                        <token>de</token>
+                        <token case_sensitive="yes">jobs
+                            <exception scope="previous">Steve</exception></token>
+                    </marker>
+                </pattern>
+                <message>« Job » peut être considéré comme un anglicisme.</message>
+                <suggestion>d'<match no="2" regexp_match="job(?iu)" regexp_replace="emploi"/></suggestion>
+                <suggestion>de <match no="2" regexp_match="job(?iu)" regexp_replace="boulot"/></suggestion>
+                <suggestion>de <match no="2" regexp_match="job(?iu)" regexp_replace="tâche"/></suggestion>
+                <suggestion>de <match no="2" regexp_match="job(?iu)" regexp_replace="travail"/></suggestion>
+                <example correction="d'emplois|de boulots|de tâches|de travails">Le secteur tertiaire manque <marker>de jobs</marker>.</example>
+                <example><marker>boulot</marker></example>
+                <example>Steve <marker>Jobs</marker>, le pionnier de l’ordinateur conçu comme une prison cool, mise au point pour supprimer leur liberté aux idiots, est mort.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <marker>
+                        <token>ce</token>
+                        <token case_sensitive="yes">job
+                            <exception scope="previous">Steve</exception></token>
+                    </marker>
+                </pattern>
+                <message>« Job » peut être considéré comme un anglicisme.</message>
+                <suggestion>cet <match no="2" regexp_match="(?i)job" regexp_replace="emploi"/></suggestion>
+                <suggestion>\1 <match no="2" regexp_match="(?i)job" regexp_replace="boulot"/></suggestion>
+                <suggestion>cette <match no="2" regexp_match="(?i)job" regexp_replace="tâche"/></suggestion>
+                <suggestion>\1 <match no="2" regexp_match="(?i)job" regexp_replace="travail"/></suggestion>
+                <example correction="cet emploi|ce boulot|cette tâche|ce travail">J'apprécie <marker>ce job</marker>.</example>
+                <example><marker>boulot</marker></example>
+                <example>Steve <marker>Jobs</marker>, le pionnier de l’ordinateur conçu comme une prison cool, mise au point pour supprimer leur liberté aux idiots, est mort.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="D . p" postag_regexp="yes"/>
+                    <marker>
+                        <token case_sensitive="yes">jobs</token>
+                    </marker>
+                </pattern>
+                <message>« Job » peut être considéré comme un anglicisme.</message>
+                <suggestion><match no="2" regexp_match="(?i)jobs" regexp_replace="emplois"/></suggestion>
+                <suggestion><match no="2" regexp_match="(?i)jobs" regexp_replace="boulots"/></suggestion>
+                <suggestion><match no="2" regexp_match="(?i)jobs" regexp_replace="tâches"/></suggestion>
+                <suggestion><match no="2" regexp_match="(?i)jobs" regexp_replace="travails"/></suggestion>
+                <example correction="emplois|boulots|tâches|travails">J'apprécie ces <marker>jobs</marker>.</example>
+                <example><marker>boulot</marker></example>
+                <example>Steve <marker>Jobs</marker>, le pionnier de l’ordinateur conçu comme une prison cool, mise au point pour supprimer leur liberté aux idiots, est mort.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <marker>
+                        <token>job
+                            <exception scope="previous">de</exception>
+                            <exception scope="previous" postag="D.*" postag_regexp="yes"/></token>
+                    </marker>
+                </pattern>
+                <message>« Job » peut être considéré comme un anglicisme.</message>
+                <suggestion>emploi</suggestion>
+                <suggestion>boulot</suggestion>
+                <suggestion>travail</suggestion>
+                <example correction="Emploi|Boulot|Travail"><marker>Job</marker> de rêve !</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <marker>
+                        <token>jobs
+                            <exception scope="previous">de</exception>
+                            <exception scope="previous" postag="D.*" postag_regexp="yes"/></token>
+                    </marker>
+                </pattern>
+                <message>« Job » peut être considéré comme un anglicisme.</message>
+                <suggestion>emplois</suggestion>
+                <suggestion>boulots</suggestion>
+                <suggestion>tâches</suggestion>
+                <suggestion>travails</suggestion>
+                <example correction="Emplois|Boulots|Tâches|Travails"><marker>Jobs</marker> de rêve !</example>
+            </rule>
+        </rulegroup>
+        <rule id="ORIENTERING" name="orientering">
+            <pattern>
+                <token regexp="yes">orientering|orienterings</token>
+            </pattern>
+            <message>« Orientering » peut être considéré comme un anglicisme.</message>
+            <suggestion>orientation</suggestion>
+            <suggestion>course d'orientation</suggestion>
+            <example correction="orientation|course d'orientation"><marker>orientering</marker></example>
+            <example><marker>orientation</marker></example>
+        </rule>
+        <rule id="OPENER" name="opener">
+            <pattern>
+                <token regexp="yes">opener|openers</token>
+            </pattern>
+            <message>« Opener » peut être considéré comme un anglicisme.</message>
+            <suggestion>ouvre-boîte</suggestion>
+            <suggestion>décapsuleur</suggestion>
+            <example correction="ouvre-boîte|décapsuleur"><marker>opener</marker></example>
+            <example><marker>décapsuleur</marker></example>
+        </rule>
+        <rulegroup id="JUMBO-JET" name="jumbo-jet">
+            <rule>
+                <pattern>
+                    <token regexp="yes">jumbojet|jumbojets</token>
+                </pattern>
+                <message>« Jumbo-jet » peut être considéré comme un anglicisme.</message>
+                <suggestion>gros-porteur</suggestion>
+                <example correction="gros-porteur"><marker>jumbojet</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">jumbo|jumbos</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">jet|jets</token>
+                </pattern>
+                <message>« Jumbo-jet » peut être considéré comme un anglicisme.</message>
+                <suggestion>gros-porteur</suggestion>
+                <example correction="gros-porteur"><marker>jumbo jet</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="OPEN_BAR" name="open bar">
+            <rule>
+                <pattern>
+                    <token regexp="yes">openbar|openbars</token>
+                </pattern>
+                <message>« Open bar pot » peut être considéré comme un anglicisme.</message>
+                <suggestion>consommations gratuites</suggestion>
+                <example correction="consommations gratuites"><marker>openbar</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">open|opens</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">bar|bars</token>
+                </pattern>
+                <message>« Open bar pot » peut être considéré comme un anglicisme.</message>
+                <suggestion>consommations gratuites</suggestion>
+                <example correction="consommations gratuites"><marker>open bar</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="MELTING_POT" name="melting pot" default="off">
+            <rule>
+                <pattern>
+                    <token regexp="yes">melting-pot|melting-pots</token>
+                </pattern>
+                <message>« Melting pot » peut être considéré comme un anglicisme.</message>
+                <suggestion>creuset</suggestion>
+                <example correction="creuset"><marker>melting-pot</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">melting|meltings</token>
+                    <token regexp="yes">pot|pots</token>
+                </pattern>
+                <message>« Melting-pot » peut être considéré comme un anglicisme.</message>
+                <suggestion>creuset</suggestion>
+                <example correction="creuset"><marker>melting pot</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="PLYWOOD" name="plywood">
+            <rule>
+                <pattern>
+                    <token regexp="yes">plywood|plywoods|ply-woods|plys-woods|ply-wood</token>
+                </pattern>
+                <message>« Plywood » peut être considéré comme un anglicisme.</message>
+                <suggestion>contreplaqué</suggestion>
+                <example correction="contreplaqué"><marker>plywood</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">ply|plys</token>
+                    <token regexp="yes">wood|woods</token>
+                </pattern>
+                <message>« Plywood » peut être considéré comme un anglicisme.</message>
+                <suggestion>contreplaqué</suggestion>
+                <example correction="contreplaqué"><marker>ply wood</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="SHORT_CUT" name="short cut">
+            <rule>
+                <pattern>
+                    <token regexp="yes">shortcut|shortcuts</token>
+                </pattern>
+                <message>« Short cut » peut être considéré comme un anglicisme.</message>
+                <suggestion>raccourci</suggestion>
+                <example correction="raccourci"><marker>shortcut</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">short|shorts</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">cut|cuts</token>
+                </pattern>
+                <message>« Short cut » peut être considéré comme un anglicisme.</message>
+                <suggestion>raccourci</suggestion>
+                <example correction="raccourci"><marker>short cut</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="CREDIBILITY_GAP" name="credibility gap">
+            <rule>
+                <pattern>
+                    <token regexp="yes">credibility|credibilities|credibilitys</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">gap|gaps</token>
+                </pattern>
+                <message>« Credibility gap » peut être considéré comme un anglicisme.</message>
+                <suggestion>manque de crédibilité</suggestion>
+                <suggestion>crise de confiance</suggestion>
+                <suggestion>écart entre la façade et la réalité</suggestion>
+                <example correction="manque de crédibilité|crise de confiance|écart entre la façade et la réalité"><marker>credibility gap</marker></example>
+                <example><marker>manque de crédibilité</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="CREAM_PUFF" name="cream puff">
+            <rule>
+                <pattern>
+                    <token regexp="yes">creampuff|creampuffs</token>
+                </pattern>
+                <message>« Cream puff » peut être considéré comme un anglicisme.</message>
+                <suggestion>chou à la crème</suggestion>
+                <example correction="chou à la crème"><marker>creampuff</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">cream|creams</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">puff|puffs</token>
+                </pattern>
+                <message>« Cream puff » peut être considéré comme un anglicisme.</message>
+                <suggestion>chou à la crème</suggestion>
+                <example correction="chou à la crème"><marker>cream puff</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BADMAN" name="badman">
+            <rule>
+                <pattern>
+                    <token regexp="yes">badman|badmen|badmans|bad-man|bad-men|bad-mans</token>
+                </pattern>
+                <message>« Badman » peut être considéré comme un anglicisme.</message>
+                <suggestion>bandit</suggestion>
+                <suggestion>mauvais garçon</suggestion>
+                <suggestion>méchant</suggestion>
+                <example correction="bandit|mauvais garçon|méchant"><marker>badman</marker></example>
+                <example><marker>bandit</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>bad</token>
+                    <token regexp="yes">man|men|mans</token>
+                </pattern>
+                <message>« Badman » peut être considéré comme un anglicisme.</message>
+                <suggestion>bandit</suggestion>
+                <suggestion>mauvais garçon</suggestion>
+                <suggestion>méchant</suggestion>
+                <example correction="bandit|mauvais garçon|méchant"><marker>bad man</marker></example>
+                <example><marker>bandit</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BAD_LUCK" name="bad luck">
+            <rule>
+                <pattern>
+                    <token regexp="yes">bad-luck|bad-lucks|badluck|badlucks</token>
+                </pattern>
+                <message>« Badluck » peut être considéré comme un anglicisme.</message>
+                <suggestion>malchance</suggestion>
+                <example correction="malchance"><marker>badluck</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>bad</token>
+                    <token regexp="yes">luck|lucks</token>
+                </pattern>
+                <message>« Badluck » peut être considéré comme un anglicisme.</message>
+                <suggestion>malchance</suggestion>
+                <example correction="malchance"><marker>bad luck</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="TOMBOY" name="tomboy">
+            <rule>
+                <pattern>
+                    <token regexp="yes">tomboy|tomboys|tom-boy|tom-boys</token>
+                </pattern>
+                <message>« Tomboy » peut être considéré comme un anglicisme.</message>
+                <suggestion>garçon manqué</suggestion>
+                <example correction="garçon manqué"><marker>tomboy</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">tom|toms</token>
+                    <token regexp="yes">boy|boys</token>
+                </pattern>
+                <message>« Tomboy » peut être considéré comme un anglicisme.</message>
+                <suggestion>garçon manqué</suggestion>
+                <example correction="garçon manqué"><marker>tom boy</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="ROAD_MOVIE" name="road movie" default="off">
+            <!-- deactivated : widespread usage -->
+            <rule>
+                <pattern>
+                    <token regexp="yes">roadmovie|roadmovies|road-movie|road-movies</token>
+                </pattern>
+                <message>« Road-movie » peut être considéré comme un anglicisme.</message>
+                <suggestion>film de route</suggestion>
+                <suggestion>film d'errance</suggestion>
+                <example correction="film de route|film d'errance"><marker>road-movie</marker></example>
+                <example><marker>film de route</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">road|roads</token>
+                    <token regexp="yes">movie|movies</token>
+                </pattern>
+                <message>« Road-movie » peut être considéré comme un anglicisme.</message>
+                <suggestion>film de route</suggestion>
+                <suggestion>film d'errance</suggestion>
+                <example correction="film de route|film d'errance"><marker>road movie</marker></example>
+                <example><marker>film de route</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="SUCCESS_STORY" name="success story">
+            <rule>
+                <pattern>
+                    <token regexp="yes">success|successes</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">story|stories|storys</token>
+                </pattern>
+                <message>« Success story » peut être considéré comme un anglicisme.</message>
+                <suggestion>réussite commerciale</suggestion>
+                <suggestion>réussite</suggestion>
+                <suggestion>histoire d'une réussite</suggestion>
+                <suggestion>récit d'une réussite</suggestion>
+                <example correction="réussite commerciale|réussite|histoire d'une réussite|récit d'une réussite"><marker>success story</marker></example>
+                <example><marker>réussite</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="TOUCH-TONE" name="touch-tone">
+            <rule>
+                <pattern>
+                    <token regexp="yes">touchtone|touchtones</token>
+                </pattern>
+                <message>« Touch-tone » peut être considéré comme un anglicisme.</message>
+                <suggestion>à touches numériques</suggestion>
+                <suggestion>à touches</suggestion>
+                <example correction="à touches numériques|à touches"><marker>touchtone</marker></example>
+                <example><marker>à touches</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">touch|touchs</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">tone|tones</token>
+                </pattern>
+                <message>« Touch-tone » peut être considéré comme un anglicisme.</message>
+                <suggestion>à touches numériques</suggestion>
+                <suggestion>à touches</suggestion>
+                <example correction="à touches numériques|à touches"><marker>touch tone</marker></example>
+                <example><marker>à touches</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="OVERBOOKING" name="overbooking">
+            <rule>
+                <pattern>
+                    <token regexp="yes">overbooking|overbookings|over-booking|over-bookings</token>
+                </pattern>
+                <message>« Overbooking » peut être considéré comme un anglicisme.</message>
+                <suggestion>surréaction</suggestion>
+                <example correction="surréaction"><marker>overbooking</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">over|overs</token>
+                    <token regexp="yes">booking|bookings</token>
+                </pattern>
+                <message>« Overbooking » peut être considéré comme un anglicisme.</message>
+                <suggestion>surréaction</suggestion>
+                <example correction="surréaction"><marker>over booking</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="OVERDOSE" name="overdose" default="off">
+            <!-- deactivated : widespread usage -->
+            <rule>
+                <pattern>
+                    <token regexp="yes">overdose|overdoses|over-dose|over-doses</token>
+                </pattern>
+                <message>« Overdose » peut être considéré comme un anglicisme.</message>
+                <suggestion>surdose</suggestion>
+                <example correction="surdose"><marker>overdose</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">over|overs</token>
+                    <token regexp="yes">dose|doses</token>
+                </pattern>
+                <message>« Overdose » peut être considéré comme un anglicisme.</message>
+                <suggestion>surdose</suggestion>
+                <example correction="surdose"><marker>over dose</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="COVER_CHARGE" name="cover charge">
+            <rule>
+                <pattern>
+                    <token regexp="yes">cover|covers</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">charge|charges</token>
+                </pattern>
+                <message>« Cover charge » peut être considéré comme un anglicisme.</message>
+                <suggestion>couvert</suggestion>
+                <suggestion>prix de couvert</suggestion>
+                <example correction="couvert|prix de couvert"><marker>cover charge</marker></example>
+                <example><marker>prix de couvert</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="FOREMAN" name="foreman">
+            <rule>
+                <pattern>
+                    <token regexp="yes">fore-?m[ae]ns?</token>
+                </pattern>
+                <message>« Foreman » peut être considéré comme un anglicisme.</message>
+                <suggestion>contremaître</suggestion>
+                <suggestion>chef d'équipe</suggestion>
+                <suggestion>chef d'atelier</suggestion>
+                <suggestion>chef de chantier</suggestion>
+                <suggestion>agent de maîtrise</suggestion>
+                <example correction="contremaître|chef d'équipe|chef d'atelier|chef de chantier|agent de maîtrise"><marker>foreman</marker></example>
+                <example><marker>contremaître</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">fore|fores</token>
+                    <token regexp="yes">man|men|mans</token>
+                </pattern>
+                <message>« Foreman » peut être considéré comme un anglicisme.</message>
+                <suggestion>contremaître</suggestion>
+                <suggestion>chef d'équipe</suggestion>
+                <suggestion>chef d'atelier</suggestion>
+                <suggestion>chef de chantier</suggestion>
+                <suggestion>agent de maîtrise</suggestion>
+                <example correction="contremaître|chef d'équipe|chef d'atelier|chef de chantier|agent de maîtrise"><marker>fore man</marker></example>
+                <example><marker>contremaître</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="LINE-UP" name="line-up">
+            <rule>
+                <pattern>
+                    <token regexp="yes">lines?ups?</token>
+                </pattern>
+                <message>« Line-up » peut être considéré comme un anglicisme. Pour éviter la critique, employez plutôt (boutique, restaurant) <suggestion>file d'attente</suggestion>, <suggestion>queue</suggestion> (ordre de présentation d’une émission de télévision) <suggestion>mise en page</suggestion>, <suggestion>titres</suggestion>.</message>
+                <example correction="file d'attente|queue|mise en page|titres"><marker>lineup</marker></example>
+                <example><marker>queue</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">lines?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">up|ups</token>
+                </pattern>
+                <message>« Line-up » peut être considéré comme un anglicisme. Pour éviter la critique, employez plutôt (boutique, restaurant) <suggestion>file d'attente</suggestion>, <suggestion>queue</suggestion> (ordre de présentation d’une émission de télévision) <suggestion>mise en page</suggestion>, <suggestion>titres</suggestion>.</message>
+                <example correction="file d'attente|queue|mise en page|titres"><marker>line up</marker></example>
+                <example><marker>queue</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="COVER-UP" name="cover-up">
+            <rule>
+                <pattern>
+                    <token regexp="yes">covers?ups?</token>
+                </pattern>
+                <message>« Cover-up » peut être considéré comme un anglicisme.</message>
+                <suggestion>étouffement</suggestion>
+                <suggestion>dissimulation</suggestion>
+                <suggestion>étouffement</suggestion>
+                <example correction="étouffement|dissimulation"><marker>coverup</marker></example>
+                <example><marker>étouffement</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">cover|covers</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">up|ups</token>
+                </pattern>
+                <message>« Cover-up » peut être considéré comme un anglicisme.</message>
+                <suggestion>étouffement</suggestion>
+                <suggestion>dissimulation</suggestion>
+                <suggestion>étouffement</suggestion>
+                <example correction="étouffement|dissimulation"><marker>cover up</marker></example>
+                <example><marker>étouffement</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="LAB" name="lab">
+            <antipattern>
+                <token regexp="yes" skip="1">Phoenix|Dorma|Porsche|Inequality</token>
+                <token regexp="yes">Labs?</token>
+            </antipattern>
+            <pattern>
+                <token regexp="yes" case_sensitive="yes">labs?
+                    <exception scope="previous">fab</exception></token>
+            </pattern>
+            <message>« Lab » peut être considéré comme un anglicisme. Employez <suggestion><match no="1" regexp_match="(?i)ab" regexp_replace="abo"/></suggestion>.</message>
+            <example correction="labo"><marker>lab</marker></example>
+            <example>Porsche Digital Labs</example>
+        </rule>
+        <rule id="COVER" name="cover">
+            <pattern>
+                <token regexp="yes" case_sensitive="yes">cover|covers</token>
+            </pattern>
+            <message>« Cover » peut être considéré comme un anglicisme. Employez <suggestion>couverture</suggestion>, <suggestion>pochette</suggestion> (de disque), <suggestion>emballage</suggestion>, <suggestion>enveloppe</suggestion>.</message>
+            <example correction="couverture|pochette|emballage|enveloppe"><marker>cover</marker></example>
+            <example><marker>pochette</marker></example>
+        </rule>
+        <rule id="FLY" name="fly" default="off">
+            <pattern>
+                <token regexp="yes">fly|flies|flys</token>
+            </pattern>
+            <message>« Fly » peut être considéré comme un anglicisme.</message>
+            <suggestion>braguette</suggestion>
+            <example correction="braguette"><marker>fly</marker></example>
+        </rule>
+        <rule id="FOAM" name="foam">
+            <pattern>
+                <token regexp="yes">foam|foams</token>
+            </pattern>
+            <message>« Foam » peut être considéré comme un anglicisme.</message>
+            <suggestion>mousse</suggestion>
+            <example correction="mousse"><marker>foam</marker></example>
+        </rule>
+        <rule id="FLUSH" name="flush">
+            <pattern>
+                <token regexp="yes" case_sensitive="yes">flush|flushs</token>
+            </pattern>
+            <message>« Flush » peut être considéré comme un anglicisme. Employez <suggestion>quinte</suggestion> (cartes), <suggestion>au ras de</suggestion>, <suggestion>à ras de</suggestion>, <suggestion>au niveau de</suggestion>, <suggestion>à fleur de</suggestion>.</message>
+            <example correction="quinte|au ras de|à ras de|au niveau de|à fleur de"><marker>flush</marker></example>
+            <example><marker>quinte</marker></example>
+        </rule>
+        <rule id="STUCCO" name="stucco">
+            <pattern>
+                <token regexp="yes">stucc?os?</token>
+            </pattern>
+            <message>« Stucco » peut être considéré comme un anglicisme.</message>
+            <suggestion>stuc</suggestion>
+            <suggestion>marbre artificiel</suggestion>
+            <suggestion>faux marbre</suggestion>
+            <example correction="stuc|marbre artificiel|faux marbre"><marker>stucco</marker></example>
+            <example><marker>stuc</marker></example>
+        </rule>
+        <rule id="SUBPOENA" name="subpoena">
+            <pattern>
+                <token regexp="yes">subpoenas?</token>
+            </pattern>
+            <message>« Subpoena » peut être considéré comme un anglicisme.</message>
+            <suggestion>citation à comparaître</suggestion>
+            <suggestion>citation</suggestion>
+            <example correction="citation à comparaître|citation"><marker>subpoena</marker></example>
+            <example><marker>citation</marker></example>
+        </rule>
+        <rule id="DIMMER" name="dimmer">
+            <pattern>
+                <token regexp="yes">dimmers?</token>
+            </pattern>
+            <message>« Dimmer » peut être considéré comme un anglicisme.</message>
+            <suggestion>gradateur</suggestion>
+            <suggestion>variateur de lumière</suggestion>
+            <suggestion>variateur</suggestion>
+            <suggestion>variateur d'ambiance</suggestion>
+            <example correction="gradateur|variateur de lumière|variateur|variateur d'ambiance"><marker>dimmer</marker></example>
+            <example><marker>variateur</marker></example>
+        </rule>
+        <rule id="ESPRESSO" name="espresso">
+            <pattern>
+                <token regexp="yes">espresso|espressi|espressos</token>
+            </pattern>
+            <message>« Espresso » peut être considéré comme un anglicisme.</message>
+            <suggestion>expresso</suggestion>
+            <suggestion>café express</suggestion>
+            <example correction="expresso|café express"><marker>espresso</marker></example>
+            <example><marker>café express</marker></example>
+        </rule>
+        <rule id="EXTRAMARITAL" name="extramarital">
+            <pattern>
+                <token regexp="yes">extramarital|extramaritaux|extramaritals|extramaritale|extramaritales</token>
+            </pattern>
+            <message>« Extramarital » peut être considéré comme un anglicisme.</message>
+            <suggestion>extraconjugal</suggestion>
+            <example correction="extraconjugal"><marker>extramarital</marker></example>
+        </rule>
+        <rule id="TRAIL" name="trail">
+            <pattern>
+                <token regexp="yes">trails?</token>
+            </pattern>
+            <message>'Trail' peut être considéré comme un anglicisme. Employez <suggestion><match no="1" regexp_match="(?i)trail" regexp_replace="chemin"/></suggestion>, <suggestion><match no="1" regexp_match="(?i)trail" regexp_replace="sentier"/></suggestion>, <suggestion><match no="1" regexp_match="(?i)trail" regexp_replace="piste"/></suggestion>.</message>
+            <example correction="chemin|sentier|piste"><marker>trail</marker></example>
+            <example><marker>piste</marker></example>
+        </rule>
+        <rulegroup id="TRAILER" name="trailer">
+            <rule>
+                <pattern>
+                    <token regexp="yes">trailers?
+                        <exception scope="previous" postag="D m s"/></token>
+                </pattern>
+                <message>'Trailer' peut être considéré comme un anglicisme. Employez <suggestion><match no="1" regexp_match="(?i)trailer" regexp_replace="bande-annonce"/></suggestion> (cinéma), <suggestion><match no="1" regexp_match="(?i)trailer" regexp_replace="remorque"/></suggestion> (derrière une voiture) ou <suggestion><match no="1" regexp_match="(?i)trailer" regexp_replace="van"/></suggestion> (pour les chevaux).</message>
+                <example correction="bande-annonce|remorque|van"><marker>trailer</marker></example>
+                <example><marker>remorque</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="D m s"/>
+                    <token>trailer</token>
+                </pattern>
+                <message>'Trailer' peut être considéré comme un anglicisme.</message>
+                <suggestion><match no="1" postag="(D) (m) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> bande-annonce</suggestion>
+                <suggestion><match no="1" postag="(D) (m) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> remorque</suggestion>
+                <suggestion>\1 van</suggestion>
+                <example correction="cette bande-annonce|cette remorque|ce van"><marker>ce trailer</marker></example>
+                <example><marker>remorque</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="FREE-FOR-ALL" name="free-for-all">
+            <rule>
+                <pattern>
+                    <token>free</token>
+                    <token min="0">-</token>
+                    <token>for</token>
+                    <token min="0">-</token>
+                    <token>all</token>
+                </pattern>
+                <message>« Free-for-all » peut être considéré comme un anglicisme.</message>
+                <suggestion>pagaille</suggestion>
+                <suggestion>mêlée</suggestion>
+                <suggestion>mêlée générale</suggestion>
+                <suggestion>méli-mélo</suggestion>
+                <example correction="pagaille|mêlée|mêlée générale|méli-mélo"><marker>free for all</marker></example>
+                <example><marker>pagaille</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BLIND_DATE" name="blind date">
+            <rule>
+                <pattern>
+                    <token regexp="yes">blind|blinds</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">date|dates</token>
+                </pattern>
+                <message>« Blind date » peut être considéré comme un anglicisme.</message>
+                <suggestion>rendez-vous arrangé</suggestion>
+                <suggestion>rencontre arrangée</suggestion>
+                <example correction="rendez-vous arrangé|rencontre arrangée"><marker>blind date</marker></example>
+                <example correction="rendez-vous arrangé|rencontre arrangée"><marker>blind-date</marker></example>
+                <example><marker>rencontre arrangée</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BLIND_PIG" name="blind pig">
+            <rule>
+                <pattern>
+                    <token regexp="yes">blind|blinds</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">pigs|pig</token>
+                </pattern>
+                <message>« Blind pig » peut être considéré comme un anglicisme.</message>
+                <suggestion>bar clandestin</suggestion>
+                <suggestion>cabaret borgne</suggestion>
+                <example correction="bar clandestin|cabaret borgne"><marker>blind pig</marker></example>
+                <example><marker>cabaret clandestin</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="FOLLOW-UP" name="follow-up">
+            <rule>
+                <pattern>
+                    <token regexp="yes">followups?</token>
+                </pattern>
+                <message>« Follow-up » peut être considéré comme un anglicisme.</message>
+                <suggestion>suivi</suggestion>
+                <suggestion>suite</suggestion>
+                <example correction="suivi|suite"><marker>followup</marker></example>
+                <example><marker>suivi</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">follow|follows</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">up|ups</token>
+                </pattern>
+                <message>« Follow-up » peut être considéré comme un anglicisme.</message>
+                <suggestion>suivi</suggestion>
+                <suggestion>suite</suggestion>
+                <example correction="suivi|suite"><marker>follow up</marker></example>
+                <example><marker>suivi</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="BLIND" name="blind">
+            <pattern>
+                <token regexp="yes">blind|blinds</token>
+            </pattern>
+            <message>« Blind » peut être considéré comme un anglicisme.</message>
+            <suggestion>store</suggestion>
+            <suggestion>jalousie</suggestion>
+            <example correction="store|jalousie"><marker>blind</marker></example>
+            <example>mes <marker>jalousies</marker></example>
+        </rule>
+        <rule id="TRACTION_AID" name="traction aid">
+            <pattern>
+                <token regexp="yes">tractions?</token>
+                <token regexp="yes">aids?</token>
+            </pattern>
+            <message>« Traction aid » peut être considéré comme un anglicisme.</message>
+            <suggestion>plaque d'adhérence</suggestion>
+            <example correction="plaque d'adhérence"><marker>traction aid</marker></example>
+        </rule>
+        <rule id="PICKLE" name="pickle">
+            <pattern>
+                <token regexp="yes">pickles?</token>
+            </pattern>
+            <message>« Pickle » peut être considéré comme un anglicisme.</message>
+            <suggestion>cornichon mariné</suggestion>
+            <suggestion>cornichon à l'aneth</suggestion>
+            <example correction="cornichon mariné|cornichon à l'aneth"><marker>pickle</marker></example>
+            <example><marker>cornichon mariné</marker></example>
+        </rule>
+        <rule id="CRATE" name="crate">
+            <pattern>
+                <token regexp="yes">crate|crates</token>
+            </pattern>
+            <message>« Crate » peut être considéré comme un anglicisme. Employez <suggestion>caisse</suggestion> (légumes, boissons gazeuses), <suggestion>cageot</suggestion> (emballage à claire-voie), <suggestion>cagette</suggestion> (petit cageot), <suggestion>emballage</suggestion>, <suggestion>boîte</suggestion>, <suggestion>carton</suggestion> (boissons gazeuses).</message>
+            <example correction="caisse|cageot|cagette|emballage|boîte|carton"><marker>crate</marker></example>
+            <example><marker>cageot</marker></example>
+        </rule>
+        <rulegroup id="CRASH_TEST" name="crash test">
+            <rule>
+                <pattern>
+                    <token regexp="yes">crashtests?</token>
+                </pattern>
+                <message>« Crash test » peut être considéré comme un anglicisme.</message>
+                <suggestion>simulation d'accident</suggestion>
+                <example correction="simulation d'accident"><marker>crashtest</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>crash</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">tests?</token>
+                </pattern>
+                <message>« Crash test » peut être considéré comme un anglicisme.</message>
+                <suggestion>simulation d'accident</suggestion>
+                <example correction="simulation d'accident"><marker>crash test</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="ANYTIME" name="anytime">
+            <rule>
+                <pattern>
+                    <token regexp="yes">anytimes?</token>
+                </pattern>
+                <message>« Anytime » peut être considéré comme un anglicisme.</message>
+                <suggestion>n'importe quand</suggestion>
+                <example correction="n'importe quand"><marker>anytime</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>any</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">times?</token>
+                </pattern>
+                <message>« Anytime » peut être considéré comme un anglicisme.</message>
+                <suggestion>n'importe quand</suggestion>
+                <example correction="n'importe quand"><marker>any time</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="ANYWAY" name="anyway">
+            <rule>
+                <pattern>
+                    <token regexp="yes">anyways?</token>
+                </pattern>
+                <message>« Anyway » peut être considéré comme un anglicisme.</message>
+                <suggestion>de toute façon</suggestion>
+                <suggestion>quand même</suggestion>
+                <suggestion>en tout cas</suggestion>
+                <example correction="de toute façon|quand même|en tout cas"><marker>anyway</marker></example>
+                <example><marker>en tout cas</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>any</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">ways?</token>
+                </pattern>
+                <message>« Anyway » peut être considéré comme un anglicisme.</message>
+                <suggestion>de toute façon</suggestion>
+                <suggestion>quand même</suggestion>
+                <suggestion>en tout cas</suggestion>
+                <example correction="de toute façon|quand même|en tout cas"><marker>any way</marker></example>
+                <example><marker>en tout cas</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="JELLYFISH" name="jellyfish">
+            <rule>
+                <pattern>
+                    <token regexp="yes">jellyfish|jellyfishs|jellyfishes</token>
+                </pattern>
+                <message>« Jellyfish » peut être considéré comme un anglicisme.</message>
+                <suggestion>méduse</suggestion>
+                <example correction="méduse"><marker>jellyfish</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>jelly</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">fish|fishes|fishs</token>
+                </pattern>
+                <message>« Jellyfish » peut être considéré comme un anglicisme.</message>
+                <suggestion>méduse</suggestion>
+                <example correction="méduse"><marker>jelly fish</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="JELLY_BEAN" name="jelly bean">
+            <rule>
+                <pattern>
+                    <token regexp="yes">jellybeans?|jellybine?</token>
+                </pattern>
+                <message>« Jelly bean » peut être considéré comme un anglicisme.</message>
+                <suggestion>jujube</suggestion>
+                <suggestion>dragées à la gelée de sucre</suggestion>
+                <example correction="jujube|dragées à la gelée de sucre"><marker>jellybean</marker></example>
+                <example><marker>jujube</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>jelly</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">bean|beans|bines|bine</token>
+                </pattern>
+                <message>« Jelly bean » peut être considéré comme un anglicisme.</message>
+                <suggestion>jujube</suggestion>
+                <suggestion>dragées à la gelée de sucre</suggestion>
+                <example correction="jujube|dragées à la gelée de sucre"><marker>jelly bean</marker></example>
+                <example><marker>jujube</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="POTLUCK" name="potluck">
+            <rule>
+                <pattern>
+                    <token regexp="yes">potluck|potlucks</token>
+                </pattern>
+                <message>« Potluck » peut être considéré comme un anglicisme.</message>
+                <suggestion>repas-partage</suggestion>
+                <example correction="repas-partage"><marker>potluck</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>pot</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">luck|lucks</token>
+                </pattern>
+                <message>« Potluck » peut être considéré comme un anglicisme.</message>
+                <suggestion>repas-partage</suggestion>
+                <example correction="repas-partage"><marker>pot luck</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="PAINKILLER" name="painkiller">
+            <rule>
+                <pattern>
+                    <token regexp="yes">painkillers?</token>
+                </pattern>
+                <message>« Painkiller » peut être considéré comme un anglicisme.</message>
+                <suggestion>analgésique</suggestion>
+                <example correction="analgésique"><marker>painkiller</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>pain</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">killer|killers</token>
+                </pattern>
+                <message>« Painkiller » peut être considéré comme un anglicisme.</message>
+                <suggestion>analgésique</suggestion>
+                <example correction="analgésique"><marker>pain killer</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="PACKSACK" name="packsack">
+            <rule>
+                <pattern>
+                    <token regexp="yes">packsacks?</token>
+                </pattern>
+                <message>« Packsack » peut être considéré comme un anglicisme.</message>
+                <suggestion>sac à dos</suggestion>
+                <example correction="sac à dos"><marker>packsack</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>pack</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">sack|sac|sacs|sacks</token>
+                </pattern>
+                <message>« Packsack » peut être considéré comme un anglicisme.</message>
+                <suggestion>sac à dos</suggestion>
+                <example correction="sac à dos"><marker>pack sack</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="PHOTORADAR" name="photoradar">
+            <rule>
+                <pattern>
+                    <token regexp="yes">photoradar|photoradars</token>
+                </pattern>
+                <message>« Photoradar » peut être considéré comme un anglicisme.</message>
+                <suggestion>cinémomètre</suggestion>
+                <suggestion>cinémomètre photo</suggestion>
+                <example correction="cinémomètre|cinémomètre photo"><marker>photoradar</marker></example>
+                <example><marker>cinémomètre</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>photo</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">radar|radars</token>
+                </pattern>
+                <message>« Photoradar » peut être considéré comme un anglicisme.</message>
+                <suggestion>cinémomètre</suggestion>
+                <suggestion>cinémomètre photo</suggestion>
+                <example correction="cinémomètre|cinémomètre photo"><marker>photo radar</marker></example>
+                <example><marker>cinémomètre</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="CARPORT" name="carport">
+            <rule>
+                <pattern>
+                    <token regexp="yes">carport|carports</token>
+                </pattern>
+                <message>« Carport » peut être considéré comme un anglicisme.</message>
+                <suggestion>abri de voiture</suggestion>
+                <suggestion>abri voiture</suggestion>
+                <example correction="abri de voiture|abri voiture"><marker>carport</marker></example>
+                <example><marker>abri voiture</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>car</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">port|ports</token>
+                </pattern>
+                <message>« Carport » peut être considéré comme un anglicisme.</message>
+                <suggestion>abri de voiture</suggestion>
+                <suggestion>abri voiture</suggestion>
+                <example correction="abri de voiture|abri voiture"><marker>car port</marker></example>
+                <example><marker>abri voiture</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="SIT-UP" name="sit-up">
+            <rule>
+                <pattern>
+                    <token regexp="yes">situp|situps</token>
+                </pattern>
+                <message>« Sit-up » peut être considéré comme un anglicisme.</message>
+                <suggestion>redressement assis</suggestion>
+                <example correction="redressement assis"><marker>situp</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">sit|sits</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">up|ups</token>
+                </pattern>
+                <message>« Sit-up » peut être considéré comme un anglicisme.</message>
+                <suggestion>redressement assis</suggestion>
+                <example correction="redressement assis"><marker>sit up</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="PRIME-TIME" name="prime-time" default="off">
+            <rule>
+                <pattern>
+                    <token regexp="yes">primetime|primetimes|primestimes</token>
+                </pattern>
+                <message>« Prime-time » peut être considéré comme un anglicisme.</message>
+                <suggestion>heure de grande écoute</suggestion>
+                <example correction="heure de grande écoute"><marker>primetime</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>prime</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">time|times</token>
+                </pattern>
+                <message>« Prime-time » peut être considéré comme un anglicisme.</message>
+                <suggestion>heure de grande écoute</suggestion>
+                <example correction="heure de grande écoute"><marker>prime time</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="FREE_SHOP" name="free-shop">
+            <rule>
+                <pattern>
+                    <token regexp="yes" skip="1">free|frees</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">shop|shops</token>
+                </pattern>
+                <message>« Free shop » peut être considéré comme un anglicisme.</message>
+                <suggestion>boutique franche</suggestion>
+                <example correction="boutique franche"><marker>free shop</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">freeshop|freeshops</token>
+                </pattern>
+                <message>« Free shop » peut être considéré comme un anglicisme.</message>
+                <suggestion>boutique franche</suggestion>
+                <example correction="boutique franche"><marker>freeshop</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="NON_STOP" name="non-stop" tags="picky">
+            <rule>
+                <pattern>
+                    <token>non</token>
+                    <token regexp="yes">stop|stops
+                        <exception scope="next" regexp="yes">(?-i)[A-Z].*</exception></token>
+                </pattern>
+                <message>« Non-stop » peut être considéré comme un anglicisme.</message>
+                <suggestion>sans interruption</suggestion>
+                <suggestion>en continu</suggestion>
+                <example correction="sans interruption|en continu"><marker>non stop</marker></example>
+                <example><marker>sans escale</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">non-?stop|non-?stops
+                        <exception scope="next" regexp="yes">(?-i)[A-Z].*</exception></token>
+                </pattern>
+                <message>« Non-stop » peut être considéré comme un anglicisme.</message>
+                <suggestion>sans interruption</suggestion>
+                <suggestion>en continu</suggestion>
+                <example correction="sans interruption|en continu"><marker>nonstop</marker></example>
+                <example correction="sans interruption|en continu"><marker>non-stop</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="SEX-SHOP" name="sex-shop" default="off">
+            <!-- deactivated : widespread usage -->
+            <rule>
+                <pattern>
+                    <token>sex</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">shop|shops</token>
+                </pattern>
+                <message>« Sex-shop » peut être considéré comme un anglicisme.</message>
+                <suggestion>boutique érotique</suggestion>
+                <suggestion>sexerie</suggestion>
+                <suggestion>érothèque</suggestion>
+                <example correction="boutique érotique|sexerie|érothèque"><marker>sex shop</marker></example>
+                <example><marker>sexerie</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">sexshop|sexshops</token>
+                </pattern>
+                <message>« Sex-shop » peut être considéré comme un anglicisme.</message>
+                <suggestion>boutique érotique</suggestion>
+                <suggestion>sexerie</suggestion>
+                <suggestion>érothèque</suggestion>
+                <example correction="boutique érotique|sexerie|érothèque"><marker>sexshop</marker></example>
+                <example><marker>sexerie</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="KNOW-HOW" name="know-how">
+            <rule>
+                <pattern>
+                    <token regexp="yes" skip="1">know|knows</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">how|hows</token>
+                </pattern>
+                <message>« Know-how » peut être considéré comme un anglicisme.</message>
+                <suggestion>savoir-faire</suggestion>
+                <example correction="savoir-faire"><marker>know how</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">knowhows?</token>
+                </pattern>
+                <message>« Know-how » peut être considéré comme un anglicisme.</message>
+                <suggestion>savoir-faire</suggestion>
+                <example correction="savoir-faire"><marker>knowhow</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="GHETTO_BLASTER" name="ghetto blaster">
+            <pattern>
+                <token regexp="yes">ghetto|ghettos|getto|gettos|geto|getos</token>
+                <token min="0">-</token>
+                <token regexp="yes">blaster|blasters</token>
+            </pattern>
+            <message>« Ghetto blaster » peut être considéré comme un anglicisme.</message>
+            <suggestion>chaîne stéréo</suggestion>
+            <example correction="chaîne stéréo"><marker>ghetto blaster</marker></example>
+            <example><marker>chaîner stéréo</marker></example>
+        </rule>
+        <rule default="off" id="MARKETING" name="marketing">
+            <pattern>
+                <token regexp="yes">mark[ée]tings?</token>
+            </pattern>
+            <message>« Marketing » peut être considéré comme un anglicisme.</message>
+            <suggestion>mercatique</suggestion>
+            <example correction="mercatique"><marker>marketing</marker></example>
+            <example><marker>mercatique</marker></example>
+        </rule>
+        <rulegroup id="ADDICTION" name="addiction" default="off">
+            <!-- deactivated : widespread usage -->
+            <rule>
+                <pattern>
+                    <token regexp="yes">add?ictions?
+                        <exception scope="previous" postag="D . s" postag_regexp="yes"/>
+                        <exception scope="next" regexp="yes">à|aux</exception></token>
+                </pattern>
+                <message>« Addiction » peut être considéré comme un anglicisme.</message>
+                <suggestion>dépendance</suggestion>
+                <example correction="dépendance"><marker>addiction</marker></example>
+                <example><marker>dépendance</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="D . s" postag_regexp="yes"/>
+                    <token regexp="yes">add?ictions?
+                        <exception scope="next" regexp="yes">à|aux</exception></token>
+                </pattern>
+                <message>Le mot « Addiction » peut être considéré comme un anglicisme.</message>
+                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> dépendance</suggestion>
+                <example correction="sa dépendance"><marker>son addiction</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="D . s" postag_regexp="yes"/>
+                    <token regexp="yes">add?ictions?</token>
+                    <token regexp="yes">à</token>
+                </pattern>
+                <message>Le mot « Addiction » peut être considéré comme un anglicisme.</message>
+                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> dépendance \3</suggestion>
+                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 m $3"/> penchant pour</suggestion>
+                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> passion pour</suggestion>
+                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> faiblesse pour</suggestion>
+                <example correction="La dépendance à|Le penchant pour|La passion pour|La faiblesse pour"><marker>L'addiction à</marker> la télévision est un nouveau phénomène de notre siècle.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="D . s" postag_regexp="yes"/>
+                    <token regexp="yes">add?ictions?</token>
+                    <token>aux</token>
+                </pattern>
+                <message>Le mot « Addiction » peut être considéré comme un anglicisme.</message>
+                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> dépendance \3</suggestion>
+                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 m $3"/> penchant pour les</suggestion>
+                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> passion pour les</suggestion>
+                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> faiblesse pour les</suggestion>
+                <example correction="La dépendance aux|Le penchant pour les|La passion pour les|La faiblesse pour les"><marker>L'addiction aux</marker> jeux vidéos est un nouveau phénomène de notre siècle.</example>
+            </rule>
+        </rulegroup>
+        <rule id="CINEPLEX" name="cineplex">
+            <pattern>
+                <token regexp="yes">cinéplex|cinéplexs|cinéplexe|cinépléxes|cineplex|cineplexs|cineplexes|cineplexe</token>
+            </pattern>
+            <message>« Cineplex » peut être considéré comme un anglicisme.</message>
+            <suggestion>complexe multisalle</suggestion>
+            <suggestion>multiplexe</suggestion>
+            <example correction="complexe multisalle|multiplexe"><marker>cinéplex</marker></example>
+            <example><marker>complexe multisalle</marker></example>
+        </rule>
+        <rule id="IRISH_COFFEE" name="Irish coffee" default="off">
+            <!-- deactivated : widespread usage -->
+            <pattern>
+                <token>irish</token>
+                <token regexp="yes">coffees?</token>
+            </pattern>
+            <message>« Irish coffee » peut être considéré comme un anglicisme.</message>
+            <suggestion>café irlandais</suggestion>
+            <example correction="café irlandais"><marker>irish coffee</marker></example>
+        </rule>
+        <rule id="FADING" name="fading">
+            <pattern>
+                <token regexp="yes">fadings?</token>
+            </pattern>
+            <message>« Fading » peut être considéré comme un anglicisme.</message>
+            <suggestion>évanouissement</suggestion>
+            <example correction="évanouissement"><marker>fading</marker></example>
+        </rule>
+        <rule id="CRACKING" name="cracking">
+            <pattern>
+                <token regexp="yes">crackings?</token>
+            </pattern>
+            <message>« Cracking » peut être considéré comme un anglicisme.</message>
+            <suggestion>craquage</suggestion>
+            <example correction="craquage"><marker>cracking</marker></example>
+        </rule>
+        <rule id="CUTE" name="cute">
+            <pattern>
+                <token regexp="yes">cutes?</token>
+            </pattern>
+            <message>« Cute » peut être considéré comme un anglicisme.</message>
+            <suggestion>joli</suggestion>
+            <suggestion>mignon</suggestion>
+            <suggestion>beau</suggestion>
+            <suggestion>sympathique</suggestion>
+            <suggestion>charmant</suggestion>
+            <example correction="joli|mignon|beau|sympathique|charmant"><marker>cute</marker></example>
+            <example><marker>mignon</marker></example>
+        </rule>
+        <rule id="STRIPPING" name="stripping">
+            <pattern>
+                <token regexp="yes">strippings?</token>
+            </pattern>
+            <message>« Stripping » peut être considéré comme un anglicisme. Employez <suggestion>éveinage</suggestion> (médecine).</message>
+            <example correction="éveinage"><marker>stripping</marker></example>
+        </rule>
+        <rule id="FRANCHISING" name="franchising">
+            <pattern>
+                <token regexp="yes">franchisings?</token>
+            </pattern>
+            <message>« Franchising » peut être considéré comme un anglicisme.</message>
+            <suggestion>franchisage</suggestion>
+            <example correction="franchisage"><marker>franchising</marker></example>
+        </rule>
+        <rulegroup id="CASH" name="cash">
+            <rule>
+                <antipattern>
+                    <token postag="[NJ].*" postag_regexp="yes"/>
+                    <token case_sensitive="yes">cash</token>
+                </antipattern>
+                <antipattern>
+                    <token postag="V.*" postag_regexp="yes" inflected="yes" skip="3">payer</token>
+                    <token case_sensitive="yes">cash</token>
+                </antipattern>
+                <pattern>
+                    <token case_sensitive="yes">cash
+                        <exception scope="next" regexp="yes">games?|money|-|boxes|flow|express|spot|penney</exception>
+                        <exception scope="previous" regexp="yes">Johnny|-|hard|radar|online</exception></token>
+                </pattern>
+                <message>« Cash » peut être considéré comme un anglicisme.</message>
+                <suggestion>argent comptant</suggestion>
+                <suggestion>argent</suggestion>
+                <suggestion>franc</suggestion>
+                <suggestion>liquide</suggestion>
+                <suggestion>franchement</suggestion>
+                <example correction="argent comptant|argent|franc|liquide|franchement"><marker>cash</marker></example>
+                <example><marker>argent comptant</marker></example>
+                <example>Johnny Cash est né en 1932.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="[NJ] m sp?" postag_regexp="yes"/>
+                    <marker>
+                        <token case_sensitive="yes">cash
+                            <exception scope="next" regexp="yes">games?|money|-|boxes|flow|express|spot|penney</exception>
+                            <exception scope="previous" regexp="yes">Johnny|-|hard|gros|radar|online</exception></token>
+                    </marker>
+                </pattern>
+                <message>« Cash » peut être considéré comme un anglicisme.</message>
+                <suggestion>franc</suggestion>
+                <suggestion>en liquide</suggestion>
+                <example correction="franc|en liquide">Un bonus <marker>cash</marker>.</example>
+                <example><marker>argent comptant</marker></example>
+                <example>Johnny Cash est né en 1932.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="[NJ] m p" postag_regexp="yes"/>
+                    <marker>
+                        <token case_sensitive="yes">cash
+                            <exception scope="next" regexp="yes">games?|money|-|boxes|flow|express|spot|penney</exception>
+                            <exception scope="previous" regexp="yes">Johnny|-|hard|radar|online</exception></token>
+                    </marker>
+                </pattern>
+                <message>« Cash » peut être considéré comme un anglicisme.</message>
+                <suggestion>francs</suggestion>
+                <suggestion>en liquide</suggestion>
+                <example correction="francs|en liquide">Des achats <marker>cash</marker>.</example>
+                <example><marker>argent comptant</marker></example>
+                <example>Johnny Cash est né en 1932.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="V.*" postag_regexp="yes" inflected="yes" skip="3">payer</token>
+                    <marker>
+                        <token case_sensitive="yes">cash
+                            <exception scope="next" regexp="yes">games?|money|-|boxes|flow|express|spot|penney</exception>
+                            <exception scope="previous" regexp="yes">Johnny|-|hard|radar|online|en</exception></token>
+                    </marker>
+                </pattern>
+                <message>« Cash » peut être considéré comme un anglicisme.</message>
+                <suggestion>comptant</suggestion>
+                <suggestion>en liquide</suggestion>
+                <example correction="comptant|en liquide">Il a payé <marker>cash</marker>.</example>
+                <example><marker>argent comptant</marker></example>
+                <example>Johnny Cash est né en 1932.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="[NJ] f s" postag_regexp="yes"/>
+                    <marker>
+                        <token case_sensitive="yes">cash
+                            <exception scope="next" regexp="yes">games?|money|-|boxes|flow|express|spot|penney</exception>
+                            <exception scope="previous" regexp="yes">Johnny|-|hard|radar|online</exception></token>
+                    </marker>
+                </pattern>
+                <message>« Cash » peut être considéré comme un anglicisme.</message>
+                <suggestion>franche</suggestion>
+                <suggestion>en liquide</suggestion>
+                <example correction="franche|en liquide">Une culture <marker>cash</marker>.</example>
+                <example><marker>argent comptant</marker></example>
+                <example>Johnny Cash est né en 1932.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="[NJ] f p" postag_regexp="yes"/>
+                    <marker>
+                        <token case_sensitive="yes">cash
+                            <exception scope="next" regexp="yes">games?|money|-|boxes|flow|express|spot|penney</exception>
+                            <exception scope="previous" regexp="yes">Johnny|-|hard|radar|online</exception></token>
+                    </marker>
+                </pattern>
+                <message>« Cash » peut être considéré comme un anglicisme.</message>
+                <suggestion>franches</suggestion>
+                <suggestion>en liquide</suggestion>
+                <example correction="franches|en liquide">Des cultures <marker>cash</marker>.</example>
+                <example><marker>argent comptant</marker></example>
+                <example>Johnny Cash est né en 1932.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>en</token>
+                    <marker>
+                        <token case_sensitive="yes">cash
+                            <exception scope="next" regexp="yes">games?|money|-|boxes|flow|express|spot|penney</exception></token>
+                    </marker>
+                </pattern>
+                <message>« Cash » peut être considéré comme un anglicisme.</message>
+                <suggestion>liquide</suggestion>
+                <example correction="liquide">Il a payé en <marker>cash</marker>.</example>
+                <example><marker>argent comptant</marker></example>
+                <example>Johnny Cash est né en 1932.</example>
+            </rule>
+        </rulegroup>
+        <rule id="COOLER" name="cooler">
+            <pattern>
+                <token regexp="yes">cooll?ers?</token>
+            </pattern>
+            <message>« Cooler » peut être considéré comme un anglicisme.</message>
+            <suggestion>glacière</suggestion>
+            <example correction="glacière"><marker>cooler</marker></example>
+        </rule>
+        <rulegroup id="MASKING_TAPE" name="masking tape">
+            <rule>
+                <pattern>
+                    <token regexp="yes" skip="1">maskings?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">tapes?</token>
+                </pattern>
+                <message>« Masking tape » peut être considéré comme un anglicisme.</message>
+                <suggestion>papier-cache adhésif</suggestion>
+                <suggestion>papier adhésif de masquage</suggestion>
+                <suggestion>papier à maroufler</suggestion>
+                <example correction="papier-cache adhésif|papier adhésif de masquage|papier à maroufler"><marker>masking tape</marker></example>
+                <example><marker>papier-cache adhésif</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">maskingtapes?</token>
+                </pattern>
+                <message>« Masking tape » peut être considéré comme un anglicisme.</message>
+                <suggestion>papier-cache adhésif</suggestion>
+                <suggestion>papier adhésif de masquage</suggestion>
+                <suggestion>papier à maroufler</suggestion>
+                <example correction="papier-cache adhésif|papier adhésif de masquage|papier à maroufler"><marker>maskingtape</marker></example>
+                <example><marker>papier-cache adhésif</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="RED_TAPE" name="red tape">
+            <rule>
+                <pattern>
+                    <token regexp="yes" skip="1">reds?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">tapes?</token>
+                </pattern>
+                <message>« Red tape » peut être considéré comme un anglicisme.</message>
+                <suggestion>chinoiserie administrative</suggestion>
+                <suggestion>formalité</suggestion>
+                <example correction="chinoiserie administrative|formalité"><marker>red tape</marker></example>
+                <example><marker>formalité</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">redtapes?</token>
+                </pattern>
+                <message>« Red tape » peut être considéré comme un anglicisme.</message>
+                <suggestion>chinoiserie administrative</suggestion>
+                <suggestion>formalité</suggestion>
+                <example correction="chinoiserie administrative|formalité"><marker>redtape</marker></example>
+                <example><marker>formalité</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="JUST_IN_TIME" name="just in time">
+            <pattern>
+                <token regexp="yes" skip="1">justs?</token>
+                <token>in</token>
+                <token regexp="yes">times?</token>
+            </pattern>
+            <message>« Just in time » peut être considéré comme un anglicisme. Employez <suggestion>méthode de production à flux tendus</suggestion>, <suggestion>juste-à-temps</suggestion> (nom masculin).</message>
+            <example correction="méthode de production à flux tendus|juste-à-temps"><marker>just in time</marker></example>
+            <example><marker>juste-à-temps</marker></example>
+        </rule>
+        <rule id="JUST_TOO_BAD" name="just too bad">
+            <pattern>
+                <token regexp="yes" skip="1">justs?</token>
+                <token>too</token>
+                <token regexp="yes">bads?</token>
+            </pattern>
+            <message>« Just too bad » peut être considéré comme un anglicisme. Employez <suggestion>c'est bien dommage</suggestion>, <suggestion>on n'y peut rien</suggestion> (nom masculin).</message>
+            <example correction="c'est bien dommage|on n'y peut rien"><marker>just too bad</marker></example>
+            <example><marker>c'est bien dommage</marker></example>
+        </rule>
+        <rule id="TEASING" name="teasing">
+            <pattern>
+                <token regexp="yes">teasings?</token>
+            </pattern>
+            <message>« Teasing » peut être considéré comme un anglicisme.</message>
+            <suggestion>aguichage</suggestion>
+            <example correction="aguichage"><marker>teasing</marker></example>
+        </rule>
+        <rule id="LEASING" name="leasing">
+            <pattern>
+                <token regexp="yes">leasings?</token>
+            </pattern>
+            <message>« Leasing » peut être considéré comme un anglicisme.</message>
+            <suggestion>crédit-bail</suggestion>
+            <example correction="crédit-bail"><marker>leasing</marker></example>
+        </rule>
+        <rule id="WOOFER" name="woofer">
+            <pattern>
+                <token regexp="yes">woofers?</token>
+            </pattern>
+            <message>« Woofer » peut être considéré comme un anglicisme.</message>
+            <suggestion>haut-parleur de graves</suggestion>
+            <example correction="haut-parleur de graves"><marker>woofer</marker></example>
+        </rule>
+        <rule id="LOSER" name="loser">
+            <pattern>
+                <token regexp="yes">losers?</token>
+            </pattern>
+            <message>« Loser » peut être considéré comme un anglicisme.</message>
+            <suggestion>perdant</suggestion>
+            <example correction="perdant"><marker>loser</marker></example>
+        </rule>
+        <rule id="BOOMER" name="boomer" default="off">
+            <!-- This rule is no good anymore -->
+            <antipattern>
+                <token regexp="yes">baby|ok(ay)?</token>
+                <token min="0">,</token>
+                <token>boomer</token>
+            </antipattern>
+            <pattern>
+                <token regexp="yes">boomers?</token>
+            </pattern>
+            <message>« Boomer » peut être considéré comme un anglicisme.</message>
+            <suggestion>haut-parleur de graves</suggestion>
+            <example correction="haut-parleur de graves"><marker>boomer</marker></example>
+        </rule>
+        <rule id="CHARTER" name="charter">
+            <pattern>
+                <token regexp="yes">charters?</token>
+            </pattern>
+            <message>« Charter » peut être considéré comme un anglicisme.</message>
+            <suggestion>vol nolisé</suggestion>
+            <suggestion>avion nolisé</suggestion>
+            <example correction="vol nolisé|avion nolisé"><marker>charter</marker></example>
+            <example><marker>vol nolisé</marker></example>
+        </rule>
+        <rule id="HEY" name="hey">
+            <antipattern>
+                <token>hey</token>
+                <token>.</token>
+                <token>com</token>
+            </antipattern>
+            <antipattern>
+                <token>hey</token>
+                <token>hey</token>
+            </antipattern>
+            <pattern>
+                <token>hey</token>
+            </pattern>
+            <message>« Hey » peut être considéré comme un anglicisme.</message>
+            <suggestion>hé</suggestion>
+            <suggestion>salut</suggestion>
+            <suggestion>coucou</suggestion>
+            <example correction="hé|salut|coucou"><marker>hey</marker></example>
+        </rule>
+        <rule id="ENGINEERING" name="engineering">
+            <pattern>
+                <token regexp="yes" case_sensitive="yes">engineerings?
+                    <exception scope="previous" regexp="yes">reverse|social</exception></token>
+            </pattern>
+            <message>« Engineering » peut être considéré comme un anglicisme.</message>
+            <suggestion>ingénierie</suggestion>
+            <example correction="ingénierie"><marker>engineering</marker></example>
+        </rule>
+        <rule id="FACTORING" name="factoring">
+            <pattern>
+                <token regexp="yes">factorings?</token>
+            </pattern>
+            <message>« Factoring » peut être considéré comme un anglicisme.</message>
+            <suggestion>affacturage</suggestion>
+            <example correction="affacturage"><marker>factoring</marker></example>
+        </rule>
+        <rule id="ROYALTIES" name="royalties">
+            <pattern>
+                <token regexp="yes">royalty|royalties|royaltys</token>
+            </pattern>
+            <message>« Royalties » peut être considéré comme un anglicisme.</message>
+            <suggestion>redevances</suggestion>
+            <example correction="redevances"><marker>royalties</marker></example>
+            <example><marker>redevance</marker></example>
+        </rule>
+        <rule id="COLESLAW" name="coleslaw">
+            <pattern>
+                <token regexp="yes">coleslaws?</token>
+            </pattern>
+            <message>« Coleslaw » peut être considéré comme un anglicisme.</message>
+            <suggestion>salade de chou</suggestion>
+            <example correction="salade de chou"><marker>coleslaw</marker></example>
+        </rule>
+        <rulegroup id="EGGNOG" name="eggnog">
+            <rule>
+                <pattern>
+                    <token regexp="yes">eggnog|eggnogg|eggnogs|eggnoggs|egg-nog|egg-nogs|egg-nogg|egg-noggs</token>
+                </pattern>
+                <message>« Eggnog » peut être considéré comme un anglicisme. Employez <suggestion>lait de poule</suggestion> (boisson alcoolisée).</message>
+                <example correction="lait de poule"><marker>eggnog</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>egg</token>
+                    <token regexp="yes">nog|noggs</token>
+                </pattern>
+                <message>« Eggnog » peut être considéré comme un anglicisme. Employez <suggestion>lait de poule</suggestion> (boisson alcoolisée).</message>
+                <example correction="lait de poule"><marker>egg nog</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="HOLD-UP" name="hold-up">
+            <rule>
+                <pattern>
+                    <token regexp="yes">hold-?ups?</token>
+                </pattern>
+                <message>« Hold-up » peut être considéré comme un anglicisme.</message>
+                <suggestion>vol à main armée</suggestion>
+                <example correction="vol à main armée"><marker>hold-up</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>hold</token>
+                    <token regexp="yes">ups?</token>
+                </pattern>
+                <message>« Hold-up » peut être considéré comme un anglicisme.</message>
+                <suggestion>vol à main armée</suggestion>
+                <example correction="vol à main armée"><marker>hold up</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="HOUSE-BOAT" name="house-boat">
+            <rule>
+                <pattern>
+                    <token regexp="yes">houseboats?</token>
+                </pattern>
+                <message>« House-boat » peut être considéré comme un anglicisme.</message>
+                <suggestion>bateau-maison</suggestion>
+                <suggestion>péniche</suggestion>
+                <suggestion>maison flottante</suggestion>
+                <example correction="bateau-maison|péniche|maison flottante"><marker>houseboat</marker></example>
+                <example><marker>péniche</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>house</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">boats?</token>
+                </pattern>
+                <message>« House-boat » peut être considéré comme un anglicisme.</message>
+                <suggestion>bateau-maison</suggestion>
+                <suggestion>péniche</suggestion>
+                <suggestion>maison flottante</suggestion>
+                <example correction="bateau-maison|péniche|maison flottante"><marker>house boat</marker></example>
+                <example><marker>péniche</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="WARGAME" name="wargame">
+            <rule>
+                <pattern>
+                    <token regexp="yes">wargames?</token>
+                </pattern>
+                <message>« Wargame » peut être considéré comme un anglicisme.</message>
+                <suggestion>jeu de guerre</suggestion>
+                <suggestion>jeu de simulation de guerre</suggestion>
+                <suggestion>jeu de simulation de conflit</suggestion>
+                <suggestion>simulation de guerre</suggestion>
+                <suggestion>simulation de guerre</suggestion>
+                <example correction="jeu de guerre|jeu de simulation de guerre|jeu de simulation de conflit|simulation de guerre"><marker>wargame</marker></example>
+                <example><marker>jeu de guerre</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>war</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">games?</token>
+                </pattern>
+                <message>« Wargame » peut être considéré comme un anglicisme.</message>
+                <suggestion>jeu de guerre</suggestion>
+                <suggestion>jeu de simulation de guerre</suggestion>
+                <suggestion>jeu de simulation de conflit</suggestion>
+                <suggestion>simulation de guerre</suggestion>
+                <suggestion>simulation de guerre</suggestion>
+                <example correction="jeu de guerre|jeu de simulation de guerre|jeu de simulation de conflit|simulation de guerre"><marker>war game</marker></example>
+                <example><marker>jeu de guerre</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup default="off" id="SNOWBOARD" name="snow(board)">
+            <rule>
+                <pattern>
+                    <token regexp="yes">snowboards?</token>
+                </pattern>
+                <message>« Snow(board) » peut être considéré comme un anglicisme.</message>
+                <suggestion>surf des neiges</suggestion>
+                <example correction="surf des neiges"><marker>snowboard</marker></example>
+                <example><marker>surf des neiges</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>snow</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">boards?</token>
+                </pattern>
+                <message>« Snow(board) » peut être considéré comme un anglicisme.</message>
+                <suggestion>surf des neiges</suggestion>
+                <example correction="surf des neiges"><marker>snow board</marker></example>
+                <example><marker>surf des neiges</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="ANTISKATING" name="antiskating">
+            <rule>
+                <pattern>
+                    <token regexp="yes">antiskatings?</token>
+                </pattern>
+                <message>« Antiskating » peut être considéré comme un anglicisme.</message>
+                <suggestion>antiripage</suggestion>
+                <suggestion>antipatinage</suggestion>
+                <example correction="antiripage|antipatinage"><marker>antiskating</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>anti</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">skatings?</token>
+                </pattern>
+                <message>« Antiskating » peut être considéré comme un anglicisme.</message>
+                <suggestion>antiripage</suggestion>
+                <suggestion>antipatinage</suggestion>
+                <example correction="antiripage|antipatinage"><marker>anti skating</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="ATTACHE-CASE" name="attaché-case">
+            <rule>
+                <pattern>
+                    <token regexp="yes">attachés|attaché|attache|attaches</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">cases?</token>
+                </pattern>
+                <message>« Attaché-case » peut être considéré comme un anglicisme.</message>
+                <suggestion>mallette</suggestion>
+                <suggestion>mallette porte-documents</suggestion>
+                <suggestion>porte-documents</suggestion>
+                <example correction="mallette|mallette porte-documents|porte-documents"><marker>attaché case</marker></example>
+                <example><marker>mallette</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">attachés?-cases?</token>
+                </pattern>
+                <message>« Attaché-case » peut être considéré comme un anglicisme.</message>
+                <suggestion>mallette</suggestion>
+                <suggestion>mallette porte-documents</suggestion>
+                <suggestion>porte-documents</suggestion>
+                <example correction="mallette|mallette porte-documents|porte-documents"><marker>attaché-case</marker></example>
+                <example><marker>mallette</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="HIT-AND-RUN" name="hit-and-run">
+            <rule>
+                <pattern>
+                    <token regexp="yes">hits?</token>
+                    <token min="0">-</token>
+                    <token>and</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">runs?</token>
+                </pattern>
+                <message>« Hit-and-run » peut être considéré comme un anglicisme.</message>
+                <suggestion>délit de fuite</suggestion>
+                <example correction="délit de fuite"><marker>hit and run</marker></example>
+                <example correction="délit de fuite"><marker>hit-and-run</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="HIT-PARADE" name="hit-parade" default="off">
+            <rule>
+                <pattern>
+                    <token regexp="yes">hit-parades?</token>
+                </pattern>
+                <message>« Hit-parade » peut être considéré comme un anglicisme.</message>
+                <suggestion>palmarès</suggestion>
+                <example correction="palmarès"><marker>hit-parade</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>hit</token>
+                    <token regexp="yes">parades|parade</token>
+                </pattern>
+                <message>« Hit-parade » peut être considéré comme un anglicisme.</message>
+                <suggestion>palmarès</suggestion>
+                <example correction="palmarès"><marker>hit parade</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="ANGLEDOZER" name="angledozer">
+            <rule>
+                <pattern>
+                    <token regexp="yes">angle-?dozers?</token>
+                </pattern>
+                <message>« Angledozer » peut être considéré comme un anglicisme.</message>
+                <suggestion>bouteur biais</suggestion>
+                <example correction="bouteur biais"><marker>angledozer</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>angle</token>
+                    <token regexp="yes">dozers?</token>
+                </pattern>
+                <message>« Angledozer » peut être considéré comme un anglicisme.</message>
+                <suggestion>bouteur biais</suggestion>
+                <example correction="bouteur biais"><marker>angle dozer</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="WALK-OVER" name="walk-over">
+            <rule>
+                <pattern>
+                    <token regexp="yes">walk-over|walkover|walkovers|walk-overs</token>
+                </pattern>
+                <message>« Walk-over » peut être considéré comme un anglicisme.</message>
+                <suggestion>victoire par défaut</suggestion>
+                <example correction="victoire par défaut"><marker>walk-over</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>walk</token>
+                    <token regexp="yes">overs?</token>
+                </pattern>
+                <message>« Walk-over » peut être considéré comme un anglicisme.</message>
+                <suggestion>victoire par défaut</suggestion>
+                <example correction="victoire par défaut"><marker>walk over</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="EXTRA-DRY" name="extra-dry">
+            <rule>
+                <pattern>
+                    <token regexp="yes">extra-dry|extradry|extradries|extra-dries</token>
+                </pattern>
+                <message>« Extra-dry » peut être considéré comme un anglicisme.</message>
+                <suggestion>extra sec</suggestion>
+                <example correction="extra sec"><marker>extra-dry</marker></example>
+                <example><marker>très sec</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>extra</token>
+                    <token regexp="yes">dry|dries</token>
+                </pattern>
+                <message>« Extra-dry » peut être considéré comme un anglicisme.</message>
+                <suggestion>extra sec</suggestion>
+                <example correction="extra sec"><marker>extra dry</marker></example>
+                <example><marker>très sec</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="GAS-OIL" name="gas-oil">
+            <rule>
+                <pattern>
+                    <token regexp="yes">gas-oil|gasoil</token>
+                </pattern>
+                <message>« Gas-oil » peut être considéré comme un anglicisme.</message>
+                <suggestion>gazole</suggestion>
+                <example correction="gazole"><marker>gas-oil</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>gas</token>
+                    <token>oil</token>
+                </pattern>
+                <message>« Gas-oil » peut être considéré comme un anglicisme.</message>
+                <suggestion>gazole</suggestion>
+                <example correction="gazole"><marker>gas oil</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="SKATEBOARD" name="skate(board)" default="off">
+            <!-- deactivated : widespread usage -->
+            <rule>
+                <pattern>
+                    <token regexp="yes">skate-board|skateboards|skate-boards|skateboard|skate|skates</token>
+                </pattern>
+                <message>« Skate(board) » peut être considéré comme un anglicisme.</message>
+                <suggestion>planche à roulettes</suggestion>
+                <example correction="planche à roulettes"><marker>skate</marker></example>
+                <example><marker>planche à roulette</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">skates?</token>
+                    <token regexp="yes">boards?</token>
+                </pattern>
+                <message>« Skate(board) » peut être considéré comme un anglicisme.</message>
+                <suggestion>planche à roulettes</suggestion>
+                <example correction="planche à roulettes"><marker>skate board</marker></example>
+                <example><marker>planche à roulette</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="B2B" name="B2B, b to b" default="off">
+            <!-- deactivated : widespread usage -->
+            <rule>
+                <pattern>
+                    <token regexp="yes">b2bs?|b-to-b</token>
+                </pattern>
+                <message>« B2B » peut être considéré comme un anglicisme.</message>
+                <suggestion>commerce interentreprises</suggestion>
+                <example correction="Commerce interentreprises"><marker>B2B</marker></example>
+                <example><marker>commerce interentreprises</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>b</token>
+                    <token>to</token>
+                    <token>b</token>
+                </pattern>
+                <message>« B2B » peut être considéré comme un anglicisme.</message>
+                <suggestion>commerce interentreprises</suggestion>
+                <example correction="commerce interentreprises"><marker>b to b</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="CHECK_POINT" name="check point">
+            <rule>
+                <pattern>
+                    <token>checkpoint
+                        <exception scope="previous" regexp="yes">the|and|of|or|on</exception>
+                        <exception scope="next">Charlie</exception></token>
+                </pattern>
+                <message>« Check point » peut être considéré comme un anglicisme.</message>
+                <suggestion>point de contrôle</suggestion>
+                <example correction="point de contrôle"><marker>checkpoint</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token case_sensitive="yes">checkpoints</token>
+                </pattern>
+                <message>« Check point » peut être considéré comme un anglicisme.</message>
+                <suggestion>points de contrôle</suggestion>
+                <example correction="points de contrôle"><marker>checkpoints</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes" case_sensitive="yes">checks?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">points?</token>
+                </pattern>
+                <message>« Check point » peut être considéré comme un anglicisme.</message>
+                <suggestion>point de contrôle</suggestion>
+                <example correction="point de contrôle"><marker>check point</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="CHECK_OUT" name="check out">
+            <rule>
+                <pattern>
+                    <token regexp="yes" case_sensitive="yes">checkouts?
+                        <exception scope="previous" regexp="yes">&amp;|at</exception></token>
+                </pattern>
+                <message>« Check out » peut être considéré comme un anglicisme. Employez <suggestion>sortie</suggestion>.</message>
+                <example correction="sortie"><marker>checkout</marker></example>
+                <example><marker>régler la note</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>au</token>
+                    <token regexp="yes" case_sensitive="yes">checkouts?</token>
+                </pattern>
+                <message>« Check out » peut être considéré comme un anglicisme. Employez <suggestion>à la sortie</suggestion>.</message>
+                <example correction="à la sortie"><marker>au checkout</marker></example>
+                <example><marker>régler la note</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>du</token>
+                    <token regexp="yes" case_sensitive="yes">checkouts?</token>
+                </pattern>
+                <message>« Check out » peut être considéré comme un anglicisme. Employez <suggestion>de la sortie</suggestion>.</message>
+                <example correction="de la sortie"><marker>du checkout</marker></example>
+                <example><marker>régler la note</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="D m s"/>
+                    <token regexp="yes" case_sensitive="yes">checkouts?</token>
+                </pattern>
+                <message>« Check out » peut être considéré comme un anglicisme. Employez <suggestion><match no="1" postag="(D) (m) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> sortie</suggestion>.</message>
+                <example correction="la sortie"><marker>le checkout</marker></example>
+                <example><marker>régler la note</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">checks?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">outs?</token>
+                </pattern>
+                <message>« Check out » peut être considéré comme un anglicisme. Employez <suggestion>régler la note</suggestion> (hôtel), <suggestion>quitter la chambre</suggestion> (hôtel).</message>
+                <example correction="régler la note|quitter la chambre"><marker>check out</marker></example>
+                <example><marker>régler la note</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="PEER-TO-PEER" name="peer-to-peer" default="off">
+            <!-- deactivated : widespread usage -->
+            <rule>
+                <pattern>
+                    <token>P2P</token>
+                </pattern>
+                <message>« Peer to peer (P2P) » peut être considéré comme un anglicisme.</message>
+                <suggestion>poste à poste</suggestion>
+                <suggestion>pair à pair</suggestion>
+                <example correction="Poste à poste|Pair à pair"><marker>P2P</marker></example>
+                <example><marker>poste à poste</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">peer|p</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">to|2</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">peer|p</token>
+                </pattern>
+                <message>« Peer to peer (P2P) » peut être considéré comme un anglicisme.</message>
+                <suggestion>poste à poste</suggestion>
+                <suggestion>pair à pair</suggestion>
+                <example correction="poste à poste|pair à pair"><marker>peer to peer</marker></example>
+                <example><marker>poste à poste</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="LIFEGUARD" name="lifeguard">
+            <rule>
+                <pattern>
+                    <token regexp="yes">lifeguards?</token>
+                </pattern>
+                <message>« Lifeguard » peut être considéré comme un anglicisme.</message>
+                <suggestion>maître-nageur</suggestion>
+                <suggestion>maître-sauveteur</suggestion>
+                <suggestion>surveillant de plage</suggestion>
+                <suggestion>surveillant de baignade</suggestion>
+                <example correction="maître-nageur|maître-sauveteur|surveillant de plage|surveillant de baignade"><marker>lifeguard</marker></example>
+                <example><marker>maître-nageur</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>life</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">guards?</token>
+                </pattern>
+                <message>« Lifeguard » peut être considéré comme un anglicisme.</message>
+                <suggestion>maître-nageur</suggestion>
+                <suggestion>maître-sauveteur</suggestion>
+                <suggestion>surveillant de plage</suggestion>
+                <suggestion>surveillant de baignade</suggestion>
+                <example correction="maître-nageur|maître-sauveteur|surveillant de plage|surveillant de baignade"><marker>life guard</marker></example>
+                <example><marker>maître-nageur</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="MINILAB" name="minilab">
+            <rule>
+                <pattern>
+                    <token regexp="yes">minilabs?</token>
+                </pattern>
+                <message>« Minilab » peut être considéré comme un anglicisme.</message>
+                <suggestion>minilabo</suggestion>
+                <example correction="minilabo"><marker>minilab</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>mini</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">labs?</token>
+                </pattern>
+                <message>« Minilab » peut être considéré comme un anglicisme.</message>
+                <suggestion>minilabo</suggestion>
+                <example correction="minilabo"><marker>mini lab</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="MINI-PUTT" name="mini-putt">
+            <rule>
+                <pattern>
+                    <token regexp="yes">miniputts?</token>
+                </pattern>
+                <message>« Mini-putt » peut être considéré comme un anglicisme.</message>
+                <suggestion>golf miniature</suggestion>
+                <suggestion>minigolf</suggestion>
+                <example correction="golf miniature|minigolf"><marker>miniputt</marker></example>
+                <example><marker>golf miniature</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>mini</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">putts?</token>
+                </pattern>
+                <message>« Mini-putt » peut être considéré comme un anglicisme.</message>
+                <suggestion>golf miniature</suggestion>
+                <suggestion>minigolf</suggestion>
+                <example correction="golf miniature|minigolf"><marker>mini putt</marker></example>
+                <example><marker>golf miniature</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="LIVING-ROOM" name="living(-room)">
+            <rule>
+                <pattern>
+                    <token regexp="yes">living|livingroom|livings|livingrooms|livingsrooms
+                        <exception scope="next">-</exception></token>
+                </pattern>
+                <message>« Living(-room) » peut être considéré comme un anglicisme.</message>
+                <suggestion>salle de séjour</suggestion>
+                <suggestion>séjour</suggestion>
+                <example correction="salle de séjour|séjour"><marker>livingroom</marker></example>
+                <example><marker>séjour</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">livings?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">rooms?</token>
+                </pattern>
+                <message>« Living(-room) » peut être considéré comme un anglicisme.</message>
+                <suggestion>salle de séjour</suggestion>
+                <suggestion>séjour</suggestion>
+                <example correction="salle de séjour|séjour"><marker>living room</marker></example>
+                <example><marker>séjour</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BOOKCROSSING" name="bookcrossing">
+            <rule>
+                <pattern>
+                    <token regexp="yes">bookcrossings?</token>
+                </pattern>
+                <message>« Bookcrossing » peut être considéré comme un anglicisme.</message>
+                <suggestion>passe-livres</suggestion>
+                <suggestion>bouquinomadisme</suggestion>
+                <example correction="passe-livres|bouquinomadisme"><marker>bookcrossing</marker></example>
+                <example><marker>bouquinomadisme</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">books?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">crossings?</token>
+                </pattern>
+                <message>« Bookcrossing » peut être considéré comme un anglicisme.</message>
+                <suggestion>passe-livres</suggestion>
+                <suggestion>bouquinomadisme</suggestion>
+                <example correction="passe-livres|bouquinomadisme"><marker>book crossing</marker></example>
+                <example><marker>bouquinomadisme</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="CAMERAMAN" name="cameraman">
+            <rule>
+                <pattern>
+                    <token regexp="yes">cameraman|cameramen|camerawoman|camerawomen|cameramans|camerawomans</token>
+                </pattern>
+                <message>« Cameraman » peut être considéré comme un anglicisme.</message>
+                <suggestion>cadreur</suggestion>
+                <example correction="cadreur"><marker>cameraman</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>camera</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">mans?|men|womans?|women</token>
+                </pattern>
+                <message>« Cameraman » peut être considéré comme un anglicisme.</message>
+                <suggestion>cadreur</suggestion>
+                <example correction="cadreur"><marker>camera man</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="SPACE_OPERA" name="space opera" default="off">
+            <!-- deactivated : widespread usage -->
+            <rule>
+                <pattern>
+                    <token>space</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">opéra|opera|opéras|operas</token>
+                </pattern>
+                <message>« Space-opera » peut être considéré comme un anglicisme.</message>
+                <suggestion>opéra de l'espace</suggestion>
+                <example correction="opéra de l'espace"><marker>space opera</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="GRASPING-REFLEX" name="grasping-reflex">
+            <rule>
+                <pattern>
+                    <token regexp="yes">graspingreflex|graspingreflexs|graspingreflexes</token>
+                </pattern>
+                <message>« Grasping-reflex » peut être considéré comme un anglicisme.</message>
+                <suggestion>réflexe d'agrippement</suggestion>
+                <example correction="réflexe d'agrippement"><marker>graspingreflex</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>grasping</token>
+                    <token min="0">-</token>
+                    <token>reflex</token>
+                </pattern>
+                <message>« Grasping-reflex » peut être considéré comme un anglicisme.</message>
+                <suggestion>réflexe d'agrippement</suggestion>
+                <example correction="réflexe d'agrippement"><marker>grasping reflex</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="HOT_MONEY" name="hot money">
+            <rule>
+                <pattern>
+                    <token>hotmoney</token>
+                </pattern>
+                <message>« Hot-money » peut être considéré comme un anglicisme.</message>
+                <suggestion>capitaux flottants</suggestion>
+                <suggestion>capitaux fébriles</suggestion>
+                <example correction="capitaux flottants|capitaux fébriles"><marker>hotmoney</marker></example>
+                <example><marker>capitaux flottants</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>hot</token>
+                    <token min="0">-</token>
+                    <token>money</token>
+                </pattern>
+                <message>« Hot-money » peut être considéré comme un anglicisme.</message>
+                <suggestion>capitaux flottants</suggestion>
+                <suggestion>capitaux fébriles</suggestion>
+                <example correction="capitaux flottants|capitaux fébriles"><marker>hot money</marker></example>
+                <example><marker>capitaux flottants</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BODY-BUILDING" name="body-building" default="off">
+            <rule>
+                <pattern>
+                    <token regexp="yes">bodybuildings|bodybuilding</token>
+                </pattern>
+                <message>« Body-building » peut être considéré comme un anglicisme.</message>
+                <suggestion>culturisme</suggestion>
+                <example correction="culturisme"><marker>bodybuilding</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>body</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">buildings?</token>
+                </pattern>
+                <message>« Body-building » peut être considéré comme un anglicisme.</message>
+                <suggestion>culturisme</suggestion>
+                <example correction="culturisme"><marker>body building</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="COME-BACK" name="come-back">
+            <rule>
+                <pattern>
+                    <token regexp="yes">comeback|comesbacks|comebacks
+                        <exception scope="previous">s</exception></token>
+                </pattern>
+                <message>« Come-back » peut être considéré comme un anglicisme.</message>
+                <suggestion>retour</suggestion>
+                <example correction="retour"><marker>comeback</marker></example>
+                <example><marker>retour en vogue</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="[DP].*" postag_regexp="yes"/>
+                    <marker>
+                        <token regexp="yes">comes?</token>
+                        <token min="0">-</token>
+                        <token regexp="yes">backs?</token>
+                    </marker>
+                </pattern>
+                <message>« Come-back » peut être considéré comme un anglicisme.</message>
+                <suggestion>retour</suggestion>
+                <example correction="retour">Un <marker>come back</marker></example>
+                <example><marker>retour en vogue</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="TIME-SHARING" name="time sharing">
+            <rule>
+                <pattern>
+                    <token regexp="yes">timesharing|timesharings</token>
+                </pattern>
+                <message>« Time-sharing » peut être considéré comme un anglicisme.</message>
+                <suggestion>temps partagé</suggestion>
+                <example correction="temps partagé"><marker>timesharing</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">times?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">sharings?</token>
+                </pattern>
+                <message>« Time-sharing » peut être considéré comme un anglicisme.</message>
+                <suggestion>temps partagé</suggestion>
+                <example correction="temps partagé"><marker>time sharing</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="SISTER-SHIP" name="sister-ship">
+            <rule>
+                <pattern>
+                    <token regexp="yes">sistership|sisterships|sistersship</token>
+                </pattern>
+                <message>« Sister-ship » peut être considéré comme un anglicisme.</message>
+                <suggestion>navire-jumeau</suggestion>
+                <example correction="navire-jumeau"><marker>sistership</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">sisters?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">ships?</token>
+                </pattern>
+                <message>« Sister ship » peut être considéré comme un anglicisme.</message>
+                <suggestion>navire-jumeau</suggestion>
+                <example correction="navire-jumeau"><marker>sister ship</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="VANITY-CASE" name="vanity-case">
+            <rule>
+                <pattern>
+                    <token regexp="yes">vanitycases?</token>
+                </pattern>
+                <message>« Vanity-case » peut être considéré comme un anglicisme.</message>
+                <suggestion>mallette de toilette</suggestion>
+                <example correction="mallette de toilette"><marker>vanitycase</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">vanity|vanities</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">cases?</token>
+                </pattern>
+                <message>« Vanity-case » peut être considéré comme un anglicisme.</message>
+                <suggestion>mallette de toilette</suggestion>
+                <example correction="mallette de toilette"><marker>vanity case</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="TOP-SECRET" name="top-secret">
+            <rule>
+                <pattern>
+                    <token regexp="yes">topsecrets?</token>
+                </pattern>
+                <message>« Top-secret » peut être considéré comme un anglicisme.</message>
+                <suggestion>ultrasecret</suggestion>
+                <suggestion>absolument confidentiel</suggestion>
+                <example correction="ultrasecret|absolument confidentiel"><marker>topsecret</marker></example>
+                <example><marker>ultrasecret</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>top</token>
+                    <token min="0">-</token>
+                    <token>secret</token>
+                </pattern>
+                <message>« Top-secret » peut être considéré comme un anglicisme.</message>
+                <suggestion>ultrasecret</suggestion>
+                <suggestion>absolument confidentiel</suggestion>
+                <example correction="ultrasecret|absolument confidentiel"><marker>top secret</marker></example>
+                <example><marker>ultrasecret</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="FREELANCE" name="freelance" default="off">
+            <!-- very low apply rate -->
+            <rule>
+                <pattern>
+                    <token regexp="yes">freelances?</token>
+                </pattern>
+                <message>« Freelance » peut être considéré comme un anglicisme.</message>
+                <suggestion>pigiste</suggestion>
+                <suggestion>indépendant</suggestion>
+                <example correction="pigiste|indépendant"><marker>freelance</marker></example>
+                <example><marker>indépendant</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>free</token>
+                    <token min="0">-</token>
+                    <token>lance</token>
+                </pattern>
+                <message>« Freelance » peut être considéré comme un anglicisme.</message>
+                <suggestion>pigiste</suggestion>
+                <suggestion>indépendant</suggestion>
+                <example correction="pigiste|indépendant"><marker>free lance</marker></example>
+                <example><marker>indépendant</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="GAME_DESIGNER" name="game designer">
+            <pattern>
+                <token regexp="yes">games?</token>
+                <token min="0">-</token>
+                <token regexp="yes">designers?</token>
+            </pattern>
+            <message>« Game designer » peut être considéré comme un anglicisme.</message>
+            <suggestion>concepteur de jeux vidéos</suggestion>
+            <suggestion>concepteur de jeux</suggestion>
+            <example correction="concepteur de jeux vidéos|concepteur de jeux"><marker>game designer</marker></example>
+            <example><marker>concepteur de jeux</marker></example>
+        </rule>
+        <rule id="JOKE" name="joke">
+            <pattern>
+                <token regexp="yes">jokes?</token>
+            </pattern>
+            <message>« Joke » peut être considéré comme un anglicisme.</message>
+            <suggestion>farce</suggestion>
+            <suggestion>tour</suggestion>
+            <suggestion>canular</suggestion>
+            <suggestion>blague</suggestion>
+            <example correction="farce|tour|canular|blague"><marker>joke</marker></example>
+            <example><marker>farce</marker></example>
+        </rule>
+        <rule id="CLEAN" name="clean">
+            <pattern>
+                <token regexp="yes" case_sensitive="yes">cleans?
+                    <exception scope="next" regexp="yes">(?-i)[A-Z].*|free|cut|diesel|-|sheet|girl</exception></token>
+            </pattern>
+            <message>« Clean » peut être considéré comme un anglicisme.</message>
+            <suggestion>net</suggestion>
+            <suggestion>sobre</suggestion>
+            <suggestion>sans surcharge</suggestion>
+            <suggestion>dépouillé</suggestion>
+            <suggestion>soigné</suggestion>
+            <suggestion>sain</suggestion>
+            <example correction="net|sobre|sans surcharge|dépouillé|soigné|sain"><marker>clean</marker></example>
+            <example><marker>sobre</marker></example>
+        </rule>
+        <rule id="LATE_BLOOMER" name="late bloomer">
+            <pattern>
+                <token regexp="yes">lates?</token>
+                <token min="0">-</token>
+                <token regexp="yes">bloomers?</token>
+            </pattern>
+            <message>« Late bloomer » peut être considéré comme un anglicisme.</message>
+            <suggestion>vocation tardive</suggestion>
+            <example correction="vocation tardive"><marker>late bloomer</marker></example>
+        </rule>
+        <rule id="HOLDING" name="holding">
+            <pattern>
+                <token regexp="yes">holdings?</token>
+            </pattern>
+            <message>« Holding » peut être considéré comme un anglicisme.</message>
+            <suggestion>société de portefeuille</suggestion>
+            <suggestion>société de participation</suggestion>
+            <example correction="société de portefeuille|société de participation"><marker>holding</marker></example>
+            <example><marker>société de participation</marker></example>
+        </rule>
+        <rule id="HOBBY" name="hobby">
+            <pattern>
+                <token regexp="yes">hobby|hobbies|hobbys</token>
+            </pattern>
+            <message>« Hobby » peut être considéré comme un anglicisme.</message>
+            <suggestion>passe-temps</suggestion>
+            <example correction="passe-temps"><marker>hobby</marker></example>
+        </rule>
+        <rule id="HURRICANE" name="hurricane">
+            <pattern>
+                <token regexp="yes">hurricanes?</token>
+            </pattern>
+            <message>« Hurricane » peut être considéré comme un anglicisme.</message>
+            <suggestion>cyclone</suggestion>
+            <example correction="cyclone"><marker>hurricane</marker></example>
+        </rule>
+        <rulegroup id="JOYSTICK" name="joystick">
+            <rule>
+                <pattern>
+                    <token regexp="yes">joysticks?</token>
+                </pattern>
+                <message>« Joystick » peut être considéré comme un anglicisme. Employez <suggestion>manette de jeu</suggestion> (informatique), <suggestion>manche à balai</suggestion> (informatique).</message>
+                <example correction="manette de jeu|manche à balai"><marker>joystick</marker></example>
+                <example><marker>manche à balai</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">joys?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">sticks?</token>
+                </pattern>
+                <message>« Joystick » peut être considéré comme un anglicisme. Employez <suggestion>manette de jeu</suggestion> (informatique), <suggestion>manche à balai</suggestion> (informatique).</message>
+                <example correction="manette de jeu|manche à balai"><marker>joy stick</marker></example>
+                <example><marker>manche à balai</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="JOINT_VENTURE" name="joint venture">
+            <pattern>
+                <token>joint</token>
+                <token min="0">-</token>
+                <token>venture</token>
+            </pattern>
+            <message>« Joint venture » peut être considéré comme un anglicisme.</message>
+            <suggestion>coentreprise</suggestion>
+            <suggestion>entreprise conjointe</suggestion>
+            <suggestion>entreprise commune</suggestion>
+            <suggestion>opération conjointe</suggestion>
+            <example correction="coentreprise|entreprise conjointe|entreprise commune|opération conjointe"><marker>joint venture</marker></example>
+            <example><marker>entreprise conjointe</marker></example>
+        </rule>
+        <rule id="DIRECTORS_CUT" name="director's cut" default="off">
+            <!-- deactivated : widespread usage -->
+            <pattern>
+                <token regexp="yes" skip="2">director'?s?'?</token>
+                <token regexp="yes" skip="1">cuts?</token>
+            </pattern>
+            <message>« Director's cut » peut être considéré comme un anglicisme.</message>
+            <suggestion>version d'auteur</suggestion>
+            <suggestion>version du réalisateur</suggestion>
+            <suggestion>version réalisateur</suggestion>
+            <example correction="version d'auteur|version du réalisateur|version réalisateur"><marker>director's cut</marker></example>
+            <example><marker>version réalisateur</marker></example>
+        </rule>
+        <rule id="TILT" name="tilt">
+            <pattern>
+                <token regexp="yes">tilts?</token>
+            </pattern>
+            <message>« Tilt » peut être considéré comme un anglicisme. Employez <suggestion>déclic</suggestion> (billard électrique).</message>
+            <example correction="déclic"><marker>tilt</marker></example>
+        </rule>
+        <rule id="BULLYING" name="bullying">
+            <pattern>
+                <token regexp="yes">bullying|bulliing</token>
+            </pattern>
+            <message>« Bullying » peut être considéré comme un anglicisme.</message>
+            <suggestion>harcèlement</suggestion>
+            <suggestion>intimidation</suggestion>
+            <example correction="harcèlement|intimidation"><marker>bullying</marker></example>
+            <example><marker>harcèlement</marker></example>
+        </rule>
+        <rule id="HAPPY_SLAPPING" name="happy slapping">
+            <pattern>
+                <token>happy</token>
+                <token>slapping</token>
+            </pattern>
+            <message>« Happy slapping » peut être considéré comme un anglicisme.</message>
+            <suggestion>vidéolynchage</suggestion>
+            <example correction="vidéolynchage"><marker>happy slapping</marker></example>
+        </rule>
+        <rule id="BLOOPER" name="blooper">
+            <pattern>
+                <token regexp="yes">bloopers?</token>
+            </pattern>
+            <message>« Blooper » peut être considéré comme un anglicisme. Employez <suggestion>gaffe de tournage</suggestion>, <suggestion>gaffe</suggestion>, <suggestion>bêtisier</suggestion> (ensemble de gaffes), <suggestion>sottisier</suggestion> (ensemble de gaffes).</message>
+            <example correction="gaffe de tournage|gaffe|bêtisier|sottisier"><marker>blooper</marker></example>
+            <example><marker>gaffe de tournage</marker></example>
+        </rule>
+        <rule id="WHITE_HAT" name="white hat">
+            <pattern>
+                <token regexp="yes">whites?</token>
+                <token regexp="yes">hats?</token>
+            </pattern>
+            <message>« White hat » peut être considéré comme un anglicisme.</message>
+            <suggestion>bidouilleur</suggestion>
+            <suggestion>mordu de l'informatique</suggestion>
+            <suggestion>fouineur</suggestion>
+            <example correction="bidouilleur|mordu de l'informatique|fouineur"><marker>white hat</marker></example>
+            <example><marker>fouineur</marker></example>
+        </rule>
+        <rule id="BLACK_HAT" name="black hat">
+            <pattern>
+                <token regexp="yes">blacks?</token>
+                <token regexp="yes">hats?</token>
+            </pattern>
+            <message>« Black hat » peut être considéré comme un anglicisme.</message>
+            <suggestion>pirate informatique</suggestion>
+            <suggestion>pirate</suggestion>
+            <suggestion>braqueur informatique</suggestion>
+            <suggestion>cyberpirate</suggestion>
+            <example correction="pirate informatique|pirate|braqueur informatique|cyberpirate"><marker>black hat</marker></example>
+            <example><marker>pirate</marker></example>
+        </rule>
+        <rule id="SERIAL_KILLER" name="serial killer">
+            <pattern>
+                <token regexp="yes">serials?</token>
+                <token regexp="yes">killers?</token>
+            </pattern>
+            <message>« Serial killer » peut être considéré comme un anglicisme.</message>
+            <suggestion>tueur en série</suggestion>
+            <example correction="tueur en série"><marker>serial killer</marker></example>
+        </rule>
+        <rule default="off" id="PODCAST" name="podcast">
+            <pattern>
+                <token regexp="yes">podcasts?</token>
+            </pattern>
+            <message>« Podcast » peut être considéré comme un anglicisme. Employez <suggestion>balado</suggestion>, <suggestion>fichier balado</suggestion>, <suggestion>émission balado</suggestion>, <suggestion>baladoémission</suggestion>, <suggestion>émission baladodiffusée</suggestion>, <suggestion>billet balado</suggestion>, <suggestion>billet baladodiffusé</suggestion>, <suggestion>baladobillet</suggestion>.</message>
+            <example correction="balado|fichier balado|émission balado|baladoémission|émission baladodiffusée|billet balado|billet baladodiffusé|baladobillet"><marker>podcast</marker></example>
+            <example><marker>balado</marker></example>
+        </rule>
+        <rule id="SURVIVAL_HORROR" name="survival horror">
+            <pattern>
+                <token regexp="yes">survivals?</token>
+                <token regexp="yes">horrors?</token>
+            </pattern>
+            <message>« Survival horror » peut être considéré comme un anglicisme.</message>
+            <suggestion>jeu d'horreur</suggestion>
+            <example correction="jeu d'horreur"><marker>survival horror</marker></example>
+        </rule>
+        <rule id="SHAREWARE" name="shareware">
+            <pattern>
+                <token regexp="yes">sharewares?</token>
+            </pattern>
+            <message>« Shareware » peut être considéré comme un anglicisme.</message>
+            <suggestion>partagiciel</suggestion>
+            <suggestion>contribuciel</suggestion>
+            <suggestion>logiciel à contribution</suggestion>
+            <example correction="partagiciel|contribuciel|logiciel à contribution"><marker>shareware</marker></example>
+            <example><marker>partagiciel</marker></example>
+        </rule>
+        <rule id="WARNINGS" name="warnings">
+            <pattern>
+                <token regexp="yes">warnings?</token>
+            </pattern>
+            <message>« Warnings » peut être considéré comme un anglicisme. Employez <suggestion>feux de détresse</suggestion> (automobile).</message>
+            <example correction="feux de détresse"><marker>warnings</marker></example>
+        </rule>
+        <rule id="PHREAKING" name="phreaking">
+            <pattern>
+                <token regexp="yes">phreakings?</token>
+            </pattern>
+            <message>« Phreaking » peut être considéré comme un anglicisme.</message>
+            <suggestion>piratage téléphonique</suggestion>
+            <suggestion>sabotage téléphonique</suggestion>
+            <example correction="piratage téléphonique|sabotage téléphonique"><marker>phreaking</marker></example>
+            <example><marker>piratage téléphonique</marker></example>
+        </rule>
+        <rule id="VAPORWARE" name="vaporware">
+            <pattern>
+                <token regexp="yes">vapou?rwares?</token>
+            </pattern>
+            <message>« Vaporware » peut être considéré comme un anglicisme.</message>
+            <suggestion>logiciel fantôme</suggestion>
+            <suggestion>fumiciel</suggestion>
+            <example correction="logiciel fantôme|fumiciel"><marker>vaporware</marker></example>
+            <example><marker>fumiciel</marker></example>
+        </rule>
+        <rule id="SMILEY" name="smiley" default="off">
+            <!-- deactivated : widespread usage -->
+            <pattern>
+                <token regexp="yes">smileys?|smilies</token>
+            </pattern>
+            <message>« Smiley » peut être considéré comme un anglicisme.</message>
+            <suggestion>binette</suggestion>
+            <suggestion>frimousse</suggestion>
+            <example correction="binette|frimousse"><marker>smiley</marker></example>
+            <example><marker>frimousse</marker></example>
+        </rule>
+        <rule id="SHOOTEM_UP" name="shoot'em up">
+            <pattern>
+                <token regexp="yes" skip="1">shoots?</token>
+                <token regexp="yes">them|em</token>
+                <token regexp="yes">ups?</token>
+            </pattern>
+            <message>« Shoot'em up » peut être considéré comme un anglicisme.</message>
+            <suggestion>jeu de tir</suggestion>
+            <example correction="jeu de tir"><marker>shoot them up</marker></example>
+        </rule>
+        <rulegroup id="BEATEM_UP" name="beat'em up">
+            <rule>
+                <pattern>
+                    <token regexp="yes" skip="1">beats?</token>
+                    <token regexp="yes">them|em</token>
+                    <token regexp="yes">ups?</token>
+                </pattern>
+                <message>« Beat'em up » peut être considéré comme un anglicisme.</message>
+                <suggestion>jeu de combat à progression</suggestion>
+                <example correction="jeu de combat à progression"><marker>beat em up</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes" skip="1">beats?'em</token>
+                    <token regexp="yes">ups?</token>
+                </pattern>
+                <message>« Beat'em up » peut être considéré comme un anglicisme.</message>
+                <suggestion>jeu de combat à progression</suggestion>
+                <example correction="jeu de combat à progression"><marker>beat'em up</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="FLAT" name="flat">
+            <pattern>
+                <token regexp="yes">flats?</token>
+            </pattern>
+            <message>« Flat » peut être considéré comme un anglicisme. Employez <suggestion>crevaison</suggestion>, <suggestion>peinture mate</suggestion>, <suggestion>plat</suggestion> (plongeon), <suggestion>crevé</suggestion>, <suggestion>dégonflé</suggestion>, <suggestion>plat</suggestion>, <suggestion>à plat</suggestion>, <suggestion>mat</suggestion> (couleur), <suggestion>éventé</suggestion> (bière, boisson gazeuse), <suggestion>sans bulles</suggestion> (bière, boisson gazeuse).</message>
+            <example correction="crevaison|peinture mate|plat|crevé|dégonflé|à plat|mat|éventé|sans bulles"><marker>flat</marker></example>
+            <example><marker>crevaison</marker></example>
+        </rule>
+        <rule id="FLAMING" name="flaming">
+            <pattern>
+                <token regexp="yes">flamm?ings?</token>
+            </pattern>
+            <message>« Flaming » peut être considéré comme un anglicisme. Employez <suggestion>flingue</suggestion> (OQLF), <suggestion>agression</suggestion>.</message>
+            <example correction="flingue|agression"><marker>flaming</marker></example>
+            <example><marker>flingue</marker></example>
+        </rule>
+        <rule id="HOAX" name="hoax">
+            <pattern>
+                <token regexp="yes">hoaxs?|hoaxes</token>
+            </pattern>
+            <message>« Hoax » peut être considéré comme un anglicisme.</message>
+            <suggestion>canular</suggestion>
+            <example correction="canular"><marker>hoax</marker></example>
+        </rule>
+        <rule id="HOME_CINEMA" name="home cinema" default="off">
+            <!-- deactivated : widespread usage -->
+            <pattern>
+                <token>home</token>
+                <token regexp="yes">cin[ée]mas?</token>
+            </pattern>
+            <message>« Home cinema » peut être considéré comme un anglicisme.</message>
+            <suggestion>cinéma à domicile</suggestion>
+            <suggestion>cinédom</suggestion>
+            <suggestion>cinéma maison</suggestion>
+            <example correction="cinéma à domicile|cinédom|cinéma maison">Le <marker>home cinema</marker> est un phénomène nouveau.</example>
+            <example>Le <marker>cinéma à domicile</marker> est un phénomène nouveau.</example>
+        </rule>
+        <rule id="EBOOK" name="ebook" default="off">
+            <!-- deactivated : widespread usage -->
+            <pattern>
+                <token regexp="yes">e-?books?</token>
+            </pattern>
+            <message>« Ebook » peut être considéré comme un anglicisme.</message>
+            <suggestion>livre électronique</suggestion>
+            <suggestion>livrel</suggestion>
+            <example correction="livre électronique|livrel">Les <marker>ebooks</marker> sont difficiles à lire.</example>
+            <example>Les <marker>livres électroniques</marker> sont difficiles à lire.</example>
+        </rule>
+        <rule id="BUG" name="bug" default="off">
+            <antipattern>
+                <token>Bugs</token>
+                <token regexp="yes">Bunny|Moran</token>
+            </antipattern>
+            <pattern>
+                <token regexp="yes">bugs?</token>
+            </pattern>
+            <message>« Bug » peut être considéré comme un anglicisme. Employez <suggestion><match no="1" regexp_match="(?i)bug" regexp_replace="bogue"/></suggestion>.</message>
+            <example correction="bogue"><marker>bug</marker></example>
+            <example>Bugs Bunny</example>
+        </rule>
+        <rule id="PODCASTING" name="podcasting" default="off">
+            <!-- deactivated : widespread usage -->
+            <pattern>
+                <token regexp="yes">podcastings?</token>
+            </pattern>
+            <message>« Podcasting » peut être considéré comme un anglicisme.</message>
+            <suggestion>diffusion pour baladeur</suggestion>
+            <suggestion>baladodiffusion</suggestion>
+            <example correction="diffusion pour baladeur|baladodiffusion"><marker>podcasting</marker></example>
+            <example><marker>baladodiffusion</marker></example>
+        </rule>
+        <rule id="SPEED_DATING" name="speed dating" default="off">
+            <!-- deactivated : widespread usage -->
+            <pattern>
+                <token>speed</token>
+                <token regexp="yes">datings?</token>
+            </pattern>
+            <message>« Speed dating » peut être considéré comme un anglicisme.</message>
+            <suggestion>séance de rencontres express</suggestion>
+            <suggestion>séances de rencontres éclair</suggestion>
+            <suggestion>rencontres express</suggestion>
+            <suggestion>rencontres éclair</suggestion>
+            <example correction="séance de rencontres express|séances de rencontres éclair|rencontres express|rencontres éclair">Il fait du <marker>speed dating</marker>.</example>
+            <example>Il fait une <marker>séance de rencontres éclair</marker>.</example>
+        </rule>
+        <rule id="FREEWARE" name="freeware">
+            <pattern>
+                <token regexp="yes">freewares?</token>
+            </pattern>
+            <message>« Freeware » peut être considéré comme un anglicisme.</message>
+            <suggestion>logiciel gratuit</suggestion>
+            <suggestion>graticiel</suggestion>
+            <suggestion>gratuiciel</suggestion>
+            <example correction="logiciel gratuit|graticiel|gratuiciel">Il fait un <marker>freeware</marker>.</example>
+            <example>Il fait un <marker>logiciel gratuit</marker>.</example>
+        </rule>
+        <rule id="ADWARE" name="adware">
+            <pattern>
+                <token regexp="yes">adwares?</token>
+            </pattern>
+            <message>« Adware » peut être considéré comme un anglicisme.</message>
+            <suggestion>logiciel publicitaire</suggestion>
+            <suggestion>annonciel</suggestion>
+            <suggestion>logiciel de publicité</suggestion>
+            <suggestion>gratuiciel publicitaire</suggestion>
+            <example correction="logiciel publicitaire|annonciel|logiciel de publicité|gratuiciel publicitaire">Il fait un <marker>adware</marker>.</example>
+            <example>Il fait un <marker>logiciel publicitaire</marker>.</example>
+        </rule>
+        <rule id="SPAMDEXING" name="spamdexing">
+            <pattern>
+                <token>spamdexing</token>
+            </pattern>
+            <message>« Spamdexing » peut être considéré comme un anglicisme.</message>
+            <suggestion>référencement abusif</suggestion>
+            <suggestion>indexation abusive</suggestion>
+            <example correction="référencement abusif|indexation abusive">Il fait du <marker>spamdexing</marker>.</example>
+            <example>Il fait du <marker>référencement abusif</marker>.</example>
+        </rule>
+        <rule id="PHISHING" name="phishing">
+            <pattern>
+                <token>phishing</token>
+            </pattern>
+            <message>« Phishing » peut être considéré comme un anglicisme.</message>
+            <suggestion>filoutage</suggestion>
+            <suggestion>hameçonnage</suggestion>
+            <example correction="filoutage|hameçonnage">Il fait du <marker>phishing</marker>.</example>
+            <example>Il fait du <marker>hameçonnage</marker>.</example>
+        </rule>
+        <rule id="SPAMMING" name="spamming">
+            <pattern>
+                <token regexp="yes">spamm?ing</token>
+            </pattern>
+            <message>« Spamming » peut être considéré comme un anglicisme.</message>
+            <suggestion>pollupostage</suggestion>
+            <suggestion>arrosage</suggestion>
+            <example correction="pollupostage|arrosage">Il fait du <marker>spamming</marker>.</example>
+            <example>Il fait du <marker>pollupostage</marker>.</example>
+        </rule>
+        <rule id="SPAM" name="spam">
+            <pattern>
+                <token regexp="yes">spams?</token>
+            </pattern>
+            <message>« Spam » peut être considéré comme un anglicisme. Employez <suggestion><match no="1" regexp_match="(?i)spam" regexp_replace="pourriel"/></suggestion>.</message>
+            <example correction="pourriel"><marker>spam</marker>.</example>
+        </rule>
+        <rule id="MAILING" name="mailing">
+            <pattern>
+                <token regexp="yes" case_sensitive="yes">maill?ings?
+                    <exception scope="previous">-</exception></token>
+            </pattern>
+            <message>« Mailing » peut être considéré comme un anglicisme.</message>
+            <suggestion><match no="1" regexp_match="maill?ing(?iu)" regexp_replace="publipostage"/></suggestion>
+            <example correction="publipostage"><marker>mailing</marker>.</example>
+        </rule>
+        <rule id="OVER_MY_DEAD_BODY" name="over my dead body">
+            <pattern>
+                <token>over</token>
+                <token regexp="yes">my|our</token>
+                <token>dead</token>
+                <token regexp="yes">bodys?|bodies</token>
+            </pattern>
+            <message>« Over my dead body » peut être considéré comme un anglicisme.</message>
+            <suggestion>il faudra me passer sur le corps</suggestion>
+            <suggestion>il faudra nous passer sur le corps</suggestion>
+            <suggestion>jamais de la vie</suggestion>
+            <suggestion>plutôt mourir</suggestion>
+            <example correction="il faudra me passer sur le corps|il faudra nous passer sur le corps|jamais de la vie|plutôt mourir"><marker>over my dead body</marker></example>
+            <example><marker>plutôt mourir</marker></example>
+        </rule>
+        <rule id="MALWARE" name="malware">
+            <pattern>
+                <token regexp="yes">malwares?</token>
+            </pattern>
+            <message>« Malware » peut être considéré comme un anglicisme.</message>
+            <suggestion>logiciel malveillant</suggestion>
+            <suggestion>maliciel</suggestion>
+            <suggestion>programme malveillant</suggestion>
+            <suggestion>antiprogramme</suggestion>
+            <example correction="logiciel malveillant|maliciel|programme malveillant|antiprogramme"><marker>malware</marker></example>
+            <example><marker>logiciel malveillant</marker></example>
+        </rule>
+        <rule id="NAGWARE" name="nagware">
+            <pattern>
+                <token regexp="yes">nagwares?</token>
+            </pattern>
+            <message>« Nagware » peut être considéré comme un anglicisme.</message>
+            <suggestion>logiciel harcelant</suggestion>
+            <suggestion>agaciel</suggestion>
+            <suggestion>harceliciel</suggestion>
+            <example correction="logiciel harcelant|agaciel|harceliciel"><marker>nagware</marker></example>
+            <example><marker>logiciel harcelant</marker></example>
+        </rule>
+        <rule id="E-COMMERCE" name="e-commerce" default="off">
+            <pattern>
+                <token regexp="yes">e-commerces?</token>
+            </pattern>
+            <message>« E-commerce » est considéré comme un anglicisme. En voici des équivalents :</message>
+            <suggestion>commerce électronique</suggestion>
+            <suggestion>commerce en ligne</suggestion>
+            <suggestion>commerce virtuel</suggestion>
+            <suggestion>commerce Internet</suggestion>
+            <suggestion>commerce sur Internet</suggestion>
+            <suggestion>cybercommerce</suggestion>
+            <example correction="commerce électronique|commerce en ligne|commerce virtuel|commerce Internet|commerce sur Internet|cybercommerce"><marker>e-commerce</marker></example>
+            <example><marker>commerce électronique</marker></example>
+        </rule>
+        <rule id="MERCHANDISING" name="merchandising">
+            <pattern>
+                <token regexp="yes">merchandisings?</token>
+            </pattern>
+            <message>« Merchandising » peut être considéré comme un anglicisme.</message>
+            <suggestion>marchandisage</suggestion>
+            <example correction="marchandisage"><marker>merchandising</marker></example>
+        </rule>
+        <rule default="off" id="SEXY" name="sexy">
+            <pattern>
+                <token regexp="yes">sexys?|sexies</token>
+            </pattern>
+            <message>« Sexy » peut être considéré comme un anglicisme.</message>
+            <suggestion>attrayant</suggestion>
+            <suggestion>séduisant</suggestion>
+            <suggestion>aguichant</suggestion>
+            <suggestion>suggestif</suggestion>
+            <suggestion>désirable</suggestion>
+            <suggestion>érotique</suggestion>
+            <example correction="attrayant|séduisant|aguichant|suggestif|désirable|érotique"><marker>sexy</marker></example>
+            <example><marker>attrayant</marker></example>
+        </rule>
+        <rule default="off" id="SPONSOR" name="sponsor">
+            <pattern>
+                <token regexp="yes">sponsors?</token>
+            </pattern>
+            <message>« Sponsor » peut être considéré comme un anglicisme.</message>
+            <suggestion>commanditaire</suggestion>
+            <suggestion>parrain</suggestion>
+            <suggestion>parraineur</suggestion>
+            <suggestion>mécène</suggestion>
+            <suggestion>bailleur de fonds</suggestion>
+            <example correction="commanditaire|parrain|parraineur|mécène|bailleur de fonds"><marker>sponsor</marker></example>
+            <example><marker>bailleur de fonds</marker></example>
+        </rule>
+        <rule id="SOFTWARE" name="software">
+            <pattern>
+                <token regexp="yes">softwares?</token>
+            </pattern>
+            <message>« Software » peut être considéré comme un anglicisme.</message>
+            <suggestion>logiciel</suggestion>
+            <example correction="logiciel"><marker>software</marker></example>
+        </rule>
+        <rule id="CALIPER" name="caliper">
+            <pattern>
+                <token regexp="yes">calipers?</token>
+            </pattern>
+            <message>« Caliper » peut être considéré comme un anglicisme.</message>
+            <suggestion>étrier de frein</suggestion>
+            <example correction="étrier de frein"><marker>caliper</marker></example>
+        </rule>
+        <rule id="LAST_CALL" name="last call">
+            <pattern>
+                <token>last</token>
+                <token regexp="yes">calls?</token>
+            </pattern>
+            <message>« Last call » peut être considéré comme un anglicisme.</message>
+            <suggestion>dernière commande</suggestion>
+            <suggestion>dernier service</suggestion>
+            <example correction="dernière commande|dernier service"><marker>last call</marker></example>
+            <example><marker>dernière commande</marker></example>
+        </rule>
+        <rule id="NAPKIN" name="napkin">
+            <pattern>
+                <token>napkin</token>
+            </pattern>
+            <message>« Napkin » peut être considéré comme un anglicisme.</message>
+            <suggestion>serviette de table</suggestion>
+            <example correction="serviette de table"><marker>napkin</marker>.</example>
+        </rule>
+        <rule id="HELLO" name="hello" tags="picky">
+            <antipattern>
+                <token regexp="yes" skip="-1">hellos?</token>
+                <token inflected="yes" regexp="yes">&textes;</token>
+            </antipattern>
+            <antipattern>
+                <token regexp="yes" skip="-1">hellos?</token>
+                <token regexp="yes">[12]\d\d\d</token>
+            </antipattern>
+            <pattern>
+                <token postag="SENT_START"/>
+                <marker>
+                    <token regexp="yes">hellos?
+                        <exception scope="next" regexp="yes">yes|neighbor|everybody|I|it|world|star|Kitty|(?-i)Bank|[=]|pro|at|my|for|of|by|business|team</exception></token>
+                </marker>
+            </pattern>
+            <message>Cette salutation anglaise peut être remplacée par un synonyme français afin d'apporter de la fluidité à votre texte.</message>
+            <suggestion>salut</suggestion>
+            <suggestion>coucou</suggestion>
+            <suggestion>bonjour</suggestion>
+            <suggestion>allô</suggestion>
+            <example correction="Salut|Coucou|Bonjour|Allô"><marker>Hello</marker>.</example>
+            <example><marker>allô</marker>.</example>
+            <example>En anglais Hello=bonjour.</example>
+            <example>Ma fille veut le nouveau Hello Kitty pour son anniversaire.</example>
+        </rule>
+        <rule id="HOOD" name="hood">
+            <pattern>
+                <token regexp="yes">hoods?</token>
+            </pattern>
+            <message>« Hood » peut être considéré comme un anglicisme. Employez <suggestion>capot</suggestion> (automobile), ou <suggestion>quartier</suggestion> (argot).</message>
+            <example correction="capot|quartier"><marker>hood</marker>.</example>
+            <example correction="capot|quartier">Il vient de mon <marker>hood</marker>.</example>
+        </rule>
+        <rule id="HOLD" name="hold">
+            <pattern>
+                <token regexp="yes">holds?</token>
+            </pattern>
+            <message>« Hold » peut être considéré comme un anglicisme. Employez <suggestion>en attente</suggestion> (téléphone), <suggestion>en garde</suggestion> (téléphone).</message>
+            <example correction="en attente|en garde"><marker>hold</marker>.</example>
+            <example><marker>en attente</marker>.</example>
+        </rule>
+        <rule id="HOLDSTER" name="holdster">
+            <pattern>
+                <token regexp="yes">holdsters?</token>
+            </pattern>
+            <message>« Holdster » peut être considéré comme un anglicisme.</message>
+            <suggestion>étui</suggestion>
+            <example correction="étui"><marker>holdster</marker>.</example>
+        </rule>
+        <rule id="NAPHTA" name="naphta">
+            <pattern>
+                <token>naphta</token>
+            </pattern>
+            <message>« Naphta » peut être considéré comme un anglicisme.</message>
+            <suggestion>naphte</suggestion>
+            <example correction="naphte"><marker>naphta</marker>.</example>
+        </rule>
+        <rule id="NO_VACANCY" name="no vacancy">
+            <pattern>
+                <token>no</token>
+                <token>vacancy</token>
+            </pattern>
+            <message>« No vacancy » peut être considéré comme un anglicisme. Employez <suggestion>complet</suggestion> (affiche d'hôtel).</message>
+            <example correction="complet"><marker>no vacancy</marker>.</example>
+        </rule>
+        <rule id="NO_FAULT" name="no fault">
+            <pattern>
+                <token>no</token>
+                <token>fault</token>
+            </pattern>
+            <message>« No fault » peut être considéré comme un anglicisme.</message>
+            <suggestion>assurance inconditionnelle</suggestion>
+            <suggestion>indemnisation sans égard à la responsabilité</suggestion>
+            <example correction="assurance inconditionnelle|indemnisation sans égard à la responsabilité"><marker>no fault</marker>.</example>
+            <example><marker>assurance inconditionnelle</marker>.</example>
+        </rule>
+        <rule id="WHISHFUL_THINKING" name="wishful thinking">
+            <pattern>
+                <token>wishful</token>
+                <token>thinking</token>
+            </pattern>
+            <message>« Wishful thinking » peut être considéré comme un anglicisme.</message>
+            <suggestion>prendre ses désirs pour des réalités</suggestion>
+            <example correction="prendre ses désirs pour des réalités"><marker>wishful thinking</marker>.</example>
+        </rule>
+        <rule id="STEERING" name="steering">
+            <pattern>
+                <token regexp="yes">steerings?</token>
+            </pattern>
+            <message>« Steering » peut être considéré comme un anglicisme.(steering wheel).</message>
+            <suggestion>volant</suggestion>
+            <example correction="volant"><marker>steering</marker>.</example>
+        </rule>
+        <rule id="STANDING_OVATION" name="standing ovation">
+            <pattern>
+                <token>standing</token>
+                <token regexp="yes">ovations?</token>
+            </pattern>
+            <message>« Standing ovation » peut être considéré comme un anglicisme.</message>
+            <suggestion>ovation</suggestion>
+            <example correction="ovation"><marker>standing ovation</marker>.</example>
+        </rule>
+        <rulegroup id="DEAL" name="deal">
+            <antipattern>
+                <token regexp="yes">deals?</token>
+                <token regexp="yes">for|of|and|"|\?</token>
+            </antipattern>
+            <rule>
+                <pattern>
+                    <token regexp="yes" case_sensitive="yes">deals?
+                        <exception scope="previous" postag="D m s"/>
+                        <exception scope="previous" regexp="yes">ce|du|new|-|you|no|great|a|real|and|«</exception></token>
+                </pattern>
+                <message>« Deal » peut être considéré comme un anglicisme.</message>
+                <suggestion><match no="3" regexp_match="deal(?iu)" regexp_replace="marché" case_conversion="preserve"/></suggestion>
+                <suggestion><match no="3" regexp_match="deal(?iu)" regexp_replace="affaire" case_conversion="preserve"/></suggestion>
+                <suggestion><match no="3" regexp_match="deal(?iu)" regexp_replace="accord" case_conversion="preserve"/></suggestion>
+                <suggestion><match no="3" regexp_match="deal(?iu)" regexp_replace="offre" case_conversion="preserve"/></suggestion>
+                <example correction="marché|affaire|accord|offre"><marker>deal</marker></example>
+                <example><marker>marché</marker></example>
+                <example>Le New Deal mis en place par le président Franklin D. Roosevelt.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>du</token>
+                    <token>deal</token>
+                </pattern>
+                <message>« Deal » peut être considéré comme un anglicisme.</message>
+                <suggestion>du marché</suggestion>
+                <suggestion>de l'affaire</suggestion>
+                <suggestion>de l'accord</suggestion>
+                <suggestion>de l'offre</suggestion>
+                <example correction="du marché|de l'affaire|de l'accord|de l'offre"><marker>du deal</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="D m s">
+                        <exception regexp="yes">[cl]e</exception></token>
+                    <token>deal</token>
+                </pattern>
+                <message>« Deal » peut être considéré comme un anglicisme.</message>
+                <suggestion>\1 marché</suggestion>
+                <suggestion><match no="1" postag="(D) (m) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> affaire</suggestion>
+                <suggestion>\1 accord</suggestion>
+                <suggestion><match no="1" postag="(D) (m) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> offre</suggestion>
+                <example correction="un marché|une affaire|un accord|une offre"><marker>un deal</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>ce</token>
+                    <token>deal</token>
+                </pattern>
+                <message>« Deal » peut être considéré comme un anglicisme.</message>
+                <suggestion>\1 <match no="2" regexp_match="deal" regexp_replace="marché" case_conversion="preserve"/></suggestion>
+                <suggestion>cette <match no="2" regexp_match="deal" regexp_replace="affaire" case_conversion="preserve"/></suggestion>
+                <suggestion>cet <match no="2" regexp_match="deal" regexp_replace="accord" case_conversion="preserve"/></suggestion>
+                <suggestion>cette <match no="2" regexp_match="deal" regexp_replace="offre" case_conversion="preserve"/></suggestion>
+                <example correction="ce marché|cette affaire|cet accord|cette offre"><marker>ce deal</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>le</token>
+                    <token case_sensitive="yes">deal</token>
+                </pattern>
+                <message>« Deal » peut être considéré comme un anglicisme.</message>
+                <suggestion>\1 <match no="2" regexp_match="deal" regexp_replace="marché" case_conversion="preserve"/></suggestion>
+                <suggestion>l'<match no="2" regexp_match="deal" regexp_replace="affaire" case_conversion="preserve"/></suggestion>
+                <suggestion>l'<match no="2" regexp_match="deal" regexp_replace="accord" case_conversion="preserve"/></suggestion>
+                <suggestion>l'<match no="2" regexp_match="deal" regexp_replace="offre" case_conversion="preserve"/></suggestion>
+                <example correction="le marché|l'affaire|l'accord|l'offre"><marker>le deal</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="STAMINA" name="stamina">
+            <pattern>
+                <token>stamina</token>
+            </pattern>
+            <message>« Stamina » peut être considéré comme un anglicisme.</message>
+            <suggestion>endurance</suggestion>
+            <suggestion>résistance</suggestion>
+            <example correction="endurance|résistance"><marker>stamina</marker>.</example>
+            <example><marker>résistance</marker>.</example>
+        </rule>
+        <rulegroup id="DEADLINE" name="deadline">
+            <rule>
+                <pattern>
+                    <token regexp="yes">dead-?lines?</token>
+                </pattern>
+                <message>« Deadline » peut être considéré comme un anglicisme.</message>
+                <suggestion>heure de tombée</suggestion>
+                <suggestion>date limite</suggestion>
+                <suggestion>heure limite</suggestion>
+                <suggestion>échéance</suggestion>
+                <suggestion>date butoir</suggestion>
+                <example correction="heure de tombée|date limite|heure limite|échéance|date butoir"><marker>deadline</marker></example>
+                <example><marker>échéance</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>dead</token>
+                    <token regexp="yes">lines?</token>
+                </pattern>
+                <message>« Deadline » peut être considéré comme un anglicisme.</message>
+                <suggestion>heure de tombée</suggestion>
+                <suggestion>date limite</suggestion>
+                <suggestion>échéance</suggestion>
+                <example correction="heure de tombée|date limite|échéance"><marker>dead line</marker></example>
+                <example><marker>échéance</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="SUNLIGHT" name="sunlight">
+            <rule>
+                <pattern>
+                    <token regexp="yes">sunlights?</token>
+                </pattern>
+                <message>« Sunlight » peut être considéré comme un anglicisme.</message>
+                <suggestion>projecteur</suggestion>
+                <example correction="projecteur"><marker>sunlight</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>sun</token>
+                    <token regexp="yes">lights?</token>
+                </pattern>
+                <message>« Sunlight » peut être considéré comme un anglicisme.</message>
+                <suggestion>projecteur</suggestion>
+                <example correction="projecteur"><marker>sun light</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="SPRINGBOARD" name="springboard">
+            <rule>
+                <pattern>
+                    <token regexp="yes">spring-?boards?</token>
+                </pattern>
+                <message>« Springboard » peut être considéré comme un anglicisme.</message>
+                <suggestion>tremplin</suggestion>
+                <example correction="tremplin"><marker>springboard</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>spring</token>
+                    <token regexp="yes">boards?</token>
+                </pattern>
+                <message>« Springboard » peut être considéré comme un anglicisme.</message>
+                <suggestion>tremplin</suggestion>
+                <example correction="tremplin"><marker>spring board</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="DROP-OUT" name="drop-out">
+            <rule>
+                <pattern>
+                    <token regexp="yes">dropouts?</token>
+                </pattern>
+                <message>« Drop-out » peut être considéré comme un anglicisme.</message>
+                <suggestion>marginal</suggestion>
+                <suggestion>élève en rupture scolaire</suggestion>
+                <example correction="marginal|élève en rupture scolaire"><marker>dropout</marker></example>
+                <example><marker>marginal</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">drops?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">outs?</token>
+                </pattern>
+                <message>« Drop-out » peut être considéré comme un anglicisme.</message>
+                <suggestion>marginal</suggestion>
+                <suggestion>élève en rupture scolaire</suggestion>
+                <example correction="marginal|élève en rupture scolaire"><marker>drop out</marker></example>
+                <example><marker>marginal</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="STAKEHOLDER" name="stakeholder">
+            <rule>
+                <pattern>
+                    <token regexp="yes">stake-?holders?</token>
+                </pattern>
+                <message>« Stakeholder » peut être considéré comme un anglicisme. Employez <suggestion>décideur</suggestion>, <suggestion>intéressé</suggestion>, <suggestion>partie prenante</suggestion>, <suggestion>dépositaire d'enjeux</suggestion> (common law).</message>
+                <example correction="décideur|intéressé|partie prenante|dépositaire d'enjeux"><marker>stakeholder</marker></example>
+                <example><marker>décideur</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>stake</token>
+                    <token regexp="yes">holders?</token>
+                </pattern>
+                <message>« Stakeholder » peut être considéré comme un anglicisme. Employez <suggestion>décideur</suggestion>, <suggestion>intéressé</suggestion>, <suggestion>partie prenante</suggestion>, <suggestion>dépositaire d'enjeux</suggestion> (common law).</message>
+                <example correction="décideur|intéressé|partie prenante|dépositaire d'enjeux"><marker>stake holder</marker></example>
+                <example><marker>décideur</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="STAINLESS" name="stainless (steel)">
+            <pattern>
+                <token>stainless</token>
+            </pattern>
+            <message>« Stainless (steel) » peut être considéré comme un anglicisme.</message>
+            <suggestion>acier inoxydable</suggestion>
+            <suggestion>inox</suggestion>
+            <example correction="acier inoxydable|inox"><marker>stainless</marker>.</example>
+            <example><marker>acier inoxydable</marker>.</example>
+        </rule>
+        <rule id="SQUEEZE_BOTTLE" name="squeeze bottle">
+            <pattern>
+                <token>squeeze</token>
+                <token regexp="yes">bottles?</token>
+            </pattern>
+            <message>« Squeeze bottle » peut être considéré comme un anglicisme.</message>
+            <suggestion>contenant souple</suggestion>
+            <example correction="contenant souple"><marker>squeeze bottle</marker>.</example>
+        </rule>
+        <rule id="SWAMP" name="swamp">
+            <pattern>
+                <token regexp="yes">swamps?</token>
+            </pattern>
+            <message>« Swamp » peut être considéré comme un anglicisme.</message>
+            <suggestion>marais</suggestion>
+            <suggestion>marécage</suggestion>
+            <example correction="marais|marécage"><marker>swamp</marker>.</example>
+            <example><marker>marécage</marker>.</example>
+        </rule>
+        <rule id="ZIPPER" name="zipper">
+            <pattern>
+                <token regexp="yes">zippeu?rs?</token>
+            </pattern>
+            <message>« Zipper » peut être considéré comme un anglicisme.</message>
+            <suggestion>fermeture à glissière</suggestion>
+            <suggestion>glissière</suggestion>
+            <example correction="fermeture à glissière|glissière"><marker>zipper</marker>.</example>
+            <example><marker>fermeture à glissière</marker>.</example>
+        </rule>
+        <rule id="BUMPER" name="bumper">
+            <pattern>
+                <token regexp="yes">bumpers?</token>
+            </pattern>
+            <message>« Bumper » peut être considéré comme un anglicisme.</message>
+            <suggestion>pare-choc</suggestion>
+            <example correction="pare-choc"><marker>bumper</marker>.</example>
+        </rule>
+        <rule id="BANSHEE" name="banshee">
+            <pattern>
+                <token regexp="yes">bansh[ie]es?</token>
+            </pattern>
+            <message>« Banshee » peut être considéré comme un anglicisme.</message>
+            <suggestion>dame blanche</suggestion>
+            <example correction="dame blanche"><marker>banshee</marker>.</example>
+        </rule>
+        <rule id="FLASHER" name="flasher">
+            <pattern>
+                <token regexp="yes">flashers?</token>
+            </pattern>
+            <message>« Flasher » peut être considéré comme un anglicisme. Employez <suggestion>clignotant</suggestion>, <suggestion>feux de détresse</suggestion> (emergency flashers).</message>
+            <example correction="clignotant|feux de détresse"><marker>flasher</marker>.</example>
+            <example><marker>clignotant</marker>.</example>
+        </rule>
+        <rule id="FREAK" name="freak">
+            <pattern>
+                <token regexp="yes">freaks?</token>
+            </pattern>
+            <message>« Freak » peut être considéré comme un anglicisme.</message>
+            <suggestion>hippie</suggestion>
+            <suggestion>marginal</suggestion>
+            <suggestion>drogué</suggestion>
+            <example correction="hippie|marginal|drogué"><marker>freak</marker>.</example>
+            <example><marker>drogué</marker>.</example>
+        </rule>
+        <rule id="SCAB" name="scab">
+            <pattern>
+                <token regexp="yes">scabs?</token>
+            </pattern>
+            <message>« Scab » peut être considéré comme un anglicisme. Employez <suggestion>briseur de grève</suggestion>, <suggestion>jaune</suggestion> (péjoratif).</message>
+            <example correction="briseur de grève|jaune"><marker>scab</marker>.</example>
+            <example><marker>briseur de grève</marker>.</example>
+        </rule>
+        <rulegroup id="CHAINSAW" name="chainsaw">
+            <rule>
+                <pattern>
+                    <token regexp="yes">chain-?saws?</token>
+                </pattern>
+                <message>« Chainsaw » peut être considéré comme un anglicisme.</message>
+                <suggestion>tronçonneuse</suggestion>
+                <suggestion>scie à chaîne</suggestion>
+                <example correction="tronçonneuse|scie à chaîne"><marker>chainsaw</marker></example>
+                <example><marker>tronçonneuse</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>chain</token>
+                    <token regexp="yes">saws?</token>
+                </pattern>
+                <message>« Chainsaw » peut être considéré comme un anglicisme.</message>
+                <suggestion>tronçonneuse</suggestion>
+                <suggestion>scie à chaîne</suggestion>
+                <example correction="tronçonneuse|scie à chaîne"><marker>chain saw</marker></example>
+                <example><marker>tronçonneuse</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="OVERTIME" name="overtime">
+            <rule>
+                <pattern>
+                    <token regexp="yes">over-?times?</token>
+                </pattern>
+                <message>« Overtime » peut être considéré comme un anglicisme.</message>
+                <suggestion>heures supplémentaires</suggestion>
+                <example correction="heures supplémentaires"><marker>overtime</marker>.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>over</token>
+                    <token regexp="yes">times?</token>
+                </pattern>
+                <message>« Overtime » peut être considéré comme un anglicisme.</message>
+                <suggestion>heures supplémentaires</suggestion>
+                <example correction="heures supplémentaires"><marker>over time</marker>.</example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="OVERSIZE" name="oversize(d)">
+            <rule>
+                <pattern>
+                    <token regexp="yes">over-?sized?s?</token>
+                </pattern>
+                <message>« Oversize(d) » peut être considéré comme un anglicisme.</message>
+                <suggestion>grand format</suggestion>
+                <suggestion>très grand format</suggestion>
+                <example correction="grand format|très grand format"><marker>oversize</marker>.</example>
+                <example><marker>grand format</marker>.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>over</token>
+                    <token regexp="yes">size|sized|sizeds|sizes</token>
+                </pattern>
+                <message>« Oversize(d) » peut être considéré comme un anglicisme.</message>
+                <suggestion>grand format</suggestion>
+                <suggestion>très grand format</suggestion>
+                <example correction="grand format|très grand format"><marker>over size</marker>.</example>
+                <example><marker>grand format</marker>.</example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="ONE-MAN_SHOW" name="one-(wo)man show" default="off">
+            <rule>
+                <pattern>
+                    <token>one</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">man|woman</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">shows?</token>
+                </pattern>
+                <message>« One-man show » peut être considéré comme un anglicisme.</message>
+                <suggestion>spectacle solo</suggestion>
+                <suggestion>seul en scène</suggestion>
+                <example correction="spectacle solo|seul en scène"><marker>one man show</marker></example>
+                <example correction="spectacle solo|seul en scène"><marker>one-man show</marker></example>
+                <example><marker>solo</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">one-(man|woman)-show</token>
+                </pattern>
+                <message>« One-man show » peut être considéré comme un anglicisme.</message>
+                <suggestion>spectacle solo</suggestion>
+                <suggestion>seul en scène</suggestion>
+                <example correction="spectacle solo|seul en scène"><marker>one-man-show</marker></example>
+                <example><marker>solo</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="OFFSHORE" name="offshore" default="off">
+            <rule>
+                <pattern>
+                    <token regexp="yes">off[-‑‐]?shores?</token>
+                </pattern>
+                <message>« Offshore » peut être considéré comme un anglicisme.</message>
+                <suggestion>en mer</suggestion>
+                <suggestion>au large</suggestion>
+                <suggestion>en haute mer</suggestion>
+                <suggestion>hauturier</suggestion>
+                <suggestion>pélagique</suggestion>
+                <example correction="en mer|au large|en haute mer|hauturier|pélagique"><marker>offshore</marker></example>
+                <example><marker>en mer</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>off</token>
+                    <token regexp="yes">shores?</token>
+                </pattern>
+                <message>« Offshore » peut être considéré comme un anglicisme.</message>
+                <suggestion>en mer</suggestion>
+                <suggestion>au large</suggestion>
+                <suggestion>en haute mer</suggestion>
+                <suggestion>hauturier</suggestion>
+                <suggestion>pélagique</suggestion>
+                <example correction="en mer|au large|en haute mer|hauturier|pélagique"><marker>off shore</marker></example>
+                <example><marker>en mer</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="BOLT" name="bolt" default="off">
+            <antipattern>
+                <token regexp="yes">(?-i)Alex|Brice|Usain|Robert|von</token>
+                <token>Bolt</token>
+            </antipattern>
+            <pattern>
+                <token regexp="yes">bolts?</token>
+            </pattern>
+            <message>« Bolt » peut être considéré comme un anglicisme.</message>
+            <suggestion>boulon</suggestion>
+            <example correction="boulon"><marker>bolt</marker>.</example>
+            <example>Usain Bolt est un athlète jamaïcain.</example>
+        </rule>
+        <rule id="PAGEANT" name="pageant">
+            <pattern>
+                <token regexp="yes">pageants?</token>
+            </pattern>
+            <message>« Pageant » peut être considéré comme un anglicisme.</message>
+            <suggestion>spectacle historique</suggestion>
+            <suggestion>reconstitution historique</suggestion>
+            <suggestion>spectacle fastueux</suggestion>
+            <example correction="spectacle historique|reconstitution historique|spectacle fastueux"><marker>pageant</marker>.</example>
+            <example><marker>spectacle fastueux</marker>.</example>
+        </rule>
+        <rule id="BICYCLE" name="bicycle">
+            <pattern>
+                <token regexp="yes">b[iy]cycles?</token>
+            </pattern>
+            <message>« Bicycle » peut être considéré comme un anglicisme.</message>
+            <suggestion>vélo</suggestion>
+            <suggestion>bicyclette</suggestion>
+            <suggestion>moto</suggestion>
+            <example correction="vélo|bicyclette|moto"><marker>bicycle</marker>.</example>
+            <example><marker>vélo</marker>.</example>
+        </rule>
+        <rulegroup id="BEAT" name="beat">
+            <rule>
+                <pattern>
+                    <or>
+                        <token>du</token>
+                        <token postag="[DJ] . s" postag_regexp="yes"/>
+                    </or>
+                    <marker>
+                        <token case_sensitive="yes">beat
+                            <exception scope="previous">afro</exception>
+                            <exception scope="next" regexp="yes">them|-</exception></token>
+                    </marker>
+                </pattern>
+                <message>« Beat » peut être considéré comme un anglicisme.</message>
+                <suggestion>rythme</suggestion>
+                <suggestion>tempo</suggestion>
+                <suggestion>son</suggestion>
+                <example correction="rythme|tempo|son">Il parle du <marker>beat</marker>.</example>
+                <example>Il parle de <marker>rythme</marker>.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">[mts]es|[vn]os|leurs|des?|les</token>
+                    <marker>
+                        <token case_sensitive="yes">beats
+                            <exception scope="next" regexp="yes">funky|dance|-</exception></token>
+                    </marker>
+                </pattern>
+                <message>« Beat » peut être considéré comme un anglicisme.</message>
+                <suggestion>rythmes</suggestion>
+                <suggestion>tempos</suggestion>
+                <suggestion>sons</suggestion>
+                <example correction="rythmes|tempos|sons">Il parle des <marker>beats</marker>.</example>
+                <example>Il parle de <marker>rythme</marker>.</example>
+            </rule>
+        </rulegroup>
+        <rule id="BOXING_DAY" name="Boxing Day">
+            <pattern>
+                <token>Boxing</token>
+                <token>Day</token>
+            </pattern>
+            <message>« Boxing Day » peut être considéré comme un anglicisme.</message>
+            <suggestion>les soldes d'après Noël</suggestion>
+            <suggestion>l'Après-Noël</suggestion>
+            <example correction="Les soldes d'après Noël|L'Après-Noël">Il parle du <marker>Boxing Day</marker>.</example>
+            <example>Il parle <marker>des soldes d'après Noël</marker>.</example>
+        </rule>
+        <rule id="VENEER" name="veneer">
+            <pattern>
+                <token regexp="yes">veneers?</token>
+            </pattern>
+            <message>« Veneer » peut être considéré comme un anglicisme.</message>
+            <suggestion>contreplaqué</suggestion>
+            <example correction="contreplaqué"><marker>veneer</marker></example>
+        </rule>
+        <rulegroup id="CHECKLIST" name="checklist">
+            <rule>
+                <pattern>
+                    <token regexp="yes">check[-‑‐]?lists?</token>
+                </pattern>
+                <message>« Checklist » peut être considéré comme un anglicisme.</message>
+                <suggestion>liste de contrôle</suggestion>
+                <suggestion>liste de vérification</suggestion>
+                <suggestion>aide-mémoire</suggestion>
+                <example correction="liste de contrôle|liste de vérification|aide-mémoire"><marker>checklist</marker></example>
+                <example><marker>liste de contrôle</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">checks?</token>
+                    <token regexp="yes">lists?</token>
+                </pattern>
+                <message>« Checklist » peut être considéré comme un anglicisme.</message>
+                <suggestion>liste de contrôle</suggestion>
+                <suggestion>liste de vérification</suggestion>
+                <suggestion>aide-mémoire</suggestion>
+                <example correction="liste de contrôle|liste de vérification|aide-mémoire"><marker>check list</marker></example>
+                <example><marker>liste de contrôle</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="TRAVELERS_CHEQUE" name="traveler's cheque">
+            <pattern>
+                <token regexp="yes">traveller'?s?'?</token>
+                <token regexp="yes">ch[èe]ques?|checks?</token>
+            </pattern>
+            <message>« Traveller's cheque » peut être considéré comme un anglicisme.</message>
+            <suggestion>chèque de voyage</suggestion>
+            <example correction="chèque de voyage"><marker>traveller's cheque</marker></example>
+        </rule>
+        <rule id="GLAMOUR" name="glamour" default="off">
+            <pattern>
+                <token regexp="yes">glamou?rs?</token>
+            </pattern>
+            <message>« Glamour » peut être considéré comme un anglicisme.</message>
+            <suggestion>séduction</suggestion>
+            <suggestion>prestige</suggestion>
+            <suggestion>beauté sensuelle et luxueuse</suggestion>
+            <example correction="séduction|prestige|beauté sensuelle et luxueuse"><marker>glamour</marker></example>
+            <example><marker>prestige</marker></example>
+        </rule>
+        <rulegroup id="EG" name="e.g.">
+            <antipattern>
+                <token>E</token>
+                <token>.</token>
+                <token>G</token>
+                <token>.</token>
+                <token regexp="yes" spacebefore="no">[A-Z]</token>
+            </antipattern>
+            <antipattern>
+                <token>.</token>
+                <token spacebefore="no">E</token>
+                <token>.</token>
+                <token>G</token>
+                <token>.</token>
+            </antipattern>
+            <rule>
+                <pattern>
+                    <token>e</token>
+                    <token>.</token>
+                    <token>g</token>
+                    <token>.</token>
+                </pattern>
+                <message>« e.g. » peut être considéré comme un anglicisme.</message>
+                <suggestion>par exemple</suggestion>
+                <suggestion>p. ex.</suggestion>
+                <example correction="par exemple|p. ex."><marker>e.g.</marker></example>
+                <example><marker>p. ex.</marker></example>
+            </rule>
+            <rule>
+                <antipattern>
+                    <token regexp="yes">(?-i)EG</token>
+                </antipattern>
+                <pattern>
+                    <token>eg</token>
+                </pattern>
+                <message>« e.g. » peut être considéré comme un anglicisme.</message>
+                <suggestion>par exemple</suggestion>
+                <suggestion>p. ex.</suggestion>
+                <example correction="par exemple|p. ex."><marker>eg</marker></example>
+                <example><marker>p. ex.</marker></example>
+            </rule>
+        </rulegroup>
+        <!-- doesn't work due to sentence splitting
+        <rulegroup id="PS" name="P.S.">
+            <rule>
+                <pattern>
+                    <token>P</token>
+                    <token>.</token>
+                    <token>S</token>
+                    <token>.</token>
+                </pattern>
+                <message>« P.S. » peut être considéré comme un anglicisme.</message>
+                <suggestion>P.-S.</suggestion>
+                <example correction="P.-S."><marker>P.S.</marker></example>
+            </rule>
+        </rulegroup>
+        -->
+        <rulegroup id="VG" name="v.g.">
+            <antipattern>
+                <token>V</token>
+                <token>.</token>
+                <token>G</token>
+                <token>.</token>
+                <token regexp="yes" spacebefore="no">[A-Z]</token>
+            </antipattern>
+            <antipattern>
+                <token>.</token>
+                <token spacebefore="no">V</token>
+                <token>.</token>
+                <token>G</token>
+                <token>.</token>
+            </antipattern>
+            <rule>
+                <pattern>
+                    <token>v</token>
+                    <token>.</token>
+                    <token>g</token>
+                    <token>.</token>
+                </pattern>
+                <message>« v.g. » peut être considéré comme un anglicisme.</message>
+                <suggestion>par exemple</suggestion>
+                <suggestion>p. ex.</suggestion>
+                <example correction="par exemple|p. ex."><marker>v.g.</marker></example>
+                <example><marker>p. ex.</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>vg
+                        <exception scope="previous">sony</exception></token>
+                </pattern>
+                <message>« v.g. » peut être considéré comme un anglicisme.</message>
+                <suggestion>par exemple</suggestion>
+                <suggestion>p. ex.</suggestion>
+                <example correction="par exemple|p. ex."><marker>vg</marker></example>
+                <example><marker>p. ex.</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="IE" name="i.e.">
+            <antipattern>
+                <token>I</token>
+                <token>.</token>
+                <token>E</token>
+                <token>.</token>
+                <token regexp="yes" spacebefore="no">[A-Z]</token>
+            </antipattern>
+            <antipattern>
+                <token>.</token>
+                <token spacebefore="no">I</token>
+                <token>.</token>
+                <token>E</token>
+                <token>.</token>
+            </antipattern>
+            <antipattern>
+                <token spacebefore="no">'</token>
+                <token>ie</token>
+            </antipattern>
+            <rule>
+                <pattern>
+                    <token>i</token>
+                    <token>.</token>
+                    <token>e</token>
+                    <token>.</token>
+                </pattern>
+                <message>L'abréviation 'i.e.' peut être considéré comme un anglicisme.</message>
+                <suggestion>c'est-à-dire</suggestion>
+                <suggestion>c.-à-d.</suggestion>
+                <example correction="c'est-à-dire|c.-à-d."><marker>i.e.</marker></example>
+                <example><marker>c-à-d.</marker></example>
+                <example>Pascal Van Yperseel (1957-....), avec le G. I.E.C., Prix Nobel de la Paix 2004.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>ie
+                        <exception scope="previous">-</exception></token>
+                </pattern>
+                <message>L'abréviation 'i.e.' peut être considéré comme un anglicisme.</message>
+                <suggestion>c'est-à-dire</suggestion>
+                <suggestion>c.-à-d.</suggestion>
+                <example correction="c'est-à-dire|c.-à-d."><marker>ie</marker></example>
+                <example><marker>c-à-d.</marker></example>
+                <example>Foi Baha' ie</example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="SELF-CONTROL" name="self-control">
+            <rule>
+                <pattern>
+                    <token regexp="yes">self[-‑‐]control</token>
+                </pattern>
+                <message>« Self-control » peut être considéré comme un anglicisme.</message>
+                <suggestion>maîtrise de soi</suggestion>
+                <example correction="maîtrise de soi"><marker>self-control</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>self</token>
+                    <token>control</token>
+                </pattern>
+                <message>« Self-control » peut être considéré comme un anglicisme.</message>
+                <suggestion>maîtrise de soi</suggestion>
+                <example correction="maîtrise de soi"><marker>self control</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="HARD_SELLING" name="hard selling">
+            <pattern>
+                <token regexp="yes">hards?</token>
+                <token regexp="yes">sellings?</token>
+            </pattern>
+            <message>« Hard selling » peut être considéré comme un anglicisme.</message>
+            <suggestion>vente à l'arrachée</suggestion>
+            <suggestion>vente forcée</suggestion>
+            <example correction="vente à l'arrachée|vente forcée"><marker>hard selling</marker></example>
+            <example><marker>vente forcée</marker></example>
+        </rule>
+        <rule id="SNAP" name="snap">
+            <pattern>
+                <token regexp="yes">snaps?</token>
+            </pattern>
+            <message>« Snap » peut être considéré comme un anglicisme.</message>
+            <suggestion>bouton-pression</suggestion>
+            <suggestion>fermoir à pression</suggestion>
+            <example correction="bouton-pression|fermoir à pression"><marker>snap</marker></example>
+            <example><marker>bouton-pression</marker></example>
+        </rule>
+        <rule id="RIM" name="rim">
+            <pattern>
+                <token regexp="yes">rims?</token>
+            </pattern>
+            <message>« Rim » peut être considéré comme un anglicisme. Employez <suggestion>jante</suggestion> (de roue).</message>
+            <example correction="jante"><marker>rim</marker></example>
+        </rule>
+        <rule id="REWRITING" name="rewriting">
+            <pattern>
+                <token regexp="yes">re[-‑‐]?writings?</token>
+            </pattern>
+            <message>« Rewriting » peut être considéré comme un anglicisme.</message>
+            <suggestion>réécriture</suggestion>
+            <suggestion>adaptation</suggestion>
+            <example correction="réécriture|adaptation"><marker>rewriting</marker></example>
+            <example><marker>réécriture</marker></example>
+        </rule>
+        <rulegroup id="RENT_A_CAR" name="rent-a-car">
+            <rule>
+                <pattern>
+                    <token regexp="yes">rents?</token>
+                    <token min="0">-</token>
+                    <token>a</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">cars?</token>
+                </pattern>
+                <message>« Rent-a-car » peut être considéré comme un anglicisme. Pour éviter la critique, employez plutôt <suggestion>voitures de location</suggestion>, <suggestion>location de voitures</suggestion>.</message>
+                <example correction="voitures de location|location de voitures"><marker>rent a car</marker></example>
+                <example correction="voitures de location|location de voitures"><marker>rent-a-car</marker></example>
+                <example><marker>location de voitures</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="PARTNER" name="partner">
+            <pattern>
+                <token regexp="yes">partners?</token>
+            </pattern>
+            <message>« Partner » peut être considéré comme un anglicisme.</message>
+            <suggestion>partenaire</suggestion>
+            <suggestion>associé</suggestion>
+            <suggestion>partenaire d'affaires</suggestion>
+            <suggestion>partenaire commercial</suggestion>
+            <example correction="partenaire|associé|partenaire d'affaires|partenaire commercial"><marker>partner</marker>.</example>
+            <example><marker>associé</marker>.</example>
+        </rule>
+        <rule id="PARTNERSHIP" name="partnership">
+            <pattern>
+                <token regexp="yes">partnerships?</token>
+            </pattern>
+            <message>« Partnership » peut être considéré comme un anglicisme. Employez <suggestion>partenariat</suggestion>, <suggestion>société de personnes</suggestion> (en administration).</message>
+            <example correction="partenariat|société de personnes"><marker>partnership</marker>.</example>
+            <example><marker>partenariat</marker>.</example>
+        </rule>
+        <rulegroup id="BACK_ORDER" name="back order">
+            <rule>
+                <pattern>
+                    <token regexp="yes">backs?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">orders?</token>
+                </pattern>
+                <message>« Back order » peut être considéré comme un anglicisme. Employez <suggestion>en souffrance</suggestion> (commande), <suggestion>en rupture de stock</suggestion> (commande), <suggestion>livraison différée</suggestion>, <suggestion>rupture de stock</suggestion>.</message>
+                <example correction="en souffrance|en rupture de stock|livraison différée|rupture de stock"><marker>back order</marker>.</example>
+                <example><marker>en souffrance</marker>.</example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="WET_SUIT" name="wet suit">
+            <rule>
+                <pattern>
+                    <token regexp="yes">wetsuits?</token>
+                </pattern>
+                <message>« Wet suit » peut être considéré comme un anglicisme.</message>
+                <suggestion>combinaison isolante</suggestion>
+                <suggestion>combinaison isothermique</suggestion>
+                <suggestion>combinaison de plongée</suggestion>
+                <example correction="combinaison isolante|combinaison isothermique|combinaison de plongée"><marker>wetsuit</marker>.</example>
+                <example><marker>combinaison isolante</marker>.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">wets?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">suits?</token>
+                </pattern>
+                <message>« Wet suit » peut être considéré comme un anglicisme.</message>
+                <suggestion>combinaison isolante</suggestion>
+                <suggestion>combinaison isothermique</suggestion>
+                <suggestion>combinaison de plongée</suggestion>
+                <example correction="combinaison isolante|combinaison isothermique|combinaison de plongée"><marker>wet suit</marker>.</example>
+                <example><marker>combinaison isolante</marker>.</example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="WATERPROOF" name="waterproof">
+            <rule>
+                <pattern>
+                    <token regexp="yes">waterproofs?</token>
+                </pattern>
+                <message>« Waterproof » peut être considéré comme un anglicisme.</message>
+                <suggestion>imperméable</suggestion>
+                <example correction="imperméable"><marker>waterproof</marker>.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">waters?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">proofs?</token>
+                </pattern>
+                <message>« Waterproof » peut être considéré comme un anglicisme.</message>
+                <suggestion>imperméable</suggestion>
+                <example correction="imperméable"><marker>water proof</marker>.</example>
+            </rule>
+        </rulegroup>
+        <rule id="LIGHTER" name="lighter">
+            <pattern>
+                <token regexp="yes">lighters?</token>
+            </pattern>
+            <message>« Lighter » peut être considéré comme un anglicisme. Employez <suggestion>briquet</suggestion> (en général), <suggestion>allume-cigare</suggestion> (dans une voiture).</message>
+            <example correction="briquet|allume-cigare"><marker>lighter</marker>.</example>
+            <example><marker>allume-cigare</marker>.</example>
+        </rule>
+        <rule id="ZUCCHINI" name="zucchini">
+            <pattern>
+                <token regexp="yes">zucchinis?</token>
+            </pattern>
+            <message>« Zucchini » peut être considéré comme un anglicisme.</message>
+            <suggestion>courgette</suggestion>
+            <example correction="courgette"><marker>zucchini</marker>.</example>
+        </rule>
+        <rule id="WIPER" name="wiper">
+            <pattern>
+                <token regexp="yes">wipers?</token>
+            </pattern>
+            <message>« Wiper » peut être considéré comme un anglicisme.</message>
+            <suggestion>essuie-glace</suggestion>
+            <example correction="essuie-glace"><marker>wiper</marker></example>
+        </rule>
+        <rule id="WISE" name="wise">
+            <pattern>
+                <token regexp="yes">wises?</token>
+            </pattern>
+            <message>« Wise » peut être considéré comme un anglicisme.</message>
+            <suggestion>habile</suggestion>
+            <suggestion>rusé</suggestion>
+            <suggestion>malin</suggestion>
+            <suggestion>futé</suggestion>
+            <example correction="habile|rusé|malin|futé"><marker>wise</marker>.</example>
+            <example><marker>malin</marker>.</example>
+        </rule>
+        <rule id="CIRCA" name="circa">
+            <pattern>
+                <token>circa</token>
+            </pattern>
+            <message>« Circa » peut être considéré comme un anglicisme.</message>
+            <suggestion>vers</suggestion>
+            <example correction="vers"><marker>circa</marker>.</example>
+        </rule>
+        <rule id="NOZZLE" name="nozzle">
+            <pattern>
+                <token regexp="yes">nozzles?</token>
+            </pattern>
+            <message>« Nozzle » peut être considéré comme un anglicisme.</message>
+            <suggestion>arroseur automatique</suggestion>
+            <suggestion>tourniquet d'arrosage</suggestion>
+            <suggestion>gicleur de lave-glace</suggestion>
+            <example correction="arroseur automatique|tourniquet d'arrosage|gicleur de lave-glace"><marker>nozzle</marker>.</example>
+            <example><marker>tourniquet d'arrosage</marker>.</example>
+        </rule>
+        <rulegroup id="PET_SHOP" name="pet shop">
+            <antipattern>
+                <token>pet</token>
+                <token>shop</token>
+                <token regexp="yes">boy.*</token>
+            </antipattern>
+            <rule>
+                <pattern>
+                    <token regexp="yes">petshops?</token>
+                </pattern>
+                <message>« Pet shop » peut être considéré comme un anglicisme.</message>
+                <suggestion>animalerie</suggestion>
+                <example correction="animalerie"><marker>petshop</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">pets?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">shops?</token>
+                </pattern>
+                <message>« Pet shop » peut être considéré comme un anglicisme.</message>
+                <suggestion>animalerie</suggestion>
+                <example correction="animalerie"><marker>pet shop</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="BACKBENCHER" name="backbencher">
+            <rule>
+                <pattern>
+                    <token regexp="yes">backbenchers?</token>
+                </pattern>
+                <message>« Backbencher » peut être considéré comme un anglicisme.</message>
+                <suggestion>simple député</suggestion>
+                <suggestion>député</suggestion>
+                <example correction="simple député|député"><marker>backbencher</marker></example>
+                <example><marker>simple député</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>back</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">benchers?</token>
+                </pattern>
+                <message>« Backbencher » peut être considéré comme un anglicisme.</message>
+                <suggestion>simple député</suggestion>
+                <suggestion>député</suggestion>
+                <example correction="simple député|député"><marker>back bencher</marker></example>
+                <example><marker>simple député</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="DOGGY_BAG" name="doggy-bag" default="off">
+            <rule>
+                <pattern>
+                    <token regexp="yes">doggy|doggie</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">bags?</token>
+                </pattern>
+                <message>« Doggy bag » peut être considéré comme un anglicisme.</message>
+                <suggestion>sac à restes</suggestion>
+                <suggestion>emporte-restes</suggestion>
+                <example correction="sac à restes|emporte-restes"><marker>doggy bag</marker></example>
+                <example correction="sac à restes|emporte-restes"><marker>doggy-bag</marker></example>
+                <example><marker>sac à restes</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="COCOONING" name="cocooning">
+            <pattern>
+                <token regexp="yes">cocoonings?</token>
+            </pattern>
+            <message>« Cocooning » peut être considéré comme un anglicisme.</message>
+            <suggestion>cocounage</suggestion>
+            <suggestion>coconnage</suggestion>
+            <example correction="cocounage|coconnage"><marker>cocooning</marker>.</example>
+            <example><marker>cocounage</marker>.</example>
+        </rule>
+        <rule id="COMICS" name="comics" default="off">
+            <!-- deactivated : in the French-speaking world, the meaning has narrowed to refer specifically to American comics, just as manga refers to Japanese comics -->
+            <antipattern>
+                <token regexp="yes">Marvel|DC</token>
+                <token>Comics</token>
+            </antipattern>
+            <pattern>
+                <token regexp="yes">comics?</token>
+            </pattern>
+            <message>« Comics » peut être considéré comme un anglicisme.</message>
+            <suggestion>bande dessinée</suggestion>
+            <example correction="bande dessinée"><marker>comics</marker>.</example>
+        </rule>
+        <rule id="FIXING" name="fixing">
+            <pattern>
+                <token regexp="yes">fixings?</token>
+            </pattern>
+            <message>« Fixing » peut être considéré comme un anglicisme.</message>
+            <suggestion>fixage</suggestion>
+            <example correction="fixage"><marker>fixing</marker>.</example>
+        </rule>
+        <rule id="CLIPPER" name="clipper">
+            <pattern>
+                <token regexp="yes" case_sensitive="yes">clippers?
+                    <exception scope="previous">-</exception></token>
+            </pattern>
+            <message>« Clipper » peut être considéré comme un anglicisme. Employez <suggestion>tondeuse</suggestion> (à cheveux), <suggestion>rasoir</suggestion>, <suggestion>coupe-ongles</suggestion>.</message>
+            <example correction="tondeuse|rasoir|coupe-ongles"><marker>clipper</marker>.</example>
+            <example><marker>tondeuse</marker> à cheveux.</example>
+        </rule>
+        <rulegroup id="CONDOMINIUM" name="condo(minium)">
+            <antipattern>
+                <token regexp="yes">(?-i)[A-Z].*</token>
+                <token regexp="yes">condos?|condominiums?</token>
+            </antipattern>
+            <rule>
+                <pattern>
+                    <token regexp="yes">condo|condominium
+                        <exception scope="previous" regexp="yes">le|ce|au</exception></token>
+                </pattern>
+                <message>« Condo(minium) » peut être considéré comme un anglicisme.</message>
+                <suggestion>appartement</suggestion>
+                <example correction="appartement"><marker>condo</marker>.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>le</token>
+                    <token regexp="yes">condo|condominium</token>
+                </pattern>
+                <message>« Condo(minium) » peut être considéré comme un anglicisme.</message>
+                <suggestion>la copropriété</suggestion>
+                <suggestion>l'appartement</suggestion>
+                <example correction="la copropriété|l'appartement"><marker>le condo</marker>.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>ce</token>
+                    <token regexp="yes">condo|condominium</token>
+                </pattern>
+                <message>« Condo(minium) » peut être considéré comme un anglicisme.</message>
+                <suggestion>cette copropriété</suggestion>
+                <suggestion>cet appartement</suggestion>
+                <example correction="cette copropriété|cet appartement"><marker>ce condo</marker>.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>au</token>
+                    <token regexp="yes">condo|condominium</token>
+                </pattern>
+                <message>« Condo(minium) » peut être considéré comme un anglicisme.</message>
+                <suggestion>à la copropriété</suggestion>
+                <suggestion>à l'appartement</suggestion>
+                <example correction="à la copropriété|à l'appartement"><marker>au condo</marker>.</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">condos|condominiums</token>
+                </pattern>
+                <message>« Condo(minium) » peut être considéré comme un anglicisme.</message>
+                <suggestion>copropriétés</suggestion>
+                <suggestion>appartements</suggestion>
+                <example correction="copropriétés|appartements"><marker>condos</marker>.</example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="COCONUT" name="coconut">
+            <rule>
+                <pattern>
+                    <token regexp="yes">coconuts?</token>
+                </pattern>
+                <message>« Coconut » peut être considéré comme un anglicisme.</message>
+                <suggestion>noix de coco</suggestion>
+                <example correction="noix de coco"><marker>coconut</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">cocos?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">nuts?</token>
+                </pattern>
+                <message>« Coconut » peut être considéré comme un anglicisme.</message>
+                <suggestion>noix de coco</suggestion>
+                <example correction="noix de coco"><marker>coco nut</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="CHECKUP" name="checkup">
+            <rule>
+                <pattern>
+                    <token regexp="yes">check-?ups?</token>
+                </pattern>
+                <message>« Checkup » peut être considéré comme un anglicisme.</message>
+                <suggestion>inspection</suggestion>
+                <suggestion>révision</suggestion>
+                <suggestion>bilan de santé</suggestion>
+                <suggestion>examen périodique</suggestion>
+                <suggestion>examen de contrôle</suggestion>
+                <suggestion>examen médical complet</suggestion>
+                <example correction="inspection|révision|bilan de santé|examen périodique|examen de contrôle|examen médical complet"><marker>checkup</marker></example>
+                <example correction="inspection|révision|bilan de santé|examen périodique|examen de contrôle|examen médical complet"><marker>check-up</marker></example>
+                <example><marker>bilan de santé</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">checks?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">ups?</token>
+                </pattern>
+                <message>« Checkup » peut être considéré comme un anglicisme.</message>
+                <suggestion>inspection</suggestion>
+                <suggestion>révision</suggestion>
+                <suggestion>bilan de santé</suggestion>
+                <suggestion>examen périodique</suggestion>
+                <suggestion>examen de contrôle</suggestion>
+                <suggestion>examen médical complet</suggestion>
+                <example correction="inspection|révision|bilan de santé|examen périodique|examen de contrôle|examen médical complet"><marker>check up</marker></example>
+                <example><marker>bilan de santé</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="FLASH-BACK" name="flash-back">
+            <rule>
+                <pattern>
+                    <token regexp="yes">flashbacks?
+                        <exception case_sensitive="yes">FlashBack</exception></token>
+                </pattern>
+                <message>« Flash-back » peut être considéré comme un anglicisme.</message>
+                <suggestion>retour</suggestion>
+                <suggestion>rétrospective</suggestion>
+                <example correction="retour|rétrospective"><marker>flashback</marker></example>
+                <example><marker>retour en arrière</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">flashes|flashs?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">backs?</token>
+                </pattern>
+                <message>« Flash-back » peut être considéré comme un anglicisme.</message>
+                <suggestion>retour</suggestion>
+                <suggestion>rétrospective</suggestion>
+                <example correction="retour|rétrospective"><marker>flash back</marker></example>
+                <example><marker>retour en arrière</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="FLASHLIGHT" name="flashlight">
+            <rule>
+                <pattern>
+                    <token regexp="yes">flashlights?</token>
+                </pattern>
+                <message>« Flashlight » peut être considéré comme un anglicisme.</message>
+                <suggestion>lampe de poche</suggestion>
+                <example correction="lampe de poche"><marker>flashlight</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token regexp="yes">flashes|flashs?</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">lights?</token>
+                </pattern>
+                <message>« Flashlight » peut être considéré comme un anglicisme.</message>
+                <suggestion>lampe de poche</suggestion>
+                <example correction="lampe de poche"><marker>flash light</marker></example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="SIX-PACK" name="six-pack">
+            <rule>
+                <pattern>
+                    <token regexp="yes">sixpacks?</token>
+                </pattern>
+                <message>« Six-pack » peut être considéré comme un anglicisme.</message>
+                <suggestion>emballage de six</suggestion>
+                <suggestion>carton de six</suggestion>
+                <example correction="emballage de six|carton de six"><marker>sixpack</marker></example>
+                <example><marker>emballage de six</marker></example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token>six</token>
+                    <token min="0">-</token>
+                    <token regexp="yes">packs?</token>
+                </pattern>
+                <message>« Six-pack » peut être considéré comme un anglicisme.</message>
+                <suggestion>emballage de six</suggestion>
+                <suggestion>carton de six</suggestion>
+                <example correction="emballage de six|carton de six"><marker>six pack</marker></example>
+                <example><marker>emballage de six</marker></example>
+            </rule>
+        </rulegroup>
+        <rule id="HADDOCK" name="haddock">
+            <pattern>
+                <token regexp="yes">haddocks?
+                    <exception scope="previous">capitaine</exception></token>
+            </pattern>
+            <message>« Haddock » peut être considéré comme un anglicisme.</message>
+            <suggestion>aiglefin</suggestion>
+            <suggestion>églefin</suggestion>
+            <example correction="aiglefin|églefin"><marker>haddock</marker></example>
+            <example><marker>aiglefin</marker></example>
+            <example>Le capitaine Haddock est l'ami de Tintin.</example>
+        </rule>
+        <rule id="PACEMAKER" name="pacemaker">
+            <pattern>
+                <token regexp="yes">pacemakers?</token>
+            </pattern>
+            <message>« Pacemaker » peut être considéré comme un anglicisme.</message>
+            <suggestion>stimulateur cardiaque</suggestion>
+            <example correction="stimulateur cardiaque"><marker>pacemaker</marker></example>
+        </rule>
+        <rule id="LOCKER" name="locker">
+            <pattern>
+                <token regexp="yes">lockers?</token>
+            </pattern>
+            <message>« Locker » peut être considéré comme un anglicisme.</message>
+            <suggestion>casier</suggestion>
+            <suggestion>remise</suggestion>
+            <suggestion>débarras</suggestion>
+            <suggestion>armoire extérieure</suggestion>
+            <example correction="casier|remise|débarras|armoire extérieure"><marker>locker</marker></example>
+            <example><marker>remise</marker></example>
+        </rule>
+        <rule id="VISIO" name="raccourci visio" tone_tags="formal">
+            <antipattern>
+                <token>visio</token>
+                <token>raconte</token>
+                <token>comment</token>
+            </antipattern>
+            <antipattern>
+                <token>visio</token>
+                <token regexp="yes">Wettini|Rotchari|Baronti|Tnugdali|Edwardi|Fursei|Pauli|Sancti|Bernoldi|Karoli|in|:|de</token>
+            </antipattern>
+            <pattern>
+                <token regexp="yes">en|la|une|des|les|cette|ces</token>
+                <marker>
+                    <token>visio</token>
+                </marker>
+            </pattern>
+            <message>« \1 » est un raccourci familier. Employez <suggestion>visioconférence</suggestion> dans un contexte plus sérieux.</message>
+            <example correction="visioconférence">Nous pourrons régler ce problème dans notre prochain entretien en <marker>visio</marker>.</example>
+            <example>Le but de la Visio Karoli Grossi est clairement de légitimer la succession des Carolingiens.</example>
+            <example>La Visio raconte comment le fier chevalier Tondale...</example>
+        </rule>
+        <rule id="FORM" name="form" default="off">
+            <pattern>
+                <token regexp="yes">forms?</token>
+            </pattern>
+            <message>'\1' peut être considéré comme un anglicisme. Employez <suggestion><match no="1" regexp_match="(form)(s)?" regexp_replace="questionnaire$2"/></suggestion>, <suggestion><match no="1" regexp_match="(form)(s)?" regexp_replace="formulaire$2"/></suggestion>, <suggestion><match no="1" regexp_match="(form)(s)?" regexp_replace="forme$2"/></suggestion>, <suggestion>mouler</suggestion>.</message>
+            <example correction="questionnaire|formulaire|forme|mouler">Je lui ai donné cette <marker>form</marker> a remplir</example>
+        </rule>
+        <rule id="LINK" name="link">
+            <pattern>
+                <token case_sensitive="yes">link</token>
+            </pattern>
+            <message>« \1 » peut être considéré comme un anglicisme.</message>
+            <suggestion>lien</suggestion>
+            <example correction="lien">Pense à mettre <marker>link</marker> entre les deux éléments.</example>
+        </rule>
+        <rule id="SEARCH" name="search">
+            <pattern>
+                <token>search</token>
+            </pattern>
+            <message>« \1 » peut être considéré comme un anglicisme.</message>
+            <suggestion>recherche</suggestion>
+            <example correction="recherche">Pense à rajouter une <marker>search</marker> pour les deux éléments.</example>
+        </rule>
+    </category>
+    <category id="CAT_ANGLICISMES" name="Anglicismes (calques, emprunts directs, etc.)" type="style">
         <rulegroup id="TITRES_EN_ANGLAIS" name="titres en anglais" default="off">
             <rule>
                 <pattern>
@@ -12255,2820 +18552,6 @@ USA
             <example correction="en panne|hors d'usage|hors service|en dérangement|irrecevable|non recevable|irrégulier|contraire au règlement|qui ne figure pas à l'ordre du jour|qui n'est pas inscrit à l'ordre du jour"><marker>hors d’ordre</marker></example>
             <example><marker>hors d’usage</marker></example>
         </rule>
-        <rulegroup id="PHOTO-FINISH" name="photo-finish">
-            <rule>
-                <pattern>
-                    <token regexp="yes">photos?</token>
-                    <token regexp="yes">finishs?|finishes</token>
-                </pattern>
-                <message>« Photo-finish » peut être considéré comme un anglicisme.</message>
-                <suggestion>photo d'arrivée</suggestion>
-                <example correction="photo d'arrivée"><marker>photo finish</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">photos?-?finishe?s?</token>
-                </pattern>
-                <message>« Photo-finish » peut être considéré comme un anglicisme.</message>
-                <suggestion>photo d'arrivée</suggestion>
-                <example correction="photo d'arrivée"><marker>photo-finish</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="VISE-GRIP" name="vise-grip">
-            <rule>
-                <pattern>
-                    <token regexp="yes">vi[sc]es?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">grips?|grippes?</token>
-                </pattern>
-                <message>« Vise-grip » peut être considéré comme un anglicisme.</message>
-                <suggestion>pince-étau</suggestion>
-                <example correction="pince-étau"><marker>vise grip</marker></example>
-                <example correction="pince-étau"><marker>vise-grip</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="PACKAGE_DEAL" name="package deal">
-            <rule>
-                <pattern>
-                    <token regexp="yes">packages?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">deals?</token>
-                </pattern>
-                <message>« Package deal » peut être considéré comme un anglicisme.</message>
-                <suggestion>accord global</suggestion>
-                <suggestion>entente globale</suggestion>
-                <example correction="accord global|entente globale"><marker>package deal</marker></example>
-                <example correction="accord global|entente globale"><marker>package-deal</marker></example>
-                <example><marker>accord global</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="QUEEN_SIZE" name="queen size">
-            <rule>
-                <pattern>
-                    <token regexp="yes">queens?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">sizes?</token>
-                </pattern>
-                <message>« Queen size » peut être considéré comme un anglicisme. Employez <suggestion>grand format</suggestion> (lit), <suggestion>longue</suggestion> (cigarette).</message>
-                <example correction="grand format|longue">lit <marker>queen size</marker></example>
-                <example correction="grand format|longue">lit <marker>queen-size</marker></example>
-                <example>lit <marker>grand format</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="MELTING-POT" name="melting-pot" default="off">
-            <rule>
-                <pattern>
-                    <token regexp="yes">meltings?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">pots?</token>
-                </pattern>
-                <message>« Melting pot » peut être considéré comme un anglicisme.</message>
-                <suggestion>creuset</suggestion>
-                <example correction="creuset"><marker>melting pot</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">melting-pots?</token>
-                </pattern>
-                <message>« Melting pot » peut être considéré comme un anglicisme.</message>
-                <suggestion>creuset</suggestion>
-                <example correction="creuset"><marker>melting-pot</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="MILK-SHAKE" name="milk-shake" default="off">
-            <!-- deactivated : widespread usage -->
-            <rule>
-                <pattern>
-                    <token regexp="yes">milks?</token>
-                    <token regexp="yes">shakes?</token>
-                </pattern>
-                <message>« Milk-shake » peut être considéré comme un anglicisme.</message>
-                <suggestion>lait fouetté</suggestion>
-                <example correction="lait fouetté"><marker>milk shake</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">milk-?shakes?</token>
-                </pattern>
-                <message>« Milk-shake » peut être considéré comme un anglicisme.</message>
-                <suggestion>lait fouetté</suggestion>
-                <example correction="lait fouetté"><marker>milk-shake</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="KING_SIZE" name="king size">
-            <pattern>
-                <token regexp="yes">king?</token>
-                <token regexp="yes">sizes?</token>
-            </pattern>
-            <message>« King size » peut être considéré comme un anglicisme. Employez <suggestion>très grand format</suggestion> (lit), <suggestion>longue</suggestion> (cigarette).</message>
-            <example correction="très grand format|longue">lit <marker>king size</marker></example>
-            <example>lit <marker>très grand format</marker></example>
-        </rule>
-        <rule id="EXTRA_LARGE" name="extra large" default="off">
-            <!-- deactivated : widespread usage -->
-            <pattern>
-                <token regexp="yes">extras?</token>
-                <token regexp="yes">larges?</token>
-            </pattern>
-            <message>« Extra large » peut être considéré comme un anglicisme.</message>
-            <suggestion>très grand</suggestion>
-            <example correction="très grand"><marker>extra large</marker></example>
-        </rule>
-        <rule id="POLL" name="poll">
-            <pattern>
-                <token regexp="yes">polls?
-                    <exception scope="previous">-</exception></token>
-            </pattern>
-            <message>« Poll » peut être considéré comme un anglicisme.</message>
-            <suggestion>bureau de vote</suggestion>
-            <suggestion>bureau de scrutin</suggestion>
-            <example correction="bureau de vote|bureau de scrutin"><marker>poll</marker></example>
-            <example><marker>bureau de vote</marker></example>
-        </rule>
-        <rule id="POLE_POSITION" name="pole position" default="off">
-            <!-- deactivated : widespread usage -->
-            <pattern>
-                <token regexp="yes">poles?</token>
-                <token regexp="yes">positions?</token>
-            </pattern>
-            <message>« Pole position » peut être considéré comme un anglicisme.</message>
-            <suggestion>position de tête</suggestion>
-            <example correction="position de tête"><marker>pole position</marker></example>
-        </rule>
-        <rule id="OFF" name="off">
-            <antipattern>
-                <token skip="5">on</token>
-                <token>off</token>
-            </antipattern>
-            <pattern>
-                <token regexp="yes">offs?
-                    <exception scope="previous">-</exception>
-                    <exception scope="next">-</exception></token>
-            </pattern>
-            <message>« Off » peut être considéré comme un anglicisme. Employez <suggestion>hors champ</suggestion>, <suggestion>libre</suggestion> (journée), <suggestion>de congé</suggestion> (journée), <suggestion>en congé</suggestion> (ne pas travailler), <suggestion>arrêt</suggestion> (appareil électrique), <suggestion>fermé</suggestion> (robinet).</message>
-            <example correction="hors champ|libre|de congé|en congé|arrêt|fermé"><marker>off</marker></example>
-            <example><marker>hors champ</marker></example>
-        </rule>
-        <rule id="PATCH" name="patch" default="off">
-            <pattern>
-                <token regexp="yes"> patch|patches|patchs
-                    <exception case_sensitive="yes">PATCH</exception><!-- HTTP Method --></token>
-            </pattern>
-            <message>'Patch' peut être considéré comme un anglicisme. Employez <suggestion><match no="1" regexp_match="(?i)patche?" regexp_replace="pièce"/></suggestion> (chambre à air, ballon, morceau de tissu), <suggestion><match no="1" regexp_match="(?i)patche?" regexp_replace="timbre"/> <match no="1" regexp_match="(?i)patche?" regexp_replace="cutané"/></suggestion>, <suggestion><match no="1" regexp_match="(?i)patche?" regexp_replace="correctif"/></suggestion> (informatique), <suggestion><match no="1" regexp_match="(?i)patche?" regexp_replace="retouche"/></suggestion> (informatique), <suggestion><match no="1" regexp_match="(?i)patche?" regexp_replace="solution"/> temporaire</suggestion>.</message>
-            <example correction="pièce|timbre cutané|correctif|retouche|solution temporaire"><marker>patch</marker></example>
-            <example correction="pièces|timbres cutanés|correctifs|retouches|solutions temporaire"><marker>patches</marker></example>
-            <example><marker>rustine</marker></example>
-        </rule>
-        <rule id="MUFFLER" name="muffler">
-            <pattern>
-                <token regexp="yes">mufflers?</token>
-            </pattern>
-            <message>« Muffler » peut être considéré comme un anglicisme. Employez <suggestion>tuyau d'échappement</suggestion>, <suggestion>silencieux</suggestion> (langue technique), <suggestion>pot d'échappement</suggestion>, <suggestion>pot</suggestion> (courant), <suggestion>système d'échappement</suggestion>, <suggestion>échappement</suggestion> (courant).</message>
-            <example correction="tuyau d'échappement|silencieux|pot d'échappement|pot|système d'échappement|échappement"><marker>muffler</marker></example>
-            <example><marker>tuyau d’échappement</marker></example>
-        </rule>
-        <rule id="NIL" name="nil">
-            <pattern case_sensitive="yes">
-                <token regexp="yes">nils?</token>
-            </pattern>
-            <message>« nil » peut être considéré comme un anglicisme.</message>
-            <suggestion>néant</suggestion>
-            <suggestion>sans objet</suggestion>
-            <suggestion>s. o.</suggestion>
-            <example correction="néant|sans objet|s. o."><marker>nil</marker></example>
-            <example><marker>sans objet</marker></example>
-            <example><marker>Le Nil est un fleuve d’Afrique.</marker></example>
-        </rule>
-        <rule id="NURSING" name="nursing">
-            <pattern>
-                <token regexp="yes">nursings?</token>
-            </pattern>
-            <message>« Nursing » peut être considéré comme un anglicisme.</message>
-            <suggestion>profession d'infirmier</suggestion>
-            <suggestion>études d'infirmier</suggestion>
-            <suggestion>formation en soins infirmiers</suggestion>
-            <suggestion>soins infirmiers</suggestion>
-            <example correction="profession d'infirmier|études d'infirmier|formation en soins infirmiers|soins infirmiers"><marker>nursing</marker></example>
-            <example><marker>soins infirmiers</marker></example>
-        </rule>
-        <rulegroup id="MUST" name="must">
-            <antipattern>
-                <token>must</token>
-                <token>du</token>
-                <token>must</token>
-            </antipattern>
-            <rule>
-                <pattern>
-                    <token postag="D . s" postag_regexp="yes">
-                        <exception regexp="yes">le|la</exception></token>
-                    <marker>
-                        <token>must
-                            <exception scope="next" regexp="yes">-|have|"|see|read</exception></token>
-                    </marker>
-                </pattern>
-                <message>Cette expression peut être considérée comme un anglicisme.</message>
-                <suggestion>incontournable</suggestion>
-                <suggestion>indispensable</suggestion>
-                <example correction="incontournable|indispensable">C'est un <marker>must</marker> en cette saison.</example>
-                <example><marker>incontournable</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="D . p" postag_regexp="yes"/>
-                    <marker>
-                        <token>must
-                            <exception scope="next" regexp="yes">-|have|"|see|read</exception></token>
-                    </marker>
-                </pattern>
-                <message>Cette expression peut être considérée comme un anglicisme.</message>
-                <suggestion>incontournables</suggestion>
-                <suggestion>indispensables</suggestion>
-                <example correction="incontournables|indispensables">Ce sont les <marker>must</marker> en cette saison.</example>
-                <example><marker>incontournable</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <marker>
-                        <token>le</token>
-                        <token>must
-                            <exception scope="next" regexp="yes">-|have|"|see|read</exception></token>
-                    </marker>
-                </pattern>
-                <message>Cette expression peut être considérée comme un anglicisme.</message>
-                <suggestion>l'incontournable</suggestion>
-                <suggestion>l'indispensable</suggestion>
-                <suggestion>le meilleur</suggestion>
-                <suggestion>le mieux</suggestion>
-                <example correction="l'incontournable|l'indispensable|le meilleur|le mieux">C'est <marker>le must</marker> en cette saison.</example>
-                <example><marker>incontournable</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="D . s" postag_regexp="yes">
-                        <exception regexp="yes">le|la</exception></token>
-                    <marker>
-                        <token>must</token>
-                        <token>have</token>
-                    </marker>
-                </pattern>
-                <message>Cette expression peut être considérée comme un anglicisme.</message>
-                <suggestion>incontournable</suggestion>
-                <suggestion>indispensable</suggestion>
-                <example correction="incontournable|indispensable">C'est un <marker>must have</marker> en cette saison.</example>
-                <example><marker>incontournable</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="D . p" postag_regexp="yes">
-                        <exception regexp="yes">le|la</exception></token>
-                    <marker>
-                        <token>must</token>
-                        <token>have</token>
-                    </marker>
-                </pattern>
-                <message>Cette expression peut être considérée comme un anglicisme.</message>
-                <suggestion>incontournables</suggestion>
-                <suggestion>indispensables</suggestion>
-                <example correction="incontournables|indispensables">Ce sont des <marker>must have</marker> en cette saison.</example>
-                <example><marker>incontournable</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <marker>
-                        <token regexp="yes">le|la</token>
-                        <token>must</token>
-                        <token>have</token>
-                    </marker>
-                </pattern>
-                <message>Cette expression peut être considérée comme un anglicisme.</message>
-                <suggestion>l'incontournable</suggestion>
-                <suggestion>l'indispensable</suggestion>
-                <example correction="l'incontournable|l'indispensable">C'est <marker>le must have</marker> en cette saison.</example>
-                <example><marker>incontournable</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">aux|des</token>
-                    <marker>
-                        <token>must
-                            <exception scope="next" regexp="yes">-|have|"|see|read</exception></token>
-                    </marker>
-                </pattern>
-                <message>Cette expression peut être considérée comme un anglicisme.</message>
-                <suggestion>incontournables</suggestion>
-                <suggestion>indispensables</suggestion>
-                <example correction="incontournables|indispensables">C'est un des <marker>must</marker> en cette saison.</example>
-                <example><marker>incontournable</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <marker>
-                        <token regexp="yes">de|du</token>
-                        <token>must
-                            <exception scope="next" regexp="yes">-|have|"|see|read</exception></token>
-                    </marker>
-                </pattern>
-                <message>Cette expression peut être considérée comme un anglicisme.</message>
-                <suggestion>de l'incontournable</suggestion>
-                <suggestion>de l'indispensable</suggestion>
-                <example correction="de l'incontournable|de l'indispensable">C'est <marker>du must</marker> en cette saison.</example>
-                <example><marker>incontournable</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="[PD].*" postag_regexp="yes">
-                        <exception postag="D . s" postag_regexp="yes"/></token>
-                    <marker>
-                        <token>must</token>
-                        <token>have</token>
-                    </marker>
-                </pattern>
-                <message>Cette expression peut être considérée comme un anglicisme.</message>
-                <suggestion>incontournables</suggestion>
-                <suggestion>indispensables</suggestion>
-                <example correction="incontournables|indispensables">Ce sont des <marker>must have</marker> en cette saison.</example>
-                <example><marker>incontournable</marker></example>
-            </rule>
-        </rulegroup>
-        <rule default="off" id="PARKING" name="parking">
-            <pattern>
-                <token regexp="yes">parkings?</token>
-            </pattern>
-            <message>« Parking » peut être considéré comme un anglicisme. Employez <suggestion>stationnement</suggestion> (action), <suggestion>parc de stationnement</suggestion> (lieu), <suggestion>parc à voitures</suggestion> (lieu), <suggestion>parc-autos</suggestion> (lieu), <suggestion>parc à autos</suggestion> (lieu), <suggestion>parcage</suggestion> (action), <suggestion>garage</suggestion> (action ou lieu couvert). Note : « Stationnement » est un régionalisme (Québec) au sens de « parc de stationnement ».</message>
-            <example correction="stationnement|parc de stationnement|parc à voitures|parc-autos|parc à autos|parcage|garage"><marker>parking</marker></example>
-            <example><marker>parc de stationnement</marker></example>
-        </rule>
-        <rule id="MEMBERSHIP" name="membership">
-            <pattern>
-                <token regexp="yes">memberships?</token>
-            </pattern>
-            <message>« Membership » peut être considéré comme un anglicisme.</message>
-            <suggestion>effectif</suggestion>
-            <suggestion>nombre de membres</suggestion>
-            <example correction="effectif|nombre de membres"><marker>membership</marker></example>
-            <example><marker>effectif</marker></example>
-        </rule>
-        <rule id="MEDLEY" name="medley" default="off">
-            <pattern>
-                <token regexp="yes">medleys?</token>
-            </pattern>
-            <message>« Medley » peut être considéré comme un anglicisme.</message>
-            <suggestion>pot-pourri</suggestion>
-            <example correction="pot-pourri"><marker>medley</marker></example>
-        </rule>
-        <rule id="METER" name="meter">
-            <pattern>
-                <token regexp="yes">meters?
-                    <exception scope="previous">hour</exception></token>
-            </pattern>
-            <message>« Meter » peut être considéré comme un anglicisme.</message>
-            <suggestion>compteur</suggestion>
-            <example correction="compteur"><marker>meter</marker></example>
-        </rule>
-        <rule id="MEETING" name="meeting">
-            <antipattern>
-                <token>Meeting</token>
-                <token>ID</token>
-            </antipattern>
-            <pattern>
-                <token regexp="yes">meetings?</token>
-            </pattern>
-            <message>« Meeting » peut être considéré comme un anglicisme.</message>
-            <suggestion><match no="1" regexp_match="(?i)meeting?" regexp_replace="réunion"/></suggestion>
-            <suggestion>rencontre</suggestion>
-            <example correction="réunion|rencontre"><marker>meeting</marker></example>
-            <example><marker>réunion</marker></example>
-        </rule>
-        <rule id="LOADER" name="loader">
-            <pattern>
-                <token regexp="yes">loaders?</token>
-            </pattern>
-            <message>« Loader » peut être considéré comme un anglicisme. Employez <suggestion>chargeuse</suggestion> (véhicule).</message>
-            <example correction="chargeuse"><marker>loader</marker></example>
-        </rule>
-        <rule id="LIVE" name="live" tags="picky">
-            <antipattern>
-                <token>black</token>
-                <token regexp="yes">lives?</token>
-                <token regexp="yes">matters?</token>
-            </antipattern>
-            <antipattern>
-                <token regexp="yes">xbox|ableton|facebook|quizlet</token>
-                <token>live</token>
-            </antipattern>
-            <antipattern>
-                <token>live</token>
-                <token>nation</token>
-            </antipattern>
-            <antipattern>
-                <token postag="V.*" postag_regexp="yes" inflected="yes">partir</token>
-                <token>en</token>
-                <token>live</token>
-            </antipattern>
-            <pattern>
-                <token>en</token>
-                <token>live
-                    <exception scope="next" regexp="yes">streaming|shows?|-</exception></token>
-            </pattern>
-            <message>« Live » peut être considéré comme un anglicisme. Employez <suggestion>\1 <match no="2" regexp_match="live" regexp_replace="direct" case_conversion="preserve"/></suggestion>.</message>
-            <example correction="en direct">Nous sommes <marker>en live</marker> depuis notre studio.</example>
-            <example><marker>en direct</marker></example>
-            <example>Black Lives Matter</example>
-        </rule>
-        <rule id="LISTING" name="listing">
-            <pattern>
-                <token regexp="yes">listings?</token>
-            </pattern>
-            <message>« Listing » peut être considéré comme un anglicisme. Employez <suggestion>listage</suggestion> (informatique).</message>
-            <example correction="listage"><marker>listing</marker></example>
-        </rule>
-        <rule id="LIFT" name="lift">
-            <pattern>
-                <token regexp="yes">lifts?</token>
-            </pattern>
-            <message>« Lift » peut être considéré comme un anglicisme. Employez <suggestion>monte-charge</suggestion> (ascenseur pour objets), <suggestion>pont élévateur</suggestion> (garage), <suggestion>chariot élévateur</suggestion> (véhicule pour soulever des charges), <suggestion>prendre en voiture</suggestion>, <suggestion>voiturer</suggestion> (familier), <suggestion>reconduire</suggestion>, <suggestion>ramener</suggestion>, <suggestion>déposer</suggestion>.</message>
-            <example correction="monte-charge|pont élévateur|chariot élévateur|prendre en voiture|voiturer|reconduire|ramener|déposer"><marker>lift</marker></example>
-            <example><marker>monte-charge</marker></example>
-        </rule>
-        <rule id="HOSE" name="hose">
-            <pattern>
-                <token regexp="yes">hoses?</token>
-            </pattern>
-            <message>« Hose » peut être considéré comme un anglicisme.</message>
-            <suggestion>tuyau d'arrosage</suggestion>
-            <suggestion>tuyau</suggestion>
-            <example correction="tuyau d'arrosage|tuyau"><marker>hose</marker></example>
-            <example><marker>tuyau</marker></example>
-        </rule>
-        <rule id="FULL" name="full">
-            <antipattern>
-                <token>full</token>
-                <token regexp="yes">HD|House</token>
-            </antipattern>
-            <pattern>
-                <token regexp="yes">fulls?
-                    <exception scope="next" postag="UNKNOWN"/>
-                    <exception scope="next" regexp="yes">(?-i)[A-Z].*|-</exception></token>
-            </pattern>
-            <message>« Full » peut être considéré comme un anglicisme. Employez <suggestion>main pleine</suggestion> (cartes), <suggestion>plein</suggestion>, <suggestion>beaucoup</suggestion>.</message>
-            <example correction="main pleine|plein|beaucoup"><marker>full</marker></example>
-            <example><marker>plein</marker></example>
-        </rule>
-        <rulegroup id="FUN" name="fun">
-            <rule>
-                <antipattern>
-                    <token>fun</token>
-                    <token regexp="yes">facts?</token>
-                </antipattern>
-                <pattern>
-                    <token regexp="yes" case_sensitive="yes">funs?
-                        <exception scope="next" regexp="yes">radio|day|brothers|["»]|boxe?s?</exception>
-                        <exception scope="previous" regexp="yes">having|sur</exception></token>
-                </pattern>
-                <message>« Fun » peut être considéré comme un anglicisme.</message>
-                <suggestion><match no="1" regexp_match="fun(?iu)" regexp_replace="plaisir"/></suggestion>
-                <suggestion><match no="1" regexp_match="fun(?iu)" regexp_replace="sympa"/></suggestion>
-                <suggestion><match no="1" regexp_match="fun(?iu)" regexp_replace="drôle"/></suggestion>
-                <example correction="plaisir|sympa|drôle"><marker>fun</marker></example>
-                <example><marker>plaisir</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="INTERCOM" name="intercom">
-            <pattern>
-                <token regexp="yes">intercoms?</token>
-            </pattern>
-            <message>« Intercom » peut être considéré comme un anglicisme.</message>
-            <suggestion>interphone</suggestion>
-            <example correction="interphone"><marker>intercom</marker></example>
-        </rule>
-        <rule id="FILIBUSTER" name="filibuster">
-            <pattern>
-                <token regexp="yes">filibusters?</token>
-            </pattern>
-            <message>« Filibuster » peut être considéré comme un anglicisme.</message>
-            <suggestion>obstruction systématique</suggestion>
-            <example correction="obstruction systématique"><marker>filibuster</marker></example>
-        </rule>
-        <rule id="ENTREPRENEURSHIP" name="entrepreneurship">
-            <pattern>
-                <token regexp="yes">entrepreneurships?</token>
-            </pattern>
-            <message>« Entrepreneurship » peut être considéré comme un anglicisme.</message>
-            <suggestion>esprit d'entreprise</suggestion>
-            <suggestion>entrepreneuriat</suggestion>
-            <example correction="esprit d'entreprise|entrepreneuriat"><marker>entrepreneurship</marker></example>
-            <example><marker>esprit d’entreprise</marker></example>
-        </rule>
-        <rule id="ESCALATOR" name="escalator" default="off">
-            <!-- deactivated : widespread usage -->
-            <pattern>
-                <token regexp="yes">escalators?</token>
-            </pattern>
-            <message>« Escalator » peut être considéré comme un anglicisme.</message>
-            <suggestion>escalier mécanique</suggestion>
-            <example correction="escalier mécanique"><marker>escalator</marker></example>
-        </rule>
-        <rule id="DUMP" name="dump">
-            <pattern>
-                <token regexp="yes">dumps?</token>
-            </pattern>
-            <message>« Dump » peut être considéré comme un anglicisme. Employez <suggestion>décharge</suggestion>, <suggestion>dépotoir</suggestion>, <suggestion>dépôt d'ordures</suggestion>, <suggestion>terril</suggestion> (résidus d’extraction minière).</message>
-            <example correction="décharge|dépotoir|dépôt d'ordures|terril"><marker>dump</marker></example>
-            <example><marker>décharge</marker></example>
-        </rule>
-        <rule id="ENCRYPTION" name="encryption">
-            <pattern>
-                <token regexp="yes">encryptions?</token>
-            </pattern>
-            <message>« Encryption » peut être considéré comme un anglicisme.</message>
-            <suggestion>cryptage</suggestion>
-            <suggestion>chiffrement</suggestion>
-            <example correction="cryptage|chiffrement"><marker>encryption</marker></example>
-            <example><marker>cryptage</marker></example>
-        </rule>
-        <rule id="COOKIE" name="cookie" default="off">
-            <!-- picky -->
-            <pattern>
-                <token regexp="yes">cookies?</token>
-            </pattern>
-            <message>« Cookie » peut être considéré comme un anglicisme.</message>
-            <suggestion><match no="1" regexp_match="(?i)cookie" regexp_replace="biscuit"/></suggestion>
-            <suggestion><match no="1" regexp_match="(?i)cookie" regexp_replace="témoin"/> de connexion</suggestion>
-            <suggestion><match no="1" regexp_match="(?i)cookie" regexp_replace="témoin"/></suggestion>
-            <example correction="biscuit|témoin de connexion|témoin"><marker>cookie</marker></example>
-            <example><marker>témoin de connexion</marker></example>
-        </rule>
-        <rule id="CORDUROY" name="corduroy">
-            <pattern>
-                <token regexp="yes">corduroys?</token>
-            </pattern>
-            <message>« Corduroy » peut être considéré comme un anglicisme.</message>
-            <suggestion>velours côtelé</suggestion>
-            <example correction="velours côtelé"><marker>corduroy</marker></example>
-        </rule>
-        <rule id="CONTAINER" name="container">
-            <pattern>
-                <token regexp="yes">containers?</token>
-            </pattern>
-            <message>« Container » peut être considéré comme un anglicisme.</message>
-            <suggestion>conteneur</suggestion>
-            <example correction="conteneur"><marker>container</marker></example>
-        </rule>
-        <rule id="BRANDING" name="branding">
-            <pattern>
-                <token regexp="yes">branding|bradings</token>
-            </pattern>
-            <message>« Branding » peut être considéré comme un anglicisme. Employez <suggestion>stratégie de marque</suggestion>, <suggestion>valorisation de la marque</suggestion>, <suggestion>image de marque</suggestion>, <suggestion>pouvoir de la marque</suggestion>, <suggestion>notoriété</suggestion> (figuré).</message>
-            <example correction="stratégie de marque|valorisation de la marque|image de marque|pouvoir de la marque|notoriété"><marker>branding</marker></example>
-            <example><marker>stratégie de marque</marker></example>
-        </rule>
-        <rulegroup id="CHUM" name="chum">
-            <rule>
-                <pattern>
-                    <token postag="D.*|J m s" postag_regexp="yes"/>
-                    <marker>
-                        <token case_sensitive="yes">chum</token>
-                    </marker>
-                </pattern>
-                <message>« Chum » peut être considéré comme un anglicisme.</message>
-                <suggestion>ami</suggestion>
-                <suggestion>copain</suggestion>
-                <suggestion>camarade</suggestion>
-                <suggestion>collègue</suggestion>
-                <suggestion>petit ami</suggestion>
-                <suggestion>compagnon</suggestion>
-                <suggestion>conjoint</suggestion>
-                <example correction="ami|copain|camarade|collègue|petit ami|compagnon|conjoint">Un <marker>chum</marker></example>
-                <example><marker>ami</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="D.*|J m p" postag_regexp="yes"/>
-                    <marker>
-                        <token case_sensitive="yes">chums</token>
-                    </marker>
-                </pattern>
-                <message>« Chum » peut être considéré comme un anglicisme.</message>
-                <suggestion>amis</suggestion>
-                <suggestion>copains</suggestion>
-                <suggestion>camarades</suggestion>
-                <suggestion>collègues</suggestion>
-                <suggestion>petits amis</suggestion>
-                <suggestion>compagnons</suggestion>
-                <suggestion>conjoints</suggestion>
-                <example correction="amis|copains|camarades|collègues|petits amis|compagnons|conjoints">Des <marker>chums</marker></example>
-                <example><marker>ami</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="CHEAP" name="cheap">
-            <rule>
-                <antipattern>
-                    <token regexp="yes">order|price|be|by|amazing|not|after|great|beautiful</token>
-                    <token>cheap</token>
-                </antipattern>
-                <pattern>
-                    <token case_sensitive="yes">cheap
-                        <exception scope="next" regexp="yes">awesome|under|labour|jordans|nikes|that|beautiful|beats|nike|perfect|ordinary|price|best</exception></token>
-                </pattern>
-                <message>« Cheap » peut être considéré comme un anglicisme. Employez <suggestion>ordinaire</suggestion>, <suggestion>bon marché</suggestion> ou <suggestion>abordable</suggestion>.</message>
-                <example correction="ordinaire|bon marché|abordable"><marker>cheap</marker></example>
-                <example><marker>bon marché</marker></example>
-                <example>Order cheap 240 mg buy online dosage.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>de</token>
-                    <token regexp="yes" case_sensitive="yes">cheaps?
-                        <exception scope="next" regexp="yes">awesome|labour|beautiful|beats|nike|perfect|ordinary|price|best</exception></token>
-                </pattern>
-                <message>« Cheap » peut être considéré comme un anglicisme. Employez <suggestion>d'ordinaire</suggestion>, <suggestion>de bon marché</suggestion> ou <suggestion>d'abordable</suggestion>.</message>
-                <example correction="d'ordinaire|de bon marché|d'abordable"><marker>de cheap</marker></example>
-                <example><marker>bon marché</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BUILDING" name="building">
-            <rule>
-                <pattern>
-                    <token postag="D . s" postag_regexp="yes"/>
-                    <marker>
-                        <token>building</token>
-                    </marker>
-                </pattern>
-                <message>« Building » peut être considéré comme un anglicisme.</message>
-                <suggestion>édifice</suggestion>
-                <suggestion>gratte-ciel</suggestion>
-                <suggestion>immeuble</suggestion>
-                <example correction="édifice|gratte-ciel|immeuble">Un <marker>building</marker></example>
-                <example><marker>édifice</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="D . p" postag_regexp="yes"/>
-                    <marker>
-                        <token>buildings</token>
-                    </marker>
-                </pattern>
-                <message>« Building » peut être considéré comme un anglicisme.</message>
-                <suggestion>édifices</suggestion>
-                <suggestion>gratte-ciel</suggestion>
-                <suggestion>gratte-ciels</suggestion>
-                <suggestion>immeubles</suggestion>
-                <example correction="édifices|gratte-ciel|gratte-ciels|immeubles">Des <marker>buildings</marker></example>
-                <example><marker>édifice</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="CASTING" name="casting">
-            <pattern>
-                <token regexp="yes">castings?</token>
-            </pattern>
-            <message>« Casting » peut être considéré comme un anglicisme.</message>
-            <suggestion>distribution</suggestion>
-            <suggestion>distribution artistique</suggestion>
-            <example correction="distribution|distribution artistique"><marker>casting</marker></example>
-            <example><marker>distribution</marker></example>
-        </rule>
-        <rule id="CART" name="cart">
-            <pattern>
-                <token regexp="yes">carts?</token>
-            </pattern>
-            <message>« Cart » peut être considéré comme un anglicisme.</message>
-            <suggestion>voiturette</suggestion>
-            <suggestion>voiturette électrique</suggestion>
-            <example correction="voiturette|voiturette électrique"><marker>cart</marker></example>
-            <example><marker>voiturette</marker></example>
-        </rule>
-        <rule id="CANCELLATION" name="cancellation">
-            <pattern>
-                <token regexp="yes">cancellations?</token>
-            </pattern>
-            <message>« Cancellation » peut être considéré comme un anglicisme.</message>
-            <suggestion>annulation</suggestion>
-            <example correction="annulation"><marker>cancellation</marker></example>
-        </rule>
-        <rule id="CASHEW" name="cashew">
-            <pattern>
-                <token regexp="yes">cashews?</token>
-            </pattern>
-            <message>« Cashew » peut être considéré comme un anglicisme.</message>
-            <suggestion>cajou</suggestion>
-            <suggestion>noix de cajou</suggestion>
-            <example correction="cajou|noix de cajou"><marker>cashew</marker></example>
-            <example><marker>cajou</marker></example>
-        </rule>
-        <rule id="CLUTCH" name="clutch">
-            <pattern>
-                <token regexp="yes">clutchs?|clutches</token>
-            </pattern>
-            <message>« Clutch » peut être considéré comme un anglicisme.</message>
-            <suggestion>embrayage</suggestion>
-            <suggestion>pédale d'embrayage</suggestion>
-            <example correction="embrayage|pédale d'embrayage"><marker>clutch</marker></example>
-            <example><marker>embrayage</marker></example>
-        </rule>
-        <rule id="BVLD" name="bvld">
-            <pattern>
-                <token>bvld</token>
-            </pattern>
-            <message>« Bvld. » peut être considéré comme un anglicisme.</message>
-            <suggestion>boul.</suggestion>
-            <suggestion>bd.</suggestion>
-            <example correction="boul.|bd."><marker>bvld</marker></example>
-            <example><marker>boul.</marker></example>
-        </rule>
-        <rule id="BOUNCER" name="bouncer">
-            <pattern>
-                <token regexp="yes">bouncers?</token>
-            </pattern>
-            <message>« Bouncer » peut être considéré comme un anglicisme.</message>
-            <suggestion>videur</suggestion>
-            <suggestion>homme de main</suggestion>
-            <example correction="videur|homme de main"><marker>bouncer</marker></example>
-            <example><marker>homme de main</marker></example>
-        </rule>
-        <rulegroup id="BOSS" name="boss">
-            <antipattern>
-                <token>hugo</token>
-                <token>boss</token>
-            </antipattern>
-            <antipattern>
-                <token>
-                    <exception postag="D.*" postag_regexp="yes"/></token>
-                <token regexp="yes" case_sensitive="yes">Boss|BOSS</token>
-            </antipattern>
-            <rule>
-                <pattern>
-                    <token>boss
-                        <exception scope="previous" regexp="yes">des|big|-|aux|l[ea]|de</exception>
-                        <exception scope="previous" postag="D . p" postag_regexp="yes"/></token>
-                </pattern>
-                <message>« Boss » peut être considéré comme un anglicisme.</message>
-                <suggestion>patron</suggestion>
-                <suggestion>superviseur</suggestion>
-                <suggestion>supérieur</suggestion>
-                <suggestion>expert</suggestion>
-                <suggestion>directeur</suggestion>
-                <example correction="patron|superviseur|supérieur|expert|directeur"><marker>boss</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>le</token>
-                    <token>boss</token>
-                </pattern>
-                <message>« Boss » peut être considéré comme un anglicisme.</message>
-                <suggestion>le patron</suggestion>
-                <suggestion>le superviseur</suggestion>
-                <suggestion>le supérieur</suggestion>
-                <suggestion>l'expert</suggestion>
-                <suggestion>le directeur</suggestion>
-                <example correction="le patron|le superviseur|le supérieur|l'expert|le directeur">C'est lui <marker>le boss</marker>.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">de|du</token>
-                    <token>boss</token>
-                </pattern>
-                <message>« Boss » peut être considéré comme un anglicisme.</message>
-                <suggestion>\1 patron</suggestion>
-                <suggestion>\1 superviseur</suggestion>
-                <suggestion>\1 supérieur</suggestion>
-                <suggestion>de l'expert</suggestion>
-                <suggestion>\1 directeur</suggestion>
-                <example correction="du patron|du superviseur|du supérieur|de l'expert|du directeur">Il faut que je te parle <marker>du boss</marker>.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <or>
-                        <token postag="D . p|J . p" postag_regexp="yes"/>
-                        <token regexp="yes">aux|des</token>
-                    </or>
-                    <marker>
-                        <token case_sensitive="yes">boss</token>
-                    </marker>
-                </pattern>
-                <message>« Boss » peut être considéré comme un anglicisme.</message>
-                <suggestion>patrons</suggestion>
-                <suggestion>experts</suggestion>
-                <suggestion>supérieurs</suggestion>
-                <suggestion>chefs</suggestion>
-                <suggestion>directeurs</suggestion>
-                <example correction="patrons|experts|supérieurs|chefs|directeurs">Les <marker>boss</marker> arrivent.</example>
-            </rule>
-        </rulegroup>
-        <rule id="BREAKER" name="breaker">
-            <pattern>
-                <token regexp="yes">breakers?</token>
-            </pattern>
-            <message>« Breaker » peut être considéré comme un anglicisme. Employez <suggestion>disjoncteur</suggestion> (plusieurs circuits), <suggestion>coupe-circuit</suggestion> (un circuit).</message>
-            <example correction="disjoncteur|coupe-circuit"><marker>breaker</marker></example>
-            <example><marker>disjoncteur</marker></example>
-        </rule>
-        <rule id="REFILL" name="refill">
-            <pattern>
-                <token regexp="yes">refills?</token>
-            </pattern>
-            <message>« Refill » peut être considéré comme un anglicisme. Employez <suggestion>recharge</suggestion> (pour un stylo ou un briquet ou en général), <suggestion>nouvelle cartouche</suggestion> (stylo), <suggestion>cartouche</suggestion> (stylo), <suggestion>mine de rechange</suggestion> (stylomine), <suggestion>feuilles de rechange</suggestion> (calepin), <suggestion>deuxième verre</suggestion> (bar), <suggestion>la même chose</suggestion> (bar).</message>
-            <example correction="recharge|nouvelle cartouche|cartouche|mine de rechange|feuilles de rechange|deuxième verre|la même chose"><marker>refill</marker></example>
-            <example><marker>recharge</marker></example>
-        </rule>
-        <rule id="SMILE" name="smile">
-            <pattern>
-                <token regexp="yes" case_sensitive="yes">smiles?</token>
-            </pattern>
-            <message>« Smile » peut être considéré comme un anglicisme.</message>
-            <suggestion><match no="1" regexp_match="smile" regexp_replace="sourire"/></suggestion>
-            <example correction="sourire"><marker>smile</marker></example>
-        </rule>
-        <rule id="FLANNELETTE" name="flannelette">
-            <pattern>
-                <token regexp="yes">flann?ell?ettes?</token>
-            </pattern>
-            <message>« Flannelette » peut être considéré comme un anglicisme.</message>
-            <suggestion>finette</suggestion>
-            <suggestion>pilou</suggestion>
-            <suggestion>flanelle de coton</suggestion>
-            <example correction="finette|pilou|flanelle de coton"><marker>flannelette</marker></example>
-            <example><marker>finette</marker></example>
-        </rule>
-        <rule default="off" id="FAN" name="fan">
-            <pattern>
-                <token regexp="yes">fans?</token>
-            </pattern>
-            <message>« Fan » peut être considéré comme un anglicisme. Employez <suggestion>admirateur</suggestion>, <suggestion>partisan</suggestion>, <suggestion>adepte</suggestion>, <suggestion>ventilateur</suggestion> (maison, appartement, atelier, moteur), <suggestion>hotte</suggestion> (cuisinière).</message>
-            <example correction="admirateur|partisan|adepte|ventilateur|hotte"><marker>fan</marker></example>
-            <example><marker>admirateur</marker></example>
-        </rule>
-        <rule id="FEELING" name="feeling">
-            <pattern>
-                <token regexp="yes">feelings?</token>
-            </pattern>
-            <message>« Feeling » peut être considéré comme un anglicisme.</message>
-            <suggestion>sentiment</suggestion>
-            <suggestion>impression</suggestion>
-            <example correction="sentiment|impression"><marker>feeling</marker></example>
-            <example><marker>impression</marker></example>
-        </rule>
-        <rule default="off" id="FAX" name="fax">
-            <pattern>
-                <token regexp="yes">faxs?|faxes</token>
-            </pattern>
-            <message>« Fax » peut être considéré comme un anglicisme.</message>
-            <suggestion>télécopie</suggestion>
-            <suggestion>télécopieur</suggestion>
-            <example correction="télécopie|télécopieur"><marker>fax</marker></example>
-            <example><marker>télécopieur</marker></example>
-        </rule>
-        <rule id="MOMENTUM" name="momentum">
-            <pattern>
-                <token regexp="yes">momentums?</token>
-            </pattern>
-            <message>« Momentum » peut être considéré comme un anglicisme. Employez <suggestion>élan</suggestion>, <suggestion>initiative</suggestion>, <suggestion>impulsion du moment</suggestion>, <suggestion>vitesse acquise</suggestion>, <suggestion>lancée</suggestion>, <suggestion>dynamisme</suggestion>, <suggestion>dynamique</suggestion> (substantif), <suggestion>circonstances favorables</suggestion>, <suggestion>conjoncture favorable</suggestion>, <suggestion>force</suggestion>, <suggestion>avoir le vent en poupe</suggestion> (personne ; familier).</message>
-            <example correction="élan|initiative|impulsion du moment|vitesse acquise|lancée|dynamisme|dynamique|circonstances favorables|conjoncture favorable|force|avoir le vent en poupe"><marker>momentum</marker></example>
-            <example><marker>élan</marker></example>
-        </rule>
-        <rule id="BLENDER" name="blender" default="off">
-            <pattern>
-                <token regexp="yes">blenders?</token>
-            </pattern>
-            <message>« Blender » peut être considéré comme un anglicisme.</message>
-            <suggestion>mélangeur</suggestion>
-            <example correction="mélangeur"><marker>blender</marker></example>
-        </rule>
-        <rulegroup id="MINIVAN" name="minivan">
-            <rule>
-                <pattern>
-                    <token regexp="yes">mini-?vans?</token>
-                </pattern>
-                <message>« Minivan » peut être considéré comme un anglicisme. Employez <suggestion>monospace</suggestion>. Ce mot se prononce à la française.</message>
-                <example correction="monospace"><marker>minivan</marker></example>
-                <example>Le <marker>monospace</marker>.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">minis?</token>
-                    <token regexp="yes">vans?</token>
-                </pattern>
-                <message>« Minivan » peut être considéré comme un anglicisme. Employez <suggestion>monospace</suggestion>. Ce mot se prononce à la française.</message>
-                <example correction="monospace"><marker>mini van</marker></example>
-                <example>Le <marker>monospace</marker>.</example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="MAKING_OF" name="making of">
-            <rule>
-                <pattern>
-                    <token regexp="yes">makings?
-                        <exception scope="previous">the</exception></token>
-                    <token min="0">-</token>
-                    <token regexp="yes">of|off|ofs|offs</token>
-                </pattern>
-                <message>« Making of » peut être considéré comme un anglicisme.</message>
-                <suggestion>coulisses</suggestion>
-                <suggestion>genèse</suggestion>
-                <suggestion>réalisation</suggestion>
-                <suggestion>tournage</suggestion>
-                <suggestion>secrets de tournage</suggestion>
-                <example correction="coulisses|genèse|réalisation|tournage|secrets de tournage"><marker>making of</marker></example>
-                <example correction="coulisses|genèse|réalisation|tournage|secrets de tournage"><marker>making-of</marker></example>
-                <example>les <marker>coulisses</marker></example>
-                <example>Robert E. Kapsis, Hitchcock : The Making of a Reputation, University of Chicago Press, 1992.</example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="HAS_BEEN" name="has been">
-            <rule>
-                <pattern>
-                    <token>has</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">beens?</token>
-                </pattern>
-                <message>« Has been » peut être considéré comme un anglicisme. Employez <suggestion>qui a fait son temps</suggestion>, <suggestion>dépassé</suggestion>, <suggestion>démodé</suggestion> (familier).</message>
-                <example correction="qui a fait son temps|dépassé|démodé"><marker>has been</marker></example>
-                <example correction="qui a fait son temps|dépassé|démodé"><marker>has-been</marker></example>
-                <example>Les <marker>dépassés</marker>.</example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="MASS_MEDIA" name="mass media">
-            <rule>
-                <pattern>
-                    <token regexp="yes">mass|masses</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">média|media|medias|médias</token>
-                </pattern>
-                <message>« Mass media » peut être considéré comme un anglicisme.</message>
-                <suggestion>média de masse</suggestion>
-                <example correction="média de masse"><marker>mass media</marker></example>
-                <example correction="média de masse"><marker>mass-media</marker></example>
-                <example>les <marker>média de masse</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="LAZY-BOY" name="lazy-boy">
-            <rule>
-                <pattern>
-                    <token regexp="yes">lazys?|lazies</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">boys?</token>
-                </pattern>
-                <message>« Lazy-boy » peut être considéré comme un anglicisme.</message>
-                <suggestion>fauteuil de repos</suggestion>
-                <example correction="fauteuil de repos"><marker>lazy boy</marker></example>
-                <example correction="fauteuil de repos"><marker>lazy-boy</marker></example>
-                <example>les <marker>fauteuils de repos</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="HATCHBACK" name="hatchback">
-            <rule>
-                <pattern>
-                    <token regexp="yes">hatchbacks?</token>
-                </pattern>
-                <message>« Hatchback » peut être considéré comme un anglicisme. Employez <suggestion>hayon</suggestion> (partie mobile de la voiture), <suggestion>coupé avec hayon</suggestion>, <suggestion>berline avec hayon</suggestion>, <suggestion>trois portes</suggestion>, <suggestion>cinq portes</suggestion>. Un « coupé » possède deux portes latérales ; une « berline » en possède quatre.</message>
-                <example correction="hayon|coupé avec hayon|berline avec hayon|trois portes|cinq portes"><marker>hatchback</marker></example>
-                <example>les <marker>hayons</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">hatchs?|hatches</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">backs?</token>
-                </pattern>
-                <message>« Hatchback » peut être considéré comme un anglicisme. Employez <suggestion>hayon</suggestion> (partie mobile de la voiture), <suggestion>coupé avec hayon</suggestion>, <suggestion>berline avec hayon</suggestion>, <suggestion>trois portes</suggestion>, <suggestion>cinq portes</suggestion>. Un « coupé » possède deux portes latérales ; une « berline » en possède quatre.</message>
-                <example correction="hayon|coupé avec hayon|berline avec hayon|trois portes|cinq portes"><marker>hatch back</marker></example>
-                <example>les <marker>hayons</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="MARSHMALLOW" name="marshmallow">
-            <rule>
-                <pattern>
-                    <token regexp="yes">marshs?|marshes</token>
-                    <token regexp="yes">mallows?</token>
-                </pattern>
-                <message>« Marshmallow » peut être considéré comme un anglicisme.</message>
-                <suggestion>guimauve</suggestion>
-                <example correction="guimauve"><marker>marsh mallow</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="HAPPY-FEW" name="happy-few">
-            <rule>
-                <pattern>
-                    <token regexp="yes">happys?|happies</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">fews?</token>
-                </pattern>
-                <message>« Happy-few » peut être considéré comme un anglicisme. Employez <suggestion>privilégiés</suggestion>, <suggestion>l'élite</suggestion>, <suggestion>la crème</suggestion> (familier).</message>
-                <example correction="privilégiés|l'élite|la crème"><marker>happy few</marker></example>
-                <example correction="privilégiés|l'élite|la crème"><marker>happy-few</marker></example>
-                <example>les <marker>privilégiés</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="HIGH-TECH" name="high-tech" default="off">
-            <rule>
-                <pattern>
-                    <token regexp="yes">high-?techs?</token>
-                </pattern>
-                <message>« High-tech » peut être considéré comme un anglicisme. Employez <suggestion>haute technologie</suggestion> (substantif), <suggestion>de pointe</suggestion> (locution adjectivale).</message>
-                <example correction="haute technologie|de pointe"><marker>hightech</marker></example>
-                <example correction="haute technologie|de pointe"><marker>high-tech</marker></example>
-                <example><marker>haute technologie</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">highs?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">techs?</token>
-                </pattern>
-                <message>« High-tech » peut être considéré comme un anglicisme. Employez <suggestion>haute technologie</suggestion> (substantif), <suggestion>de pointe</suggestion> (locution adjectivale).</message>
-                <example correction="haute technologie|de pointe"><marker>high tech</marker></example>
-                <example><marker>haute technologie</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="FOURSOME" name="foursome">
-            <rule>
-                <pattern>
-                    <token regexp="yes">foursome|four-some|foursomes|four-somes</token>
-                </pattern>
-                <message>« Foursome » peut être considéré comme un anglicisme. Employez <suggestion>quatuor</suggestion> (général), <suggestion>double</suggestion> (golf).</message>
-                <example correction="quatuor|double"><marker>foursome</marker></example>
-                <example><marker>double</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">fours?</token>
-                    <token regexp="yes">somes?</token>
-                </pattern>
-                <message>« Foursome » peut être considéré comme un anglicisme. Employez <suggestion>quatuor</suggestion> (général), <suggestion>double</suggestion> (golf).</message>
-                <example correction="quatuor|double"><marker>four some</marker></example>
-                <example><marker>double</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="FULL_PIN" name="full pin">
-            <rule>
-                <pattern>
-                    <token regexp="yes">fullpins?</token>
-                </pattern>
-                <message>« Full pin » peut être considéré comme un anglicisme. Employez <suggestion>un max</suggestion> (familier ; degré d’intensité), <suggestion>à pleins tubes</suggestion> (familier ; volume), <suggestion>à plein régime</suggestion> (vitesse), <suggestion>à toute allure</suggestion> (vitesse), <suggestion>à fond de train</suggestion> (familier ; vitesse), <suggestion>à fond la caisse</suggestion> (familier ; vitesse), <suggestion>à toute vapeur</suggestion> (familier ; vitesse), <suggestion>à toute pompe</suggestion> (familier ; vitesse), <suggestion>à pleine gomme</suggestion> (familier ; vitesse).</message>
-                <example correction="un max|à pleins tubes|à plein régime|à toute allure|à fond de train|à fond la caisse|à toute vapeur|à toute pompe|à pleine gomme"><marker>fullpin</marker></example>
-                <example><marker>à plein régime</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">fulls?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">pins?</token>
-                </pattern>
-                <message>« Full pin » peut être considéré comme un anglicisme. Employez <suggestion>un max</suggestion> (familier ; degré d’intensité), <suggestion>à plein tubes</suggestion> (familier ; volume), <suggestion>à plein régime</suggestion> (vitesse), <suggestion>à toute allure</suggestion> (vitesse), <suggestion>à fond de train</suggestion> (familier ; vitesse), <suggestion>à fond la caisse</suggestion> (familier ; vitesse), <suggestion>à toute vapeur</suggestion> (familier ; vitesse), <suggestion>à toute pompe</suggestion> (familier ; vitesse), <suggestion>à pleine gomme</suggestion> (familier ; vitesse).</message>
-                <example correction="un max|à plein tubes|à plein régime|à toute allure|à fond de train|à fond la caisse|à toute vapeur|à toute pompe|à pleine gomme"><marker>full pin</marker></example>
-                <example><marker>à plein régime</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="FAIRWAY" name="fairway">
-            <rule>
-                <pattern>
-                    <token regexp="yes" case_sensitive="yes">fair-?ways?</token>
-                </pattern>
-                <message>« Fairway » peut être considéré comme un anglicisme. Employez <suggestion>allée</suggestion> (golf).</message>
-                <example correction="allée"><marker>fairway</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes" case_sensitive="yes">fairs?</token>
-                    <token regexp="yes">ways?</token>
-                </pattern>
-                <message>« Fairway » peut être considéré comme un anglicisme. Employez <suggestion>allée</suggestion> (golf).</message>
-                <example correction="allée"><marker>fair way</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="FAIR-PLAY" name="fair-play">
-            <rule>
-                <pattern>
-                    <token regexp="yes">fair-?plays?</token>
-                </pattern>
-                <message>« Fair-play » peut être considéré comme un anglicisme. Employez <suggestion>franc-jeu</suggestion> (substantif), <suggestion>loyal</suggestion> (adjectif), <suggestion>régulier</suggestion> (adjectif).</message>
-                <example correction="franc-jeu|loyal|régulier"><marker>fair-play</marker></example>
-                <example><marker>franc-jeu</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">fairs?</token>
-                    <token regexp="yes">plays?</token>
-                </pattern>
-                <message>« Fair-play » peut être considéré comme un anglicisme. Employez <suggestion>franc-jeu</suggestion> (substantif), <suggestion>loyal</suggestion> (adjectif), <suggestion>régulier</suggestion> (adjectif).</message>
-                <example correction="franc-jeu|loyal|régulier"><marker>fair play</marker></example>
-                <example><marker>franc-jeu</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="EGG_ROLL" name="egg roll">
-            <rule>
-                <pattern>
-                    <token regexp="yes">eggs?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">rolls?</token>
-                </pattern>
-                <message>« Egg roll » peut être considéré comme un anglicisme.</message>
-                <suggestion>rouleau de printemps</suggestion>
-                <suggestion>pâté impérial</suggestion>
-                <example correction="rouleau de printemps|pâté impérial"><marker>egg roll</marker></example>
-                <example><marker>rouleau impérial</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">eggrolls?</token>
-                </pattern>
-                <message>« Egg roll » peut être considéré comme un anglicisme.</message>
-                <suggestion>rouleau de printemps</suggestion>
-                <suggestion>pâté impérial</suggestion>
-                <example correction="rouleau de printemps|pâté impérial"><marker>eggroll</marker></example>
-                <example><marker>rouleau impérial</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="CLAM_CHOWDER" name="clam chowder">
-            <rule>
-                <pattern>
-                    <token regexp="yes">clams?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">chowders?</token>
-                </pattern>
-                <message>« Clam chowder » peut être considéré comme un anglicisme.</message>
-                <suggestion>chaudrée de palourde</suggestion>
-                <example correction="chaudrée de palourde"><marker>clam chowder</marker></example>
-                <example><marker>chaudrée de palourdes</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">clamchowders?</token>
-                </pattern>
-                <message>« Clam chowder » peut être considéré comme un anglicisme.</message>
-                <suggestion>chaudrée de palourde</suggestion>
-                <example correction="chaudrée de palourde"><marker>clamchowder</marker></example>
-                <example><marker>chaudrée de palourdes</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="CROWBAR" name="crowbar">
-            <rule>
-                <pattern>
-                    <token regexp="yes">crows?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">bars?|barres?</token>
-                </pattern>
-                <message>« Crowbar » peut être considéré comme un anglicisme. Employez <suggestion>pied-de-biche</suggestion>, <suggestion>pince-monseigneur</suggestion>, <suggestion>pince à levier</suggestion>, <suggestion>barre à mine</suggestion> (pour creuser, essoucher).</message>
-                <example correction="pied-de-biche|pince-monseigneur|pince à levier|barre à mine"><marker>crow bar</marker></example>
-                <example><marker>pied-de-biche</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">crowbars?|crowbarres?</token>
-                </pattern>
-                <message>« Crowbar » peut être considéré comme un anglicisme. Employez <suggestion>pied-de-biche</suggestion>, <suggestion>pince-monseigneur</suggestion>, <suggestion>pince à levier</suggestion>, <suggestion>barre à mine</suggestion> (pour creuser, essoucher).</message>
-                <example correction="pied-de-biche|pince-monseigneur|pince à levier|barre à mine"><marker>crowbar</marker></example>
-                <example><marker>pied-de-biche</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="GAZEBO" name="Gazebo">
-            <pattern>
-                <token regexp="yes">gazebos?</token>
-            </pattern>
-            <message>« Gazebo » peut être considéré comme un anglicisme.</message>
-            <suggestion>pavillon</suggestion>
-            <suggestion>tonnelle</suggestion>
-            <suggestion>kiosque de jardin</suggestion>
-            <suggestion>gloriette</suggestion>
-            <example correction="pavillon|tonnelle|kiosque de jardin|gloriette"><marker>gazebo</marker></example>
-            <example><marker>pavillon</marker></example>
-        </rule>
-        <rule id="PAD" name="pad">
-            <pattern>
-                <token regexp="yes">pads?|paddes?
-                    <exception scope="previous">-</exception></token>
-            </pattern>
-            <message>« Pad » peut être considéré comme un anglicisme. Employez <suggestion>épaulette</suggestion>, <suggestion>bloc-notes</suggestion>, <suggestion>nuque longue</suggestion> (coupe de cheveux), <suggestion>clavier</suggestion> (informatique), <suggestion>pavé numérique</suggestion> (informatique), <suggestion>coussin chauffant</suggestion>, <suggestion>coussinet</suggestion>, <suggestion>tampon encreur</suggestion> (article de bureau).</message>
-            <example correction="épaulette|bloc-notes|nuque longue|clavier|pavé numérique|coussin chauffant|coussinet|tampon encreur"><marker>pad</marker></example>
-            <example><marker>nuque longue</marker></example>
-        </rule>
-        <rule id="EXHIBIT" name="exhibit">
-            <pattern>
-                <token regexp="yes">exhibits?</token>
-            </pattern>
-            <message>« Exhibit » peut être considéré comme un anglicisme. Employez <suggestion>pièce à conviction</suggestion> (droit), <suggestion>pièce</suggestion> (droit), <suggestion>objet exposé</suggestion> (exposition), <suggestion>pièce d'exposition</suggestion> (exposition), <suggestion>pièce exposée</suggestion> (exposition), <suggestion>produit</suggestion> (foire agricole).</message>
-            <example correction="pièce à conviction|pièce|objet exposé|pièce d'exposition|pièce exposée|produit"><marker>exhibit</marker></example>
-            <example><marker>pièce à conviction</marker></example>
-        </rule>
-        <rulegroup id="EX-OFFICIO" name="ex officio">
-            <rule>
-                <pattern>
-                    <token>ex</token>
-                    <token min="0">-</token>
-                    <token>officio</token>
-                </pattern>
-                <message>« Ex officio » peut être considéré comme un anglicisme.</message>
-                <suggestion>d'office</suggestion>
-                <suggestion>de droit</suggestion>
-                <example correction="d'office|de droit"><marker>ex officio</marker></example>
-                <example correction="d'office|de droit"><marker>ex-officio</marker></example>
-                <example><marker>d’office</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="EYE-LINER" name="eye-liner" default="off">
-            <!-- deactivated : widespread usage -->
-            <rule>
-                <pattern>
-                    <token regexp="yes">eyes?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">liners?</token>
-                </pattern>
-                <message>« Eye liner » peut être considéré comme un anglicisme.</message>
-                <suggestion>crayon</suggestion>
-                <example correction="crayon"><marker>eye liner</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">eyes?-?liners?</token>
-                </pattern>
-                <message>« Eye-liner » peut être considéré comme un anglicisme.</message>
-                <suggestion>crayon</suggestion>
-                <example correction="crayon"><marker>eyeliner</marker></example>
-                <example correction="crayon"><marker>eye-liner</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="CRUISE_CONTROL" name="cruise control">
-            <rule>
-                <pattern>
-                    <token regexp="yes">cruises?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">controls?</token>
-                </pattern>
-                <message>« Cruise control » peut être considéré comme un anglicisme.</message>
-                <suggestion>régulateur de vitesse</suggestion>
-                <example correction="régulateur de vitesse"><marker>cruise control</marker></example>
-                <example correction="régulateur de vitesse"><marker>cruise-control</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">cruisecontrols?</token>
-                </pattern>
-                <message>« Cruise control » peut être considéré comme un anglicisme.</message>
-                <suggestion>régulateur de vitesse</suggestion>
-                <example correction="régulateur de vitesse"><marker>cruisecontrol</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="CLAPBOARD" name="clapboard">
-            <rule>
-                <pattern>
-                    <token regexp="yes">claps?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">boards?</token>
-                </pattern>
-                <message>« Clapboard » peut être considéré comme un anglicisme.</message>
-                <suggestion>clin d'aluminium</suggestion>
-                <example correction="clin d'aluminium"><marker>clap board</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">clapboards?</token>
-                </pattern>
-                <message>« Clapboard » peut être considéré comme un anglicisme.</message>
-                <suggestion>clin d'aluminium</suggestion>
-                <example correction="clin d'aluminium"><marker>clapboard</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup default="off" id="FAST_FOOD" name="fast food">
-            <rule>
-                <pattern>
-                    <token regexp="yes">fasts?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">foods?</token>
-                </pattern>
-                <message>« Fast food » peut être considéré comme un anglicisme.</message>
-                <suggestion>repas-minute</suggestion>
-                <suggestion>restaurant-minute</suggestion>
-                <suggestion>cuisine-minute</suggestion>
-                <suggestion>plat-minute</suggestion>
-                <suggestion>prêt-à-manger</suggestion>
-                <suggestion>restauration-minute</suggestion>
-                <example correction="repas-minute|restaurant-minute|cuisine-minute|plat-minute|prêt-à-manger|restauration-minute"><marker>fast food</marker></example>
-                <example><marker>repas-minute</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">fastfoods?</token>
-                </pattern>
-                <message>« Fast food » peut être considéré comme un anglicisme.</message>
-                <suggestion>repas-minute</suggestion>
-                <suggestion>restaurant-minute</suggestion>
-                <suggestion>cuisine-minute</suggestion>
-                <suggestion>plat-minute</suggestion>
-                <suggestion>prêt-à-manger</suggestion>
-                <suggestion>restauration-minute</suggestion>
-                <example correction="repas-minute|restaurant-minute|cuisine-minute|plat-minute|prêt-à-manger|restauration-minute"><marker>fastfood</marker></example>
-                <example><marker>repas-minute</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BURNOUT" name="burnout" tags="picky">
-            <rule>
-                <pattern>
-                    <token regexp="yes">burns?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">outs?</token>
-                </pattern>
-                <message>« Burnout » peut être considéré comme un anglicisme.</message>
-                <suggestion>surmenage</suggestion>
-                <suggestion>épuisement professionnel</suggestion>
-                <example correction="surmenage|épuisement professionnel"><marker>burn out</marker></example>
-                <example><marker>surmenage</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">burnouts?</token>
-                </pattern>
-                <message>« Burnout » peut être considéré comme un anglicisme.</message>
-                <suggestion>surmenage</suggestion>
-                <suggestion>épuisement professionnel</suggestion>
-                <example correction="surmenage|épuisement professionnel"><marker>burnout</marker></example>
-                <example><marker>surmenage</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BED_AND_BREAKFAST" name="bed and breakfast" default="off">
-            <rule>
-                <pattern>
-                    <token regexp="yes">beds?</token>
-                    <token min="0">-</token>
-                    <token>and</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">breakfasts?</token>
-                </pattern>
-                <message>« Bed and breakfast » peut être considéré comme un anglicisme.</message>
-                <suggestion>chambre d'hôte</suggestion>
-                <suggestion>maison d'hôte</suggestion>
-                <example correction="chambre d'hôte|maison d'hôte"><marker>bed and breakfast</marker></example>
-                <example correction="chambre d'hôte|maison d'hôte"><marker>bed-and-breakfast</marker></example>
-                <example><marker>chambre d’hôte</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BOW-WINDOW" name="bow-window" tags="picky">
-            <rule>
-                <pattern>
-                    <token regexp="yes">bows?</token>
-                    <token regexp="yes">windows?</token>
-                </pattern>
-                <message>« Bow-window » peut être considéré comme un anglicisme.</message>
-                <suggestion>fenêtre arquée</suggestion>
-                <suggestion>fenêtre en saillie</suggestion>
-                <example correction="fenêtre arquée|fenêtre en saillie"><marker>bow window</marker></example>
-                <example><marker>fenêtre arquée</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">bow-?windows?</token>
-                </pattern>
-                <message>« Bow-window » peut être considéré comme un anglicisme.</message>
-                <suggestion>fenêtre arquée</suggestion>
-                <suggestion>fenêtre en saillie</suggestion>
-                <example correction="fenêtre arquée|fenêtre en saillie"><marker>bow-window</marker></example>
-                <example><marker>fenêtre arquée</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BRAINSTORMING" name="brainstorming">
-            <rule>
-                <pattern>
-                    <token regexp="yes">brains?</token>
-                    <token regexp="yes">stormings?</token>
-                </pattern>
-                <message>« Brainstorming » peut être considéré comme un anglicisme.</message>
-                <suggestion>remue-méninges</suggestion>
-                <example correction="remue-méninges"><marker>brain storming</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">brain-?stormings?</token>
-                </pattern>
-                <message>« Brainstorming » peut être considéré comme un anglicisme.</message>
-                <suggestion>remue-méninges</suggestion>
-                <example correction="remue-méninges"><marker>brainstorming</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BELLBOY" name="bellboy">
-            <rule>
-                <pattern>
-                    <token regexp="yes">bells?</token>
-                    <token regexp="yes">boys?</token>
-                </pattern>
-                <message>« Bellboy » peut être considéré comme un anglicisme.</message>
-                <suggestion>chasseur</suggestion>
-                <example correction="chasseur"><marker>bell boy</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">bell-?boys?</token>
-                </pattern>
-                <message>« Bellboy » peut être considéré comme un anglicisme.</message>
-                <suggestion>chasseur</suggestion>
-                <example correction="chasseur"><marker>bellboy</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BLOCK_HEATER" name="block heater">
-            <rule>
-                <pattern>
-                    <token regexp="yes">blocks?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">heaters?</token>
-                </pattern>
-                <message>« Block heater » peut être considéré comme un anglicisme.</message>
-                <suggestion>chauffe-moteur</suggestion>
-                <example correction="chauffe-moteur"><marker>block heater</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">blocks?heaters?</token>
-                </pattern>
-                <message>« Block heater » peut être considéré comme un anglicisme.</message>
-                <suggestion>chauffe-moteur</suggestion>
-                <example correction="chauffe-moteur"><marker>blockheater</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BACKUP" name="backup">
-            <rule>
-                <pattern>
-                    <token case_sensitive="yes">back
-                        <exception scope="previous" regexp="yes">database</exception></token>
-                    <token min="0">-</token>
-                    <token>up
-                        <exception scope="next" regexp="yes">camera|system|story</exception></token>
-                </pattern>
-                <message>« Backup » peut être considéré comme un anglicisme.</message>
-                <suggestion>copie</suggestion>
-                <suggestion>sauvegarde informatique</suggestion>
-                <suggestion>fichier de sauvegarde</suggestion>
-                <suggestion>renfort</suggestion>
-                <example correction="copie|sauvegarde informatique|fichier de sauvegarde|renfort"><marker>back up</marker></example>
-                <example><marker>fichier de sauvegarde</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token case_sensitive="yes">back
-                        <exception scope="previous">database</exception></token>
-                    <token min="0">-</token>
-                    <token regexp="yes">ups?
-                        <exception scope="next" regexp="yes">managers?|restore|["]|system|camera</exception></token>
-                </pattern>
-                <message>« Backup » peut être considéré comme un anglicisme.</message>
-                <suggestion>copies</suggestion>
-                <suggestion>sauvegardes informatiques</suggestion>
-                <suggestion>fichiers de sauvegarde</suggestion>
-                <suggestion>renforts</suggestion>
-                <example correction="copies|sauvegardes informatiques|fichiers de sauvegarde|renforts"><marker>back up</marker></example>
-                <example><marker>fichier de sauvegarde</marker></example>
-            </rule>
-            <rule>
-                <antipattern>
-                    <token>database</token>
-                    <token case_sensitive="yes">backup</token>
-                </antipattern>
-                <pattern>
-                    <token case_sensitive="yes">backup
-                        <exception scope="previous" postag="D . p" postag_regexp="yes"/>
-                        <exception scope="next" regexp="yes">managers?|restore|["]|system|camera</exception></token>
-                </pattern>
-                <message>« Backup » peut être considéré comme un anglicisme.</message>
-                <suggestion>copie</suggestion>
-                <suggestion>sauvegarde informatique</suggestion>
-                <suggestion>fichier de sauvegarde</suggestion>
-                <suggestion>renfort</suggestion>
-                <example correction="copie|sauvegarde informatique|fichier de sauvegarde|renfort"><marker>backup</marker></example>
-                <example><marker>fichier de sauvegarde</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="D . p|P.*" postag_regexp="yes"/>
-                    <marker>
-                        <token case_sensitive="yes" regexp="yes">backups?</token>
-                    </marker>
-                </pattern>
-                <message>« Backup » peut être considéré comme un anglicisme.</message>
-                <suggestion>copies</suggestion>
-                <suggestion>sauvegardes informatiques</suggestion>
-                <suggestion>fichiers de sauvegarde</suggestion>
-                <suggestion>renforts</suggestion>
-                <example correction="copies|sauvegardes informatiques|fichiers de sauvegarde|renforts">Les <marker>backups</marker></example>
-                <example><marker>fichier de sauvegarde</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="ALL_DRESSED" name="all dressed">
-            <rule>
-                <pattern>
-                    <token>all</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">dressed|dress</token>
-                </pattern>
-                <message>« All dressed » peut être considéré comme un anglicisme. Employez <suggestion>garnie</suggestion> (pizza).</message>
-                <example correction="garnie"><marker>all dressed</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">alldressed|alldress</token>
-                </pattern>
-                <message>« All dressed » peut être considéré comme un anglicisme. Employez <suggestion>garnie</suggestion> (pizza).</message>
-                <example correction="garnie"><marker>alldressed</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="COACH" name="coach" default="off">
-            <!-- very low apply rate -->
-            <pattern>
-                <token regexp="yes">coach|coaches|coachs</token>
-            </pattern>
-            <message>« Coach » est considéré comme un anglicisme. En voici des alternatives : <suggestion>entraîneur</suggestion> (sport), <suggestion>accompagnateur</suggestion> (entreprise, etc.), (un) <suggestion>coupé</suggestion> (automobile à deux portes et quatre places).</message>
-            <example correction="entraîneur|accompagnateur|coupé"><marker>coach</marker></example>
-            <example><marker>entraîneur</marker></example>
-        </rule>
-        <rule id="BAND" name="band">
-            <pattern>
-                <token postag="[PD].*" postag_regexp="yes"/>
-                <marker>
-                    <token regexp="yes" case_sensitive="yes">bands?</token>
-                </marker>
-            </pattern>
-            <message>« Band » peut être considéré comme un anglicisme.</message>
-            <suggestion>groupe</suggestion>
-            <suggestion>formation</suggestion>
-            <suggestion>ensemble</suggestion>
-            <suggestion>orchestre</suggestion>
-            <example correction="groupe|formation|ensemble|orchestre">Un <marker>band</marker></example>
-            <example><marker>group</marker></example>
-        </rule>
-        <rule id="SPLIT" name="split">
-            <pattern>
-                <token regexp="yes">splits?
-                    <exception scope="previous">-</exception></token>
-            </pattern>
-            <message>« Split » peut être considéré comme un anglicisme. Employez <suggestion>grand écart</suggestion> (figure de gymnastique), <suggestion>maison à deux niveaux</suggestion> (bâtiment).</message>
-            <example correction="grand écart|maison à deux niveaux"><marker>split</marker></example>
-            <example><marker>grand écart</marker></example>
-        </rule>
-        <rule id="SMOKE" name="smoke">
-            <pattern>
-                <token regexp="yes">smokes?</token>
-            </pattern>
-            <message>« Smoke » peut être considéré comme un anglicisme. Employez <suggestion>bille</suggestion> (jeu pour enfants).</message>
-            <example correction="bille"><marker>smoke</marker></example>
-        </rule>
-        <rule id="SMELTER" name="smelter">
-            <pattern>
-                <token regexp="yes">smelters?</token>
-            </pattern>
-            <message>« Smelter » peut être considéré comme un anglicisme.</message>
-            <suggestion>haut-fourneau</suggestion>
-            <suggestion>fonderie</suggestion>
-            <example correction="haut-fourneau|fonderie"><marker>smelter</marker></example>
-            <example><marker>fonderie</marker></example>
-        </rule>
-        <rule id="SMOOTH" name="smooth">
-            <pattern>
-                <token regexp="yes">smooths?</token>
-            </pattern>
-            <message>« Smooth » peut être considéré comme un anglicisme. Employez <suggestion>doux</suggestion>, <suggestion>calme</suggestion>, <suggestion>pénard</suggestion> (familier).</message>
-            <example correction="doux|calme|pénard"><marker>smooth</marker></example>
-            <example><marker>doux</marker></example>
-        </rule>
-        <rule id="TOO_BAD" name="too bad">
-            <pattern>
-                <token>too</token>
-                <token>bad</token>
-            </pattern>
-            <message>« Too bad » peut être considéré comme un anglicisme.</message>
-            <suggestion>c'est quand même incroyable !</suggestion>
-            <suggestion>quel dommage !</suggestion>
-            <suggestion>tant pis !</suggestion>
-            <example correction="c'est quand même incroyable !|quel dommage !|tant pis !"><marker>too bad</marker></example>
-            <example><marker>tant pis !</marker></example>
-        </rule>
-        <rule id="PER_CAPITA" name="per capita">
-            <pattern>
-                <token>per</token>
-                <token regexp="yes">capp?itas?</token>
-            </pattern>
-            <message>« Per capita » peut être considéré comme un anglicisme. Employez <suggestion>par personne</suggestion>, <suggestion>par habitant</suggestion>, <suggestion>par tête</suggestion>, <suggestion>par tête de pipe</suggestion> (familier).</message>
-            <example correction="par personne|par habitant|par tête|par tête de pipe"><marker>per capita</marker></example>
-            <example><marker>par tête</marker></example>
-        </rule>
-        <rule id="FIXTURE" name="fixture">
-            <pattern>
-                <token regexp="yes">fixtures?</token>
-            </pattern>
-            <message>« Fixture » peut être considéré comme un anglicisme. Employez <suggestion>installations sanitaires</suggestion> (salle de bain), <suggestion>plomberie</suggestion>, <suggestion>tuyauterie</suggestion>, <suggestion>appareillage électrique</suggestion>, <suggestion>appareils électriques</suggestion>, <suggestion>luminaire</suggestion>, <suggestion>applique</suggestion>, <suggestion>plafonnier</suggestion>, <suggestion>suspension</suggestion>, <suggestion>appareil d'éclairage</suggestion>, <suggestion>installation électrique</suggestion>, <suggestion>accessoire fixe</suggestion>.</message>
-            <example correction="installations sanitaires|plomberie|tuyauterie|appareillage électrique|appareils électriques|luminaire|applique|plafonnier|suspension|appareil d'éclairage|installation électrique|accessoire fixe"><marker>fixture</marker></example>
-            <example><marker>plomberie</marker></example>
-        </rule>
-        <rule id="PLASTER" name="plaster">
-            <pattern>
-                <token regexp="yes">plasters?</token>
-            </pattern>
-            <message>« Plaster » peut être considéré comme un anglicisme.</message>
-            <suggestion>pansement</suggestion>
-            <example correction="pansement"><marker>plaster</marker></example>
-        </rule>
-        <rule id="PLUG" name="plug">
-            <pattern>
-                <token regexp="yes">plugs?</token>
-            </pattern>
-            <message>« Plug » peut être considéré comme un anglicisme.</message>
-            <suggestion>prise de courant</suggestion>
-            <suggestion>prise électrique</suggestion>
-            <suggestion>fiche</suggestion>
-            <suggestion>publicité gratuite</suggestion>
-            <suggestion>publicité dissimulée</suggestion>
-            <example correction="prise de courant|prise électrique|fiche|publicité gratuite|publicité dissimulée"><marker>plug</marker></example>
-            <example><marker>prise de courant</marker></example>
-        </rule>
-        <rulegroup id="LOOK" name="look">
-            <antipattern>
-                <token>
-                    <exception postag="SENT_START"/></token>
-                <token case_sensitive="yes" regexp="yes">Looks?</token>
-            </antipattern>
-            <rule>
-                <pattern>
-                    <token postag="D m s">
-                        <exception regexp="yes">le|ce</exception></token>
-                    <token>look</token>
-                </pattern>
-                <message>« Look » est un considéré comme un anglicisme. En voici quelques alternatives :</message>
-                <suggestion><match no="1" postag="(D) (m) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> allure</suggestion>
-                <suggestion><match no="1" postag="(D) (m) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> apparence</suggestion>
-                <suggestion>\1 style</suggestion>
-                <suggestion>\1 aspect</suggestion>
-                <example correction="une allure|une apparence|un style|un aspect"><marker>un look</marker></example>
-                <example><marker>allure</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>ce</token>
-                    <token>look</token>
-                </pattern>
-                <message>« Look » est un considéré comme un anglicisme. En voici quelques alternatives :</message>
-                <suggestion>cette allure</suggestion>
-                <suggestion>cette apparence</suggestion>
-                <suggestion>ce style</suggestion>
-                <suggestion>cet aspect</suggestion>
-                <example correction="cette allure|cette apparence|ce style|cet aspect"><marker>ce look</marker></example>
-                <example><marker>allure</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">[dl]e</token>
-                    <token>look</token>
-                </pattern>
-                <message>« Look » est un considéré comme un anglicisme. En voici quelques alternatives :</message>
-                <suggestion><match no="1" regexp_match="(?iu)e" regexp_replace="'"/>allure</suggestion>
-                <suggestion><match no="1" regexp_match="(?iu)e" regexp_replace="'"/>apparence</suggestion>
-                <suggestion>\1 style</suggestion>
-                <suggestion><match no="1" regexp_match="(?iu)e" regexp_replace="'"/>aspect</suggestion>
-                <example correction="l'allure|l'apparence|le style|l'aspect"><marker>le look</marker></example>
-                <example><marker>allure</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">looks?
-                        <exception scope="previous" regexp="yes">de|it</exception>
-                        <exception scope="previous" postag="D m s"/></token>
-                </pattern>
-                <message>« Look » est un considéré comme un anglicisme. En voici quelques alternatives :</message>
-                <suggestion><match no="1" regexp_match="look(?iu)" regexp_replace="allure"/></suggestion>
-                <suggestion><match no="1" regexp_match="look(?iu)" regexp_replace="apparence"/></suggestion>
-                <suggestion><match no="1" regexp_match="look(?iu)" regexp_replace="style"/></suggestion>
-                <suggestion><match no="1" regexp_match="look(?iu)" regexp_replace="aspect"/></suggestion>
-                <example correction="allures|apparences|styles|aspects">des <marker>looks</marker></example>
-                <example><marker>allure</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>de</token>
-                    <token>looks</token>
-                </pattern>
-                <message>« Look » est un considéré comme un anglicisme. En voici quelques alternatives :</message>
-                <suggestion><match no="1" regexp_match="(?iu)e" regexp_replace="'"/>allures</suggestion>
-                <suggestion><match no="1" regexp_match="(?iu)e" regexp_replace="'"/>apparences</suggestion>
-                <suggestion>\1 styles</suggestion>
-                <suggestion><match no="1" regexp_match="(?iu)e" regexp_replace="'"/>aspects</suggestion>
-                <example correction="d'allures|d'apparences|de styles|d'aspects"><marker>de looks</marker></example>
-                <example><marker>allure</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="SMOOTHY" name="smoothy">
-            <pattern>
-                <token regexp="yes">smoothys?|smoothies</token>
-            </pattern>
-            <message>« Smoothy » peut être considéré comme un anglicisme.</message>
-            <suggestion>onctueux</suggestion>
-            <suggestion>crémeux</suggestion>
-            <suggestion>baratté</suggestion>
-            <example correction="onctueux|crémeux|baratté"><marker>smoothy</marker></example>
-            <example><marker>baratté</marker></example>
-        </rule>
-        <rule id="PER_DIEM" name="per diem">
-            <pattern>
-                <token>per</token>
-                <token regexp="yes">diems?</token>
-            </pattern>
-            <message>« Per diem » peut être considéré comme un anglicisme.</message>
-            <suggestion>allocation journalière</suggestion>
-            <suggestion>indemnité journalière</suggestion>
-            <example correction="allocation journalière|indemnité journalière"><marker>per diem</marker></example>
-            <example><marker>allocation journalière</marker></example>
-        </rule>
-        <rule id="JUNKIE" name="junk(ie)">
-            <pattern>
-                <token regexp="yes">junkie|junky|junkies|junkys|junk|junks</token>
-            </pattern>
-            <message>« Junk(ie) » peut être considéré comme un anglicisme.</message>
-            <suggestion>toxicomane</suggestion>
-            <suggestion>drogué</suggestion>
-            <example correction="toxicomane|drogué"><marker>junkie</marker></example>
-            <example><marker>drogué</marker></example>
-        </rule>
-        <rule id="SPEECH" name="speech">
-            <pattern>
-                <token regexp="yes">speechs?|speeches</token>
-            </pattern>
-            <message>« Speech » peut être considéré comme un anglicisme.</message>
-            <suggestion>allocution</suggestion>
-            <suggestion>discours</suggestion>
-            <suggestion>sermon</suggestion>
-            <suggestion>remontrances</suggestion>
-            <example correction="allocution|discours|sermon|remontrances"><marker>speech</marker></example>
-            <example><marker>discours</marker></example>
-        </rule>
-        <rule id="PATTERN" name="pattern">
-            <pattern>
-                <token regexp="yes">patterns?</token>
-            </pattern>
-            <message>« Pattern » peut être considéré comme un anglicisme.</message>
-            <suggestion>modèle</suggestion>
-            <suggestion>schéma</suggestion>
-            <suggestion>structure</suggestion>
-            <suggestion>déroulement</suggestion>
-            <suggestion>cheminement</suggestion>
-            <suggestion>processus</suggestion>
-            <suggestion>configuration</suggestion>
-            <suggestion>type</suggestion>
-            <suggestion>patron</suggestion>
-            <suggestion>trame</suggestion>
-            <suggestion>motif</suggestion>
-            <suggestion>configuration</suggestion>
-            <example correction="modèle|schéma|structure|déroulement|cheminement|processus|configuration|type|patron|trame|motif"><marker>pattern</marker></example>
-            <example><marker>modèle</marker></example>
-        </rule>
-        <rule id="DRILL" name="drill">
-            <pattern>
-                <token regexp="yes">drills?</token>
-            </pattern>
-            <message>« Drill » peut être considéré comme un anglicisme. Employez <suggestion>perceuse</suggestion> (bois, métal), <suggestion>foreuse</suggestion> (pierre), <suggestion>roulette</suggestion> (dentiste), <suggestion>exercice militaire</suggestion> (armée), <suggestion>exercice d'apprentissage</suggestion> (enseignement).</message>
-            <example correction="perceuse|foreuse|roulette|exercice militaire|exercice d'apprentissage"><marker>drill</marker></example>
-            <example><marker>perceuse</marker></example>
-        </rule>
-        <rule id="DRUMMER" name="drummer">
-            <pattern>
-                <token regexp="yes">drummers?</token>
-            </pattern>
-            <message>« Drummer » peut être considéré comme un anglicisme.</message>
-            <suggestion>batteur</suggestion>
-            <suggestion>percussionniste</suggestion>
-            <example correction="batteur|percussionniste"><marker>drummer</marker></example>
-            <example><marker>batteur</marker></example>
-        </rule>
-        <rule id="PEELING" name="peeling">
-            <pattern>
-                <token regexp="yes">peelings?</token>
-            </pattern>
-            <message>« Peeling » peut être considéré comme un anglicisme.</message>
-            <suggestion>dermabrasion</suggestion>
-            <example correction="dermabrasion"><marker>peeling</marker></example>
-        </rule>
-        <rulegroup id="DRIVING_RANGE" name="driving range">
-            <rule>
-                <pattern>
-                    <token regexp="yes">drivings?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">ranges?</token>
-                </pattern>
-                <message>« Driving range » peut être considéré comme un anglicisme.</message>
-                <suggestion>terrain d'exercice</suggestion>
-                <example correction="terrain d'exercice"><marker>driving range</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="SPLIT-LEVEL" name="split-level">
-            <rule>
-                <pattern>
-                    <token regexp="yes">splitlevels?</token>
-                </pattern>
-                <message>« Split-level » peut être considéré comme un anglicisme.</message>
-                <suggestion>maison sur deux niveaux</suggestion>
-                <suggestion>maison à deux niveaux</suggestion>
-                <example correction="maison sur deux niveaux|maison à deux niveaux"><marker>splitlevel</marker></example>
-                <example><marker>maison sur deux niveaux</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">splits?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">levels?</token>
-                </pattern>
-                <message>« Split-level » peut être considéré comme un anglicisme.</message>
-                <suggestion>maison sur deux niveaux</suggestion>
-                <suggestion>maison à deux niveaux</suggestion>
-                <example correction="maison sur deux niveaux|maison à deux niveaux"><marker>split level</marker></example>
-                <example><marker>maison sur deux niveaux</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="PUSH-UP" name="push-up" default="off">
-            <rule>
-                <pattern>
-                    <token regexp="yes">pushups?</token>
-                </pattern>
-                <message>« Push-up » peut être considéré comme un anglicisme.</message>
-                <suggestion>traction</suggestion>
-                <suggestion>pompe</suggestion>
-                <example correction="traction|pompe"><marker>pushup</marker></example>
-                <example><marker>pompe</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">pushs?|pushes</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">ups?</token>
-                </pattern>
-                <message>« Push-up » peut être considéré comme un anglicisme.</message>
-                <suggestion>traction</suggestion>
-                <suggestion>pompe</suggestion>
-                <example correction="traction|pompe"><marker>push up</marker></example>
-                <example><marker>pompe</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="DRIVEWAY" name="driveway">
-            <rule>
-                <pattern>
-                    <token regexp="yes">driveway|drive-way|drive-ways|driveways</token>
-                </pattern>
-                <message>« Driveway » peut être considéré comme un anglicisme.</message>
-                <suggestion>allée</suggestion>
-                <suggestion>passage</suggestion>
-                <suggestion>entrée de garage</suggestion>
-                <suggestion>entrée de maison</suggestion>
-                <example correction="allée|passage|entrée de garage|entrée de maison"><marker>driveway</marker></example>
-                <example><marker>passage</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">drives?</token>
-                    <token regexp="yes">ways?</token>
-                </pattern>
-                <message>« Driveway » peut être considéré comme un anglicisme.</message>
-                <suggestion>allée</suggestion>
-                <suggestion>passage</suggestion>
-                <suggestion>entrée de garage</suggestion>
-                <suggestion>entrée de maison</suggestion>
-                <example correction="allée|passage|entrée de garage|entrée de maison"><marker>drive way</marker></example>
-                <example><marker>passage</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="SPEED_BUMP" name="speed bump">
-            <rule>
-                <pattern>
-                    <token regexp="yes">speedbumps?</token>
-                </pattern>
-                <message>« Speed bump » peut être considéré comme un anglicisme.</message>
-                <suggestion>ralentisseur</suggestion>
-                <example correction="ralentisseur"><marker>speedbump</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">speeds?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">bumps?</token>
-                </pattern>
-                <message>« Speed bump » peut être considéré comme un anglicisme.</message>
-                <suggestion>ralentisseur</suggestion>
-                <example correction="ralentisseur"><marker>speed bump</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="STAND-BY" name="stand-by">
-            <rule>
-                <pattern>
-                    <token regexp="yes">stand-by|stand-bys|standby|standbys|standbies|stand-bies</token>
-                </pattern>
-                <message>« Stand-by » peut être considéré comme un anglicisme.</message>
-                <suggestion>en attente</suggestion>
-                <suggestion>attente</suggestion>
-                <suggestion>liste d'attente</suggestion>
-                <suggestion>passage en attente</suggestion>
-                <suggestion>vol sur attente</suggestion>
-                <example correction="en attente|attente|liste d'attente|passage en attente|vol sur attente"><marker>stand-by</marker></example>
-                <example><marker>attente</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">stand|stands</token>
-                    <token regexp="yes">bies|by|bys</token>
-                </pattern>
-                <message>« Stand-by » peut être considéré comme un anglicisme.</message>
-                <suggestion>en attente</suggestion>
-                <suggestion>attente</suggestion>
-                <suggestion>liste d'attente</suggestion>
-                <suggestion>passage en attente</suggestion>
-                <suggestion>vol sur attente</suggestion>
-                <example correction="en attente|attente|liste d'attente|passage en attente|vol sur attente"><marker>stand by</marker></example>
-                <example><marker>attente</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="JUNK_BOND" name="junk bond">
-            <rule>
-                <pattern>
-                    <token regexp="yes">junkbou?nds?</token>
-                </pattern>
-                <message>« Junk bond » peut être considéré comme un anglicisme.</message>
-                <suggestion>obligation spéculative</suggestion>
-                <suggestion>obligation pourrie</suggestion>
-                <example correction="obligation spéculative|obligation pourrie"><marker>junkbond</marker></example>
-                <example><marker>obligation spéculative</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">junk|junks</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">bond|bonds|bounds|bound</token>
-                </pattern>
-                <message>« Junk bond » peut être considéré comme un anglicisme.</message>
-                <suggestion>obligation spéculative</suggestion>
-                <suggestion>obligation pourrie</suggestion>
-                <example correction="obligation spéculative|obligation pourrie"><marker>junk bond</marker></example>
-                <example><marker>obligation spéculative</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="JUMP_SUIT" name="jump suit">
-            <rule>
-                <pattern>
-                    <token regexp="yes">jumpsuit|jumpsuits</token>
-                </pattern>
-                <message>« Jump suit » peut être considéré comme un anglicisme.</message>
-                <suggestion>combinaison-pantalon</suggestion>
-                <suggestion>combinaison</suggestion>
-                <example correction="combinaison-pantalon|combinaison"><marker>jumpsuit</marker></example>
-                <example><marker>combinaison</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">jump|jumps</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">suit|suits</token>
-                </pattern>
-                <message>« Jump suit » peut être considéré comme un anglicisme.</message>
-                <suggestion>combinaison-pantalon</suggestion>
-                <suggestion>combinaison</suggestion>
-                <example correction="combinaison-pantalon|combinaison"><marker>jump suit</marker></example>
-                <example><marker>combinaison</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="JUNK_FOOD" name="junk food">
-            <rule>
-                <pattern>
-                    <token regexp="yes">junkfood|junkfoods</token>
-                </pattern>
-                <message>« Junk food » peut être considéré comme un anglicisme.</message>
-                <suggestion>malbouffe</suggestion>
-                <suggestion>camelote</suggestion>
-                <suggestion>saloperies</suggestion>
-                <!--(familier)-->
-                <suggestion>aliment vide</suggestion>
-                <example correction="malbouffe|camelote|saloperies|aliment vide"><marker>junkfood</marker></example>
-                <example><marker>camelote</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">junk|junks</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">food|foods</token>
-                </pattern>
-                <message>« Junk food » peut être considéré comme un anglicisme.</message>
-                <suggestion>malbouffe</suggestion>
-                <suggestion>camelote</suggestion>
-                <suggestion>saloperies</suggestion>
-                <!--(familier)-->
-                <suggestion>aliment vide</suggestion>
-                <example correction="malbouffe|camelote|saloperies|aliment vide"><marker>junk food</marker></example>
-                <example><marker>camelote</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="JUNK_MAIL" name="junk mail">
-            <rule>
-                <pattern>
-                    <token regexp="yes">junkmail|junkmails</token>
-                </pattern>
-                <message>« Junk mail » peut être considéré comme un anglicisme.</message>
-                <suggestion>pourriel</suggestion>
-                <suggestion>courrier-poubelle</suggestion>
-                <suggestion>courriel-rebut</suggestion>
-                <suggestion>polluriel</suggestion>
-                <suggestion>courrier publicitaire importun</suggestion>
-                <example correction="pourriel|courrier-poubelle|courriel-rebut|polluriel|courrier publicitaire importun"><marker>junkmail</marker></example>
-                <example><marker>pourriel</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">junk|junks</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">mail|mails</token>
-                </pattern>
-                <message>« Junk mail » peut être considéré comme un anglicisme.</message>
-                <suggestion>pourriel</suggestion>
-                <suggestion>courrier-poubelle</suggestion>
-                <suggestion>courriel-rebut</suggestion>
-                <suggestion>polluriel</suggestion>
-                <suggestion>courrier publicitaire importun</suggestion>
-                <example correction="pourriel|courrier-poubelle|courriel-rebut|polluriel|courrier publicitaire importun"><marker>junk mail</marker></example>
-                <example><marker>pourriel</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="LIFTING" name="lifting" default="off">
-            <pattern>
-                <token regexp="yes">lifting|liftings</token>
-            </pattern>
-            <message>« Lifting » peut être considéré comme un anglicisme.</message>
-            <suggestion>lissage</suggestion>
-            <suggestion>remodelage</suggestion>
-            <example correction="lissage|remodelage"><marker>lifting</marker></example>
-            <example><marker>remodelage</marker></example>
-        </rule>
-        <rulegroup id="JOB" name="job" tags="picky">
-            <antipattern>
-                <token regexp="yes">jobs?</token>
-                <token regexp="yes">recrui?ting|dating|-|sharing|design</token>
-            </antipattern>
-            <antipattern>
-                <token regexp="yes">dating|blow|inside|good|"|steve|-|great|fantastic|your|enjoy|[\#]|loub|bullshit</token>
-                <token regexp="yes">jobs?</token>
-            </antipattern>
-            <antipattern>
-                <token>
-                    <exception postag="SENT_START"/></token>
-                <token regexp="yes">(?-i)Jobs?|(?-i)JOBS?</token>
-            </antipattern>
-            <antipattern>
-                <token regexp="yes" skip="1">(?-i)Jobs?|(?-i)JOBS?</token>
-                <token regexp="yes">(?-i)[A-Z].*</token>
-            </antipattern>
-            <antipattern>
-                <token regexp="yes" skip="1">(?-i)Jobs?|(?-i)JOBS?</token>
-                <token postag="[YK]" postag_regexp="yes"/>
-            </antipattern>
-            <rule>
-                <pattern>
-                    <marker>
-                        <token postag="D . s" postag_regexp="yes">
-                            <exception postag="D f s"/>
-                            <exception regexp="yes">le|ce</exception></token>
-                        <token case_sensitive="yes">job</token>
-                    </marker>
-                </pattern>
-                <message>« Job » peut être considéré comme un anglicisme.</message>
-                <suggestion>\1 emploi</suggestion>
-                <suggestion>\1 boulot</suggestion>
-                <suggestion>\1 travail</suggestion>
-                <example correction="mon emploi|mon boulot|mon travail">J'apprécie <marker>mon job</marker>.</example>
-                <example><marker>boulot</marker></example>
-                <example>Steve <marker>Jobs</marker>, le pionnier de l’ordinateur conçu comme une prison cool, mise au point pour supprimer leur liberté aux idiots, est mort.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <marker>
-                        <token>le</token>
-                        <token regexp="yes" case_sensitive="yes">job|jobs
-                            <exception scope="previous">Steve</exception></token>
-                    </marker>
-                </pattern>
-                <message>« Job » peut être considéré comme un anglicisme.</message>
-                <suggestion>l'<match no="2" regexp_match="(?i)job" regexp_replace="emploi"/></suggestion>
-                <suggestion>le <match no="2" regexp_match="(?i)job" regexp_replace="boulot"/></suggestion>
-                <suggestion>la <match no="2" regexp_match="(?i)job" regexp_replace="tâche"/></suggestion>
-                <suggestion>le <match no="2" regexp_match="(?i)job" regexp_replace="travail"/></suggestion>
-                <example correction="l'emploi|le boulot|la tâche|le travail">J'apprécie <marker>le job</marker>.</example>
-                <example><marker>boulot</marker></example>
-                <example>Steve <marker>Jobs</marker>, le pionnier de l’ordinateur conçu comme une prison cool, mise au point pour supprimer leur liberté aux idiots, est mort.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <marker>
-                        <token>de</token>
-                        <token case_sensitive="yes">job
-                            <exception scope="previous">Steve</exception></token>
-                    </marker>
-                </pattern>
-                <message>« Job » peut être considéré comme un anglicisme.</message>
-                <suggestion>d'<match no="2" regexp_match="job(?iu)" regexp_replace="emploi"/></suggestion>
-                <suggestion>de <match no="2" regexp_match="job(?iu)" regexp_replace="boulot"/></suggestion>
-                <suggestion>de <match no="2" regexp_match="job(?iu)" regexp_replace="tâche"/></suggestion>
-                <suggestion>de <match no="2" regexp_match="job(?iu)" regexp_replace="travail"/></suggestion>
-                <example correction="d'emploi|de boulot|de tâche|de travail">Tu dois changer <marker>de job</marker>.</example>
-                <example><marker>boulot</marker></example>
-                <example>Steve <marker>Jobs</marker>, le pionnier de l’ordinateur conçu comme une prison cool, mise au point pour supprimer leur liberté aux idiots, est mort.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <marker>
-                        <token>de</token>
-                        <token case_sensitive="yes">jobs
-                            <exception scope="previous">Steve</exception></token>
-                    </marker>
-                </pattern>
-                <message>« Job » peut être considéré comme un anglicisme.</message>
-                <suggestion>d'<match no="2" regexp_match="job(?iu)" regexp_replace="emploi"/></suggestion>
-                <suggestion>de <match no="2" regexp_match="job(?iu)" regexp_replace="boulot"/></suggestion>
-                <suggestion>de <match no="2" regexp_match="job(?iu)" regexp_replace="tâche"/></suggestion>
-                <suggestion>de <match no="2" regexp_match="job(?iu)" regexp_replace="travail"/></suggestion>
-                <example correction="d'emplois|de boulots|de tâches|de travails">Le secteur tertiaire manque <marker>de jobs</marker>.</example>
-                <example><marker>boulot</marker></example>
-                <example>Steve <marker>Jobs</marker>, le pionnier de l’ordinateur conçu comme une prison cool, mise au point pour supprimer leur liberté aux idiots, est mort.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <marker>
-                        <token>ce</token>
-                        <token case_sensitive="yes">job
-                            <exception scope="previous">Steve</exception></token>
-                    </marker>
-                </pattern>
-                <message>« Job » peut être considéré comme un anglicisme.</message>
-                <suggestion>cet <match no="2" regexp_match="(?i)job" regexp_replace="emploi"/></suggestion>
-                <suggestion>\1 <match no="2" regexp_match="(?i)job" regexp_replace="boulot"/></suggestion>
-                <suggestion>cette <match no="2" regexp_match="(?i)job" regexp_replace="tâche"/></suggestion>
-                <suggestion>\1 <match no="2" regexp_match="(?i)job" regexp_replace="travail"/></suggestion>
-                <example correction="cet emploi|ce boulot|cette tâche|ce travail">J'apprécie <marker>ce job</marker>.</example>
-                <example><marker>boulot</marker></example>
-                <example>Steve <marker>Jobs</marker>, le pionnier de l’ordinateur conçu comme une prison cool, mise au point pour supprimer leur liberté aux idiots, est mort.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="D . p" postag_regexp="yes"/>
-                    <marker>
-                        <token case_sensitive="yes">jobs</token>
-                    </marker>
-                </pattern>
-                <message>« Job » peut être considéré comme un anglicisme.</message>
-                <suggestion><match no="2" regexp_match="(?i)jobs" regexp_replace="emplois"/></suggestion>
-                <suggestion><match no="2" regexp_match="(?i)jobs" regexp_replace="boulots"/></suggestion>
-                <suggestion><match no="2" regexp_match="(?i)jobs" regexp_replace="tâches"/></suggestion>
-                <suggestion><match no="2" regexp_match="(?i)jobs" regexp_replace="travails"/></suggestion>
-                <example correction="emplois|boulots|tâches|travails">J'apprécie ces <marker>jobs</marker>.</example>
-                <example><marker>boulot</marker></example>
-                <example>Steve <marker>Jobs</marker>, le pionnier de l’ordinateur conçu comme une prison cool, mise au point pour supprimer leur liberté aux idiots, est mort.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <marker>
-                        <token>job
-                            <exception scope="previous">de</exception>
-                            <exception scope="previous" postag="D.*" postag_regexp="yes"/></token>
-                    </marker>
-                </pattern>
-                <message>« Job » peut être considéré comme un anglicisme.</message>
-                <suggestion>emploi</suggestion>
-                <suggestion>boulot</suggestion>
-                <suggestion>travail</suggestion>
-                <example correction="Emploi|Boulot|Travail"><marker>Job</marker> de rêve !</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <marker>
-                        <token>jobs
-                            <exception scope="previous">de</exception>
-                            <exception scope="previous" postag="D.*" postag_regexp="yes"/></token>
-                    </marker>
-                </pattern>
-                <message>« Job » peut être considéré comme un anglicisme.</message>
-                <suggestion>emplois</suggestion>
-                <suggestion>boulots</suggestion>
-                <suggestion>tâches</suggestion>
-                <suggestion>travails</suggestion>
-                <example correction="Emplois|Boulots|Tâches|Travails"><marker>Jobs</marker> de rêve !</example>
-            </rule>
-        </rulegroup>
-        <rule id="ORIENTERING" name="orientering">
-            <pattern>
-                <token regexp="yes">orientering|orienterings</token>
-            </pattern>
-            <message>« Orientering » peut être considéré comme un anglicisme.</message>
-            <suggestion>orientation</suggestion>
-            <suggestion>course d'orientation</suggestion>
-            <example correction="orientation|course d'orientation"><marker>orientering</marker></example>
-            <example><marker>orientation</marker></example>
-        </rule>
-        <rule id="OPENER" name="opener">
-            <pattern>
-                <token regexp="yes">opener|openers</token>
-            </pattern>
-            <message>« Opener » peut être considéré comme un anglicisme.</message>
-            <suggestion>ouvre-boîte</suggestion>
-            <suggestion>décapsuleur</suggestion>
-            <example correction="ouvre-boîte|décapsuleur"><marker>opener</marker></example>
-            <example><marker>décapsuleur</marker></example>
-        </rule>
-        <rulegroup id="JUMBO-JET" name="jumbo-jet">
-            <rule>
-                <pattern>
-                    <token regexp="yes">jumbojet|jumbojets</token>
-                </pattern>
-                <message>« Jumbo-jet » peut être considéré comme un anglicisme.</message>
-                <suggestion>gros-porteur</suggestion>
-                <example correction="gros-porteur"><marker>jumbojet</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">jumbo|jumbos</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">jet|jets</token>
-                </pattern>
-                <message>« Jumbo-jet » peut être considéré comme un anglicisme.</message>
-                <suggestion>gros-porteur</suggestion>
-                <example correction="gros-porteur"><marker>jumbo jet</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="OPEN_BAR" name="open bar">
-            <rule>
-                <pattern>
-                    <token regexp="yes">openbar|openbars</token>
-                </pattern>
-                <message>« Open bar pot » peut être considéré comme un anglicisme.</message>
-                <suggestion>consommations gratuites</suggestion>
-                <example correction="consommations gratuites"><marker>openbar</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">open|opens</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">bar|bars</token>
-                </pattern>
-                <message>« Open bar pot » peut être considéré comme un anglicisme.</message>
-                <suggestion>consommations gratuites</suggestion>
-                <example correction="consommations gratuites"><marker>open bar</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="MELTING_POT" name="melting pot" default="off">
-            <rule>
-                <pattern>
-                    <token regexp="yes">melting-pot|melting-pots</token>
-                </pattern>
-                <message>« Melting pot » peut être considéré comme un anglicisme.</message>
-                <suggestion>creuset</suggestion>
-                <example correction="creuset"><marker>melting-pot</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">melting|meltings</token>
-                    <token regexp="yes">pot|pots</token>
-                </pattern>
-                <message>« Melting-pot » peut être considéré comme un anglicisme.</message>
-                <suggestion>creuset</suggestion>
-                <example correction="creuset"><marker>melting pot</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="PLYWOOD" name="plywood">
-            <rule>
-                <pattern>
-                    <token regexp="yes">plywood|plywoods|ply-woods|plys-woods|ply-wood</token>
-                </pattern>
-                <message>« Plywood » peut être considéré comme un anglicisme.</message>
-                <suggestion>contreplaqué</suggestion>
-                <example correction="contreplaqué"><marker>plywood</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">ply|plys</token>
-                    <token regexp="yes">wood|woods</token>
-                </pattern>
-                <message>« Plywood » peut être considéré comme un anglicisme.</message>
-                <suggestion>contreplaqué</suggestion>
-                <example correction="contreplaqué"><marker>ply wood</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="SHORT_CUT" name="short cut">
-            <rule>
-                <pattern>
-                    <token regexp="yes">shortcut|shortcuts</token>
-                </pattern>
-                <message>« Short cut » peut être considéré comme un anglicisme.</message>
-                <suggestion>raccourci</suggestion>
-                <example correction="raccourci"><marker>shortcut</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">short|shorts</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">cut|cuts</token>
-                </pattern>
-                <message>« Short cut » peut être considéré comme un anglicisme.</message>
-                <suggestion>raccourci</suggestion>
-                <example correction="raccourci"><marker>short cut</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="CREDIBILITY_GAP" name="credibility gap">
-            <rule>
-                <pattern>
-                    <token regexp="yes">credibility|credibilities|credibilitys</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">gap|gaps</token>
-                </pattern>
-                <message>« Credibility gap » peut être considéré comme un anglicisme.</message>
-                <suggestion>manque de crédibilité</suggestion>
-                <suggestion>crise de confiance</suggestion>
-                <suggestion>écart entre la façade et la réalité</suggestion>
-                <example correction="manque de crédibilité|crise de confiance|écart entre la façade et la réalité"><marker>credibility gap</marker></example>
-                <example><marker>manque de crédibilité</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="CREAM_PUFF" name="cream puff">
-            <rule>
-                <pattern>
-                    <token regexp="yes">creampuff|creampuffs</token>
-                </pattern>
-                <message>« Cream puff » peut être considéré comme un anglicisme.</message>
-                <suggestion>chou à la crème</suggestion>
-                <example correction="chou à la crème"><marker>creampuff</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">cream|creams</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">puff|puffs</token>
-                </pattern>
-                <message>« Cream puff » peut être considéré comme un anglicisme.</message>
-                <suggestion>chou à la crème</suggestion>
-                <example correction="chou à la crème"><marker>cream puff</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BADMAN" name="badman">
-            <rule>
-                <pattern>
-                    <token regexp="yes">badman|badmen|badmans|bad-man|bad-men|bad-mans</token>
-                </pattern>
-                <message>« Badman » peut être considéré comme un anglicisme.</message>
-                <suggestion>bandit</suggestion>
-                <suggestion>mauvais garçon</suggestion>
-                <suggestion>méchant</suggestion>
-                <example correction="bandit|mauvais garçon|méchant"><marker>badman</marker></example>
-                <example><marker>bandit</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>bad</token>
-                    <token regexp="yes">man|men|mans</token>
-                </pattern>
-                <message>« Badman » peut être considéré comme un anglicisme.</message>
-                <suggestion>bandit</suggestion>
-                <suggestion>mauvais garçon</suggestion>
-                <suggestion>méchant</suggestion>
-                <example correction="bandit|mauvais garçon|méchant"><marker>bad man</marker></example>
-                <example><marker>bandit</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BAD_LUCK" name="bad luck">
-            <rule>
-                <pattern>
-                    <token regexp="yes">bad-luck|bad-lucks|badluck|badlucks</token>
-                </pattern>
-                <message>« Badluck » peut être considéré comme un anglicisme.</message>
-                <suggestion>malchance</suggestion>
-                <example correction="malchance"><marker>badluck</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>bad</token>
-                    <token regexp="yes">luck|lucks</token>
-                </pattern>
-                <message>« Badluck » peut être considéré comme un anglicisme.</message>
-                <suggestion>malchance</suggestion>
-                <example correction="malchance"><marker>bad luck</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="TOMBOY" name="tomboy">
-            <rule>
-                <pattern>
-                    <token regexp="yes">tomboy|tomboys|tom-boy|tom-boys</token>
-                </pattern>
-                <message>« Tomboy » peut être considéré comme un anglicisme.</message>
-                <suggestion>garçon manqué</suggestion>
-                <example correction="garçon manqué"><marker>tomboy</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">tom|toms</token>
-                    <token regexp="yes">boy|boys</token>
-                </pattern>
-                <message>« Tomboy » peut être considéré comme un anglicisme.</message>
-                <suggestion>garçon manqué</suggestion>
-                <example correction="garçon manqué"><marker>tom boy</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="ROAD_MOVIE" name="road movie" default="off">
-            <!-- deactivated : widespread usage -->
-            <rule>
-                <pattern>
-                    <token regexp="yes">roadmovie|roadmovies|road-movie|road-movies</token>
-                </pattern>
-                <message>« Road-movie » peut être considéré comme un anglicisme.</message>
-                <suggestion>film de route</suggestion>
-                <suggestion>film d'errance</suggestion>
-                <example correction="film de route|film d'errance"><marker>road-movie</marker></example>
-                <example><marker>film de route</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">road|roads</token>
-                    <token regexp="yes">movie|movies</token>
-                </pattern>
-                <message>« Road-movie » peut être considéré comme un anglicisme.</message>
-                <suggestion>film de route</suggestion>
-                <suggestion>film d'errance</suggestion>
-                <example correction="film de route|film d'errance"><marker>road movie</marker></example>
-                <example><marker>film de route</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="SUCCESS_STORY" name="success story">
-            <rule>
-                <pattern>
-                    <token regexp="yes">success|successes</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">story|stories|storys</token>
-                </pattern>
-                <message>« Success story » peut être considéré comme un anglicisme.</message>
-                <suggestion>réussite commerciale</suggestion>
-                <suggestion>réussite</suggestion>
-                <suggestion>histoire d'une réussite</suggestion>
-                <suggestion>récit d'une réussite</suggestion>
-                <example correction="réussite commerciale|réussite|histoire d'une réussite|récit d'une réussite"><marker>success story</marker></example>
-                <example><marker>réussite</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="TOUCH-TONE" name="touch-tone">
-            <rule>
-                <pattern>
-                    <token regexp="yes">touchtone|touchtones</token>
-                </pattern>
-                <message>« Touch-tone » peut être considéré comme un anglicisme.</message>
-                <suggestion>à touches numériques</suggestion>
-                <suggestion>à touches</suggestion>
-                <example correction="à touches numériques|à touches"><marker>touchtone</marker></example>
-                <example><marker>à touches</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">touch|touchs</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">tone|tones</token>
-                </pattern>
-                <message>« Touch-tone » peut être considéré comme un anglicisme.</message>
-                <suggestion>à touches numériques</suggestion>
-                <suggestion>à touches</suggestion>
-                <example correction="à touches numériques|à touches"><marker>touch tone</marker></example>
-                <example><marker>à touches</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="OVERBOOKING" name="overbooking">
-            <rule>
-                <pattern>
-                    <token regexp="yes">overbooking|overbookings|over-booking|over-bookings</token>
-                </pattern>
-                <message>« Overbooking » peut être considéré comme un anglicisme.</message>
-                <suggestion>surréaction</suggestion>
-                <example correction="surréaction"><marker>overbooking</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">over|overs</token>
-                    <token regexp="yes">booking|bookings</token>
-                </pattern>
-                <message>« Overbooking » peut être considéré comme un anglicisme.</message>
-                <suggestion>surréaction</suggestion>
-                <example correction="surréaction"><marker>over booking</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="OVERDOSE" name="overdose" default="off">
-            <!-- deactivated : widespread usage -->
-            <rule>
-                <pattern>
-                    <token regexp="yes">overdose|overdoses|over-dose|over-doses</token>
-                </pattern>
-                <message>« Overdose » peut être considéré comme un anglicisme.</message>
-                <suggestion>surdose</suggestion>
-                <example correction="surdose"><marker>overdose</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">over|overs</token>
-                    <token regexp="yes">dose|doses</token>
-                </pattern>
-                <message>« Overdose » peut être considéré comme un anglicisme.</message>
-                <suggestion>surdose</suggestion>
-                <example correction="surdose"><marker>over dose</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="COVER_CHARGE" name="cover charge">
-            <rule>
-                <pattern>
-                    <token regexp="yes">cover|covers</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">charge|charges</token>
-                </pattern>
-                <message>« Cover charge » peut être considéré comme un anglicisme.</message>
-                <suggestion>couvert</suggestion>
-                <suggestion>prix de couvert</suggestion>
-                <example correction="couvert|prix de couvert"><marker>cover charge</marker></example>
-                <example><marker>prix de couvert</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="FOREMAN" name="foreman">
-            <rule>
-                <pattern>
-                    <token regexp="yes">fore-?m[ae]ns?</token>
-                </pattern>
-                <message>« Foreman » peut être considéré comme un anglicisme.</message>
-                <suggestion>contremaître</suggestion>
-                <suggestion>chef d'équipe</suggestion>
-                <suggestion>chef d'atelier</suggestion>
-                <suggestion>chef de chantier</suggestion>
-                <suggestion>agent de maîtrise</suggestion>
-                <example correction="contremaître|chef d'équipe|chef d'atelier|chef de chantier|agent de maîtrise"><marker>foreman</marker></example>
-                <example><marker>contremaître</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">fore|fores</token>
-                    <token regexp="yes">man|men|mans</token>
-                </pattern>
-                <message>« Foreman » peut être considéré comme un anglicisme.</message>
-                <suggestion>contremaître</suggestion>
-                <suggestion>chef d'équipe</suggestion>
-                <suggestion>chef d'atelier</suggestion>
-                <suggestion>chef de chantier</suggestion>
-                <suggestion>agent de maîtrise</suggestion>
-                <example correction="contremaître|chef d'équipe|chef d'atelier|chef de chantier|agent de maîtrise"><marker>fore man</marker></example>
-                <example><marker>contremaître</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="LINE-UP" name="line-up">
-            <rule>
-                <pattern>
-                    <token regexp="yes">lines?ups?</token>
-                </pattern>
-                <message>« Line-up » peut être considéré comme un anglicisme. Pour éviter la critique, employez plutôt (boutique, restaurant) <suggestion>file d'attente</suggestion>, <suggestion>queue</suggestion> (ordre de présentation d’une émission de télévision) <suggestion>mise en page</suggestion>, <suggestion>titres</suggestion>.</message>
-                <example correction="file d'attente|queue|mise en page|titres"><marker>lineup</marker></example>
-                <example><marker>queue</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">lines?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">up|ups</token>
-                </pattern>
-                <message>« Line-up » peut être considéré comme un anglicisme. Pour éviter la critique, employez plutôt (boutique, restaurant) <suggestion>file d'attente</suggestion>, <suggestion>queue</suggestion> (ordre de présentation d’une émission de télévision) <suggestion>mise en page</suggestion>, <suggestion>titres</suggestion>.</message>
-                <example correction="file d'attente|queue|mise en page|titres"><marker>line up</marker></example>
-                <example><marker>queue</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="COVER-UP" name="cover-up">
-            <rule>
-                <pattern>
-                    <token regexp="yes">covers?ups?</token>
-                </pattern>
-                <message>« Cover-up » peut être considéré comme un anglicisme.</message>
-                <suggestion>étouffement</suggestion>
-                <suggestion>dissimulation</suggestion>
-                <suggestion>étouffement</suggestion>
-                <example correction="étouffement|dissimulation"><marker>coverup</marker></example>
-                <example><marker>étouffement</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">cover|covers</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">up|ups</token>
-                </pattern>
-                <message>« Cover-up » peut être considéré comme un anglicisme.</message>
-                <suggestion>étouffement</suggestion>
-                <suggestion>dissimulation</suggestion>
-                <suggestion>étouffement</suggestion>
-                <example correction="étouffement|dissimulation"><marker>cover up</marker></example>
-                <example><marker>étouffement</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="LAB" name="lab">
-            <antipattern>
-                <token regexp="yes" skip="1">Phoenix|Dorma|Porsche|Inequality</token>
-                <token regexp="yes">Labs?</token>
-            </antipattern>
-            <pattern>
-                <token regexp="yes" case_sensitive="yes">labs?
-                    <exception scope="previous">fab</exception></token>
-            </pattern>
-            <message>« Lab » peut être considéré comme un anglicisme. Employez <suggestion><match no="1" regexp_match="(?i)ab" regexp_replace="abo"/></suggestion>.</message>
-            <example correction="labo"><marker>lab</marker></example>
-            <example>Porsche Digital Labs</example>
-        </rule>
-        <rule id="COVER" name="cover">
-            <pattern>
-                <token regexp="yes" case_sensitive="yes">cover|covers</token>
-            </pattern>
-            <message>« Cover » peut être considéré comme un anglicisme. Employez <suggestion>couverture</suggestion>, <suggestion>pochette</suggestion> (de disque), <suggestion>emballage</suggestion>, <suggestion>enveloppe</suggestion>.</message>
-            <example correction="couverture|pochette|emballage|enveloppe"><marker>cover</marker></example>
-            <example><marker>pochette</marker></example>
-        </rule>
-        <rule id="FLY" name="fly" default="off">
-            <pattern>
-                <token regexp="yes">fly|flies|flys</token>
-            </pattern>
-            <message>« Fly » peut être considéré comme un anglicisme.</message>
-            <suggestion>braguette</suggestion>
-            <example correction="braguette"><marker>fly</marker></example>
-        </rule>
-        <rule id="FOAM" name="foam">
-            <pattern>
-                <token regexp="yes">foam|foams</token>
-            </pattern>
-            <message>« Foam » peut être considéré comme un anglicisme.</message>
-            <suggestion>mousse</suggestion>
-            <example correction="mousse"><marker>foam</marker></example>
-        </rule>
-        <rule id="FLUSH" name="flush">
-            <pattern>
-                <token regexp="yes" case_sensitive="yes">flush|flushs</token>
-            </pattern>
-            <message>« Flush » peut être considéré comme un anglicisme. Employez <suggestion>quinte</suggestion> (cartes), <suggestion>au ras de</suggestion>, <suggestion>à ras de</suggestion>, <suggestion>au niveau de</suggestion>, <suggestion>à fleur de</suggestion>.</message>
-            <example correction="quinte|au ras de|à ras de|au niveau de|à fleur de"><marker>flush</marker></example>
-            <example><marker>quinte</marker></example>
-        </rule>
-        <rule id="STUCCO" name="stucco">
-            <pattern>
-                <token regexp="yes">stucc?os?</token>
-            </pattern>
-            <message>« Stucco » peut être considéré comme un anglicisme.</message>
-            <suggestion>stuc</suggestion>
-            <suggestion>marbre artificiel</suggestion>
-            <suggestion>faux marbre</suggestion>
-            <example correction="stuc|marbre artificiel|faux marbre"><marker>stucco</marker></example>
-            <example><marker>stuc</marker></example>
-        </rule>
-        <rule id="SUBPOENA" name="subpoena">
-            <pattern>
-                <token regexp="yes">subpoenas?</token>
-            </pattern>
-            <message>« Subpoena » peut être considéré comme un anglicisme.</message>
-            <suggestion>citation à comparaître</suggestion>
-            <suggestion>citation</suggestion>
-            <example correction="citation à comparaître|citation"><marker>subpoena</marker></example>
-            <example><marker>citation</marker></example>
-        </rule>
-        <rule id="DIMMER" name="dimmer">
-            <pattern>
-                <token regexp="yes">dimmers?</token>
-            </pattern>
-            <message>« Dimmer » peut être considéré comme un anglicisme.</message>
-            <suggestion>gradateur</suggestion>
-            <suggestion>variateur de lumière</suggestion>
-            <suggestion>variateur</suggestion>
-            <suggestion>variateur d'ambiance</suggestion>
-            <example correction="gradateur|variateur de lumière|variateur|variateur d'ambiance"><marker>dimmer</marker></example>
-            <example><marker>variateur</marker></example>
-        </rule>
-        <rule id="ESPRESSO" name="espresso">
-            <pattern>
-                <token regexp="yes">espresso|espressi|espressos</token>
-            </pattern>
-            <message>« Espresso » peut être considéré comme un anglicisme.</message>
-            <suggestion>expresso</suggestion>
-            <suggestion>café express</suggestion>
-            <example correction="expresso|café express"><marker>espresso</marker></example>
-            <example><marker>café express</marker></example>
-        </rule>
-        <rule id="EXTRAMARITAL" name="extramarital">
-            <pattern>
-                <token regexp="yes">extramarital|extramaritaux|extramaritals|extramaritale|extramaritales</token>
-            </pattern>
-            <message>« Extramarital » peut être considéré comme un anglicisme.</message>
-            <suggestion>extraconjugal</suggestion>
-            <example correction="extraconjugal"><marker>extramarital</marker></example>
-        </rule>
-        <rule id="TRAIL" name="trail">
-            <pattern>
-                <token regexp="yes">trails?</token>
-            </pattern>
-            <message>'Trail' peut être considéré comme un anglicisme. Employez <suggestion><match no="1" regexp_match="(?i)trail" regexp_replace="chemin"/></suggestion>, <suggestion><match no="1" regexp_match="(?i)trail" regexp_replace="sentier"/></suggestion>, <suggestion><match no="1" regexp_match="(?i)trail" regexp_replace="piste"/></suggestion>.</message>
-            <example correction="chemin|sentier|piste"><marker>trail</marker></example>
-            <example><marker>piste</marker></example>
-        </rule>
-        <rulegroup id="TRAILER" name="trailer">
-            <rule>
-                <pattern>
-                    <token regexp="yes">trailers?
-                        <exception scope="previous" postag="D m s"/></token>
-                </pattern>
-                <message>'Trailer' peut être considéré comme un anglicisme. Employez <suggestion><match no="1" regexp_match="(?i)trailer" regexp_replace="bande-annonce"/></suggestion> (cinéma), <suggestion><match no="1" regexp_match="(?i)trailer" regexp_replace="remorque"/></suggestion> (derrière une voiture) ou <suggestion><match no="1" regexp_match="(?i)trailer" regexp_replace="van"/></suggestion> (pour les chevaux).</message>
-                <example correction="bande-annonce|remorque|van"><marker>trailer</marker></example>
-                <example><marker>remorque</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="D m s"/>
-                    <token>trailer</token>
-                </pattern>
-                <message>'Trailer' peut être considéré comme un anglicisme.</message>
-                <suggestion><match no="1" postag="(D) (m) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> bande-annonce</suggestion>
-                <suggestion><match no="1" postag="(D) (m) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> remorque</suggestion>
-                <suggestion>\1 van</suggestion>
-                <example correction="cette bande-annonce|cette remorque|ce van"><marker>ce trailer</marker></example>
-                <example><marker>remorque</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="FREE-FOR-ALL" name="free-for-all">
-            <rule>
-                <pattern>
-                    <token>free</token>
-                    <token min="0">-</token>
-                    <token>for</token>
-                    <token min="0">-</token>
-                    <token>all</token>
-                </pattern>
-                <message>« Free-for-all » peut être considéré comme un anglicisme.</message>
-                <suggestion>pagaille</suggestion>
-                <suggestion>mêlée</suggestion>
-                <suggestion>mêlée générale</suggestion>
-                <suggestion>méli-mélo</suggestion>
-                <example correction="pagaille|mêlée|mêlée générale|méli-mélo"><marker>free for all</marker></example>
-                <example><marker>pagaille</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BLIND_DATE" name="blind date">
-            <rule>
-                <pattern>
-                    <token regexp="yes">blind|blinds</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">date|dates</token>
-                </pattern>
-                <message>« Blind date » peut être considéré comme un anglicisme.</message>
-                <suggestion>rendez-vous arrangé</suggestion>
-                <suggestion>rencontre arrangée</suggestion>
-                <example correction="rendez-vous arrangé|rencontre arrangée"><marker>blind date</marker></example>
-                <example correction="rendez-vous arrangé|rencontre arrangée"><marker>blind-date</marker></example>
-                <example><marker>rencontre arrangée</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BLIND_PIG" name="blind pig">
-            <rule>
-                <pattern>
-                    <token regexp="yes">blind|blinds</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">pigs|pig</token>
-                </pattern>
-                <message>« Blind pig » peut être considéré comme un anglicisme.</message>
-                <suggestion>bar clandestin</suggestion>
-                <suggestion>cabaret borgne</suggestion>
-                <example correction="bar clandestin|cabaret borgne"><marker>blind pig</marker></example>
-                <example><marker>cabaret clandestin</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="FOLLOW-UP" name="follow-up">
-            <rule>
-                <pattern>
-                    <token regexp="yes">followups?</token>
-                </pattern>
-                <message>« Follow-up » peut être considéré comme un anglicisme.</message>
-                <suggestion>suivi</suggestion>
-                <suggestion>suite</suggestion>
-                <example correction="suivi|suite"><marker>followup</marker></example>
-                <example><marker>suivi</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">follow|follows</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">up|ups</token>
-                </pattern>
-                <message>« Follow-up » peut être considéré comme un anglicisme.</message>
-                <suggestion>suivi</suggestion>
-                <suggestion>suite</suggestion>
-                <example correction="suivi|suite"><marker>follow up</marker></example>
-                <example><marker>suivi</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="BLIND" name="blind">
-            <pattern>
-                <token regexp="yes">blind|blinds</token>
-            </pattern>
-            <message>« Blind » peut être considéré comme un anglicisme.</message>
-            <suggestion>store</suggestion>
-            <suggestion>jalousie</suggestion>
-            <example correction="store|jalousie"><marker>blind</marker></example>
-            <example>mes <marker>jalousies</marker></example>
-        </rule>
-        <rule id="TRACTION_AID" name="traction aid">
-            <pattern>
-                <token regexp="yes">tractions?</token>
-                <token regexp="yes">aids?</token>
-            </pattern>
-            <message>« Traction aid » peut être considéré comme un anglicisme.</message>
-            <suggestion>plaque d'adhérence</suggestion>
-            <example correction="plaque d'adhérence"><marker>traction aid</marker></example>
-        </rule>
         <rule id="ALIMENT_DE_SANTE" name="aliment de santé">
             <pattern>
                 <token regexp="yes">aliment|aliments</token>
@@ -15100,3487 +18583,6 @@ USA
             <message>« Attaque cardiaque » peut être considéré comme un anglicisme (heart attack).</message>
             <suggestion>crise cardiaque</suggestion>
             <example correction="crise cardiaque"><marker>attaque cardiaque</marker></example>
-        </rule>
-        <rule id="PICKLE" name="pickle">
-            <pattern>
-                <token regexp="yes">pickles?</token>
-            </pattern>
-            <message>« Pickle » peut être considéré comme un anglicisme.</message>
-            <suggestion>cornichon mariné</suggestion>
-            <suggestion>cornichon à l'aneth</suggestion>
-            <example correction="cornichon mariné|cornichon à l'aneth"><marker>pickle</marker></example>
-            <example><marker>cornichon mariné</marker></example>
-        </rule>
-        <rule id="CRATE" name="crate">
-            <pattern>
-                <token regexp="yes">crate|crates</token>
-            </pattern>
-            <message>« Crate » peut être considéré comme un anglicisme. Employez <suggestion>caisse</suggestion> (légumes, boissons gazeuses), <suggestion>cageot</suggestion> (emballage à claire-voie), <suggestion>cagette</suggestion> (petit cageot), <suggestion>emballage</suggestion>, <suggestion>boîte</suggestion>, <suggestion>carton</suggestion> (boissons gazeuses).</message>
-            <example correction="caisse|cageot|cagette|emballage|boîte|carton"><marker>crate</marker></example>
-            <example><marker>cageot</marker></example>
-        </rule>
-        <rulegroup id="CRASH_TEST" name="crash test">
-            <rule>
-                <pattern>
-                    <token regexp="yes">crashtests?</token>
-                </pattern>
-                <message>« Crash test » peut être considéré comme un anglicisme.</message>
-                <suggestion>simulation d'accident</suggestion>
-                <example correction="simulation d'accident"><marker>crashtest</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>crash</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">tests?</token>
-                </pattern>
-                <message>« Crash test » peut être considéré comme un anglicisme.</message>
-                <suggestion>simulation d'accident</suggestion>
-                <example correction="simulation d'accident"><marker>crash test</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="ANYTIME" name="anytime">
-            <rule>
-                <pattern>
-                    <token regexp="yes">anytimes?</token>
-                </pattern>
-                <message>« Anytime » peut être considéré comme un anglicisme.</message>
-                <suggestion>n'importe quand</suggestion>
-                <example correction="n'importe quand"><marker>anytime</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>any</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">times?</token>
-                </pattern>
-                <message>« Anytime » peut être considéré comme un anglicisme.</message>
-                <suggestion>n'importe quand</suggestion>
-                <example correction="n'importe quand"><marker>any time</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="ANYWAY" name="anyway">
-            <rule>
-                <pattern>
-                    <token regexp="yes">anyways?</token>
-                </pattern>
-                <message>« Anyway » peut être considéré comme un anglicisme.</message>
-                <suggestion>de toute façon</suggestion>
-                <suggestion>quand même</suggestion>
-                <suggestion>en tout cas</suggestion>
-                <example correction="de toute façon|quand même|en tout cas"><marker>anyway</marker></example>
-                <example><marker>en tout cas</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>any</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">ways?</token>
-                </pattern>
-                <message>« Anyway » peut être considéré comme un anglicisme.</message>
-                <suggestion>de toute façon</suggestion>
-                <suggestion>quand même</suggestion>
-                <suggestion>en tout cas</suggestion>
-                <example correction="de toute façon|quand même|en tout cas"><marker>any way</marker></example>
-                <example><marker>en tout cas</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="JELLYFISH" name="jellyfish">
-            <rule>
-                <pattern>
-                    <token regexp="yes">jellyfish|jellyfishs|jellyfishes</token>
-                </pattern>
-                <message>« Jellyfish » peut être considéré comme un anglicisme.</message>
-                <suggestion>méduse</suggestion>
-                <example correction="méduse"><marker>jellyfish</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>jelly</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">fish|fishes|fishs</token>
-                </pattern>
-                <message>« Jellyfish » peut être considéré comme un anglicisme.</message>
-                <suggestion>méduse</suggestion>
-                <example correction="méduse"><marker>jelly fish</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="JELLY_BEAN" name="jelly bean">
-            <rule>
-                <pattern>
-                    <token regexp="yes">jellybeans?|jellybine?</token>
-                </pattern>
-                <message>« Jelly bean » peut être considéré comme un anglicisme.</message>
-                <suggestion>jujube</suggestion>
-                <suggestion>dragées à la gelée de sucre</suggestion>
-                <example correction="jujube|dragées à la gelée de sucre"><marker>jellybean</marker></example>
-                <example><marker>jujube</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>jelly</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">bean|beans|bines|bine</token>
-                </pattern>
-                <message>« Jelly bean » peut être considéré comme un anglicisme.</message>
-                <suggestion>jujube</suggestion>
-                <suggestion>dragées à la gelée de sucre</suggestion>
-                <example correction="jujube|dragées à la gelée de sucre"><marker>jelly bean</marker></example>
-                <example><marker>jujube</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="POTLUCK" name="potluck">
-            <rule>
-                <pattern>
-                    <token regexp="yes">potluck|potlucks</token>
-                </pattern>
-                <message>« Potluck » peut être considéré comme un anglicisme.</message>
-                <suggestion>repas-partage</suggestion>
-                <example correction="repas-partage"><marker>potluck</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>pot</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">luck|lucks</token>
-                </pattern>
-                <message>« Potluck » peut être considéré comme un anglicisme.</message>
-                <suggestion>repas-partage</suggestion>
-                <example correction="repas-partage"><marker>pot luck</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="PAINKILLER" name="painkiller">
-            <rule>
-                <pattern>
-                    <token regexp="yes">painkillers?</token>
-                </pattern>
-                <message>« Painkiller » peut être considéré comme un anglicisme.</message>
-                <suggestion>analgésique</suggestion>
-                <example correction="analgésique"><marker>painkiller</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>pain</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">killer|killers</token>
-                </pattern>
-                <message>« Painkiller » peut être considéré comme un anglicisme.</message>
-                <suggestion>analgésique</suggestion>
-                <example correction="analgésique"><marker>pain killer</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="PACKSACK" name="packsack">
-            <rule>
-                <pattern>
-                    <token regexp="yes">packsacks?</token>
-                </pattern>
-                <message>« Packsack » peut être considéré comme un anglicisme.</message>
-                <suggestion>sac à dos</suggestion>
-                <example correction="sac à dos"><marker>packsack</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>pack</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">sack|sac|sacs|sacks</token>
-                </pattern>
-                <message>« Packsack » peut être considéré comme un anglicisme.</message>
-                <suggestion>sac à dos</suggestion>
-                <example correction="sac à dos"><marker>pack sack</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="PHOTORADAR" name="photoradar">
-            <rule>
-                <pattern>
-                    <token regexp="yes">photoradar|photoradars</token>
-                </pattern>
-                <message>« Photoradar » peut être considéré comme un anglicisme.</message>
-                <suggestion>cinémomètre</suggestion>
-                <suggestion>cinémomètre photo</suggestion>
-                <example correction="cinémomètre|cinémomètre photo"><marker>photoradar</marker></example>
-                <example><marker>cinémomètre</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>photo</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">radar|radars</token>
-                </pattern>
-                <message>« Photoradar » peut être considéré comme un anglicisme.</message>
-                <suggestion>cinémomètre</suggestion>
-                <suggestion>cinémomètre photo</suggestion>
-                <example correction="cinémomètre|cinémomètre photo"><marker>photo radar</marker></example>
-                <example><marker>cinémomètre</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="CARPORT" name="carport">
-            <rule>
-                <pattern>
-                    <token regexp="yes">carport|carports</token>
-                </pattern>
-                <message>« Carport » peut être considéré comme un anglicisme.</message>
-                <suggestion>abri de voiture</suggestion>
-                <suggestion>abri voiture</suggestion>
-                <example correction="abri de voiture|abri voiture"><marker>carport</marker></example>
-                <example><marker>abri voiture</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>car</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">port|ports</token>
-                </pattern>
-                <message>« Carport » peut être considéré comme un anglicisme.</message>
-                <suggestion>abri de voiture</suggestion>
-                <suggestion>abri voiture</suggestion>
-                <example correction="abri de voiture|abri voiture"><marker>car port</marker></example>
-                <example><marker>abri voiture</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="SIT-UP" name="sit-up">
-            <rule>
-                <pattern>
-                    <token regexp="yes">situp|situps</token>
-                </pattern>
-                <message>« Sit-up » peut être considéré comme un anglicisme.</message>
-                <suggestion>redressement assis</suggestion>
-                <example correction="redressement assis"><marker>situp</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">sit|sits</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">up|ups</token>
-                </pattern>
-                <message>« Sit-up » peut être considéré comme un anglicisme.</message>
-                <suggestion>redressement assis</suggestion>
-                <example correction="redressement assis"><marker>sit up</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="PRIME-TIME" name="prime-time" default="off">
-            <rule>
-                <pattern>
-                    <token regexp="yes">primetime|primetimes|primestimes</token>
-                </pattern>
-                <message>« Prime-time » peut être considéré comme un anglicisme.</message>
-                <suggestion>heure de grande écoute</suggestion>
-                <example correction="heure de grande écoute"><marker>primetime</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>prime</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">time|times</token>
-                </pattern>
-                <message>« Prime-time » peut être considéré comme un anglicisme.</message>
-                <suggestion>heure de grande écoute</suggestion>
-                <example correction="heure de grande écoute"><marker>prime time</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="FREE_SHOP" name="free-shop">
-            <rule>
-                <pattern>
-                    <token regexp="yes" skip="1">free|frees</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">shop|shops</token>
-                </pattern>
-                <message>« Free shop » peut être considéré comme un anglicisme.</message>
-                <suggestion>boutique franche</suggestion>
-                <example correction="boutique franche"><marker>free shop</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">freeshop|freeshops</token>
-                </pattern>
-                <message>« Free shop » peut être considéré comme un anglicisme.</message>
-                <suggestion>boutique franche</suggestion>
-                <example correction="boutique franche"><marker>freeshop</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="NON_STOP" name="non-stop" tags="picky">
-            <rule>
-                <pattern>
-                    <token>non</token>
-                    <token regexp="yes">stop|stops
-                        <exception scope="next" regexp="yes">(?-i)[A-Z].*</exception></token>
-                </pattern>
-                <message>« Non-stop » peut être considéré comme un anglicisme.</message>
-                <suggestion>sans interruption</suggestion>
-                <suggestion>en continu</suggestion>
-                <example correction="sans interruption|en continu"><marker>non stop</marker></example>
-                <example><marker>sans escale</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">non-?stop|non-?stops
-                        <exception scope="next" regexp="yes">(?-i)[A-Z].*</exception></token>
-                </pattern>
-                <message>« Non-stop » peut être considéré comme un anglicisme.</message>
-                <suggestion>sans interruption</suggestion>
-                <suggestion>en continu</suggestion>
-                <example correction="sans interruption|en continu"><marker>nonstop</marker></example>
-                <example correction="sans interruption|en continu"><marker>non-stop</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="SEX-SHOP" name="sex-shop" default="off">
-            <!-- deactivated : widespread usage -->
-            <rule>
-                <pattern>
-                    <token>sex</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">shop|shops</token>
-                </pattern>
-                <message>« Sex-shop » peut être considéré comme un anglicisme.</message>
-                <suggestion>boutique érotique</suggestion>
-                <suggestion>sexerie</suggestion>
-                <suggestion>érothèque</suggestion>
-                <example correction="boutique érotique|sexerie|érothèque"><marker>sex shop</marker></example>
-                <example><marker>sexerie</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">sexshop|sexshops</token>
-                </pattern>
-                <message>« Sex-shop » peut être considéré comme un anglicisme.</message>
-                <suggestion>boutique érotique</suggestion>
-                <suggestion>sexerie</suggestion>
-                <suggestion>érothèque</suggestion>
-                <example correction="boutique érotique|sexerie|érothèque"><marker>sexshop</marker></example>
-                <example><marker>sexerie</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="KNOW-HOW" name="know-how">
-            <rule>
-                <pattern>
-                    <token regexp="yes" skip="1">know|knows</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">how|hows</token>
-                </pattern>
-                <message>« Know-how » peut être considéré comme un anglicisme.</message>
-                <suggestion>savoir-faire</suggestion>
-                <example correction="savoir-faire"><marker>know how</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">knowhows?</token>
-                </pattern>
-                <message>« Know-how » peut être considéré comme un anglicisme.</message>
-                <suggestion>savoir-faire</suggestion>
-                <example correction="savoir-faire"><marker>knowhow</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="GHETTO_BLASTER" name="ghetto blaster">
-            <pattern>
-                <token regexp="yes">ghetto|ghettos|getto|gettos|geto|getos</token>
-                <token min="0">-</token>
-                <token regexp="yes">blaster|blasters</token>
-            </pattern>
-            <message>« Ghetto blaster » peut être considéré comme un anglicisme.</message>
-            <suggestion>chaîne stéréo</suggestion>
-            <example correction="chaîne stéréo"><marker>ghetto blaster</marker></example>
-            <example><marker>chaîner stéréo</marker></example>
-        </rule>
-        <rule default="off" id="MARKETING" name="marketing">
-            <pattern>
-                <token regexp="yes">mark[ée]tings?</token>
-            </pattern>
-            <message>« Marketing » peut être considéré comme un anglicisme.</message>
-            <suggestion>mercatique</suggestion>
-            <example correction="mercatique"><marker>marketing</marker></example>
-            <example><marker>mercatique</marker></example>
-        </rule>
-        <rulegroup id="ADDICTION" name="addiction" default="off">
-            <!-- deactivated : widespread usage -->
-            <rule>
-                <pattern>
-                    <token regexp="yes">add?ictions?
-                        <exception scope="previous" postag="D . s" postag_regexp="yes"/>
-                        <exception scope="next" regexp="yes">à|aux</exception></token>
-                </pattern>
-                <message>« Addiction » peut être considéré comme un anglicisme.</message>
-                <suggestion>dépendance</suggestion>
-                <example correction="dépendance"><marker>addiction</marker></example>
-                <example><marker>dépendance</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="D . s" postag_regexp="yes"/>
-                    <token regexp="yes">add?ictions?
-                        <exception scope="next" regexp="yes">à|aux</exception></token>
-                </pattern>
-                <message>Le mot « Addiction » peut être considéré comme un anglicisme.</message>
-                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> dépendance</suggestion>
-                <example correction="sa dépendance"><marker>son addiction</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="D . s" postag_regexp="yes"/>
-                    <token regexp="yes">add?ictions?</token>
-                    <token regexp="yes">à</token>
-                </pattern>
-                <message>Le mot « Addiction » peut être considéré comme un anglicisme.</message>
-                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> dépendance \3</suggestion>
-                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 m $3"/> penchant pour</suggestion>
-                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> passion pour</suggestion>
-                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> faiblesse pour</suggestion>
-                <example correction="La dépendance à|Le penchant pour|La passion pour|La faiblesse pour"><marker>L'addiction à</marker> la télévision est un nouveau phénomène de notre siècle.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="D . s" postag_regexp="yes"/>
-                    <token regexp="yes">add?ictions?</token>
-                    <token>aux</token>
-                </pattern>
-                <message>Le mot « Addiction » peut être considéré comme un anglicisme.</message>
-                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> dépendance \3</suggestion>
-                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 m $3"/> penchant pour les</suggestion>
-                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> passion pour les</suggestion>
-                <suggestion><match no="1" postag="(D) (.) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> faiblesse pour les</suggestion>
-                <example correction="La dépendance aux|Le penchant pour les|La passion pour les|La faiblesse pour les"><marker>L'addiction aux</marker> jeux vidéos est un nouveau phénomène de notre siècle.</example>
-            </rule>
-        </rulegroup>
-        <rule id="CINEPLEX" name="cineplex">
-            <pattern>
-                <token regexp="yes">cinéplex|cinéplexs|cinéplexe|cinépléxes|cineplex|cineplexs|cineplexes|cineplexe</token>
-            </pattern>
-            <message>« Cineplex » peut être considéré comme un anglicisme.</message>
-            <suggestion>complexe multisalle</suggestion>
-            <suggestion>multiplexe</suggestion>
-            <example correction="complexe multisalle|multiplexe"><marker>cinéplex</marker></example>
-            <example><marker>complexe multisalle</marker></example>
-        </rule>
-        <rule id="IRISH_COFFEE" name="Irish coffee" default="off">
-            <!-- deactivated : widespread usage -->
-            <pattern>
-                <token>irish</token>
-                <token regexp="yes">coffees?</token>
-            </pattern>
-            <message>« Irish coffee » peut être considéré comme un anglicisme.</message>
-            <suggestion>café irlandais</suggestion>
-            <example correction="café irlandais"><marker>irish coffee</marker></example>
-        </rule>
-        <rule id="FADING" name="fading">
-            <pattern>
-                <token regexp="yes">fadings?</token>
-            </pattern>
-            <message>« Fading » peut être considéré comme un anglicisme.</message>
-            <suggestion>évanouissement</suggestion>
-            <example correction="évanouissement"><marker>fading</marker></example>
-        </rule>
-        <rule id="CRACKING" name="cracking">
-            <pattern>
-                <token regexp="yes">crackings?</token>
-            </pattern>
-            <message>« Cracking » peut être considéré comme un anglicisme.</message>
-            <suggestion>craquage</suggestion>
-            <example correction="craquage"><marker>cracking</marker></example>
-        </rule>
-        <rule id="CUTE" name="cute">
-            <pattern>
-                <token regexp="yes">cutes?</token>
-            </pattern>
-            <message>« Cute » peut être considéré comme un anglicisme.</message>
-            <suggestion>joli</suggestion>
-            <suggestion>mignon</suggestion>
-            <suggestion>beau</suggestion>
-            <suggestion>sympathique</suggestion>
-            <suggestion>charmant</suggestion>
-            <example correction="joli|mignon|beau|sympathique|charmant"><marker>cute</marker></example>
-            <example><marker>mignon</marker></example>
-        </rule>
-        <rule id="STRIPPING" name="stripping">
-            <pattern>
-                <token regexp="yes">strippings?</token>
-            </pattern>
-            <message>« Stripping » peut être considéré comme un anglicisme. Employez <suggestion>éveinage</suggestion> (médecine).</message>
-            <example correction="éveinage"><marker>stripping</marker></example>
-        </rule>
-        <rule id="FRANCHISING" name="franchising">
-            <pattern>
-                <token regexp="yes">franchisings?</token>
-            </pattern>
-            <message>« Franchising » peut être considéré comme un anglicisme.</message>
-            <suggestion>franchisage</suggestion>
-            <example correction="franchisage"><marker>franchising</marker></example>
-        </rule>
-        <rulegroup id="CASH" name="cash">
-            <rule>
-                <antipattern>
-                    <token postag="[NJ].*" postag_regexp="yes"/>
-                    <token case_sensitive="yes">cash</token>
-                </antipattern>
-                <antipattern>
-                    <token postag="V.*" postag_regexp="yes" inflected="yes" skip="3">payer</token>
-                    <token case_sensitive="yes">cash</token>
-                </antipattern>
-                <pattern>
-                    <token case_sensitive="yes">cash
-                        <exception scope="next" regexp="yes">games?|money|-|boxes|flow|express|spot|penney</exception>
-                        <exception scope="previous" regexp="yes">Johnny|-|hard|radar|online</exception></token>
-                </pattern>
-                <message>« Cash » peut être considéré comme un anglicisme.</message>
-                <suggestion>argent comptant</suggestion>
-                <suggestion>argent</suggestion>
-                <suggestion>franc</suggestion>
-                <suggestion>liquide</suggestion>
-                <suggestion>franchement</suggestion>
-                <example correction="argent comptant|argent|franc|liquide|franchement"><marker>cash</marker></example>
-                <example><marker>argent comptant</marker></example>
-                <example>Johnny Cash est né en 1932.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="[NJ] m sp?" postag_regexp="yes"/>
-                    <marker>
-                        <token case_sensitive="yes">cash
-                            <exception scope="next" regexp="yes">games?|money|-|boxes|flow|express|spot|penney</exception>
-                            <exception scope="previous" regexp="yes">Johnny|-|hard|gros|radar|online</exception></token>
-                    </marker>
-                </pattern>
-                <message>« Cash » peut être considéré comme un anglicisme.</message>
-                <suggestion>franc</suggestion>
-                <suggestion>en liquide</suggestion>
-                <example correction="franc|en liquide">Un bonus <marker>cash</marker>.</example>
-                <example><marker>argent comptant</marker></example>
-                <example>Johnny Cash est né en 1932.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="[NJ] m p" postag_regexp="yes"/>
-                    <marker>
-                        <token case_sensitive="yes">cash
-                            <exception scope="next" regexp="yes">games?|money|-|boxes|flow|express|spot|penney</exception>
-                            <exception scope="previous" regexp="yes">Johnny|-|hard|radar|online</exception></token>
-                    </marker>
-                </pattern>
-                <message>« Cash » peut être considéré comme un anglicisme.</message>
-                <suggestion>francs</suggestion>
-                <suggestion>en liquide</suggestion>
-                <example correction="francs|en liquide">Des achats <marker>cash</marker>.</example>
-                <example><marker>argent comptant</marker></example>
-                <example>Johnny Cash est né en 1932.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="V.*" postag_regexp="yes" inflected="yes" skip="3">payer</token>
-                    <marker>
-                        <token case_sensitive="yes">cash
-                            <exception scope="next" regexp="yes">games?|money|-|boxes|flow|express|spot|penney</exception>
-                            <exception scope="previous" regexp="yes">Johnny|-|hard|radar|online|en</exception></token>
-                    </marker>
-                </pattern>
-                <message>« Cash » peut être considéré comme un anglicisme.</message>
-                <suggestion>comptant</suggestion>
-                <suggestion>en liquide</suggestion>
-                <example correction="comptant|en liquide">Il a payé <marker>cash</marker>.</example>
-                <example><marker>argent comptant</marker></example>
-                <example>Johnny Cash est né en 1932.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="[NJ] f s" postag_regexp="yes"/>
-                    <marker>
-                        <token case_sensitive="yes">cash
-                            <exception scope="next" regexp="yes">games?|money|-|boxes|flow|express|spot|penney</exception>
-                            <exception scope="previous" regexp="yes">Johnny|-|hard|radar|online</exception></token>
-                    </marker>
-                </pattern>
-                <message>« Cash » peut être considéré comme un anglicisme.</message>
-                <suggestion>franche</suggestion>
-                <suggestion>en liquide</suggestion>
-                <example correction="franche|en liquide">Une culture <marker>cash</marker>.</example>
-                <example><marker>argent comptant</marker></example>
-                <example>Johnny Cash est né en 1932.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="[NJ] f p" postag_regexp="yes"/>
-                    <marker>
-                        <token case_sensitive="yes">cash
-                            <exception scope="next" regexp="yes">games?|money|-|boxes|flow|express|spot|penney</exception>
-                            <exception scope="previous" regexp="yes">Johnny|-|hard|radar|online</exception></token>
-                    </marker>
-                </pattern>
-                <message>« Cash » peut être considéré comme un anglicisme.</message>
-                <suggestion>franches</suggestion>
-                <suggestion>en liquide</suggestion>
-                <example correction="franches|en liquide">Des cultures <marker>cash</marker>.</example>
-                <example><marker>argent comptant</marker></example>
-                <example>Johnny Cash est né en 1932.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>en</token>
-                    <marker>
-                        <token case_sensitive="yes">cash
-                            <exception scope="next" regexp="yes">games?|money|-|boxes|flow|express|spot|penney</exception></token>
-                    </marker>
-                </pattern>
-                <message>« Cash » peut être considéré comme un anglicisme.</message>
-                <suggestion>liquide</suggestion>
-                <example correction="liquide">Il a payé en <marker>cash</marker>.</example>
-                <example><marker>argent comptant</marker></example>
-                <example>Johnny Cash est né en 1932.</example>
-            </rule>
-        </rulegroup>
-        <rule id="COOLER" name="cooler">
-            <pattern>
-                <token regexp="yes">cooll?ers?</token>
-            </pattern>
-            <message>« Cooler » peut être considéré comme un anglicisme.</message>
-            <suggestion>glacière</suggestion>
-            <example correction="glacière"><marker>cooler</marker></example>
-        </rule>
-        <rulegroup id="MASKING_TAPE" name="masking tape">
-            <rule>
-                <pattern>
-                    <token regexp="yes" skip="1">maskings?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">tapes?</token>
-                </pattern>
-                <message>« Masking tape » peut être considéré comme un anglicisme.</message>
-                <suggestion>papier-cache adhésif</suggestion>
-                <suggestion>papier adhésif de masquage</suggestion>
-                <suggestion>papier à maroufler</suggestion>
-                <example correction="papier-cache adhésif|papier adhésif de masquage|papier à maroufler"><marker>masking tape</marker></example>
-                <example><marker>papier-cache adhésif</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">maskingtapes?</token>
-                </pattern>
-                <message>« Masking tape » peut être considéré comme un anglicisme.</message>
-                <suggestion>papier-cache adhésif</suggestion>
-                <suggestion>papier adhésif de masquage</suggestion>
-                <suggestion>papier à maroufler</suggestion>
-                <example correction="papier-cache adhésif|papier adhésif de masquage|papier à maroufler"><marker>maskingtape</marker></example>
-                <example><marker>papier-cache adhésif</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="RED_TAPE" name="red tape">
-            <rule>
-                <pattern>
-                    <token regexp="yes" skip="1">reds?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">tapes?</token>
-                </pattern>
-                <message>« Red tape » peut être considéré comme un anglicisme.</message>
-                <suggestion>chinoiserie administrative</suggestion>
-                <suggestion>formalité</suggestion>
-                <example correction="chinoiserie administrative|formalité"><marker>red tape</marker></example>
-                <example><marker>formalité</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">redtapes?</token>
-                </pattern>
-                <message>« Red tape » peut être considéré comme un anglicisme.</message>
-                <suggestion>chinoiserie administrative</suggestion>
-                <suggestion>formalité</suggestion>
-                <example correction="chinoiserie administrative|formalité"><marker>redtape</marker></example>
-                <example><marker>formalité</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="JUST_IN_TIME" name="just in time">
-            <pattern>
-                <token regexp="yes" skip="1">justs?</token>
-                <token>in</token>
-                <token regexp="yes">times?</token>
-            </pattern>
-            <message>« Just in time » peut être considéré comme un anglicisme. Employez <suggestion>méthode de production à flux tendus</suggestion>, <suggestion>juste-à-temps</suggestion> (nom masculin).</message>
-            <example correction="méthode de production à flux tendus|juste-à-temps"><marker>just in time</marker></example>
-            <example><marker>juste-à-temps</marker></example>
-        </rule>
-        <rule id="JUST_TOO_BAD" name="just too bad">
-            <pattern>
-                <token regexp="yes" skip="1">justs?</token>
-                <token>too</token>
-                <token regexp="yes">bads?</token>
-            </pattern>
-            <message>« Just too bad » peut être considéré comme un anglicisme. Employez <suggestion>c'est bien dommage</suggestion>, <suggestion>on n'y peut rien</suggestion> (nom masculin).</message>
-            <example correction="c'est bien dommage|on n'y peut rien"><marker>just too bad</marker></example>
-            <example><marker>c'est bien dommage</marker></example>
-        </rule>
-        <rule id="TEASING" name="teasing">
-            <pattern>
-                <token regexp="yes">teasings?</token>
-            </pattern>
-            <message>« Teasing » peut être considéré comme un anglicisme.</message>
-            <suggestion>aguichage</suggestion>
-            <example correction="aguichage"><marker>teasing</marker></example>
-        </rule>
-        <rule id="LEASING" name="leasing">
-            <pattern>
-                <token regexp="yes">leasings?</token>
-            </pattern>
-            <message>« Leasing » peut être considéré comme un anglicisme.</message>
-            <suggestion>crédit-bail</suggestion>
-            <example correction="crédit-bail"><marker>leasing</marker></example>
-        </rule>
-        <rule id="WOOFER" name="woofer">
-            <pattern>
-                <token regexp="yes">woofers?</token>
-            </pattern>
-            <message>« Woofer » peut être considéré comme un anglicisme.</message>
-            <suggestion>haut-parleur de graves</suggestion>
-            <example correction="haut-parleur de graves"><marker>woofer</marker></example>
-        </rule>
-        <rule id="LOSER" name="loser">
-            <pattern>
-                <token regexp="yes">losers?</token>
-            </pattern>
-            <message>« Loser » peut être considéré comme un anglicisme.</message>
-            <suggestion>perdant</suggestion>
-            <example correction="perdant"><marker>loser</marker></example>
-        </rule>
-        <rule id="BOOMER" name="boomer" default="off">
-            <!-- This rule is no good anymore -->
-            <antipattern>
-                <token regexp="yes">baby|ok(ay)?</token>
-                <token min="0">,</token>
-                <token>boomer</token>
-            </antipattern>
-            <pattern>
-                <token regexp="yes">boomers?</token>
-            </pattern>
-            <message>« Boomer » peut être considéré comme un anglicisme.</message>
-            <suggestion>haut-parleur de graves</suggestion>
-            <example correction="haut-parleur de graves"><marker>boomer</marker></example>
-        </rule>
-        <rule id="CHARTER" name="charter">
-            <pattern>
-                <token regexp="yes">charters?</token>
-            </pattern>
-            <message>« Charter » peut être considéré comme un anglicisme.</message>
-            <suggestion>vol nolisé</suggestion>
-            <suggestion>avion nolisé</suggestion>
-            <example correction="vol nolisé|avion nolisé"><marker>charter</marker></example>
-            <example><marker>vol nolisé</marker></example>
-        </rule>
-        <rule id="HEY" name="hey">
-            <antipattern>
-                <token>hey</token>
-                <token>.</token>
-                <token>com</token>
-            </antipattern>
-            <antipattern>
-                <token>hey</token>
-                <token>hey</token>
-            </antipattern>
-            <pattern>
-                <token>hey</token>
-            </pattern>
-            <message>« Hey » peut être considéré comme un anglicisme.</message>
-            <suggestion>hé</suggestion>
-            <suggestion>salut</suggestion>
-            <suggestion>coucou</suggestion>
-            <example correction="hé|salut|coucou"><marker>hey</marker></example>
-        </rule>
-        <rule id="ENGINEERING" name="engineering">
-            <pattern>
-                <token regexp="yes" case_sensitive="yes">engineerings?
-                    <exception scope="previous" regexp="yes">reverse|social</exception></token>
-            </pattern>
-            <message>« Engineering » peut être considéré comme un anglicisme.</message>
-            <suggestion>ingénierie</suggestion>
-            <example correction="ingénierie"><marker>engineering</marker></example>
-        </rule>
-        <rule id="FACTORING" name="factoring">
-            <pattern>
-                <token regexp="yes">factorings?</token>
-            </pattern>
-            <message>« Factoring » peut être considéré comme un anglicisme.</message>
-            <suggestion>affacturage</suggestion>
-            <example correction="affacturage"><marker>factoring</marker></example>
-        </rule>
-        <rule id="ROYALTIES" name="royalties">
-            <pattern>
-                <token regexp="yes">royalty|royalties|royaltys</token>
-            </pattern>
-            <message>« Royalties » peut être considéré comme un anglicisme.</message>
-            <suggestion>redevances</suggestion>
-            <example correction="redevances"><marker>royalties</marker></example>
-            <example><marker>redevance</marker></example>
-        </rule>
-        <rule id="COLESLAW" name="coleslaw">
-            <pattern>
-                <token regexp="yes">coleslaws?</token>
-            </pattern>
-            <message>« Coleslaw » peut être considéré comme un anglicisme.</message>
-            <suggestion>salade de chou</suggestion>
-            <example correction="salade de chou"><marker>coleslaw</marker></example>
-        </rule>
-        <rulegroup id="EGGNOG" name="eggnog">
-            <rule>
-                <pattern>
-                    <token regexp="yes">eggnog|eggnogg|eggnogs|eggnoggs|egg-nog|egg-nogs|egg-nogg|egg-noggs</token>
-                </pattern>
-                <message>« Eggnog » peut être considéré comme un anglicisme. Employez <suggestion>lait de poule</suggestion> (boisson alcoolisée).</message>
-                <example correction="lait de poule"><marker>eggnog</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>egg</token>
-                    <token regexp="yes">nog|noggs</token>
-                </pattern>
-                <message>« Eggnog » peut être considéré comme un anglicisme. Employez <suggestion>lait de poule</suggestion> (boisson alcoolisée).</message>
-                <example correction="lait de poule"><marker>egg nog</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="HOLD-UP" name="hold-up">
-            <rule>
-                <pattern>
-                    <token regexp="yes">hold-?ups?</token>
-                </pattern>
-                <message>« Hold-up » peut être considéré comme un anglicisme.</message>
-                <suggestion>vol à main armée</suggestion>
-                <example correction="vol à main armée"><marker>hold-up</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>hold</token>
-                    <token regexp="yes">ups?</token>
-                </pattern>
-                <message>« Hold-up » peut être considéré comme un anglicisme.</message>
-                <suggestion>vol à main armée</suggestion>
-                <example correction="vol à main armée"><marker>hold up</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="HOUSE-BOAT" name="house-boat">
-            <rule>
-                <pattern>
-                    <token regexp="yes">houseboats?</token>
-                </pattern>
-                <message>« House-boat » peut être considéré comme un anglicisme.</message>
-                <suggestion>bateau-maison</suggestion>
-                <suggestion>péniche</suggestion>
-                <suggestion>maison flottante</suggestion>
-                <example correction="bateau-maison|péniche|maison flottante"><marker>houseboat</marker></example>
-                <example><marker>péniche</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>house</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">boats?</token>
-                </pattern>
-                <message>« House-boat » peut être considéré comme un anglicisme.</message>
-                <suggestion>bateau-maison</suggestion>
-                <suggestion>péniche</suggestion>
-                <suggestion>maison flottante</suggestion>
-                <example correction="bateau-maison|péniche|maison flottante"><marker>house boat</marker></example>
-                <example><marker>péniche</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="WARGAME" name="wargame">
-            <rule>
-                <pattern>
-                    <token regexp="yes">wargames?</token>
-                </pattern>
-                <message>« Wargame » peut être considéré comme un anglicisme.</message>
-                <suggestion>jeu de guerre</suggestion>
-                <suggestion>jeu de simulation de guerre</suggestion>
-                <suggestion>jeu de simulation de conflit</suggestion>
-                <suggestion>simulation de guerre</suggestion>
-                <suggestion>simulation de guerre</suggestion>
-                <example correction="jeu de guerre|jeu de simulation de guerre|jeu de simulation de conflit|simulation de guerre"><marker>wargame</marker></example>
-                <example><marker>jeu de guerre</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>war</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">games?</token>
-                </pattern>
-                <message>« Wargame » peut être considéré comme un anglicisme.</message>
-                <suggestion>jeu de guerre</suggestion>
-                <suggestion>jeu de simulation de guerre</suggestion>
-                <suggestion>jeu de simulation de conflit</suggestion>
-                <suggestion>simulation de guerre</suggestion>
-                <suggestion>simulation de guerre</suggestion>
-                <example correction="jeu de guerre|jeu de simulation de guerre|jeu de simulation de conflit|simulation de guerre"><marker>war game</marker></example>
-                <example><marker>jeu de guerre</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup default="off" id="SNOWBOARD" name="snow(board)">
-            <rule>
-                <pattern>
-                    <token regexp="yes">snowboards?</token>
-                </pattern>
-                <message>« Snow(board) » peut être considéré comme un anglicisme.</message>
-                <suggestion>surf des neiges</suggestion>
-                <example correction="surf des neiges"><marker>snowboard</marker></example>
-                <example><marker>surf des neiges</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>snow</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">boards?</token>
-                </pattern>
-                <message>« Snow(board) » peut être considéré comme un anglicisme.</message>
-                <suggestion>surf des neiges</suggestion>
-                <example correction="surf des neiges"><marker>snow board</marker></example>
-                <example><marker>surf des neiges</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="ANTISKATING" name="antiskating">
-            <rule>
-                <pattern>
-                    <token regexp="yes">antiskatings?</token>
-                </pattern>
-                <message>« Antiskating » peut être considéré comme un anglicisme.</message>
-                <suggestion>antiripage</suggestion>
-                <suggestion>antipatinage</suggestion>
-                <example correction="antiripage|antipatinage"><marker>antiskating</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>anti</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">skatings?</token>
-                </pattern>
-                <message>« Antiskating » peut être considéré comme un anglicisme.</message>
-                <suggestion>antiripage</suggestion>
-                <suggestion>antipatinage</suggestion>
-                <example correction="antiripage|antipatinage"><marker>anti skating</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="ATTACHE-CASE" name="attaché-case">
-            <rule>
-                <pattern>
-                    <token regexp="yes">attachés|attaché|attache|attaches</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">cases?</token>
-                </pattern>
-                <message>« Attaché-case » peut être considéré comme un anglicisme.</message>
-                <suggestion>mallette</suggestion>
-                <suggestion>mallette porte-documents</suggestion>
-                <suggestion>porte-documents</suggestion>
-                <example correction="mallette|mallette porte-documents|porte-documents"><marker>attaché case</marker></example>
-                <example><marker>mallette</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">attachés?-cases?</token>
-                </pattern>
-                <message>« Attaché-case » peut être considéré comme un anglicisme.</message>
-                <suggestion>mallette</suggestion>
-                <suggestion>mallette porte-documents</suggestion>
-                <suggestion>porte-documents</suggestion>
-                <example correction="mallette|mallette porte-documents|porte-documents"><marker>attaché-case</marker></example>
-                <example><marker>mallette</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="HIT-AND-RUN" name="hit-and-run">
-            <rule>
-                <pattern>
-                    <token regexp="yes">hits?</token>
-                    <token min="0">-</token>
-                    <token>and</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">runs?</token>
-                </pattern>
-                <message>« Hit-and-run » peut être considéré comme un anglicisme.</message>
-                <suggestion>délit de fuite</suggestion>
-                <example correction="délit de fuite"><marker>hit and run</marker></example>
-                <example correction="délit de fuite"><marker>hit-and-run</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="HIT-PARADE" name="hit-parade" default="off">
-            <rule>
-                <pattern>
-                    <token regexp="yes">hit-parades?</token>
-                </pattern>
-                <message>« Hit-parade » peut être considéré comme un anglicisme.</message>
-                <suggestion>palmarès</suggestion>
-                <example correction="palmarès"><marker>hit-parade</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>hit</token>
-                    <token regexp="yes">parades|parade</token>
-                </pattern>
-                <message>« Hit-parade » peut être considéré comme un anglicisme.</message>
-                <suggestion>palmarès</suggestion>
-                <example correction="palmarès"><marker>hit parade</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="ANGLEDOZER" name="angledozer">
-            <rule>
-                <pattern>
-                    <token regexp="yes">angle-?dozers?</token>
-                </pattern>
-                <message>« Angledozer » peut être considéré comme un anglicisme.</message>
-                <suggestion>bouteur biais</suggestion>
-                <example correction="bouteur biais"><marker>angledozer</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>angle</token>
-                    <token regexp="yes">dozers?</token>
-                </pattern>
-                <message>« Angledozer » peut être considéré comme un anglicisme.</message>
-                <suggestion>bouteur biais</suggestion>
-                <example correction="bouteur biais"><marker>angle dozer</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="WALK-OVER" name="walk-over">
-            <rule>
-                <pattern>
-                    <token regexp="yes">walk-over|walkover|walkovers|walk-overs</token>
-                </pattern>
-                <message>« Walk-over » peut être considéré comme un anglicisme.</message>
-                <suggestion>victoire par défaut</suggestion>
-                <example correction="victoire par défaut"><marker>walk-over</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>walk</token>
-                    <token regexp="yes">overs?</token>
-                </pattern>
-                <message>« Walk-over » peut être considéré comme un anglicisme.</message>
-                <suggestion>victoire par défaut</suggestion>
-                <example correction="victoire par défaut"><marker>walk over</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="EXTRA-DRY" name="extra-dry">
-            <rule>
-                <pattern>
-                    <token regexp="yes">extra-dry|extradry|extradries|extra-dries</token>
-                </pattern>
-                <message>« Extra-dry » peut être considéré comme un anglicisme.</message>
-                <suggestion>extra sec</suggestion>
-                <example correction="extra sec"><marker>extra-dry</marker></example>
-                <example><marker>très sec</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>extra</token>
-                    <token regexp="yes">dry|dries</token>
-                </pattern>
-                <message>« Extra-dry » peut être considéré comme un anglicisme.</message>
-                <suggestion>extra sec</suggestion>
-                <example correction="extra sec"><marker>extra dry</marker></example>
-                <example><marker>très sec</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="GAS-OIL" name="gas-oil">
-            <rule>
-                <pattern>
-                    <token regexp="yes">gas-oil|gasoil</token>
-                </pattern>
-                <message>« Gas-oil » peut être considéré comme un anglicisme.</message>
-                <suggestion>gazole</suggestion>
-                <example correction="gazole"><marker>gas-oil</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>gas</token>
-                    <token>oil</token>
-                </pattern>
-                <message>« Gas-oil » peut être considéré comme un anglicisme.</message>
-                <suggestion>gazole</suggestion>
-                <example correction="gazole"><marker>gas oil</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="SKATEBOARD" name="skate(board)" default="off">
-            <!-- deactivated : widespread usage -->
-            <rule>
-                <pattern>
-                    <token regexp="yes">skate-board|skateboards|skate-boards|skateboard|skate|skates</token>
-                </pattern>
-                <message>« Skate(board) » peut être considéré comme un anglicisme.</message>
-                <suggestion>planche à roulettes</suggestion>
-                <example correction="planche à roulettes"><marker>skate</marker></example>
-                <example><marker>planche à roulette</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">skates?</token>
-                    <token regexp="yes">boards?</token>
-                </pattern>
-                <message>« Skate(board) » peut être considéré comme un anglicisme.</message>
-                <suggestion>planche à roulettes</suggestion>
-                <example correction="planche à roulettes"><marker>skate board</marker></example>
-                <example><marker>planche à roulette</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="B2B" name="B2B, b to b" default="off">
-            <!-- deactivated : widespread usage -->
-            <rule>
-                <pattern>
-                    <token regexp="yes">b2bs?|b-to-b</token>
-                </pattern>
-                <message>« B2B » peut être considéré comme un anglicisme.</message>
-                <suggestion>commerce interentreprises</suggestion>
-                <example correction="Commerce interentreprises"><marker>B2B</marker></example>
-                <example><marker>commerce interentreprises</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>b</token>
-                    <token>to</token>
-                    <token>b</token>
-                </pattern>
-                <message>« B2B » peut être considéré comme un anglicisme.</message>
-                <suggestion>commerce interentreprises</suggestion>
-                <example correction="commerce interentreprises"><marker>b to b</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="CHECK_POINT" name="check point">
-            <rule>
-                <pattern>
-                    <token>checkpoint
-                        <exception scope="previous" regexp="yes">the|and|of|or|on</exception>
-                        <exception scope="next">Charlie</exception></token>
-                </pattern>
-                <message>« Check point » peut être considéré comme un anglicisme.</message>
-                <suggestion>point de contrôle</suggestion>
-                <example correction="point de contrôle"><marker>checkpoint</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token case_sensitive="yes">checkpoints</token>
-                </pattern>
-                <message>« Check point » peut être considéré comme un anglicisme.</message>
-                <suggestion>points de contrôle</suggestion>
-                <example correction="points de contrôle"><marker>checkpoints</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes" case_sensitive="yes">checks?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">points?</token>
-                </pattern>
-                <message>« Check point » peut être considéré comme un anglicisme.</message>
-                <suggestion>point de contrôle</suggestion>
-                <example correction="point de contrôle"><marker>check point</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="CHECK_OUT" name="check out">
-            <rule>
-                <pattern>
-                    <token regexp="yes" case_sensitive="yes">checkouts?
-                        <exception scope="previous" regexp="yes">&amp;|at</exception></token>
-                </pattern>
-                <message>« Check out » peut être considéré comme un anglicisme. Employez <suggestion>sortie</suggestion>.</message>
-                <example correction="sortie"><marker>checkout</marker></example>
-                <example><marker>régler la note</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>au</token>
-                    <token regexp="yes" case_sensitive="yes">checkouts?</token>
-                </pattern>
-                <message>« Check out » peut être considéré comme un anglicisme. Employez <suggestion>à la sortie</suggestion>.</message>
-                <example correction="à la sortie"><marker>au checkout</marker></example>
-                <example><marker>régler la note</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>du</token>
-                    <token regexp="yes" case_sensitive="yes">checkouts?</token>
-                </pattern>
-                <message>« Check out » peut être considéré comme un anglicisme. Employez <suggestion>de la sortie</suggestion>.</message>
-                <example correction="de la sortie"><marker>du checkout</marker></example>
-                <example><marker>régler la note</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="D m s"/>
-                    <token regexp="yes" case_sensitive="yes">checkouts?</token>
-                </pattern>
-                <message>« Check out » peut être considéré comme un anglicisme. Employez <suggestion><match no="1" postag="(D) (m) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> sortie</suggestion>.</message>
-                <example correction="la sortie"><marker>le checkout</marker></example>
-                <example><marker>régler la note</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">checks?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">outs?</token>
-                </pattern>
-                <message>« Check out » peut être considéré comme un anglicisme. Employez <suggestion>régler la note</suggestion> (hôtel), <suggestion>quitter la chambre</suggestion> (hôtel).</message>
-                <example correction="régler la note|quitter la chambre"><marker>check out</marker></example>
-                <example><marker>régler la note</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="PEER-TO-PEER" name="peer-to-peer" default="off">
-            <!-- deactivated : widespread usage -->
-            <rule>
-                <pattern>
-                    <token>P2P</token>
-                </pattern>
-                <message>« Peer to peer (P2P) » peut être considéré comme un anglicisme.</message>
-                <suggestion>poste à poste</suggestion>
-                <suggestion>pair à pair</suggestion>
-                <example correction="Poste à poste|Pair à pair"><marker>P2P</marker></example>
-                <example><marker>poste à poste</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">peer|p</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">to|2</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">peer|p</token>
-                </pattern>
-                <message>« Peer to peer (P2P) » peut être considéré comme un anglicisme.</message>
-                <suggestion>poste à poste</suggestion>
-                <suggestion>pair à pair</suggestion>
-                <example correction="poste à poste|pair à pair"><marker>peer to peer</marker></example>
-                <example><marker>poste à poste</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="LIFEGUARD" name="lifeguard">
-            <rule>
-                <pattern>
-                    <token regexp="yes">lifeguards?</token>
-                </pattern>
-                <message>« Lifeguard » peut être considéré comme un anglicisme.</message>
-                <suggestion>maître-nageur</suggestion>
-                <suggestion>maître-sauveteur</suggestion>
-                <suggestion>surveillant de plage</suggestion>
-                <suggestion>surveillant de baignade</suggestion>
-                <example correction="maître-nageur|maître-sauveteur|surveillant de plage|surveillant de baignade"><marker>lifeguard</marker></example>
-                <example><marker>maître-nageur</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>life</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">guards?</token>
-                </pattern>
-                <message>« Lifeguard » peut être considéré comme un anglicisme.</message>
-                <suggestion>maître-nageur</suggestion>
-                <suggestion>maître-sauveteur</suggestion>
-                <suggestion>surveillant de plage</suggestion>
-                <suggestion>surveillant de baignade</suggestion>
-                <example correction="maître-nageur|maître-sauveteur|surveillant de plage|surveillant de baignade"><marker>life guard</marker></example>
-                <example><marker>maître-nageur</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="MINILAB" name="minilab">
-            <rule>
-                <pattern>
-                    <token regexp="yes">minilabs?</token>
-                </pattern>
-                <message>« Minilab » peut être considéré comme un anglicisme.</message>
-                <suggestion>minilabo</suggestion>
-                <example correction="minilabo"><marker>minilab</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>mini</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">labs?</token>
-                </pattern>
-                <message>« Minilab » peut être considéré comme un anglicisme.</message>
-                <suggestion>minilabo</suggestion>
-                <example correction="minilabo"><marker>mini lab</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="MINI-PUTT" name="mini-putt">
-            <rule>
-                <pattern>
-                    <token regexp="yes">miniputts?</token>
-                </pattern>
-                <message>« Mini-putt » peut être considéré comme un anglicisme.</message>
-                <suggestion>golf miniature</suggestion>
-                <suggestion>minigolf</suggestion>
-                <example correction="golf miniature|minigolf"><marker>miniputt</marker></example>
-                <example><marker>golf miniature</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>mini</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">putts?</token>
-                </pattern>
-                <message>« Mini-putt » peut être considéré comme un anglicisme.</message>
-                <suggestion>golf miniature</suggestion>
-                <suggestion>minigolf</suggestion>
-                <example correction="golf miniature|minigolf"><marker>mini putt</marker></example>
-                <example><marker>golf miniature</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="LIVING-ROOM" name="living(-room)">
-            <rule>
-                <pattern>
-                    <token regexp="yes">living|livingroom|livings|livingrooms|livingsrooms
-                        <exception scope="next">-</exception></token>
-                </pattern>
-                <message>« Living(-room) » peut être considéré comme un anglicisme.</message>
-                <suggestion>salle de séjour</suggestion>
-                <suggestion>séjour</suggestion>
-                <example correction="salle de séjour|séjour"><marker>livingroom</marker></example>
-                <example><marker>séjour</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">livings?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">rooms?</token>
-                </pattern>
-                <message>« Living(-room) » peut être considéré comme un anglicisme.</message>
-                <suggestion>salle de séjour</suggestion>
-                <suggestion>séjour</suggestion>
-                <example correction="salle de séjour|séjour"><marker>living room</marker></example>
-                <example><marker>séjour</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BOOKCROSSING" name="bookcrossing">
-            <rule>
-                <pattern>
-                    <token regexp="yes">bookcrossings?</token>
-                </pattern>
-                <message>« Bookcrossing » peut être considéré comme un anglicisme.</message>
-                <suggestion>passe-livres</suggestion>
-                <suggestion>bouquinomadisme</suggestion>
-                <example correction="passe-livres|bouquinomadisme"><marker>bookcrossing</marker></example>
-                <example><marker>bouquinomadisme</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">books?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">crossings?</token>
-                </pattern>
-                <message>« Bookcrossing » peut être considéré comme un anglicisme.</message>
-                <suggestion>passe-livres</suggestion>
-                <suggestion>bouquinomadisme</suggestion>
-                <example correction="passe-livres|bouquinomadisme"><marker>book crossing</marker></example>
-                <example><marker>bouquinomadisme</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="CAMERAMAN" name="cameraman">
-            <rule>
-                <pattern>
-                    <token regexp="yes">cameraman|cameramen|camerawoman|camerawomen|cameramans|camerawomans</token>
-                </pattern>
-                <message>« Cameraman » peut être considéré comme un anglicisme.</message>
-                <suggestion>cadreur</suggestion>
-                <example correction="cadreur"><marker>cameraman</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>camera</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">mans?|men|womans?|women</token>
-                </pattern>
-                <message>« Cameraman » peut être considéré comme un anglicisme.</message>
-                <suggestion>cadreur</suggestion>
-                <example correction="cadreur"><marker>camera man</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="SPACE_OPERA" name="space opera" default="off">
-            <!-- deactivated : widespread usage -->
-            <rule>
-                <pattern>
-                    <token>space</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">opéra|opera|opéras|operas</token>
-                </pattern>
-                <message>« Space-opera » peut être considéré comme un anglicisme.</message>
-                <suggestion>opéra de l'espace</suggestion>
-                <example correction="opéra de l'espace"><marker>space opera</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="GRASPING-REFLEX" name="grasping-reflex">
-            <rule>
-                <pattern>
-                    <token regexp="yes">graspingreflex|graspingreflexs|graspingreflexes</token>
-                </pattern>
-                <message>« Grasping-reflex » peut être considéré comme un anglicisme.</message>
-                <suggestion>réflexe d'agrippement</suggestion>
-                <example correction="réflexe d'agrippement"><marker>graspingreflex</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>grasping</token>
-                    <token min="0">-</token>
-                    <token>reflex</token>
-                </pattern>
-                <message>« Grasping-reflex » peut être considéré comme un anglicisme.</message>
-                <suggestion>réflexe d'agrippement</suggestion>
-                <example correction="réflexe d'agrippement"><marker>grasping reflex</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="HOT_MONEY" name="hot money">
-            <rule>
-                <pattern>
-                    <token>hotmoney</token>
-                </pattern>
-                <message>« Hot-money » peut être considéré comme un anglicisme.</message>
-                <suggestion>capitaux flottants</suggestion>
-                <suggestion>capitaux fébriles</suggestion>
-                <example correction="capitaux flottants|capitaux fébriles"><marker>hotmoney</marker></example>
-                <example><marker>capitaux flottants</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>hot</token>
-                    <token min="0">-</token>
-                    <token>money</token>
-                </pattern>
-                <message>« Hot-money » peut être considéré comme un anglicisme.</message>
-                <suggestion>capitaux flottants</suggestion>
-                <suggestion>capitaux fébriles</suggestion>
-                <example correction="capitaux flottants|capitaux fébriles"><marker>hot money</marker></example>
-                <example><marker>capitaux flottants</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BODY-BUILDING" name="body-building" default="off">
-            <rule>
-                <pattern>
-                    <token regexp="yes">bodybuildings|bodybuilding</token>
-                </pattern>
-                <message>« Body-building » peut être considéré comme un anglicisme.</message>
-                <suggestion>culturisme</suggestion>
-                <example correction="culturisme"><marker>bodybuilding</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>body</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">buildings?</token>
-                </pattern>
-                <message>« Body-building » peut être considéré comme un anglicisme.</message>
-                <suggestion>culturisme</suggestion>
-                <example correction="culturisme"><marker>body building</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="COME-BACK" name="come-back">
-            <rule>
-                <pattern>
-                    <token regexp="yes">comeback|comesbacks|comebacks
-                        <exception scope="previous">s</exception></token>
-                </pattern>
-                <message>« Come-back » peut être considéré comme un anglicisme.</message>
-                <suggestion>retour</suggestion>
-                <example correction="retour"><marker>comeback</marker></example>
-                <example><marker>retour en vogue</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="[DP].*" postag_regexp="yes"/>
-                    <marker>
-                        <token regexp="yes">comes?</token>
-                        <token min="0">-</token>
-                        <token regexp="yes">backs?</token>
-                    </marker>
-                </pattern>
-                <message>« Come-back » peut être considéré comme un anglicisme.</message>
-                <suggestion>retour</suggestion>
-                <example correction="retour">Un <marker>come back</marker></example>
-                <example><marker>retour en vogue</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="TIME-SHARING" name="time sharing">
-            <rule>
-                <pattern>
-                    <token regexp="yes">timesharing|timesharings</token>
-                </pattern>
-                <message>« Time-sharing » peut être considéré comme un anglicisme.</message>
-                <suggestion>temps partagé</suggestion>
-                <example correction="temps partagé"><marker>timesharing</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">times?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">sharings?</token>
-                </pattern>
-                <message>« Time-sharing » peut être considéré comme un anglicisme.</message>
-                <suggestion>temps partagé</suggestion>
-                <example correction="temps partagé"><marker>time sharing</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="SISTER-SHIP" name="sister-ship">
-            <rule>
-                <pattern>
-                    <token regexp="yes">sistership|sisterships|sistersship</token>
-                </pattern>
-                <message>« Sister-ship » peut être considéré comme un anglicisme.</message>
-                <suggestion>navire-jumeau</suggestion>
-                <example correction="navire-jumeau"><marker>sistership</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">sisters?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">ships?</token>
-                </pattern>
-                <message>« Sister ship » peut être considéré comme un anglicisme.</message>
-                <suggestion>navire-jumeau</suggestion>
-                <example correction="navire-jumeau"><marker>sister ship</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="VANITY-CASE" name="vanity-case">
-            <rule>
-                <pattern>
-                    <token regexp="yes">vanitycases?</token>
-                </pattern>
-                <message>« Vanity-case » peut être considéré comme un anglicisme.</message>
-                <suggestion>mallette de toilette</suggestion>
-                <example correction="mallette de toilette"><marker>vanitycase</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">vanity|vanities</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">cases?</token>
-                </pattern>
-                <message>« Vanity-case » peut être considéré comme un anglicisme.</message>
-                <suggestion>mallette de toilette</suggestion>
-                <example correction="mallette de toilette"><marker>vanity case</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="TOP-SECRET" name="top-secret">
-            <rule>
-                <pattern>
-                    <token regexp="yes">topsecrets?</token>
-                </pattern>
-                <message>« Top-secret » peut être considéré comme un anglicisme.</message>
-                <suggestion>ultrasecret</suggestion>
-                <suggestion>absolument confidentiel</suggestion>
-                <example correction="ultrasecret|absolument confidentiel"><marker>topsecret</marker></example>
-                <example><marker>ultrasecret</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>top</token>
-                    <token min="0">-</token>
-                    <token>secret</token>
-                </pattern>
-                <message>« Top-secret » peut être considéré comme un anglicisme.</message>
-                <suggestion>ultrasecret</suggestion>
-                <suggestion>absolument confidentiel</suggestion>
-                <example correction="ultrasecret|absolument confidentiel"><marker>top secret</marker></example>
-                <example><marker>ultrasecret</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="FREELANCE" name="freelance" default="off">
-            <!-- very low apply rate -->
-            <rule>
-                <pattern>
-                    <token regexp="yes">freelances?</token>
-                </pattern>
-                <message>« Freelance » peut être considéré comme un anglicisme.</message>
-                <suggestion>pigiste</suggestion>
-                <suggestion>indépendant</suggestion>
-                <example correction="pigiste|indépendant"><marker>freelance</marker></example>
-                <example><marker>indépendant</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>free</token>
-                    <token min="0">-</token>
-                    <token>lance</token>
-                </pattern>
-                <message>« Freelance » peut être considéré comme un anglicisme.</message>
-                <suggestion>pigiste</suggestion>
-                <suggestion>indépendant</suggestion>
-                <example correction="pigiste|indépendant"><marker>free lance</marker></example>
-                <example><marker>indépendant</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="GAME_DESIGNER" name="game designer">
-            <pattern>
-                <token regexp="yes">games?</token>
-                <token min="0">-</token>
-                <token regexp="yes">designers?</token>
-            </pattern>
-            <message>« Game designer » peut être considéré comme un anglicisme.</message>
-            <suggestion>concepteur de jeux vidéos</suggestion>
-            <suggestion>concepteur de jeux</suggestion>
-            <example correction="concepteur de jeux vidéos|concepteur de jeux"><marker>game designer</marker></example>
-            <example><marker>concepteur de jeux</marker></example>
-        </rule>
-        <rule id="JOKE" name="joke">
-            <pattern>
-                <token regexp="yes">jokes?</token>
-            </pattern>
-            <message>« Joke » peut être considéré comme un anglicisme.</message>
-            <suggestion>farce</suggestion>
-            <suggestion>tour</suggestion>
-            <suggestion>canular</suggestion>
-            <suggestion>blague</suggestion>
-            <example correction="farce|tour|canular|blague"><marker>joke</marker></example>
-            <example><marker>farce</marker></example>
-        </rule>
-        <rule id="CLEAN" name="clean">
-            <pattern>
-                <token regexp="yes" case_sensitive="yes">cleans?
-                    <exception scope="next" regexp="yes">(?-i)[A-Z].*|free|cut|diesel|-|sheet|girl</exception></token>
-            </pattern>
-            <message>« Clean » peut être considéré comme un anglicisme.</message>
-            <suggestion>net</suggestion>
-            <suggestion>sobre</suggestion>
-            <suggestion>sans surcharge</suggestion>
-            <suggestion>dépouillé</suggestion>
-            <suggestion>soigné</suggestion>
-            <suggestion>sain</suggestion>
-            <example correction="net|sobre|sans surcharge|dépouillé|soigné|sain"><marker>clean</marker></example>
-            <example><marker>sobre</marker></example>
-        </rule>
-        <rule id="LATE_BLOOMER" name="late bloomer">
-            <pattern>
-                <token regexp="yes">lates?</token>
-                <token min="0">-</token>
-                <token regexp="yes">bloomers?</token>
-            </pattern>
-            <message>« Late bloomer » peut être considéré comme un anglicisme.</message>
-            <suggestion>vocation tardive</suggestion>
-            <example correction="vocation tardive"><marker>late bloomer</marker></example>
-        </rule>
-        <rule id="HOLDING" name="holding">
-            <pattern>
-                <token regexp="yes">holdings?</token>
-            </pattern>
-            <message>« Holding » peut être considéré comme un anglicisme.</message>
-            <suggestion>société de portefeuille</suggestion>
-            <suggestion>société de participation</suggestion>
-            <example correction="société de portefeuille|société de participation"><marker>holding</marker></example>
-            <example><marker>société de participation</marker></example>
-        </rule>
-        <rule id="HOBBY" name="hobby">
-            <pattern>
-                <token regexp="yes">hobby|hobbies|hobbys</token>
-            </pattern>
-            <message>« Hobby » peut être considéré comme un anglicisme.</message>
-            <suggestion>passe-temps</suggestion>
-            <example correction="passe-temps"><marker>hobby</marker></example>
-        </rule>
-        <rule id="HURRICANE" name="hurricane">
-            <pattern>
-                <token regexp="yes">hurricanes?</token>
-            </pattern>
-            <message>« Hurricane » peut être considéré comme un anglicisme.</message>
-            <suggestion>cyclone</suggestion>
-            <example correction="cyclone"><marker>hurricane</marker></example>
-        </rule>
-        <rulegroup id="JOYSTICK" name="joystick">
-            <rule>
-                <pattern>
-                    <token regexp="yes">joysticks?</token>
-                </pattern>
-                <message>« Joystick » peut être considéré comme un anglicisme. Employez <suggestion>manette de jeu</suggestion> (informatique), <suggestion>manche à balai</suggestion> (informatique).</message>
-                <example correction="manette de jeu|manche à balai"><marker>joystick</marker></example>
-                <example><marker>manche à balai</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">joys?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">sticks?</token>
-                </pattern>
-                <message>« Joystick » peut être considéré comme un anglicisme. Employez <suggestion>manette de jeu</suggestion> (informatique), <suggestion>manche à balai</suggestion> (informatique).</message>
-                <example correction="manette de jeu|manche à balai"><marker>joy stick</marker></example>
-                <example><marker>manche à balai</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="JOINT_VENTURE" name="joint venture">
-            <pattern>
-                <token>joint</token>
-                <token min="0">-</token>
-                <token>venture</token>
-            </pattern>
-            <message>« Joint venture » peut être considéré comme un anglicisme.</message>
-            <suggestion>coentreprise</suggestion>
-            <suggestion>entreprise conjointe</suggestion>
-            <suggestion>entreprise commune</suggestion>
-            <suggestion>opération conjointe</suggestion>
-            <example correction="coentreprise|entreprise conjointe|entreprise commune|opération conjointe"><marker>joint venture</marker></example>
-            <example><marker>entreprise conjointe</marker></example>
-        </rule>
-        <rule id="DIRECTORS_CUT" name="director's cut" default="off">
-            <!-- deactivated : widespread usage -->
-            <pattern>
-                <token regexp="yes" skip="2">director'?s?'?</token>
-                <token regexp="yes" skip="1">cuts?</token>
-            </pattern>
-            <message>« Director's cut » peut être considéré comme un anglicisme.</message>
-            <suggestion>version d'auteur</suggestion>
-            <suggestion>version du réalisateur</suggestion>
-            <suggestion>version réalisateur</suggestion>
-            <example correction="version d'auteur|version du réalisateur|version réalisateur"><marker>director's cut</marker></example>
-            <example><marker>version réalisateur</marker></example>
-        </rule>
-        <rule id="TILT" name="tilt">
-            <pattern>
-                <token regexp="yes">tilts?</token>
-            </pattern>
-            <message>« Tilt » peut être considéré comme un anglicisme. Employez <suggestion>déclic</suggestion> (billard électrique).</message>
-            <example correction="déclic"><marker>tilt</marker></example>
-        </rule>
-        <rule id="BULLYING" name="bullying">
-            <pattern>
-                <token regexp="yes">bullying|bulliing</token>
-            </pattern>
-            <message>« Bullying » peut être considéré comme un anglicisme.</message>
-            <suggestion>harcèlement</suggestion>
-            <suggestion>intimidation</suggestion>
-            <example correction="harcèlement|intimidation"><marker>bullying</marker></example>
-            <example><marker>harcèlement</marker></example>
-        </rule>
-        <rule id="HAPPY_SLAPPING" name="happy slapping">
-            <pattern>
-                <token>happy</token>
-                <token>slapping</token>
-            </pattern>
-            <message>« Happy slapping » peut être considéré comme un anglicisme.</message>
-            <suggestion>vidéolynchage</suggestion>
-            <example correction="vidéolynchage"><marker>happy slapping</marker></example>
-        </rule>
-        <rule id="BLOOPER" name="blooper">
-            <pattern>
-                <token regexp="yes">bloopers?</token>
-            </pattern>
-            <message>« Blooper » peut être considéré comme un anglicisme. Employez <suggestion>gaffe de tournage</suggestion>, <suggestion>gaffe</suggestion>, <suggestion>bêtisier</suggestion> (ensemble de gaffes), <suggestion>sottisier</suggestion> (ensemble de gaffes).</message>
-            <example correction="gaffe de tournage|gaffe|bêtisier|sottisier"><marker>blooper</marker></example>
-            <example><marker>gaffe de tournage</marker></example>
-        </rule>
-        <rule id="WHITE_HAT" name="white hat">
-            <pattern>
-                <token regexp="yes">whites?</token>
-                <token regexp="yes">hats?</token>
-            </pattern>
-            <message>« White hat » peut être considéré comme un anglicisme.</message>
-            <suggestion>bidouilleur</suggestion>
-            <suggestion>mordu de l'informatique</suggestion>
-            <suggestion>fouineur</suggestion>
-            <example correction="bidouilleur|mordu de l'informatique|fouineur"><marker>white hat</marker></example>
-            <example><marker>fouineur</marker></example>
-        </rule>
-        <rule id="BLACK_HAT" name="black hat">
-            <pattern>
-                <token regexp="yes">blacks?</token>
-                <token regexp="yes">hats?</token>
-            </pattern>
-            <message>« Black hat » peut être considéré comme un anglicisme.</message>
-            <suggestion>pirate informatique</suggestion>
-            <suggestion>pirate</suggestion>
-            <suggestion>braqueur informatique</suggestion>
-            <suggestion>cyberpirate</suggestion>
-            <example correction="pirate informatique|pirate|braqueur informatique|cyberpirate"><marker>black hat</marker></example>
-            <example><marker>pirate</marker></example>
-        </rule>
-        <rule id="SERIAL_KILLER" name="serial killer">
-            <pattern>
-                <token regexp="yes">serials?</token>
-                <token regexp="yes">killers?</token>
-            </pattern>
-            <message>« Serial killer » peut être considéré comme un anglicisme.</message>
-            <suggestion>tueur en série</suggestion>
-            <example correction="tueur en série"><marker>serial killer</marker></example>
-        </rule>
-        <rule default="off" id="PODCAST" name="podcast">
-            <pattern>
-                <token regexp="yes">podcasts?</token>
-            </pattern>
-            <message>« Podcast » peut être considéré comme un anglicisme. Employez <suggestion>balado</suggestion>, <suggestion>fichier balado</suggestion>, <suggestion>émission balado</suggestion>, <suggestion>baladoémission</suggestion>, <suggestion>émission baladodiffusée</suggestion>, <suggestion>billet balado</suggestion>, <suggestion>billet baladodiffusé</suggestion>, <suggestion>baladobillet</suggestion>.</message>
-            <example correction="balado|fichier balado|émission balado|baladoémission|émission baladodiffusée|billet balado|billet baladodiffusé|baladobillet"><marker>podcast</marker></example>
-            <example><marker>balado</marker></example>
-        </rule>
-        <rule id="SURVIVAL_HORROR" name="survival horror">
-            <pattern>
-                <token regexp="yes">survivals?</token>
-                <token regexp="yes">horrors?</token>
-            </pattern>
-            <message>« Survival horror » peut être considéré comme un anglicisme.</message>
-            <suggestion>jeu d'horreur</suggestion>
-            <example correction="jeu d'horreur"><marker>survival horror</marker></example>
-        </rule>
-        <rule id="SHAREWARE" name="shareware">
-            <pattern>
-                <token regexp="yes">sharewares?</token>
-            </pattern>
-            <message>« Shareware » peut être considéré comme un anglicisme.</message>
-            <suggestion>partagiciel</suggestion>
-            <suggestion>contribuciel</suggestion>
-            <suggestion>logiciel à contribution</suggestion>
-            <example correction="partagiciel|contribuciel|logiciel à contribution"><marker>shareware</marker></example>
-            <example><marker>partagiciel</marker></example>
-        </rule>
-        <rule id="WARNINGS" name="warnings">
-            <pattern>
-                <token regexp="yes">warnings?</token>
-            </pattern>
-            <message>« Warnings » peut être considéré comme un anglicisme. Employez <suggestion>feux de détresse</suggestion> (automobile).</message>
-            <example correction="feux de détresse"><marker>warnings</marker></example>
-        </rule>
-        <rule id="PHREAKING" name="phreaking">
-            <pattern>
-                <token regexp="yes">phreakings?</token>
-            </pattern>
-            <message>« Phreaking » peut être considéré comme un anglicisme.</message>
-            <suggestion>piratage téléphonique</suggestion>
-            <suggestion>sabotage téléphonique</suggestion>
-            <example correction="piratage téléphonique|sabotage téléphonique"><marker>phreaking</marker></example>
-            <example><marker>piratage téléphonique</marker></example>
-        </rule>
-        <rule id="VAPORWARE" name="vaporware">
-            <pattern>
-                <token regexp="yes">vapou?rwares?</token>
-            </pattern>
-            <message>« Vaporware » peut être considéré comme un anglicisme.</message>
-            <suggestion>logiciel fantôme</suggestion>
-            <suggestion>fumiciel</suggestion>
-            <example correction="logiciel fantôme|fumiciel"><marker>vaporware</marker></example>
-            <example><marker>fumiciel</marker></example>
-        </rule>
-        <rule id="SMILEY" name="smiley" default="off">
-            <!-- deactivated : widespread usage -->
-            <pattern>
-                <token regexp="yes">smileys?|smilies</token>
-            </pattern>
-            <message>« Smiley » peut être considéré comme un anglicisme.</message>
-            <suggestion>binette</suggestion>
-            <suggestion>frimousse</suggestion>
-            <example correction="binette|frimousse"><marker>smiley</marker></example>
-            <example><marker>frimousse</marker></example>
-        </rule>
-        <rule id="SHOOTEM_UP" name="shoot'em up">
-            <pattern>
-                <token regexp="yes" skip="1">shoots?</token>
-                <token regexp="yes">them|em</token>
-                <token regexp="yes">ups?</token>
-            </pattern>
-            <message>« Shoot'em up » peut être considéré comme un anglicisme.</message>
-            <suggestion>jeu de tir</suggestion>
-            <example correction="jeu de tir"><marker>shoot them up</marker></example>
-        </rule>
-        <rulegroup id="BEATEM_UP" name="beat'em up">
-            <rule>
-                <pattern>
-                    <token regexp="yes" skip="1">beats?</token>
-                    <token regexp="yes">them|em</token>
-                    <token regexp="yes">ups?</token>
-                </pattern>
-                <message>« Beat'em up » peut être considéré comme un anglicisme.</message>
-                <suggestion>jeu de combat à progression</suggestion>
-                <example correction="jeu de combat à progression"><marker>beat em up</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes" skip="1">beats?'em</token>
-                    <token regexp="yes">ups?</token>
-                </pattern>
-                <message>« Beat'em up » peut être considéré comme un anglicisme.</message>
-                <suggestion>jeu de combat à progression</suggestion>
-                <example correction="jeu de combat à progression"><marker>beat'em up</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="FLAT" name="flat">
-            <pattern>
-                <token regexp="yes">flats?</token>
-            </pattern>
-            <message>« Flat » peut être considéré comme un anglicisme. Employez <suggestion>crevaison</suggestion>, <suggestion>peinture mate</suggestion>, <suggestion>plat</suggestion> (plongeon), <suggestion>crevé</suggestion>, <suggestion>dégonflé</suggestion>, <suggestion>plat</suggestion>, <suggestion>à plat</suggestion>, <suggestion>mat</suggestion> (couleur), <suggestion>éventé</suggestion> (bière, boisson gazeuse), <suggestion>sans bulles</suggestion> (bière, boisson gazeuse).</message>
-            <example correction="crevaison|peinture mate|plat|crevé|dégonflé|à plat|mat|éventé|sans bulles"><marker>flat</marker></example>
-            <example><marker>crevaison</marker></example>
-        </rule>
-        <rule id="FLAMING" name="flaming">
-            <pattern>
-                <token regexp="yes">flamm?ings?</token>
-            </pattern>
-            <message>« Flaming » peut être considéré comme un anglicisme. Employez <suggestion>flingue</suggestion> (OQLF), <suggestion>agression</suggestion>.</message>
-            <example correction="flingue|agression"><marker>flaming</marker></example>
-            <example><marker>flingue</marker></example>
-        </rule>
-        <rule id="HOAX" name="hoax">
-            <pattern>
-                <token regexp="yes">hoaxs?|hoaxes</token>
-            </pattern>
-            <message>« Hoax » peut être considéré comme un anglicisme.</message>
-            <suggestion>canular</suggestion>
-            <example correction="canular"><marker>hoax</marker></example>
-        </rule>
-        <rule id="HOME_CINEMA" name="home cinema" default="off">
-            <!-- deactivated : widespread usage -->
-            <pattern>
-                <token>home</token>
-                <token regexp="yes">cin[ée]mas?</token>
-            </pattern>
-            <message>« Home cinema » peut être considéré comme un anglicisme.</message>
-            <suggestion>cinéma à domicile</suggestion>
-            <suggestion>cinédom</suggestion>
-            <suggestion>cinéma maison</suggestion>
-            <example correction="cinéma à domicile|cinédom|cinéma maison">Le <marker>home cinema</marker> est un phénomène nouveau.</example>
-            <example>Le <marker>cinéma à domicile</marker> est un phénomène nouveau.</example>
-        </rule>
-        <rule id="EBOOK" name="ebook" default="off">
-            <!-- deactivated : widespread usage -->
-            <pattern>
-                <token regexp="yes">e-?books?</token>
-            </pattern>
-            <message>« Ebook » peut être considéré comme un anglicisme.</message>
-            <suggestion>livre électronique</suggestion>
-            <suggestion>livrel</suggestion>
-            <example correction="livre électronique|livrel">Les <marker>ebooks</marker> sont difficiles à lire.</example>
-            <example>Les <marker>livres électroniques</marker> sont difficiles à lire.</example>
-        </rule>
-        <rule id="BUG" name="bug" default="off">
-            <antipattern>
-                <token>Bugs</token>
-                <token regexp="yes">Bunny|Moran</token>
-            </antipattern>
-            <pattern>
-                <token regexp="yes">bugs?</token>
-            </pattern>
-            <message>« Bug » peut être considéré comme un anglicisme. Employez <suggestion><match no="1" regexp_match="(?i)bug" regexp_replace="bogue"/></suggestion>.</message>
-            <example correction="bogue"><marker>bug</marker></example>
-            <example>Bugs Bunny</example>
-        </rule>
-        <rule id="PODCASTING" name="podcasting" default="off">
-            <!-- deactivated : widespread usage -->
-            <pattern>
-                <token regexp="yes">podcastings?</token>
-            </pattern>
-            <message>« Podcasting » peut être considéré comme un anglicisme.</message>
-            <suggestion>diffusion pour baladeur</suggestion>
-            <suggestion>baladodiffusion</suggestion>
-            <example correction="diffusion pour baladeur|baladodiffusion"><marker>podcasting</marker></example>
-            <example><marker>baladodiffusion</marker></example>
-        </rule>
-        <rule id="SPEED_DATING" name="speed dating" default="off">
-            <!-- deactivated : widespread usage -->
-            <pattern>
-                <token>speed</token>
-                <token regexp="yes">datings?</token>
-            </pattern>
-            <message>« Speed dating » peut être considéré comme un anglicisme.</message>
-            <suggestion>séance de rencontres express</suggestion>
-            <suggestion>séances de rencontres éclair</suggestion>
-            <suggestion>rencontres express</suggestion>
-            <suggestion>rencontres éclair</suggestion>
-            <example correction="séance de rencontres express|séances de rencontres éclair|rencontres express|rencontres éclair">Il fait du <marker>speed dating</marker>.</example>
-            <example>Il fait une <marker>séance de rencontres éclair</marker>.</example>
-        </rule>
-        <rule id="FREEWARE" name="freeware">
-            <pattern>
-                <token regexp="yes">freewares?</token>
-            </pattern>
-            <message>« Freeware » peut être considéré comme un anglicisme.</message>
-            <suggestion>logiciel gratuit</suggestion>
-            <suggestion>graticiel</suggestion>
-            <suggestion>gratuiciel</suggestion>
-            <example correction="logiciel gratuit|graticiel|gratuiciel">Il fait un <marker>freeware</marker>.</example>
-            <example>Il fait un <marker>logiciel gratuit</marker>.</example>
-        </rule>
-        <rule id="ADWARE" name="adware">
-            <pattern>
-                <token regexp="yes">adwares?</token>
-            </pattern>
-            <message>« Adware » peut être considéré comme un anglicisme.</message>
-            <suggestion>logiciel publicitaire</suggestion>
-            <suggestion>annonciel</suggestion>
-            <suggestion>logiciel de publicité</suggestion>
-            <suggestion>gratuiciel publicitaire</suggestion>
-            <example correction="logiciel publicitaire|annonciel|logiciel de publicité|gratuiciel publicitaire">Il fait un <marker>adware</marker>.</example>
-            <example>Il fait un <marker>logiciel publicitaire</marker>.</example>
-        </rule>
-        <rule id="SPAMDEXING" name="spamdexing">
-            <pattern>
-                <token>spamdexing</token>
-            </pattern>
-            <message>« Spamdexing » peut être considéré comme un anglicisme.</message>
-            <suggestion>référencement abusif</suggestion>
-            <suggestion>indexation abusive</suggestion>
-            <example correction="référencement abusif|indexation abusive">Il fait du <marker>spamdexing</marker>.</example>
-            <example>Il fait du <marker>référencement abusif</marker>.</example>
-        </rule>
-        <rule id="PHISHING" name="phishing">
-            <pattern>
-                <token>phishing</token>
-            </pattern>
-            <message>« Phishing » peut être considéré comme un anglicisme.</message>
-            <suggestion>filoutage</suggestion>
-            <suggestion>hameçonnage</suggestion>
-            <example correction="filoutage|hameçonnage">Il fait du <marker>phishing</marker>.</example>
-            <example>Il fait du <marker>hameçonnage</marker>.</example>
-        </rule>
-        <rule id="SPAMMING" name="spamming">
-            <pattern>
-                <token regexp="yes">spamm?ing</token>
-            </pattern>
-            <message>« Spamming » peut être considéré comme un anglicisme.</message>
-            <suggestion>pollupostage</suggestion>
-            <suggestion>arrosage</suggestion>
-            <example correction="pollupostage|arrosage">Il fait du <marker>spamming</marker>.</example>
-            <example>Il fait du <marker>pollupostage</marker>.</example>
-        </rule>
-        <rule id="SPAM" name="spam">
-            <pattern>
-                <token regexp="yes">spams?</token>
-            </pattern>
-            <message>« Spam » peut être considéré comme un anglicisme. Employez <suggestion><match no="1" regexp_match="(?i)spam" regexp_replace="pourriel"/></suggestion>.</message>
-            <example correction="pourriel"><marker>spam</marker>.</example>
-        </rule>
-        <rule id="MAILING" name="mailing">
-            <pattern>
-                <token regexp="yes" case_sensitive="yes">maill?ings?
-                    <exception scope="previous">-</exception></token>
-            </pattern>
-            <message>« Mailing » peut être considéré comme un anglicisme.</message>
-            <suggestion><match no="1" regexp_match="maill?ing(?iu)" regexp_replace="publipostage"/></suggestion>
-            <example correction="publipostage"><marker>mailing</marker>.</example>
-        </rule>
-        <rule id="OVER_MY_DEAD_BODY" name="over my dead body">
-            <pattern>
-                <token>over</token>
-                <token regexp="yes">my|our</token>
-                <token>dead</token>
-                <token regexp="yes">bodys?|bodies</token>
-            </pattern>
-            <message>« Over my dead body » peut être considéré comme un anglicisme.</message>
-            <suggestion>il faudra me passer sur le corps</suggestion>
-            <suggestion>il faudra nous passer sur le corps</suggestion>
-            <suggestion>jamais de la vie</suggestion>
-            <suggestion>plutôt mourir</suggestion>
-            <example correction="il faudra me passer sur le corps|il faudra nous passer sur le corps|jamais de la vie|plutôt mourir"><marker>over my dead body</marker></example>
-            <example><marker>plutôt mourir</marker></example>
-        </rule>
-        <rule id="MALWARE" name="malware">
-            <pattern>
-                <token regexp="yes">malwares?</token>
-            </pattern>
-            <message>« Malware » peut être considéré comme un anglicisme.</message>
-            <suggestion>logiciel malveillant</suggestion>
-            <suggestion>maliciel</suggestion>
-            <suggestion>programme malveillant</suggestion>
-            <suggestion>antiprogramme</suggestion>
-            <example correction="logiciel malveillant|maliciel|programme malveillant|antiprogramme"><marker>malware</marker></example>
-            <example><marker>logiciel malveillant</marker></example>
-        </rule>
-        <rule id="NAGWARE" name="nagware">
-            <pattern>
-                <token regexp="yes">nagwares?</token>
-            </pattern>
-            <message>« Nagware » peut être considéré comme un anglicisme.</message>
-            <suggestion>logiciel harcelant</suggestion>
-            <suggestion>agaciel</suggestion>
-            <suggestion>harceliciel</suggestion>
-            <example correction="logiciel harcelant|agaciel|harceliciel"><marker>nagware</marker></example>
-            <example><marker>logiciel harcelant</marker></example>
-        </rule>
-        <rule id="E-COMMERCE" name="e-commerce" default="off">
-            <pattern>
-                <token regexp="yes">e-commerces?</token>
-            </pattern>
-            <message>« E-commerce » est considéré comme un anglicisme. En voici des équivalents :</message>
-            <suggestion>commerce électronique</suggestion>
-            <suggestion>commerce en ligne</suggestion>
-            <suggestion>commerce virtuel</suggestion>
-            <suggestion>commerce Internet</suggestion>
-            <suggestion>commerce sur Internet</suggestion>
-            <suggestion>cybercommerce</suggestion>
-            <example correction="commerce électronique|commerce en ligne|commerce virtuel|commerce Internet|commerce sur Internet|cybercommerce"><marker>e-commerce</marker></example>
-            <example><marker>commerce électronique</marker></example>
-        </rule>
-        <rule id="MERCHANDISING" name="merchandising">
-            <pattern>
-                <token regexp="yes">merchandisings?</token>
-            </pattern>
-            <message>« Merchandising » peut être considéré comme un anglicisme.</message>
-            <suggestion>marchandisage</suggestion>
-            <example correction="marchandisage"><marker>merchandising</marker></example>
-        </rule>
-        <rule default="off" id="SEXY" name="sexy">
-            <pattern>
-                <token regexp="yes">sexys?|sexies</token>
-            </pattern>
-            <message>« Sexy » peut être considéré comme un anglicisme.</message>
-            <suggestion>attrayant</suggestion>
-            <suggestion>séduisant</suggestion>
-            <suggestion>aguichant</suggestion>
-            <suggestion>suggestif</suggestion>
-            <suggestion>désirable</suggestion>
-            <suggestion>érotique</suggestion>
-            <example correction="attrayant|séduisant|aguichant|suggestif|désirable|érotique"><marker>sexy</marker></example>
-            <example><marker>attrayant</marker></example>
-        </rule>
-        <rule default="off" id="SPONSOR" name="sponsor">
-            <pattern>
-                <token regexp="yes">sponsors?</token>
-            </pattern>
-            <message>« Sponsor » peut être considéré comme un anglicisme.</message>
-            <suggestion>commanditaire</suggestion>
-            <suggestion>parrain</suggestion>
-            <suggestion>parraineur</suggestion>
-            <suggestion>mécène</suggestion>
-            <suggestion>bailleur de fonds</suggestion>
-            <example correction="commanditaire|parrain|parraineur|mécène|bailleur de fonds"><marker>sponsor</marker></example>
-            <example><marker>bailleur de fonds</marker></example>
-        </rule>
-        <rule id="SOFTWARE" name="software">
-            <pattern>
-                <token regexp="yes">softwares?</token>
-            </pattern>
-            <message>« Software » peut être considéré comme un anglicisme.</message>
-            <suggestion>logiciel</suggestion>
-            <example correction="logiciel"><marker>software</marker></example>
-        </rule>
-        <rule id="CALIPER" name="caliper">
-            <pattern>
-                <token regexp="yes">calipers?</token>
-            </pattern>
-            <message>« Caliper » peut être considéré comme un anglicisme.</message>
-            <suggestion>étrier de frein</suggestion>
-            <example correction="étrier de frein"><marker>caliper</marker></example>
-        </rule>
-        <rule id="LAST_CALL" name="last call">
-            <pattern>
-                <token>last</token>
-                <token regexp="yes">calls?</token>
-            </pattern>
-            <message>« Last call » peut être considéré comme un anglicisme.</message>
-            <suggestion>dernière commande</suggestion>
-            <suggestion>dernier service</suggestion>
-            <example correction="dernière commande|dernier service"><marker>last call</marker></example>
-            <example><marker>dernière commande</marker></example>
-        </rule>
-        <rule id="NAPKIN" name="napkin">
-            <pattern>
-                <token>napkin</token>
-            </pattern>
-            <message>« Napkin » peut être considéré comme un anglicisme.</message>
-            <suggestion>serviette de table</suggestion>
-            <example correction="serviette de table"><marker>napkin</marker>.</example>
-        </rule>
-        <rule id="HELLO" name="hello" tags="picky">
-            <antipattern>
-                <token regexp="yes" skip="-1">hellos?</token>
-                <token inflected="yes" regexp="yes">&textes;</token>
-            </antipattern>
-            <antipattern>
-                <token regexp="yes" skip="-1">hellos?</token>
-                <token regexp="yes">[12]\d\d\d</token>
-            </antipattern>
-            <pattern>
-                <token postag="SENT_START"/>
-                <marker>
-                    <token regexp="yes">hellos?
-                        <exception scope="next" regexp="yes">yes|neighbor|everybody|I|it|world|star|Kitty|(?-i)Bank|[=]|pro|at|my|for|of|by|business|team</exception></token>
-                </marker>
-            </pattern>
-            <message>Cette salutation anglaise peut être remplacée par un synonyme français afin d'apporter de la fluidité à votre texte.</message>
-            <suggestion>salut</suggestion>
-            <suggestion>coucou</suggestion>
-            <suggestion>bonjour</suggestion>
-            <suggestion>allô</suggestion>
-            <example correction="Salut|Coucou|Bonjour|Allô"><marker>Hello</marker>.</example>
-            <example><marker>allô</marker>.</example>
-            <example>En anglais Hello=bonjour.</example>
-            <example>Ma fille veut le nouveau Hello Kitty pour son anniversaire.</example>
-        </rule>
-        <rule id="HOOD" name="hood">
-            <pattern>
-                <token regexp="yes">hoods?</token>
-            </pattern>
-            <message>« Hood » peut être considéré comme un anglicisme. Employez <suggestion>capot</suggestion> (automobile), ou <suggestion>quartier</suggestion> (argot).</message>
-            <example correction="capot|quartier"><marker>hood</marker>.</example>
-            <example correction="capot|quartier">Il vient de mon <marker>hood</marker>.</example>
-        </rule>
-        <rule id="HOLD" name="hold">
-            <pattern>
-                <token regexp="yes">holds?</token>
-            </pattern>
-            <message>« Hold » peut être considéré comme un anglicisme. Employez <suggestion>en attente</suggestion> (téléphone), <suggestion>en garde</suggestion> (téléphone).</message>
-            <example correction="en attente|en garde"><marker>hold</marker>.</example>
-            <example><marker>en attente</marker>.</example>
-        </rule>
-        <rule id="HOLDSTER" name="holdster">
-            <pattern>
-                <token regexp="yes">holdsters?</token>
-            </pattern>
-            <message>« Holdster » peut être considéré comme un anglicisme.</message>
-            <suggestion>étui</suggestion>
-            <example correction="étui"><marker>holdster</marker>.</example>
-        </rule>
-        <rule id="NAPHTA" name="naphta">
-            <pattern>
-                <token>naphta</token>
-            </pattern>
-            <message>« Naphta » peut être considéré comme un anglicisme.</message>
-            <suggestion>naphte</suggestion>
-            <example correction="naphte"><marker>naphta</marker>.</example>
-        </rule>
-        <rule id="NO_VACANCY" name="no vacancy">
-            <pattern>
-                <token>no</token>
-                <token>vacancy</token>
-            </pattern>
-            <message>« No vacancy » peut être considéré comme un anglicisme. Employez <suggestion>complet</suggestion> (affiche d'hôtel).</message>
-            <example correction="complet"><marker>no vacancy</marker>.</example>
-        </rule>
-        <rule id="NO_FAULT" name="no fault">
-            <pattern>
-                <token>no</token>
-                <token>fault</token>
-            </pattern>
-            <message>« No fault » peut être considéré comme un anglicisme.</message>
-            <suggestion>assurance inconditionnelle</suggestion>
-            <suggestion>indemnisation sans égard à la responsabilité</suggestion>
-            <example correction="assurance inconditionnelle|indemnisation sans égard à la responsabilité"><marker>no fault</marker>.</example>
-            <example><marker>assurance inconditionnelle</marker>.</example>
-        </rule>
-        <rule id="WHISHFUL_THINKING" name="wishful thinking">
-            <pattern>
-                <token>wishful</token>
-                <token>thinking</token>
-            </pattern>
-            <message>« Wishful thinking » peut être considéré comme un anglicisme.</message>
-            <suggestion>prendre ses désirs pour des réalités</suggestion>
-            <example correction="prendre ses désirs pour des réalités"><marker>wishful thinking</marker>.</example>
-        </rule>
-        <rule id="STEERING" name="steering">
-            <pattern>
-                <token regexp="yes">steerings?</token>
-            </pattern>
-            <message>« Steering » peut être considéré comme un anglicisme.(steering wheel).</message>
-            <suggestion>volant</suggestion>
-            <example correction="volant"><marker>steering</marker>.</example>
-        </rule>
-        <rule id="STANDING_OVATION" name="standing ovation">
-            <pattern>
-                <token>standing</token>
-                <token regexp="yes">ovations?</token>
-            </pattern>
-            <message>« Standing ovation » peut être considéré comme un anglicisme.</message>
-            <suggestion>ovation</suggestion>
-            <example correction="ovation"><marker>standing ovation</marker>.</example>
-        </rule>
-        <rulegroup id="DEAL" name="deal">
-            <antipattern>
-                <token regexp="yes">deals?</token>
-                <token regexp="yes">for|of|and|"|\?</token>
-            </antipattern>
-            <rule>
-                <pattern>
-                    <token regexp="yes" case_sensitive="yes">deals?
-                        <exception scope="previous" postag="D m s"/>
-                        <exception scope="previous" regexp="yes">ce|du|new|-|you|no|great|a|real|and|«</exception></token>
-                </pattern>
-                <message>« Deal » peut être considéré comme un anglicisme.</message>
-                <suggestion><match no="3" regexp_match="deal(?iu)" regexp_replace="marché" case_conversion="preserve"/></suggestion>
-                <suggestion><match no="3" regexp_match="deal(?iu)" regexp_replace="affaire" case_conversion="preserve"/></suggestion>
-                <suggestion><match no="3" regexp_match="deal(?iu)" regexp_replace="accord" case_conversion="preserve"/></suggestion>
-                <suggestion><match no="3" regexp_match="deal(?iu)" regexp_replace="offre" case_conversion="preserve"/></suggestion>
-                <example correction="marché|affaire|accord|offre"><marker>deal</marker></example>
-                <example><marker>marché</marker></example>
-                <example>Le New Deal mis en place par le président Franklin D. Roosevelt.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>du</token>
-                    <token>deal</token>
-                </pattern>
-                <message>« Deal » peut être considéré comme un anglicisme.</message>
-                <suggestion>du marché</suggestion>
-                <suggestion>de l'affaire</suggestion>
-                <suggestion>de l'accord</suggestion>
-                <suggestion>de l'offre</suggestion>
-                <example correction="du marché|de l'affaire|de l'accord|de l'offre"><marker>du deal</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token postag="D m s">
-                        <exception regexp="yes">[cl]e</exception></token>
-                    <token>deal</token>
-                </pattern>
-                <message>« Deal » peut être considéré comme un anglicisme.</message>
-                <suggestion>\1 marché</suggestion>
-                <suggestion><match no="1" postag="(D) (m) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> affaire</suggestion>
-                <suggestion>\1 accord</suggestion>
-                <suggestion><match no="1" postag="(D) (m) (s)" postag_regexp="yes" postag_replace="$1 f $3"/> offre</suggestion>
-                <example correction="un marché|une affaire|un accord|une offre"><marker>un deal</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>ce</token>
-                    <token>deal</token>
-                </pattern>
-                <message>« Deal » peut être considéré comme un anglicisme.</message>
-                <suggestion>\1 <match no="2" regexp_match="deal" regexp_replace="marché" case_conversion="preserve"/></suggestion>
-                <suggestion>cette <match no="2" regexp_match="deal" regexp_replace="affaire" case_conversion="preserve"/></suggestion>
-                <suggestion>cet <match no="2" regexp_match="deal" regexp_replace="accord" case_conversion="preserve"/></suggestion>
-                <suggestion>cette <match no="2" regexp_match="deal" regexp_replace="offre" case_conversion="preserve"/></suggestion>
-                <example correction="ce marché|cette affaire|cet accord|cette offre"><marker>ce deal</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>le</token>
-                    <token case_sensitive="yes">deal</token>
-                </pattern>
-                <message>« Deal » peut être considéré comme un anglicisme.</message>
-                <suggestion>\1 <match no="2" regexp_match="deal" regexp_replace="marché" case_conversion="preserve"/></suggestion>
-                <suggestion>l'<match no="2" regexp_match="deal" regexp_replace="affaire" case_conversion="preserve"/></suggestion>
-                <suggestion>l'<match no="2" regexp_match="deal" regexp_replace="accord" case_conversion="preserve"/></suggestion>
-                <suggestion>l'<match no="2" regexp_match="deal" regexp_replace="offre" case_conversion="preserve"/></suggestion>
-                <example correction="le marché|l'affaire|l'accord|l'offre"><marker>le deal</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="STAMINA" name="stamina">
-            <pattern>
-                <token>stamina</token>
-            </pattern>
-            <message>« Stamina » peut être considéré comme un anglicisme.</message>
-            <suggestion>endurance</suggestion>
-            <suggestion>résistance</suggestion>
-            <example correction="endurance|résistance"><marker>stamina</marker>.</example>
-            <example><marker>résistance</marker>.</example>
-        </rule>
-        <rulegroup id="DEADLINE" name="deadline">
-            <rule>
-                <pattern>
-                    <token regexp="yes">dead-?lines?</token>
-                </pattern>
-                <message>« Deadline » peut être considéré comme un anglicisme.</message>
-                <suggestion>heure de tombée</suggestion>
-                <suggestion>date limite</suggestion>
-                <suggestion>heure limite</suggestion>
-                <suggestion>échéance</suggestion>
-                <suggestion>date butoir</suggestion>
-                <example correction="heure de tombée|date limite|heure limite|échéance|date butoir"><marker>deadline</marker></example>
-                <example><marker>échéance</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>dead</token>
-                    <token regexp="yes">lines?</token>
-                </pattern>
-                <message>« Deadline » peut être considéré comme un anglicisme.</message>
-                <suggestion>heure de tombée</suggestion>
-                <suggestion>date limite</suggestion>
-                <suggestion>échéance</suggestion>
-                <example correction="heure de tombée|date limite|échéance"><marker>dead line</marker></example>
-                <example><marker>échéance</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="SUNLIGHT" name="sunlight">
-            <rule>
-                <pattern>
-                    <token regexp="yes">sunlights?</token>
-                </pattern>
-                <message>« Sunlight » peut être considéré comme un anglicisme.</message>
-                <suggestion>projecteur</suggestion>
-                <example correction="projecteur"><marker>sunlight</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>sun</token>
-                    <token regexp="yes">lights?</token>
-                </pattern>
-                <message>« Sunlight » peut être considéré comme un anglicisme.</message>
-                <suggestion>projecteur</suggestion>
-                <example correction="projecteur"><marker>sun light</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="SPRINGBOARD" name="springboard">
-            <rule>
-                <pattern>
-                    <token regexp="yes">spring-?boards?</token>
-                </pattern>
-                <message>« Springboard » peut être considéré comme un anglicisme.</message>
-                <suggestion>tremplin</suggestion>
-                <example correction="tremplin"><marker>springboard</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>spring</token>
-                    <token regexp="yes">boards?</token>
-                </pattern>
-                <message>« Springboard » peut être considéré comme un anglicisme.</message>
-                <suggestion>tremplin</suggestion>
-                <example correction="tremplin"><marker>spring board</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="DROP-OUT" name="drop-out">
-            <rule>
-                <pattern>
-                    <token regexp="yes">dropouts?</token>
-                </pattern>
-                <message>« Drop-out » peut être considéré comme un anglicisme.</message>
-                <suggestion>marginal</suggestion>
-                <suggestion>élève en rupture scolaire</suggestion>
-                <example correction="marginal|élève en rupture scolaire"><marker>dropout</marker></example>
-                <example><marker>marginal</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">drops?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">outs?</token>
-                </pattern>
-                <message>« Drop-out » peut être considéré comme un anglicisme.</message>
-                <suggestion>marginal</suggestion>
-                <suggestion>élève en rupture scolaire</suggestion>
-                <example correction="marginal|élève en rupture scolaire"><marker>drop out</marker></example>
-                <example><marker>marginal</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="STAKEHOLDER" name="stakeholder">
-            <rule>
-                <pattern>
-                    <token regexp="yes">stake-?holders?</token>
-                </pattern>
-                <message>« Stakeholder » peut être considéré comme un anglicisme. Employez <suggestion>décideur</suggestion>, <suggestion>intéressé</suggestion>, <suggestion>partie prenante</suggestion>, <suggestion>dépositaire d'enjeux</suggestion> (common law).</message>
-                <example correction="décideur|intéressé|partie prenante|dépositaire d'enjeux"><marker>stakeholder</marker></example>
-                <example><marker>décideur</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>stake</token>
-                    <token regexp="yes">holders?</token>
-                </pattern>
-                <message>« Stakeholder » peut être considéré comme un anglicisme. Employez <suggestion>décideur</suggestion>, <suggestion>intéressé</suggestion>, <suggestion>partie prenante</suggestion>, <suggestion>dépositaire d'enjeux</suggestion> (common law).</message>
-                <example correction="décideur|intéressé|partie prenante|dépositaire d'enjeux"><marker>stake holder</marker></example>
-                <example><marker>décideur</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="STAINLESS" name="stainless (steel)">
-            <pattern>
-                <token>stainless</token>
-            </pattern>
-            <message>« Stainless (steel) » peut être considéré comme un anglicisme.</message>
-            <suggestion>acier inoxydable</suggestion>
-            <suggestion>inox</suggestion>
-            <example correction="acier inoxydable|inox"><marker>stainless</marker>.</example>
-            <example><marker>acier inoxydable</marker>.</example>
-        </rule>
-        <rule id="SQUEEZE_BOTTLE" name="squeeze bottle">
-            <pattern>
-                <token>squeeze</token>
-                <token regexp="yes">bottles?</token>
-            </pattern>
-            <message>« Squeeze bottle » peut être considéré comme un anglicisme.</message>
-            <suggestion>contenant souple</suggestion>
-            <example correction="contenant souple"><marker>squeeze bottle</marker>.</example>
-        </rule>
-        <rule id="SWAMP" name="swamp">
-            <pattern>
-                <token regexp="yes">swamps?</token>
-            </pattern>
-            <message>« Swamp » peut être considéré comme un anglicisme.</message>
-            <suggestion>marais</suggestion>
-            <suggestion>marécage</suggestion>
-            <example correction="marais|marécage"><marker>swamp</marker>.</example>
-            <example><marker>marécage</marker>.</example>
-        </rule>
-        <rule id="ZIPPER" name="zipper">
-            <pattern>
-                <token regexp="yes">zippeu?rs?</token>
-            </pattern>
-            <message>« Zipper » peut être considéré comme un anglicisme.</message>
-            <suggestion>fermeture à glissière</suggestion>
-            <suggestion>glissière</suggestion>
-            <example correction="fermeture à glissière|glissière"><marker>zipper</marker>.</example>
-            <example><marker>fermeture à glissière</marker>.</example>
-        </rule>
-        <rule id="BUMPER" name="bumper">
-            <pattern>
-                <token regexp="yes">bumpers?</token>
-            </pattern>
-            <message>« Bumper » peut être considéré comme un anglicisme.</message>
-            <suggestion>pare-choc</suggestion>
-            <example correction="pare-choc"><marker>bumper</marker>.</example>
-        </rule>
-        <rule id="BANSHEE" name="banshee">
-            <pattern>
-                <token regexp="yes">bansh[ie]es?</token>
-            </pattern>
-            <message>« Banshee » peut être considéré comme un anglicisme.</message>
-            <suggestion>dame blanche</suggestion>
-            <example correction="dame blanche"><marker>banshee</marker>.</example>
-        </rule>
-        <rule id="FLASHER" name="flasher">
-            <pattern>
-                <token regexp="yes">flashers?</token>
-            </pattern>
-            <message>« Flasher » peut être considéré comme un anglicisme. Employez <suggestion>clignotant</suggestion>, <suggestion>feux de détresse</suggestion> (emergency flashers).</message>
-            <example correction="clignotant|feux de détresse"><marker>flasher</marker>.</example>
-            <example><marker>clignotant</marker>.</example>
-        </rule>
-        <rule id="FREAK" name="freak">
-            <pattern>
-                <token regexp="yes">freaks?</token>
-            </pattern>
-            <message>« Freak » peut être considéré comme un anglicisme.</message>
-            <suggestion>hippie</suggestion>
-            <suggestion>marginal</suggestion>
-            <suggestion>drogué</suggestion>
-            <example correction="hippie|marginal|drogué"><marker>freak</marker>.</example>
-            <example><marker>drogué</marker>.</example>
-        </rule>
-        <rule id="SCAB" name="scab">
-            <pattern>
-                <token regexp="yes">scabs?</token>
-            </pattern>
-            <message>« Scab » peut être considéré comme un anglicisme. Employez <suggestion>briseur de grève</suggestion>, <suggestion>jaune</suggestion> (péjoratif).</message>
-            <example correction="briseur de grève|jaune"><marker>scab</marker>.</example>
-            <example><marker>briseur de grève</marker>.</example>
-        </rule>
-        <rulegroup id="CHAINSAW" name="chainsaw">
-            <rule>
-                <pattern>
-                    <token regexp="yes">chain-?saws?</token>
-                </pattern>
-                <message>« Chainsaw » peut être considéré comme un anglicisme.</message>
-                <suggestion>tronçonneuse</suggestion>
-                <suggestion>scie à chaîne</suggestion>
-                <example correction="tronçonneuse|scie à chaîne"><marker>chainsaw</marker></example>
-                <example><marker>tronçonneuse</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>chain</token>
-                    <token regexp="yes">saws?</token>
-                </pattern>
-                <message>« Chainsaw » peut être considéré comme un anglicisme.</message>
-                <suggestion>tronçonneuse</suggestion>
-                <suggestion>scie à chaîne</suggestion>
-                <example correction="tronçonneuse|scie à chaîne"><marker>chain saw</marker></example>
-                <example><marker>tronçonneuse</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="OVERTIME" name="overtime">
-            <rule>
-                <pattern>
-                    <token regexp="yes">over-?times?</token>
-                </pattern>
-                <message>« Overtime » peut être considéré comme un anglicisme.</message>
-                <suggestion>heures supplémentaires</suggestion>
-                <example correction="heures supplémentaires"><marker>overtime</marker>.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>over</token>
-                    <token regexp="yes">times?</token>
-                </pattern>
-                <message>« Overtime » peut être considéré comme un anglicisme.</message>
-                <suggestion>heures supplémentaires</suggestion>
-                <example correction="heures supplémentaires"><marker>over time</marker>.</example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="OVERSIZE" name="oversize(d)">
-            <rule>
-                <pattern>
-                    <token regexp="yes">over-?sized?s?</token>
-                </pattern>
-                <message>« Oversize(d) » peut être considéré comme un anglicisme.</message>
-                <suggestion>grand format</suggestion>
-                <suggestion>très grand format</suggestion>
-                <example correction="grand format|très grand format"><marker>oversize</marker>.</example>
-                <example><marker>grand format</marker>.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>over</token>
-                    <token regexp="yes">size|sized|sizeds|sizes</token>
-                </pattern>
-                <message>« Oversize(d) » peut être considéré comme un anglicisme.</message>
-                <suggestion>grand format</suggestion>
-                <suggestion>très grand format</suggestion>
-                <example correction="grand format|très grand format"><marker>over size</marker>.</example>
-                <example><marker>grand format</marker>.</example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="ONE-MAN_SHOW" name="one-(wo)man show" default="off">
-            <rule>
-                <pattern>
-                    <token>one</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">man|woman</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">shows?</token>
-                </pattern>
-                <message>« One-man show » peut être considéré comme un anglicisme.</message>
-                <suggestion>spectacle solo</suggestion>
-                <suggestion>seul en scène</suggestion>
-                <example correction="spectacle solo|seul en scène"><marker>one man show</marker></example>
-                <example correction="spectacle solo|seul en scène"><marker>one-man show</marker></example>
-                <example><marker>solo</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">one-(man|woman)-show</token>
-                </pattern>
-                <message>« One-man show » peut être considéré comme un anglicisme.</message>
-                <suggestion>spectacle solo</suggestion>
-                <suggestion>seul en scène</suggestion>
-                <example correction="spectacle solo|seul en scène"><marker>one-man-show</marker></example>
-                <example><marker>solo</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="OFFSHORE" name="offshore" default="off">
-            <rule>
-                <pattern>
-                    <token regexp="yes">off[-‑‐]?shores?</token>
-                </pattern>
-                <message>« Offshore » peut être considéré comme un anglicisme.</message>
-                <suggestion>en mer</suggestion>
-                <suggestion>au large</suggestion>
-                <suggestion>en haute mer</suggestion>
-                <suggestion>hauturier</suggestion>
-                <suggestion>pélagique</suggestion>
-                <example correction="en mer|au large|en haute mer|hauturier|pélagique"><marker>offshore</marker></example>
-                <example><marker>en mer</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>off</token>
-                    <token regexp="yes">shores?</token>
-                </pattern>
-                <message>« Offshore » peut être considéré comme un anglicisme.</message>
-                <suggestion>en mer</suggestion>
-                <suggestion>au large</suggestion>
-                <suggestion>en haute mer</suggestion>
-                <suggestion>hauturier</suggestion>
-                <suggestion>pélagique</suggestion>
-                <example correction="en mer|au large|en haute mer|hauturier|pélagique"><marker>off shore</marker></example>
-                <example><marker>en mer</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="BOLT" name="bolt" default="off">
-            <antipattern>
-                <token regexp="yes">(?-i)Alex|Brice|Usain|Robert|von</token>
-                <token>Bolt</token>
-            </antipattern>
-            <pattern>
-                <token regexp="yes">bolts?</token>
-            </pattern>
-            <message>« Bolt » peut être considéré comme un anglicisme.</message>
-            <suggestion>boulon</suggestion>
-            <example correction="boulon"><marker>bolt</marker>.</example>
-            <example>Usain Bolt est un athlète jamaïcain.</example>
-        </rule>
-        <rule id="PAGEANT" name="pageant">
-            <pattern>
-                <token regexp="yes">pageants?</token>
-            </pattern>
-            <message>« Pageant » peut être considéré comme un anglicisme.</message>
-            <suggestion>spectacle historique</suggestion>
-            <suggestion>reconstitution historique</suggestion>
-            <suggestion>spectacle fastueux</suggestion>
-            <example correction="spectacle historique|reconstitution historique|spectacle fastueux"><marker>pageant</marker>.</example>
-            <example><marker>spectacle fastueux</marker>.</example>
-        </rule>
-        <rule id="BICYCLE" name="bicycle">
-            <pattern>
-                <token regexp="yes">b[iy]cycles?</token>
-            </pattern>
-            <message>« Bicycle » peut être considéré comme un anglicisme.</message>
-            <suggestion>vélo</suggestion>
-            <suggestion>bicyclette</suggestion>
-            <suggestion>moto</suggestion>
-            <example correction="vélo|bicyclette|moto"><marker>bicycle</marker>.</example>
-            <example><marker>vélo</marker>.</example>
-        </rule>
-        <rulegroup id="BEAT" name="beat">
-            <rule>
-                <pattern>
-                    <or>
-                        <token>du</token>
-                        <token postag="[DJ] . s" postag_regexp="yes"/>
-                    </or>
-                    <marker>
-                        <token case_sensitive="yes">beat
-                            <exception scope="previous">afro</exception>
-                            <exception scope="next" regexp="yes">them|-</exception></token>
-                    </marker>
-                </pattern>
-                <message>« Beat » peut être considéré comme un anglicisme.</message>
-                <suggestion>rythme</suggestion>
-                <suggestion>tempo</suggestion>
-                <suggestion>son</suggestion>
-                <example correction="rythme|tempo|son">Il parle du <marker>beat</marker>.</example>
-                <example>Il parle de <marker>rythme</marker>.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">[mts]es|[vn]os|leurs|des?|les</token>
-                    <marker>
-                        <token case_sensitive="yes">beats
-                            <exception scope="next" regexp="yes">funky|dance|-</exception></token>
-                    </marker>
-                </pattern>
-                <message>« Beat » peut être considéré comme un anglicisme.</message>
-                <suggestion>rythmes</suggestion>
-                <suggestion>tempos</suggestion>
-                <suggestion>sons</suggestion>
-                <example correction="rythmes|tempos|sons">Il parle des <marker>beats</marker>.</example>
-                <example>Il parle de <marker>rythme</marker>.</example>
-            </rule>
-        </rulegroup>
-        <rule id="BOXING_DAY" name="Boxing Day">
-            <pattern>
-                <token>Boxing</token>
-                <token>Day</token>
-            </pattern>
-            <message>« Boxing Day » peut être considéré comme un anglicisme.</message>
-            <suggestion>les soldes d'après Noël</suggestion>
-            <suggestion>l'Après-Noël</suggestion>
-            <example correction="Les soldes d'après Noël|L'Après-Noël">Il parle du <marker>Boxing Day</marker>.</example>
-            <example>Il parle <marker>des soldes d'après Noël</marker>.</example>
-        </rule>
-        <rule id="VENEER" name="veneer">
-            <pattern>
-                <token regexp="yes">veneers?</token>
-            </pattern>
-            <message>« Veneer » peut être considéré comme un anglicisme.</message>
-            <suggestion>contreplaqué</suggestion>
-            <example correction="contreplaqué"><marker>veneer</marker></example>
-        </rule>
-        <rulegroup id="CHECKLIST" name="checklist">
-            <rule>
-                <pattern>
-                    <token regexp="yes">check[-‑‐]?lists?</token>
-                </pattern>
-                <message>« Checklist » peut être considéré comme un anglicisme.</message>
-                <suggestion>liste de contrôle</suggestion>
-                <suggestion>liste de vérification</suggestion>
-                <suggestion>aide-mémoire</suggestion>
-                <example correction="liste de contrôle|liste de vérification|aide-mémoire"><marker>checklist</marker></example>
-                <example><marker>liste de contrôle</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">checks?</token>
-                    <token regexp="yes">lists?</token>
-                </pattern>
-                <message>« Checklist » peut être considéré comme un anglicisme.</message>
-                <suggestion>liste de contrôle</suggestion>
-                <suggestion>liste de vérification</suggestion>
-                <suggestion>aide-mémoire</suggestion>
-                <example correction="liste de contrôle|liste de vérification|aide-mémoire"><marker>check list</marker></example>
-                <example><marker>liste de contrôle</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="TRAVELERS_CHEQUE" name="traveler's cheque">
-            <pattern>
-                <token regexp="yes">traveller'?s?'?</token>
-                <token regexp="yes">ch[èe]ques?|checks?</token>
-            </pattern>
-            <message>« Traveller's cheque » peut être considéré comme un anglicisme.</message>
-            <suggestion>chèque de voyage</suggestion>
-            <example correction="chèque de voyage"><marker>traveller's cheque</marker></example>
-        </rule>
-        <rule id="GLAMOUR" name="glamour" default="off">
-            <pattern>
-                <token regexp="yes">glamou?rs?</token>
-            </pattern>
-            <message>« Glamour » peut être considéré comme un anglicisme.</message>
-            <suggestion>séduction</suggestion>
-            <suggestion>prestige</suggestion>
-            <suggestion>beauté sensuelle et luxueuse</suggestion>
-            <example correction="séduction|prestige|beauté sensuelle et luxueuse"><marker>glamour</marker></example>
-            <example><marker>prestige</marker></example>
-        </rule>
-        <rulegroup id="EG" name="e.g.">
-            <antipattern>
-                <token>E</token>
-                <token>.</token>
-                <token>G</token>
-                <token>.</token>
-                <token regexp="yes" spacebefore="no">[A-Z]</token>
-            </antipattern>
-            <antipattern>
-                <token>.</token>
-                <token spacebefore="no">E</token>
-                <token>.</token>
-                <token>G</token>
-                <token>.</token>
-            </antipattern>
-            <rule>
-                <pattern>
-                    <token>e</token>
-                    <token>.</token>
-                    <token>g</token>
-                    <token>.</token>
-                </pattern>
-                <message>« e.g. » peut être considéré comme un anglicisme.</message>
-                <suggestion>par exemple</suggestion>
-                <suggestion>p. ex.</suggestion>
-                <example correction="par exemple|p. ex."><marker>e.g.</marker></example>
-                <example><marker>p. ex.</marker></example>
-            </rule>
-            <rule>
-                <antipattern>
-                    <token regexp="yes">(?-i)EG</token>
-                </antipattern>
-                <pattern>
-                    <token>eg</token>
-                </pattern>
-                <message>« e.g. » peut être considéré comme un anglicisme.</message>
-                <suggestion>par exemple</suggestion>
-                <suggestion>p. ex.</suggestion>
-                <example correction="par exemple|p. ex."><marker>eg</marker></example>
-                <example><marker>p. ex.</marker></example>
-            </rule>
-        </rulegroup>
-        <!-- doesn't work due to sentence splitting
-        <rulegroup id="PS" name="P.S.">
-            <rule>
-                <pattern>
-                    <token>P</token>
-                    <token>.</token>
-                    <token>S</token>
-                    <token>.</token>
-                </pattern>
-                <message>« P.S. » peut être considéré comme un anglicisme.</message>
-                <suggestion>P.-S.</suggestion>
-                <example correction="P.-S."><marker>P.S.</marker></example>
-            </rule>
-        </rulegroup>
-        -->
-        <rulegroup id="VG" name="v.g.">
-            <antipattern>
-                <token>V</token>
-                <token>.</token>
-                <token>G</token>
-                <token>.</token>
-                <token regexp="yes" spacebefore="no">[A-Z]</token>
-            </antipattern>
-            <antipattern>
-                <token>.</token>
-                <token spacebefore="no">V</token>
-                <token>.</token>
-                <token>G</token>
-                <token>.</token>
-            </antipattern>
-            <rule>
-                <pattern>
-                    <token>v</token>
-                    <token>.</token>
-                    <token>g</token>
-                    <token>.</token>
-                </pattern>
-                <message>« v.g. » peut être considéré comme un anglicisme.</message>
-                <suggestion>par exemple</suggestion>
-                <suggestion>p. ex.</suggestion>
-                <example correction="par exemple|p. ex."><marker>v.g.</marker></example>
-                <example><marker>p. ex.</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>vg
-                        <exception scope="previous">sony</exception></token>
-                </pattern>
-                <message>« v.g. » peut être considéré comme un anglicisme.</message>
-                <suggestion>par exemple</suggestion>
-                <suggestion>p. ex.</suggestion>
-                <example correction="par exemple|p. ex."><marker>vg</marker></example>
-                <example><marker>p. ex.</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="IE" name="i.e.">
-            <antipattern>
-                <token>I</token>
-                <token>.</token>
-                <token>E</token>
-                <token>.</token>
-                <token regexp="yes" spacebefore="no">[A-Z]</token>
-            </antipattern>
-            <antipattern>
-                <token>.</token>
-                <token spacebefore="no">I</token>
-                <token>.</token>
-                <token>E</token>
-                <token>.</token>
-            </antipattern>
-            <antipattern>
-                <token spacebefore="no">'</token>
-                <token>ie</token>
-            </antipattern>
-            <rule>
-                <pattern>
-                    <token>i</token>
-                    <token>.</token>
-                    <token>e</token>
-                    <token>.</token>
-                </pattern>
-                <message>L'abréviation 'i.e.' peut être considéré comme un anglicisme.</message>
-                <suggestion>c'est-à-dire</suggestion>
-                <suggestion>c.-à-d.</suggestion>
-                <example correction="c'est-à-dire|c.-à-d."><marker>i.e.</marker></example>
-                <example><marker>c-à-d.</marker></example>
-                <example>Pascal Van Yperseel (1957-....), avec le G. I.E.C., Prix Nobel de la Paix 2004.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>ie
-                        <exception scope="previous">-</exception></token>
-                </pattern>
-                <message>L'abréviation 'i.e.' peut être considéré comme un anglicisme.</message>
-                <suggestion>c'est-à-dire</suggestion>
-                <suggestion>c.-à-d.</suggestion>
-                <example correction="c'est-à-dire|c.-à-d."><marker>ie</marker></example>
-                <example><marker>c-à-d.</marker></example>
-                <example>Foi Baha' ie</example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="SELF-CONTROL" name="self-control">
-            <rule>
-                <pattern>
-                    <token regexp="yes">self[-‑‐]control</token>
-                </pattern>
-                <message>« Self-control » peut être considéré comme un anglicisme.</message>
-                <suggestion>maîtrise de soi</suggestion>
-                <example correction="maîtrise de soi"><marker>self-control</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>self</token>
-                    <token>control</token>
-                </pattern>
-                <message>« Self-control » peut être considéré comme un anglicisme.</message>
-                <suggestion>maîtrise de soi</suggestion>
-                <example correction="maîtrise de soi"><marker>self control</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="HARD_SELLING" name="hard selling">
-            <pattern>
-                <token regexp="yes">hards?</token>
-                <token regexp="yes">sellings?</token>
-            </pattern>
-            <message>« Hard selling » peut être considéré comme un anglicisme.</message>
-            <suggestion>vente à l'arrachée</suggestion>
-            <suggestion>vente forcée</suggestion>
-            <example correction="vente à l'arrachée|vente forcée"><marker>hard selling</marker></example>
-            <example><marker>vente forcée</marker></example>
-        </rule>
-        <rule id="SNAP" name="snap">
-            <pattern>
-                <token regexp="yes">snaps?</token>
-            </pattern>
-            <message>« Snap » peut être considéré comme un anglicisme.</message>
-            <suggestion>bouton-pression</suggestion>
-            <suggestion>fermoir à pression</suggestion>
-            <example correction="bouton-pression|fermoir à pression"><marker>snap</marker></example>
-            <example><marker>bouton-pression</marker></example>
-        </rule>
-        <rule id="RIM" name="rim">
-            <pattern>
-                <token regexp="yes">rims?</token>
-            </pattern>
-            <message>« Rim » peut être considéré comme un anglicisme. Employez <suggestion>jante</suggestion> (de roue).</message>
-            <example correction="jante"><marker>rim</marker></example>
-        </rule>
-        <rule id="REWRITING" name="rewriting">
-            <pattern>
-                <token regexp="yes">re[-‑‐]?writings?</token>
-            </pattern>
-            <message>« Rewriting » peut être considéré comme un anglicisme.</message>
-            <suggestion>réécriture</suggestion>
-            <suggestion>adaptation</suggestion>
-            <example correction="réécriture|adaptation"><marker>rewriting</marker></example>
-            <example><marker>réécriture</marker></example>
-        </rule>
-        <rulegroup id="RENT_A_CAR" name="rent-a-car">
-            <rule>
-                <pattern>
-                    <token regexp="yes">rents?</token>
-                    <token min="0">-</token>
-                    <token>a</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">cars?</token>
-                </pattern>
-                <message>« Rent-a-car » peut être considéré comme un anglicisme. Pour éviter la critique, employez plutôt <suggestion>voitures de location</suggestion>, <suggestion>location de voitures</suggestion>.</message>
-                <example correction="voitures de location|location de voitures"><marker>rent a car</marker></example>
-                <example correction="voitures de location|location de voitures"><marker>rent-a-car</marker></example>
-                <example><marker>location de voitures</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="PARTNER" name="partner">
-            <pattern>
-                <token regexp="yes">partners?</token>
-            </pattern>
-            <message>« Partner » peut être considéré comme un anglicisme.</message>
-            <suggestion>partenaire</suggestion>
-            <suggestion>associé</suggestion>
-            <suggestion>partenaire d'affaires</suggestion>
-            <suggestion>partenaire commercial</suggestion>
-            <example correction="partenaire|associé|partenaire d'affaires|partenaire commercial"><marker>partner</marker>.</example>
-            <example><marker>associé</marker>.</example>
-        </rule>
-        <rule id="PARTNERSHIP" name="partnership">
-            <pattern>
-                <token regexp="yes">partnerships?</token>
-            </pattern>
-            <message>« Partnership » peut être considéré comme un anglicisme. Employez <suggestion>partenariat</suggestion>, <suggestion>société de personnes</suggestion> (en administration).</message>
-            <example correction="partenariat|société de personnes"><marker>partnership</marker>.</example>
-            <example><marker>partenariat</marker>.</example>
-        </rule>
-        <rulegroup id="BACK_ORDER" name="back order">
-            <rule>
-                <pattern>
-                    <token regexp="yes">backs?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">orders?</token>
-                </pattern>
-                <message>« Back order » peut être considéré comme un anglicisme. Employez <suggestion>en souffrance</suggestion> (commande), <suggestion>en rupture de stock</suggestion> (commande), <suggestion>livraison différée</suggestion>, <suggestion>rupture de stock</suggestion>.</message>
-                <example correction="en souffrance|en rupture de stock|livraison différée|rupture de stock"><marker>back order</marker>.</example>
-                <example><marker>en souffrance</marker>.</example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="WET_SUIT" name="wet suit">
-            <rule>
-                <pattern>
-                    <token regexp="yes">wetsuits?</token>
-                </pattern>
-                <message>« Wet suit » peut être considéré comme un anglicisme.</message>
-                <suggestion>combinaison isolante</suggestion>
-                <suggestion>combinaison isothermique</suggestion>
-                <suggestion>combinaison de plongée</suggestion>
-                <example correction="combinaison isolante|combinaison isothermique|combinaison de plongée"><marker>wetsuit</marker>.</example>
-                <example><marker>combinaison isolante</marker>.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">wets?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">suits?</token>
-                </pattern>
-                <message>« Wet suit » peut être considéré comme un anglicisme.</message>
-                <suggestion>combinaison isolante</suggestion>
-                <suggestion>combinaison isothermique</suggestion>
-                <suggestion>combinaison de plongée</suggestion>
-                <example correction="combinaison isolante|combinaison isothermique|combinaison de plongée"><marker>wet suit</marker>.</example>
-                <example><marker>combinaison isolante</marker>.</example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="WATERPROOF" name="waterproof">
-            <rule>
-                <pattern>
-                    <token regexp="yes">waterproofs?</token>
-                </pattern>
-                <message>« Waterproof » peut être considéré comme un anglicisme.</message>
-                <suggestion>imperméable</suggestion>
-                <example correction="imperméable"><marker>waterproof</marker>.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">waters?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">proofs?</token>
-                </pattern>
-                <message>« Waterproof » peut être considéré comme un anglicisme.</message>
-                <suggestion>imperméable</suggestion>
-                <example correction="imperméable"><marker>water proof</marker>.</example>
-            </rule>
-        </rulegroup>
-        <rule id="LIGHTER" name="lighter">
-            <pattern>
-                <token regexp="yes">lighters?</token>
-            </pattern>
-            <message>« Lighter » peut être considéré comme un anglicisme. Employez <suggestion>briquet</suggestion> (en général), <suggestion>allume-cigare</suggestion> (dans une voiture).</message>
-            <example correction="briquet|allume-cigare"><marker>lighter</marker>.</example>
-            <example><marker>allume-cigare</marker>.</example>
-        </rule>
-        <rule id="ZUCCHINI" name="zucchini">
-            <pattern>
-                <token regexp="yes">zucchinis?</token>
-            </pattern>
-            <message>« Zucchini » peut être considéré comme un anglicisme.</message>
-            <suggestion>courgette</suggestion>
-            <example correction="courgette"><marker>zucchini</marker>.</example>
-        </rule>
-        <rule id="WIPER" name="wiper">
-            <pattern>
-                <token regexp="yes">wipers?</token>
-            </pattern>
-            <message>« Wiper » peut être considéré comme un anglicisme.</message>
-            <suggestion>essuie-glace</suggestion>
-            <example correction="essuie-glace"><marker>wiper</marker></example>
-        </rule>
-        <rule id="WISE" name="wise">
-            <pattern>
-                <token regexp="yes">wises?</token>
-            </pattern>
-            <message>« Wise » peut être considéré comme un anglicisme.</message>
-            <suggestion>habile</suggestion>
-            <suggestion>rusé</suggestion>
-            <suggestion>malin</suggestion>
-            <suggestion>futé</suggestion>
-            <example correction="habile|rusé|malin|futé"><marker>wise</marker>.</example>
-            <example><marker>malin</marker>.</example>
-        </rule>
-        <rule id="CIRCA" name="circa">
-            <pattern>
-                <token>circa</token>
-            </pattern>
-            <message>« Circa » peut être considéré comme un anglicisme.</message>
-            <suggestion>vers</suggestion>
-            <example correction="vers"><marker>circa</marker>.</example>
-        </rule>
-        <rule id="NOZZLE" name="nozzle">
-            <pattern>
-                <token regexp="yes">nozzles?</token>
-            </pattern>
-            <message>« Nozzle » peut être considéré comme un anglicisme.</message>
-            <suggestion>arroseur automatique</suggestion>
-            <suggestion>tourniquet d'arrosage</suggestion>
-            <suggestion>gicleur de lave-glace</suggestion>
-            <example correction="arroseur automatique|tourniquet d'arrosage|gicleur de lave-glace"><marker>nozzle</marker>.</example>
-            <example><marker>tourniquet d'arrosage</marker>.</example>
-        </rule>
-        <rulegroup id="PET_SHOP" name="pet shop">
-            <antipattern>
-                <token>pet</token>
-                <token>shop</token>
-                <token regexp="yes">boy.*</token>
-            </antipattern>
-            <rule>
-                <pattern>
-                    <token regexp="yes">petshops?</token>
-                </pattern>
-                <message>« Pet shop » peut être considéré comme un anglicisme.</message>
-                <suggestion>animalerie</suggestion>
-                <example correction="animalerie"><marker>petshop</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">pets?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">shops?</token>
-                </pattern>
-                <message>« Pet shop » peut être considéré comme un anglicisme.</message>
-                <suggestion>animalerie</suggestion>
-                <example correction="animalerie"><marker>pet shop</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="BACKBENCHER" name="backbencher">
-            <rule>
-                <pattern>
-                    <token regexp="yes">backbenchers?</token>
-                </pattern>
-                <message>« Backbencher » peut être considéré comme un anglicisme.</message>
-                <suggestion>simple député</suggestion>
-                <suggestion>député</suggestion>
-                <example correction="simple député|député"><marker>backbencher</marker></example>
-                <example><marker>simple député</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>back</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">benchers?</token>
-                </pattern>
-                <message>« Backbencher » peut être considéré comme un anglicisme.</message>
-                <suggestion>simple député</suggestion>
-                <suggestion>député</suggestion>
-                <example correction="simple député|député"><marker>back bencher</marker></example>
-                <example><marker>simple député</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="DOGGY_BAG" name="doggy-bag" default="off">
-            <rule>
-                <pattern>
-                    <token regexp="yes">doggy|doggie</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">bags?</token>
-                </pattern>
-                <message>« Doggy bag » peut être considéré comme un anglicisme.</message>
-                <suggestion>sac à restes</suggestion>
-                <suggestion>emporte-restes</suggestion>
-                <example correction="sac à restes|emporte-restes"><marker>doggy bag</marker></example>
-                <example correction="sac à restes|emporte-restes"><marker>doggy-bag</marker></example>
-                <example><marker>sac à restes</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="COCOONING" name="cocooning">
-            <pattern>
-                <token regexp="yes">cocoonings?</token>
-            </pattern>
-            <message>« Cocooning » peut être considéré comme un anglicisme.</message>
-            <suggestion>cocounage</suggestion>
-            <suggestion>coconnage</suggestion>
-            <example correction="cocounage|coconnage"><marker>cocooning</marker>.</example>
-            <example><marker>cocounage</marker>.</example>
-        </rule>
-        <rule id="COMICS" name="comics" default="off">
-            <!-- deactivated : in the French-speaking world, the meaning has narrowed to refer specifically to American comics, just as manga refers to Japanese comics -->
-            <antipattern>
-                <token regexp="yes">Marvel|DC</token>
-                <token>Comics</token>
-            </antipattern>
-            <pattern>
-                <token regexp="yes">comics?</token>
-            </pattern>
-            <message>« Comics » peut être considéré comme un anglicisme.</message>
-            <suggestion>bande dessinée</suggestion>
-            <example correction="bande dessinée"><marker>comics</marker>.</example>
-        </rule>
-        <rule id="FIXING" name="fixing">
-            <pattern>
-                <token regexp="yes">fixings?</token>
-            </pattern>
-            <message>« Fixing » peut être considéré comme un anglicisme.</message>
-            <suggestion>fixage</suggestion>
-            <example correction="fixage"><marker>fixing</marker>.</example>
-        </rule>
-        <rule id="CLIPPER" name="clipper">
-            <pattern>
-                <token regexp="yes" case_sensitive="yes">clippers?
-                    <exception scope="previous">-</exception></token>
-            </pattern>
-            <message>« Clipper » peut être considéré comme un anglicisme. Employez <suggestion>tondeuse</suggestion> (à cheveux), <suggestion>rasoir</suggestion>, <suggestion>coupe-ongles</suggestion>.</message>
-            <example correction="tondeuse|rasoir|coupe-ongles"><marker>clipper</marker>.</example>
-            <example><marker>tondeuse</marker> à cheveux.</example>
-        </rule>
-        <rulegroup id="CONDOMINIUM" name="condo(minium)">
-            <antipattern>
-                <token regexp="yes">(?-i)[A-Z].*</token>
-                <token regexp="yes">condos?|condominiums?</token>
-            </antipattern>
-            <rule>
-                <pattern>
-                    <token regexp="yes">condo|condominium
-                        <exception scope="previous" regexp="yes">le|ce|au</exception></token>
-                </pattern>
-                <message>« Condo(minium) » peut être considéré comme un anglicisme.</message>
-                <suggestion>appartement</suggestion>
-                <example correction="appartement"><marker>condo</marker>.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>le</token>
-                    <token regexp="yes">condo|condominium</token>
-                </pattern>
-                <message>« Condo(minium) » peut être considéré comme un anglicisme.</message>
-                <suggestion>la copropriété</suggestion>
-                <suggestion>l'appartement</suggestion>
-                <example correction="la copropriété|l'appartement"><marker>le condo</marker>.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>ce</token>
-                    <token regexp="yes">condo|condominium</token>
-                </pattern>
-                <message>« Condo(minium) » peut être considéré comme un anglicisme.</message>
-                <suggestion>cette copropriété</suggestion>
-                <suggestion>cet appartement</suggestion>
-                <example correction="cette copropriété|cet appartement"><marker>ce condo</marker>.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>au</token>
-                    <token regexp="yes">condo|condominium</token>
-                </pattern>
-                <message>« Condo(minium) » peut être considéré comme un anglicisme.</message>
-                <suggestion>à la copropriété</suggestion>
-                <suggestion>à l'appartement</suggestion>
-                <example correction="à la copropriété|à l'appartement"><marker>au condo</marker>.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">condos|condominiums</token>
-                </pattern>
-                <message>« Condo(minium) » peut être considéré comme un anglicisme.</message>
-                <suggestion>copropriétés</suggestion>
-                <suggestion>appartements</suggestion>
-                <example correction="copropriétés|appartements"><marker>condos</marker>.</example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="COCONUT" name="coconut">
-            <rule>
-                <pattern>
-                    <token regexp="yes">coconuts?</token>
-                </pattern>
-                <message>« Coconut » peut être considéré comme un anglicisme.</message>
-                <suggestion>noix de coco</suggestion>
-                <example correction="noix de coco"><marker>coconut</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">cocos?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">nuts?</token>
-                </pattern>
-                <message>« Coconut » peut être considéré comme un anglicisme.</message>
-                <suggestion>noix de coco</suggestion>
-                <example correction="noix de coco"><marker>coco nut</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="CHECKUP" name="checkup">
-            <rule>
-                <pattern>
-                    <token regexp="yes">check-?ups?</token>
-                </pattern>
-                <message>« Checkup » peut être considéré comme un anglicisme.</message>
-                <suggestion>inspection</suggestion>
-                <suggestion>révision</suggestion>
-                <suggestion>bilan de santé</suggestion>
-                <suggestion>examen périodique</suggestion>
-                <suggestion>examen de contrôle</suggestion>
-                <suggestion>examen médical complet</suggestion>
-                <example correction="inspection|révision|bilan de santé|examen périodique|examen de contrôle|examen médical complet"><marker>checkup</marker></example>
-                <example correction="inspection|révision|bilan de santé|examen périodique|examen de contrôle|examen médical complet"><marker>check-up</marker></example>
-                <example><marker>bilan de santé</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">checks?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">ups?</token>
-                </pattern>
-                <message>« Checkup » peut être considéré comme un anglicisme.</message>
-                <suggestion>inspection</suggestion>
-                <suggestion>révision</suggestion>
-                <suggestion>bilan de santé</suggestion>
-                <suggestion>examen périodique</suggestion>
-                <suggestion>examen de contrôle</suggestion>
-                <suggestion>examen médical complet</suggestion>
-                <example correction="inspection|révision|bilan de santé|examen périodique|examen de contrôle|examen médical complet"><marker>check up</marker></example>
-                <example><marker>bilan de santé</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="FLASH-BACK" name="flash-back">
-            <rule>
-                <pattern>
-                    <token regexp="yes">flashbacks?
-                        <exception case_sensitive="yes">FlashBack</exception></token>
-                </pattern>
-                <message>« Flash-back » peut être considéré comme un anglicisme.</message>
-                <suggestion>retour</suggestion>
-                <suggestion>rétrospective</suggestion>
-                <example correction="retour|rétrospective"><marker>flashback</marker></example>
-                <example><marker>retour en arrière</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">flashes|flashs?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">backs?</token>
-                </pattern>
-                <message>« Flash-back » peut être considéré comme un anglicisme.</message>
-                <suggestion>retour</suggestion>
-                <suggestion>rétrospective</suggestion>
-                <example correction="retour|rétrospective"><marker>flash back</marker></example>
-                <example><marker>retour en arrière</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="FLASHLIGHT" name="flashlight">
-            <rule>
-                <pattern>
-                    <token regexp="yes">flashlights?</token>
-                </pattern>
-                <message>« Flashlight » peut être considéré comme un anglicisme.</message>
-                <suggestion>lampe de poche</suggestion>
-                <example correction="lampe de poche"><marker>flashlight</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp="yes">flashes|flashs?</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">lights?</token>
-                </pattern>
-                <message>« Flashlight » peut être considéré comme un anglicisme.</message>
-                <suggestion>lampe de poche</suggestion>
-                <example correction="lampe de poche"><marker>flash light</marker></example>
-            </rule>
-        </rulegroup>
-        <rulegroup id="SIX-PACK" name="six-pack">
-            <rule>
-                <pattern>
-                    <token regexp="yes">sixpacks?</token>
-                </pattern>
-                <message>« Six-pack » peut être considéré comme un anglicisme.</message>
-                <suggestion>emballage de six</suggestion>
-                <suggestion>carton de six</suggestion>
-                <example correction="emballage de six|carton de six"><marker>sixpack</marker></example>
-                <example><marker>emballage de six</marker></example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>six</token>
-                    <token min="0">-</token>
-                    <token regexp="yes">packs?</token>
-                </pattern>
-                <message>« Six-pack » peut être considéré comme un anglicisme.</message>
-                <suggestion>emballage de six</suggestion>
-                <suggestion>carton de six</suggestion>
-                <example correction="emballage de six|carton de six"><marker>six pack</marker></example>
-                <example><marker>emballage de six</marker></example>
-            </rule>
-        </rulegroup>
-        <rule id="HADDOCK" name="haddock">
-            <pattern>
-                <token regexp="yes">haddocks?
-                    <exception scope="previous">capitaine</exception></token>
-            </pattern>
-            <message>« Haddock » peut être considéré comme un anglicisme.</message>
-            <suggestion>aiglefin</suggestion>
-            <suggestion>églefin</suggestion>
-            <example correction="aiglefin|églefin"><marker>haddock</marker></example>
-            <example><marker>aiglefin</marker></example>
-            <example>Le capitaine Haddock est l'ami de Tintin.</example>
-        </rule>
-        <rule id="PACEMAKER" name="pacemaker">
-            <pattern>
-                <token regexp="yes">pacemakers?</token>
-            </pattern>
-            <message>« Pacemaker » peut être considéré comme un anglicisme.</message>
-            <suggestion>stimulateur cardiaque</suggestion>
-            <example correction="stimulateur cardiaque"><marker>pacemaker</marker></example>
-        </rule>
-        <rule id="LOCKER" name="locker">
-            <pattern>
-                <token regexp="yes">lockers?</token>
-            </pattern>
-            <message>« Locker » peut être considéré comme un anglicisme.</message>
-            <suggestion>casier</suggestion>
-            <suggestion>remise</suggestion>
-            <suggestion>débarras</suggestion>
-            <suggestion>armoire extérieure</suggestion>
-            <example correction="casier|remise|débarras|armoire extérieure"><marker>locker</marker></example>
-            <example><marker>remise</marker></example>
-        </rule>
-        <rule id="VISIO" name="raccourci visio" tone_tags="formal">
-            <antipattern>
-                <token>visio</token>
-                <token>raconte</token>
-                <token>comment</token>
-            </antipattern>
-            <antipattern>
-                <token>visio</token>
-                <token regexp="yes">Wettini|Rotchari|Baronti|Tnugdali|Edwardi|Fursei|Pauli|Sancti|Bernoldi|Karoli|in|:|de</token>
-            </antipattern>
-            <pattern>
-                <token regexp="yes">en|la|une|des|les|cette|ces</token>
-                <marker>
-                    <token>visio</token>
-                </marker>
-            </pattern>
-            <message>« \1 » est un raccourci familier. Employez <suggestion>visioconférence</suggestion> dans un contexte plus sérieux.</message>
-            <example correction="visioconférence">Nous pourrons régler ce problème dans notre prochain entretien en <marker>visio</marker>.</example>
-            <example>Le but de la Visio Karoli Grossi est clairement de légitimer la succession des Carolingiens.</example>
-            <example>La Visio raconte comment le fier chevalier Tondale...</example>
-        </rule>
-        <rule id="FORM" name="form" default="off">
-            <pattern>
-                <token regexp="yes">forms?</token>
-            </pattern>
-            <message>'\1' peut être considéré comme un anglicisme. Employez <suggestion><match no="1" regexp_match="(form)(s)?" regexp_replace="questionnaire$2"/></suggestion>, <suggestion><match no="1" regexp_match="(form)(s)?" regexp_replace="formulaire$2"/></suggestion>, <suggestion><match no="1" regexp_match="(form)(s)?" regexp_replace="forme$2"/></suggestion>, <suggestion>mouler</suggestion>.</message>
-            <example correction="questionnaire|formulaire|forme|mouler">Je lui ai donné cette <marker>form</marker> a remplir</example>
-        </rule>
-        <rule id="LINK" name="link">
-            <pattern>
-                <token case_sensitive="yes">link</token>
-            </pattern>
-            <message>« \1 » peut être considéré comme un anglicisme.</message>
-            <suggestion>lien</suggestion>
-            <example correction="lien">Pense à mettre <marker>link</marker> entre les deux éléments.</example>
-        </rule>
-        <rule id="SEARCH" name="search">
-            <pattern>
-                <token>search</token>
-            </pattern>
-            <message>« \1 » peut être considéré comme un anglicisme.</message>
-            <suggestion>recherche</suggestion>
-            <example correction="recherche">Pense à rajouter une <marker>search</marker> pour les deux éléments.</example>
         </rule>
     </category>
     <category id="CAT_REGLES_DE_BASE" name="Règles de base" type="style">


### PR DESCRIPTION
New style category created for "Foreign_terms" tag (tag not implemented yet, but will be available soon)

Before this commit, we had 2 Anglicism categories:
- CAT_ANGLICISMES_PICKY
- CAT_ANGLICISMES which included pure anglicisms, calques and partially adapted loanwords

Now we have 3:
- CAT_ANGLICISMES_PICKY (remains untouched)
- CAT_ANGLICISMES which now includes only calques and partially adapted loanwords
- CAT_ANGLICISMES_FOREIGN_TERMS includes only pure anglicisms, and therefore can be later tagged with "Foreign_terms"
