### PR TITLE
[pt] Add VERBOS_DE_MOVIMENTO_EM_BR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
@@ -34,6 +34,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         <!ENTITY meses_ano "(?:[Aa]bril|[Aa]gosto|[Dd]ezembro|[Ff]evereiro|[Jj]aneiro|[Jj]ulho|[Jj]unho|[Mm]aio|[Mm]arço|[Nn]ovembro|[Oo]utubro|[Ss]etembro)">
         <!ENTITY dias_semana_abrev "(?:[Ss]ex|[Ss]eg|[Ss]áb|[Dd]om|[Qq]ui|[Tt]er)">
         <!ENTITY dias_semana "(?:[Dd]omingo|[Qq]uarta(-feira)?|[Qq]uinta(-feira)?|[Ss]ábado|[Ss]egunda(-feira)?|[Ss]exta(-feira)?|[Tt]erça(-feira)?|(seg|ter|qua|qui|sex)-feira)">
+        <!ENTITY expressoes_de_tempo "yoctossegundos?|zeptossegundos?|atossegundos?|fentossegundos?|picossegundos?|nanossegundos?|microssegundos?|milissegundos?|(?:minuto|hora|dia|se(?:gundo|mana|mestre)|(?:bi|tri|quadri)mestre|ano|d(?:écada|ecénio)|mil[éê]nio|temp(?:o|orada)s?|época)s?|m(?:ês|eses)|alturas?|amanhãs?|datas?|eras?|horários?|idades?|instantes?|momentos?|ocasião|ocasiões|períodos?|quinzenas?|séculos?|vez|vezes|manhãs?|tardes?|noites?">
         <!ENTITY enderecos "Alameda|Avenida|Largo|Praça|Praceta|Rua|Terreiro|Travessa|Via|Estrada|Piso">
         <!ENTITY nomes_de_instituicoes "Anuário|Jardim|Aeroporto|Classificação|Fundação|Diretrize?s?|Península|Normas?|Consultoria|Empresa|Empirismo|Conjuração|Inconfidência|Inquisição|Rede|Códigos?|Vale|Título|Plano|Frente|Vanguarda|tradutor[ae]s?|Lei|Indústria|Realismo|Conferência|Constituição|Colégio|Conselho|Comunidade|Estatuto|Serviço|Coletivo|Assuntos|Revoluções|Tabela|Encontro|Secretaria|Consulado|Comissão|Comitês?|Fórum|Núcleo|Posto|Jornal|Sistema|Lojas?|Tribunal|Cinemateca|Nacional|Sinfonia|Vila|Protocolos?|Grupos?|Peste|Gripe|Festival|Velódromo|Memorial|Programa|Expressionismo|Assembleias?|Forças?|Câmara|Impressionismo|Clubes?|Estudos|Regimentos?|Fundo|Banco|Campeonato|Conferência|Partido|Aliança|Seleção|Museu|Taça|Copa|Organização|Unidades?|Hospital|Campanha|Corporação|Correio|Marinha|Juventude|Sociedades?|Ligas?|Letras|Literaturas?|Línguas?|Revolta|Armada|Grêmio|Jogos|Academia|Associação|Centro|Companhia|Cultura|Congressos?|Revista|Montanhas?|Morros?|Complexo|Ministério|Confederação|Coroa|Embaixada|Emirados?|Enciclopédia|Era|Escola|Exército|Circuito|Faculdade|Tesouro|Federação|Guerra|Igreja|Ilhas|Império|Torneios?|Índia|Instituição|Instituto|Mar|Repúblicas?|Revolução|União|Universidade|Superliga|Teatro">
         <!ENTITY palavras_estrangeiras "up|welcome|these|but|top|too|in|return|go|goes|baby|shop|appeal|trade|toys?|or|who|of|years|from|about|there|also|be|boom|why|this|drink|flash|revival|not|what|with|wasn?|hasn?|hadn?|few|must|through|try|off|out|cut|sessions?|games?|are|by|couldn?|can|wouldn?|might|the|is|and|for|your|back|that|you|he|she|it|we|they|him|her|them|good|bad|les?|chicos?|novi[oa]s?|herman[oa]s?|ballo|y|del|abrazo|una|besot?e?|con|placer|on|peut|dans|tout|vous|je|chaque|lui|avec|pas|du|aus|den|der|die|écoles?|une|ont|féderations?|thêatres?|des|qui|au|societés?|académies?|pour|notre|sur|institute?|ich|sie|weil|wir|mio?|degli|della|di|tuo|tra">
@@ -527,17 +528,193 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
     <!-- ********************************************************** -->
     <!-- CONFUNDIR CHEGAMOS A POR CHEGAMOS EM -->
 
