### PR TITLE
[de] improve PRP_WAS_WO: „Von was für…“

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/style.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/style.xml
@@ -1602,12 +1602,17 @@ USA
                 <example>Warum schaust du dich also nicht mal woanders um und machst deinen Städtetrip zu was besonderem?</example>
             </rule>
             <rule><!--4-->
+                <antipattern>
+                    <token>was</token>
+                    <token>für</token>
+                </antipattern>
                 <pattern>
                     <token regexp="yes" case_sensitive="yes">Bei|Für|Gegen|Hinter|Mit|Nach|Neben|Über|Vo[nr]|Zu|Zwischen</token>
                     <token>was</token>
                 </pattern>
                 <message>Möchten Sie das standardsprachliche <suggestion>Wo<match no="1" case_conversion="startlower"/></suggestion> verwenden?</message>
                 <example correction="Wofür"><marker>Für was</marker> kämpft er?</example>
+                <example>Von was für einem Defekt sprechen wir?</example>
             </rule>
             <rule default="temp_off"><!--5-->
                 <pattern>


### PR DESCRIPTION
> **Von was** für einem Defekt sprechen wir?

war zuvor falsch-positiv.
Hiermit ergänze ich die Ausnahme aus Regel 3 für die Satzanfangs-Regel 4.

Es ist anzumerken, dass das Umstellen anderer Negativ-Beispielsätze weiterhin zu vielen Falsch-Positiven führt:

> Für was Neues bin ich immer zu haben.
> Gegen was neues hilft das nicht.
> Was Großes hat er im Sinn.