### PR TITLE
SentenceAnnotator changed error type IW to IM to match documentation

### DIFF
--- a/languagetool-http-client/src/main/java/org/languagetool/remote/SentenceAnnotator.java
+++ b/languagetool-http-client/src/main/java/org/languagetool/remote/SentenceAnnotator.java
@@ -150,7 +150,7 @@ public class SentenceAnnotator {
           break;
         case "i":
           fpMatches.add(getMatchIdentifier(sentence, match));
-          errorType = "IW";
+          errorType = "IM";
           break;
         case "f":
           fpMatches.add(getMatchIdentifier(sentence, match));


### PR DESCRIPTION
While current updating the GEMA documentation and creating additional pages, I saw that this script still annotated **IW** instead of the intended **IM** for an *ignored match*.
@jaumeortola: I have only found one line that looked like it needed to be changed and changed it, so I guess this should be it. Please merge unless more lines need to be changed.