-    <rule id="CHEGAMOS_EM_BR" name="Chegamos a">
-      <pattern>
-        <marker>
-          <token>chegamos</token>
-          <token>em</token>
-        </marker>
-        <token regexp="yes">\p{Lu}\p{Ll}.*</token>
-      </pattern>
-      <message>O verbo de movimento chegar exige a preposição A. Substitua &quot;chegamos em&quot; por <suggestion>chegamos a</suggestion>.</message>
-      <example correction="chegamos a">Nós <marker>chegamos em</marker> São Paulo.</example>
-    </rule>
+    <!-- We should consider moving this to formal style; using 'a' with 'chegar' feels purist-y. -->
+    <rulegroup id="VERBOS_DE_MOVIMENTO_EM_BR" name="Verbos de movimento com a preposição em">
+        <!-- TODO -->
+        <!-- * work out what other verbs we may need -->
+        <!-- remove sub-rule IDs -->
+        <rule id="CHEGAR_EM">
+            <pattern>
+                <token regexp="yes" inflected="yes" skip="-1">
+                    chegar
+                    <exception scope="next" postag_regexp="yes" postag="V.+"/>
+                    <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
+                </token>
+                <marker>
+                    <!-- already blocks 'em'-initial AdvPs, i.e. R.+ -->
+                    <token postag_regexp="yes" postag="SP.+">em</token>
+                </marker>
+                <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            </pattern>
+            <message>O verbo de movimento &quot;<match no="1" postag_regexp="yes" postag="V.+" postag_replace="VMN0000"/>&quot; exige a preposição &quot;a&quot;.</message>
+            <suggestion>a</suggestion>
+            <example correction="a">Nós vamos chegar <marker>em</marker> São Paulo bem tarde.</example>
+            <example correction="a">Quando vocês chegam <marker>em</marker> Lisboa?</example>
+            <example correction="a">Vou chegar amanhã <marker>em</marker> Nova Iorque.</example>
+            <example correction="a">Cheguei ontem <marker>em</marker> Niterói.</example>
+            <example correction="a">Chegamos na quarta-feira <marker>em</marker> Madri.</example>
+            <!-- // example from CHEGARAM_EM_BR -->
+            <example correction="a">Os atletas chegaram <marker>em</marker> Curitiba na noite passada.</example>
+        </rule>
+
+        <rule id="CHEGAR_NO">
+            <pattern>
+                <token regexp="yes" inflected="yes" skip="-1">
+                    chegar
+                    <exception scope="next" postag_regexp="yes" postag="V.+"/>
+                    <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
+                </token>
+                <marker>
+                    <!-- already blocks 'em'-initial AdvPs, i.e. R.+ -->
+                    <token regexp="yes" postag_regexp="yes" postag="SP.+">nos?</token>
+                </marker>
+                <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            </pattern>
+            <message>O verbo de movimento &quot;<match no="1" postag_regexp="yes" postag="V.+" postag_replace="VMN0000"/>&quot; exige a preposição &quot;a&quot;.</message>
+            <suggestion><match no="2" regexp_match="n(.+)" regexp_replace="a$1"/></suggestion>
+            <example correction="ao">Nós vamos chegar <marker>no</marker> Rio de Janeiro bem tarde.</example>
+            <example correction="ao">Quando vocês chegam <marker>no</marker> Porto?</example>
+            <example correction="aos">Vou chegar amanhã <marker>nos</marker> Estados Unidos.</example>
+        </rule>
+
+        <rule id="CHEGAR_NA">
+            <pattern>
+                <token regexp="yes" inflected="yes" skip="-1">
+                    chegar
+                    <exception scope="next" postag_regexp="yes" postag="V.+"/>
+                    <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
+                </token>
+                <marker>
+                    <!-- already blocks 'em'-initial AdvPs, i.e. R.+ -->
+                    <token regexp="yes" postag_regexp="yes" postag="SP.+">nas?</token>
+                </marker>
+                <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            </pattern>
+            <message>O verbo de movimento &quot;<match no="1" postag_regexp="yes" postag="V.+" postag_replace="VMN0000"/>&quot; exige a preposição &quot;a&quot;.</message>
+            <suggestion><match no="2" regexp_match="na(.*)" regexp_replace="à$1"/></suggestion>
+            <example correction="à">Nós vamos chegar <marker>na</marker> Argentina bem tarde.</example>
+            <example correction="à">Quando vocês chegam <marker>na</marker> Cidade do México?</example>
+            <example correction="à">Vou chegar amanhã <marker>na</marker> China.</example>
+        </rule>
+
+        <rule id="CHEGAR_EM_MES_EM">
+            <pattern>
+                <token regexp="yes" inflected="yes" skip="-1">
+                    chegar
+                    <exception scope="next" postag_regexp="yes" postag="V.+"/>
+                    <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
+                </token>
+                <token postag_regexp="yes" postag="SP.+">em</token>
+                <!-- TODO year regex is a bit naïve -->
+                <token regexp="yes">&meses_ano;|[12]?[0-9]{3}</token>
+                <marker>
+                    <!-- already blocks 'em'-initial AdvPs, i.e. R.+ -->
+                    <token postag_regexp="yes" postag="SP.+">em</token>
+                </marker>
+                <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            </pattern>
+            <message>O verbo de movimento &quot;<match no="1" postag_regexp="yes" postag="V.+" postag_replace="VMN0000"/>&quot; exige a preposição &quot;a&quot;.</message>
+            <suggestion>a</suggestion>
+            <example correction="a">Chego em abril <marker>em</marker> Belo Horizonte.</example>
+            <example correction="a">Chegamos em 2003 <marker>em</marker> Porto Alegre.</example>
+        </rule>
+
+        <rule id="CHEGAR_EM_DATA_EM">
+            <pattern>
+                <token regexp="yes" inflected="yes" skip="-1">
+                    chegar
+                    <exception scope="next" postag_regexp="yes" postag="V.+"/>
+                    <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
+                </token>
+                <token postag_regexp="yes" postag="SP.+">em</token>
+                <token postag_regexp="yes" postag="Z.+"/>
+                <token>de</token>
+                <token skip="-1" regexp="yes">
+                    &meses_ano;
+                    <exception scope="next" postag_regexp="yes" postag="V.+"/>
+                    <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
+                </token>
+                <marker>
+                    <!-- already blocks 'em'-initial AdvPs, i.e. R.+ -->
+                    <token postag_regexp="yes" postag="SP.+">em</token>
+                </marker>
+                <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            </pattern>
+            <message>O verbo de movimento &quot;<match no="1" postag_regexp="yes" postag="V.+" postag_replace="VMN0000"/>&quot; exige a preposição &quot;a&quot;.</message>
+            <suggestion>a</suggestion>
+            <example correction="a">Chegou em 25 de novembro de 1883 <marker>em</marker> Düsseldorf.</example>
+            <example correction="a">Chegaremos em 14 de julho <marker>em</marker> Lyon.</example>
+        </rule>
+
+        <rule id="CHEGAR_EM_X_MINS_EM">
+            <pattern>
+                <token regexp="yes" inflected="yes" skip="-1">
+                    chegar
+                    <exception scope="next" postag_regexp="yes" postag="V.+"/>
+                    <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
+                </token>
+                <token postag_regexp="yes" postag="SP.+">em</token>
+                <token postag_regexp="yes" postag="D.+|Z0C[NP]0"/>
+                <token regexp="yes">&expressoes_de_tempo;</token>
+                <marker>
+                    <!-- already blocks 'em'-initial AdvPs, i.e. R.+ -->
+                    <token postag_regexp="yes" postag="SP.+">em</token>
+                </marker>
+                <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            </pattern>
+            <message>O verbo de movimento &quot;<match no="1" postag_regexp="yes" postag="V.+" postag_replace="VMN0000"/>&quot; exige a preposição &quot;a&quot;.</message>
+            <suggestion>a</suggestion>
+            <example correction="a">Chegarei em quatro horas <marker>em</marker> Curitiba.</example>
+            <example correction="a">Vamos chegar em algumas semanas <marker>em</marker> Campinas.</example>
+        </rule>
+
+        <rule id="CHEGAR_NO_SABADO_NO">
+            <pattern>
+                <token regexp="yes" inflected="yes" skip="-1">
+                    chegar
+                    <exception scope="next" postag_regexp="yes" postag="V.+"/>
+                    <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
+                </token>
+                <token regexp="yes" postag_regexp="yes" postag="SP.+">nos?</token>
+                <token postag_regexp="yes" postag="A.+" min="0"/>
+                <token regexp="yes">&dias_semana;</token>
+                <token postag_regexp="yes" postag="A.+" min="0"/>
+                <marker>
+                    <!-- already blocks 'em'-initial AdvPs, i.e. R.+ -->
+                    <token regexp="yes" postag_regexp="yes" postag="SP.+">nos?</token>
+                </marker>
+                <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            </pattern>
+            <message>O verbo de movimento &quot;<match no="1" postag_regexp="yes" postag="V.+" postag_replace="VMN0000"/>&quot; exige a preposição &quot;a&quot;.</message>
+            <suggestion><match no="6" regexp_match="n(.+)" regexp_replace="a$1"/></suggestion>
+            <example correction="ao">Nós vamos chegar no domingo <marker>no</marker> Rio Grande do Norte.</example>
+            <example correction="aos">Vou chegar no próximo domingo <marker>nos</marker> Emirados Árabes.</example>
+        </rule>
+
+        <rule id="CHEGAR_NA_XX_FEIRA_NA">
+            <pattern>
+                <token regexp="yes" inflected="yes" skip="-1">
+                    chegar
+                    <exception scope="next" postag_regexp="yes" postag="V.+"/>
+                    <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
+                </token>
+                <token regexp="yes" postag_regexp="yes" postag="SP.+">nas?</token>
+                <token postag_regexp="yes" postag="A.+" min="0"/>
+                <token regexp="yes">&dias_semana;</token>
+                <token postag_regexp="yes" postag="A.+" min="0"/>
+                <marker>
+                    <!-- already blocks 'em'-initial AdvPs, i.e. R.+ -->
+                    <token regexp="yes" postag_regexp="yes" postag="SP.+">nas?</token>
+                </marker>
+                <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            </pattern>
+            <message>O verbo de movimento &quot;<match no="1" postag_regexp="yes" postag="V.+" postag_replace="VMN0000"/>&quot; exige a preposição &quot;a&quot;.</message>
+            <suggestion><match no="6" regexp_match="na(.*)" regexp_replace="à$1"/></suggestion>
+            <example correction="à">Nós vamos chegar na quarta-feira <marker>na</marker> Suécia.</example>
+            <example correction="à">Vou chegar na sexta <marker>na</marker> Austrália.</example>
+            <example correction="à">Ela chegará na próxima quinta-feira <marker>na</marker> Inglaterra.</example>
+        </rule>
+    </rulegroup>
 
     <!-- FIM CHEGAMOS A POR CHEGAMOS EM -->
     <!-- ********************************************************** -->
@@ -618,7 +795,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
     <!-- ********************************************************** -->
     <!-- CONFUNDIR CHEGARAM A POR CHEGARAM EM (VERBO DE MOVIMENTO EXIGE A) -->
 
-    <rule id="CHEGARAM_EM_BR" name="Chegaram a">
+    <!-- Comment out by p-goulart to avoid double coverage; this is now covered in VERBOS_DE_MOVIMENTO_EM_BR -->
+    <!-- <rule id="CHEGARAM_EM_BR" name="Chegaram a">
       <pattern>
         <marker>
           <token>chegaram</token>
@@ -628,7 +806,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
       </pattern>
       <message>Verbos de movimento exigem a preposição A. Substitua &quot;chegaram em&quot; por <suggestion>chegaram a</suggestion>.</message>
       <example correction="chegaram a">Os atletas <marker>chegaram em</marker> Curitiba na noite passada.</example>
-    </rule>
+    </rule> -->
 
     <!-- FIM CHEGARAM A POR CHEGARAM EM (VERBO DE MOVIMENTO EXIGE A) -->
     <!-- ********************************************************** -->

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
@@ -530,12 +530,50 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 
     <!-- We should consider moving this to formal style; using 'a' with 'chegar' feels purist-y. -->
     <rulegroup id="VERBOS_DE_MOVIMENTO_EM_BR" name="Verbos de movimento com a preposição em">
+        <!-- * como vão as coisas em $place -->
+        <antipattern>
+            <token>como</token>
+            <token inflected="yes" postag_regexp="yes" postag="VM(I[^SM]|S[^IF]|[MPGN]).+">ir</token>
+            <example>Como vão as coisas em Boston?</example>
+            <example>E como vai tudo em Minas Gerais?</example>
+        </antipattern>
+
+        <!-- situar-se-ia em X: problems with mesoclisis, just being safe -->
+        <antipattern>
+            <token postag_regexp="yes" postag="VMN.+"/>
+            <token spacebefore="no" regexp="yes">&hifen;</token>
+            <token spacebefore="no" postag_regexp="yes" postag="PP.+"/>
+            <token spacebefore="no" regexp="yes">&hifen;</token>
+            <token spacebefore="no" inflected="yes" postag_regexp="yes" postag="VMII.+" skip="-1">
+                ir
+                <exception scope="next" postag_regexp="yes" postag="V.+"/>
+                <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">
+                    a(os?)?|à.*|para|pr[ao]s?
+                </exception>
+            </token>
+            <token regexp="yes">em|n[oa]s?</token>
+            <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            <example>Situar-se-ia em Marine Lines.</example>
+            <example>Alegrar-nos-íamos em Búzios.</example>
+            <example>O Charaka samhita basear-se-ia no Agnivesha samhita.</example>
+            <example>Com a pérola tornar-se-ia rei no Clube dos Caranguejos.</example>
+        </antipattern>
+
+        <!-- foi em $place que -->
+        <antipattern>
+            <token>foi</token>
+            <token>em</token>
+            <token regexp="yes" max="-1">\p{Lu}\p{Ll}+</token>
+            <token>que</token>
+            <example>Foi em Cuiabá que a banda se formou.</example>
+        </antipattern>
+
         <!-- TODO -->
         <!-- * work out what other verbs we may need -->
         <!-- remove sub-rule IDs -->
         <rule id="CHEGAR_EM">
             <pattern>
-                <token regexp="yes" inflected="yes" skip="-1">
+                <token inflected="yes" skip="-1">
                     chegar
                     <exception scope="next" postag_regexp="yes" postag="V.+"/>
                     <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
@@ -559,7 +597,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 
         <rule id="CHEGAR_NO">
             <pattern>
-                <token regexp="yes" inflected="yes" skip="-1">
+                <token inflected="yes" skip="-1">
                     chegar
                     <exception scope="next" postag_regexp="yes" postag="V.+"/>
                     <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
@@ -579,7 +617,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 
         <rule id="CHEGAR_NA">
             <pattern>
-                <token regexp="yes" inflected="yes" skip="-1">
+                <token inflected="yes" skip="-1">
                     chegar
                     <exception scope="next" postag_regexp="yes" postag="V.+"/>
                     <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
@@ -599,7 +637,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 
         <rule id="CHEGAR_EM_MES_EM">
             <pattern>
-                <token regexp="yes" inflected="yes" skip="-1">
+                <token inflected="yes" skip="-1">
                     chegar
                     <exception scope="next" postag_regexp="yes" postag="V.+"/>
                     <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
@@ -621,7 +659,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 
         <rule id="CHEGAR_EM_DATA_EM">
             <pattern>
-                <token regexp="yes" inflected="yes" skip="-1">
+                <token inflected="yes" skip="-1">
                     chegar
                     <exception scope="next" postag_regexp="yes" postag="V.+"/>
                     <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
@@ -648,7 +686,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 
         <rule id="CHEGAR_EM_X_MINS_EM">
             <pattern>
-                <token regexp="yes" inflected="yes" skip="-1">
+                <token inflected="yes" skip="-1">
                     chegar
                     <exception scope="next" postag_regexp="yes" postag="V.+"/>
                     <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
@@ -670,7 +708,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 
         <rule id="CHEGAR_NO_SABADO_NO">
             <pattern>
-                <token regexp="yes" inflected="yes" skip="-1">
+                <token inflected="yes" skip="-1">
                     chegar
                     <exception scope="next" postag_regexp="yes" postag="V.+"/>
                     <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
@@ -693,7 +731,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
 
         <rule id="CHEGAR_NA_XX_FEIRA_NA">
             <pattern>
-                <token regexp="yes" inflected="yes" skip="-1">
+                <token inflected="yes" skip="-1">
                     chegar
                     <exception scope="next" postag_regexp="yes" postag="V.+"/>
                     <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*</exception>
@@ -714,6 +752,153 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example correction="à">Vou chegar na sexta <marker>na</marker> Austrália.</example>
             <example correction="à">Ela chegará na próxima quinta-feira <marker>na</marker> Inglaterra.</example>
         </rule>
+
+        <!-- We need to be really careful with 'ir' because of the suppletion of
+             some of its forms... An initial attempt here resulted in a far too
+             greedy rule. 'Foi em Taubaté que começaram...', 'foi médico por três
+             anos em Cuiabá' etc. -->
+        <!-- this is the rule without suppletive forms, with which we can
+             hopefully be a little less cautious -->
+            <!-- foi: VMIS.+ -->
+            <!-- fora: VMIM.+ -->
+            <!-- fosse: VMSI.+ -->
+            <!-- for: VMSF._-->
+
+        <rule id="IR_EM_NO_SUPPLETION">
+            <pattern>
+                <token inflected="yes" postag_regexp="yes" postag="VM(I[^SM]|S[^IF]|[MPGN]).+" skip="-1">
+                    ir
+                    <exception scope="next" postag_regexp="yes" postag="V.+"/>
+                    <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*|para|pr[ao]s?</exception>
+                </token>
+                <marker>
+                    <token postag_regexp="yes" postag="SP.+">em</token>
+                </marker>
+                <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            </pattern>
+            <message>O verbo de movimento &quot;<match no="1" postag_regexp="yes" postag="V.+" postag_replace="VMN0000"/>&quot; exige a preposição &quot;a&quot; ou &quot;para&quot;.</message>
+            <suggestion>a</suggestion>
+            <suggestion>para</suggestion>
+            <example correction="a|para">Eu vou <marker>em</marker> São José dos Campos amanhã.</example>
+            <example correction="a|para">Iremos <marker>em</marker> Manaus.</example>
+            <example correction="a|para">Eu iria <marker>em</marker> Parati se não fosse tão longe.</example>
+            <example>Eu fui em Moscou somente para encontrá-la.</example>
+        </rule>
+
+        <rule id="IR_NO_NO_SUPPLETION">
+            <pattern>
+                <token inflected="yes" postag_regexp="yes" postag="VM(I[^SM]|S[^IF]|[MPGN]).+" skip="-1">
+                    ir
+                    <exception scope="next" postag_regexp="yes" postag="V.+"/>
+                    <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*|para|pr[ao]s?</exception>
+                </token>
+                <marker>
+                    <token postag_regexp="yes" postag="SP.+" regexp="yes">nos?</token>
+                </marker>
+                <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            </pattern>
+            <message>O verbo de movimento &quot;<match no="1" postag_regexp="yes" postag="V.+" postag_replace="VMN0000"/>&quot; exige a preposição &quot;a&quot; ou &quot;para&quot;.</message>
+            <suggestion><match no="2" regexp_match="n(.+)" regexp_replace="a$1"/></suggestion>
+            <suggestion><match no="2" regexp_match="n(.+)" regexp_replace="para $1"/></suggestion>
+            <example correction="ao|para o">Eu vou <marker>no</marker> Rio amanhã.</example>
+            <example correction="aos|para os">Iremos <marker>nos</marker> Estados Unidos.</example>
+            <example correction="ao|para o">Eu iria <marker>no</marker> Cairo se não fosse tão longe.</example>
+            <example>Eu fui no Paraguai somente para encontrá-la.</example>
+        </rule>
+
+        <rule id="IR_NA_NO_SUPPLETION">
+            <pattern>
+                <token inflected="yes" postag_regexp="yes" postag="VM(I[^SM]|S[^IF]|[MPGN]).+" skip="-1">
+                    ir
+                    <exception scope="next" postag_regexp="yes" postag="V.+"/>
+                    <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">a(os?)?|à.*|para|pr[ao]s?</exception>
+                </token>
+                <marker>
+                    <token postag_regexp="yes" postag="SP.+" regexp="yes">nas?</token>
+                </marker>
+                <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            </pattern>
+            <message>O verbo de movimento &quot;<match no="1" postag_regexp="yes" postag="V.+" postag_replace="VMN0000"/>&quot; exige a preposição &quot;a&quot; ou &quot;para&quot;.</message>
+            <suggestion><match no="2" regexp_match="na(.*)" regexp_replace="à$1"/></suggestion>
+            <suggestion><match no="2" regexp_match="n(.+)" regexp_replace="para $1"/></suggestion>
+            <example correction="à|para a">Eu vou <marker>na</marker> Alemanhã amanhã.</example>
+            <example correction="às|para as">Iremos <marker>nas</marker> Províncias Unidas.</example>
+            <example correction="à|para a">Eu iria <marker>na</marker> Glória se não fosse tão longe.</example>
+            <example>Eu fui na Cidade do Cabo somente para encontrá-la.</example>
+        </rule>
+
+        <!-- // really restrictive grammar here -->
+        <rule id="IR_EM_SUPPLETION">
+            <pattern>
+                <token postag="SENT_START"/>
+                <token postag_regexp="yes" postag="^[CRP].*" min="0" max="-1"/>
+                <token inflected="yes" postag_regexp="yes" postag="VM(I[SM]|S[IF]).+">ir</token>
+                <marker>
+                    <token postag_regexp="yes" postag="SP.+">em</token>
+                </marker>
+                <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            </pattern>
+            <message>O verbo de movimento &quot;<match no="3" postag_regexp="yes" postag="V.+" postag_replace="VMN0000"/>&quot; exige a preposição &quot;a&quot; ou &quot;para&quot;.</message>
+            <suggestion>a</suggestion>
+            <suggestion>para</suggestion>
+            <example correction="a|para">Fui <marker>em</marker> Varsóvia.</example>
+            <!-- example from the original issue -->
+            <example correction="a|para">Nunca fui <marker>em</marker> Bonito.</example>
+            <example correction="a|para">Eu fui <marker>em</marker> Gdansk.</example>
+            <example correction="a|para">Se eu fosse <marker>em</marker> Cuiabá.</example>
+            <example correction="a|para">Ele fora <marker>em</marker> Riga já várias vezes antes.</example>
+            <example correction="a|para">Se eu for <marker>em</marker> Los Angeles...</example>
+            <example>Eu fui médico em Atlântis.</example>
+        </rule>
+
+        <!-- // really restrictive grammar here -->
+        <rule id="IR_NO_SUPPLETION">
+            <pattern>
+                <token postag="SENT_START"/>
+                <token postag_regexp="yes" postag="^[CRP].*" min="0" max="-1"/>
+                <token inflected="yes" postag_regexp="yes" postag="VM(I[SM]|S[IF]).+">ir</token>
+                <marker>
+                    <token postag_regexp="yes" postag="SP.+" regexp="yes">nos?</token>
+                </marker>
+                <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            </pattern>
+            <message>O verbo de movimento &quot;<match no="3" postag_regexp="yes" postag="V.+" postag_replace="VMN0000"/>&quot; exige a preposição &quot;a&quot; ou &quot;para&quot;.</message>
+            <suggestion><match no="4" regexp_match="n(.+)" regexp_replace="a$1"/></suggestion>
+            <suggestion><match no="4" regexp_match="n(.+)" regexp_replace="para $1"/></suggestion>
+            <example correction="ao|para o">Fui <marker>no</marker> Leblon.</example>
+            <!-- example from the original issue -->
+            <example correction="aos|para os">Nunca fui <marker>nos</marker> Arcos da Lapa.</example>
+            <example correction="ao|para o">Eu fui <marker>no</marker> Porto.</example>
+            <example correction="ao|para o">Se eu fosse <marker>no</marker> Zaire.</example>
+            <example correction="ao|para o">Ele fora <marker>no</marker> Vietnã já várias vezes antes.</example>
+            <example correction="ao|para o">Se eu for <marker>no</marker> Equador...</example>
+            <example>Eu fui médico no Arizona.</example>
+        </rule>
+
+        <!-- // really restrictive grammar here -->
+        <rule id="IR_NA_SUPPLETION">
+            <pattern>
+                <token postag="SENT_START"/>
+                <token postag_regexp="yes" postag="^[CRP].*" min="0" max="-1"/>
+                <token inflected="yes" postag_regexp="yes" postag="VM(I[SM]|S[IF]).+">ir</token>
+                <marker>
+                    <token postag_regexp="yes" postag="SP.+" regexp="yes">nas?</token>
+                </marker>
+                <token regexp="yes">\p{Lu}\p{Ll}+</token>
+            </pattern>
+            <message>O verbo de movimento &quot;<match no="3" postag_regexp="yes" postag="V.+" postag_replace="VMN0000"/>&quot; exige a preposição &quot;a&quot; ou &quot;para&quot;.</message>
+            <suggestion><match no="4" regexp_match="na(.*)" regexp_replace="à$1"/></suggestion>
+            <suggestion><match no="4" regexp_match="n(.+)" regexp_replace="para $1"/></suggestion>
+            <example correction="à|para a">Fui <marker>na</marker> Praia do Flamengo.</example>
+            <!-- example from the original issue -->
+            <example correction="às|para as">Nunca fui <marker>nas</marker> Ilhas Caimã.</example>
+            <example correction="à|para a">Eu fui <marker>na</marker> Jamaica.</example>
+            <example correction="à|para a">Se eu fosse <marker>na</marker> República Dominicana.</example>
+            <example correction="à|para a">Ele fora <marker>na</marker> Rocinha já várias vezes antes.</example>
+            <example correction="à|para a">Se eu for <marker>na</marker> Coreia do Sul...</example>
+            <example>Eu fui médico na Dakota do Sul.</example>
+        </rule>
+
     </rulegroup>
 
     <!-- FIM CHEGAMOS A POR CHEGAMOS EM -->

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
@@ -547,7 +547,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <token spacebefore="no" inflected="yes" postag_regexp="yes" postag="VMII.+" skip="-1">
                 ir
                 <exception scope="next" postag_regexp="yes" postag="V.+"/>
-                <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+(:.+)?">
+                <exception regexp="yes" scope="next" postag_regexp="yes" postag="SP.+">
                     a(os?)?|à.*|para|pr[ao]s?
                 </exception>
             </token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
@@ -568,10 +568,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example>Foi em Cuiabá que a banda se formou.</example>
         </antipattern>
 
-        <!-- TODO -->
-        <!-- * work out what other verbs we may need -->
-        <!-- remove sub-rule IDs -->
-        <rule id="CHEGAR_EM">
+        <rule>
             <pattern>
                 <token inflected="yes" skip="-1">
                     chegar
@@ -595,7 +592,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example correction="a">Os atletas chegaram <marker>em</marker> Curitiba na noite passada.</example>
         </rule>
 
-        <rule id="CHEGAR_NO">
+        <rule>
             <pattern>
                 <token inflected="yes" skip="-1">
                     chegar
@@ -615,7 +612,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example correction="aos">Vou chegar amanhã <marker>nos</marker> Estados Unidos.</example>
         </rule>
 
-        <rule id="CHEGAR_NA">
+        <rule>
             <pattern>
                 <token inflected="yes" skip="-1">
                     chegar
@@ -635,7 +632,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example correction="à">Vou chegar amanhã <marker>na</marker> China.</example>
         </rule>
 
-        <rule id="CHEGAR_EM_MES_EM">
+        <rule>
             <pattern>
                 <token inflected="yes" skip="-1">
                     chegar
@@ -657,7 +654,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example correction="a">Chegamos em 2003 <marker>em</marker> Porto Alegre.</example>
         </rule>
 
-        <rule id="CHEGAR_EM_DATA_EM">
+        <rule>
             <pattern>
                 <token inflected="yes" skip="-1">
                     chegar
@@ -684,7 +681,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example correction="a">Chegaremos em 14 de julho <marker>em</marker> Lyon.</example>
         </rule>
 
-        <rule id="CHEGAR_EM_X_MINS_EM">
+        <rule>
             <pattern>
                 <token inflected="yes" skip="-1">
                     chegar
@@ -706,7 +703,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example correction="a">Vamos chegar em algumas semanas <marker>em</marker> Campinas.</example>
         </rule>
 
-        <rule id="CHEGAR_NO_SABADO_NO">
+        <rule>
             <pattern>
                 <token inflected="yes" skip="-1">
                     chegar
@@ -729,7 +726,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example correction="aos">Vou chegar no próximo domingo <marker>nos</marker> Emirados Árabes.</example>
         </rule>
 
-        <rule id="CHEGAR_NA_XX_FEIRA_NA">
+        <rule>
             <pattern>
                 <token inflected="yes" skip="-1">
                     chegar
@@ -764,7 +761,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <!-- fosse: VMSI.+ -->
             <!-- for: VMSF._-->
 
-        <rule id="IR_EM_NO_SUPPLETION">
+        <rule>
             <pattern>
                 <token inflected="yes" postag_regexp="yes" postag="VM(I[^SM]|S[^IF]|[MPGN]).+" skip="-1">
                     ir
@@ -785,7 +782,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example>Eu fui em Moscou somente para encontrá-la.</example>
         </rule>
 
-        <rule id="IR_NO_NO_SUPPLETION">
+        <rule>
             <pattern>
                 <token inflected="yes" postag_regexp="yes" postag="VM(I[^SM]|S[^IF]|[MPGN]).+" skip="-1">
                     ir
@@ -806,7 +803,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example>Eu fui no Paraguai somente para encontrá-la.</example>
         </rule>
 
-        <rule id="IR_NA_NO_SUPPLETION">
+        <rule>
             <pattern>
                 <token inflected="yes" postag_regexp="yes" postag="VM(I[^SM]|S[^IF]|[MPGN]).+" skip="-1">
                     ir
@@ -828,7 +825,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         </rule>
 
         <!-- // really restrictive grammar here -->
-        <rule id="IR_EM_SUPPLETION">
+        <rule>
             <pattern>
                 <token postag="SENT_START"/>
                 <token postag_regexp="yes" postag="^[CRP].*" min="0" max="-1"/>
@@ -852,7 +849,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         </rule>
 
         <!-- // really restrictive grammar here -->
-        <rule id="IR_NO_SUPPLETION">
+        <rule>
             <pattern>
                 <token postag="SENT_START"/>
                 <token postag_regexp="yes" postag="^[CRP].*" min="0" max="-1"/>
@@ -876,7 +873,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         </rule>
 
         <!-- // really restrictive grammar here -->
-        <rule id="IR_NA_SUPPLETION">
+        <rule>
             <pattern>
                 <token postag="SENT_START"/>
                 <token postag_regexp="yes" postag="^[CRP].*" min="0" max="-1"/>
@@ -898,7 +895,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example correction="à|para a">Se eu for <marker>na</marker> Coreia do Sul...</example>
             <example>Eu fui médico na Dakota do Sul.</example>
         </rule>
-
     </rulegroup>
 
     <!-- FIM CHEGAMOS A POR CHEGAMOS EM -->


### PR DESCRIPTION
Closes languagetooler-gmbh/languagetool-premium#5502.

For now we are contemplating only 'chegar' (the original verb in the grammar file) and 'ir' (the verb from the issue description).

Due to the tricky nature of the morphology of 'ir' (suppletion with 'ser'), as well as its flexible semantics, the actual structures that we cover here are quite restricted. It should address the most obvious errors in very simple sentences, but we may be missing errors in more complex ones. Oh well.

A few comments, *comme d'hab*:
* having to duplicate rules just because of different contractions feels very silly, surely there's a way we can improve this? Can we add some kind of function in the Java somewhere that performs all the necessary substitutions intelligently?
* I strongly believe that, especially in the case of 'chegar', tagging this only with more formal writing styles would be ideal – many of the examples I found in the corpus feel 100% more natural to me with 'em' instead of the technically correct 'a'; wht say you?