### PR TITLE
fix: crash when closing and getting hunspell object

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/DumontsHunspellDictionary.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/DumontsHunspellDictionary.java
@@ -40,16 +40,25 @@ public class DumontsHunspellDictionary implements HunspellDictionary {
 
   @Override
   public boolean spell(String word) {
+    if (closed) {
+      throw new RuntimeException("Attempt to use hunspell instance after closing");
+    }
     return hunspell.spell(word);
   }
 
   @Override
   public void add(String word) {
+    if (closed) {
+      throw new RuntimeException("Attempt to use hunspell instance after closing");
+    }
     hunspell.add(word);
   }
 
   @Override
   public List<String> suggest(String word) {
+    if (closed) {
+      throw new RuntimeException("Attempt to use hunspell instance after closing");
+    }
     return Arrays.asList(hunspell.suggest(word));
   }
 

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/DumontsHunspellDictionary.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/DumontsHunspellDictionary.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 public class DumontsHunspellDictionary implements HunspellDictionary {
   private final Hunspell hunspell;
+  private boolean closed = false;
 
   public DumontsHunspellDictionary(Path dictionary, Path affix) {
     try {
@@ -53,7 +54,13 @@ public class DumontsHunspellDictionary implements HunspellDictionary {
   }
 
   @Override
+  public boolean isClosed() {
+    return closed;
+  }
+
+  @Override
   public void close() throws IOException {
+    closed = true;
     hunspell.close();
   }
 }

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/Hunspell.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/Hunspell.java
@@ -3,6 +3,8 @@ package org.languagetool.rules.spelling.hunspell;
 import org.languagetool.JLanguageTool;
 import org.languagetool.broker.ResourceDataBroker;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.*;
 import java.nio.file.*;
 import java.util.*;
@@ -40,7 +42,7 @@ public final class Hunspell {
   public static synchronized HunspellDictionary getDictionary(Path dictionary, Path affix) {
     LanguageAndPath key = new LanguageAndPath(dictionary, affix);
     HunspellDictionary hunspell = map.get(key);
-    if (hunspell != null) {
+    if (hunspell != null && !hunspell.isClosed()) {
       return hunspell;
     }
     HunspellDictionary newHunspell = hunspellDictionaryFactory.apply(dictionary, affix);

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellDictionary.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellDictionary.java
@@ -18,7 +18,6 @@
  */
 package org.languagetool.rules.spelling.hunspell;
 
-import java.beans.PropertyChangeListener;
 import java.io.Closeable;
 import java.util.List;
 
@@ -43,5 +42,9 @@ public interface HunspellDictionary extends Closeable {
    */
   List<String> suggest(String word);
 
+  /**
+   * Indicate resource is closed.
+   * @return true when closed, otherwise false.
+   */
   boolean isClosed();
 }

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellDictionary.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellDictionary.java
@@ -18,11 +18,9 @@
  */
 package org.languagetool.rules.spelling.hunspell;
 
+import java.beans.PropertyChangeListener;
 import java.io.Closeable;
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.List;
-import java.util.Objects;
 
 public interface HunspellDictionary extends Closeable {
   /**
@@ -30,18 +28,20 @@ public interface HunspellDictionary extends Closeable {
    * @param word the word to check
    * @return true if the word is spelled correctly
    */
-  public boolean spell(String word);
+  boolean spell(String word);
 
   /**
    * Add word to the run-time dictionary
    * @param word the word to add
    */
-  public void add(String word);
+  void add(String word);
 
   /**
    * Search suggestions for the word
    * @param word the word to get suggestions for
    * @return the list of suggestions
    */
-  public List<String> suggest(String word);
+  List<String> suggest(String word);
+
+  boolean isClosed();
 }


### PR DESCRIPTION
It changes HunspellDictionary interface to add  `HunspellDictionary#isClosed` method to indicate a status of implementation of  `HunspellDictionary`. Hunspell class will check its status. When it is closed status, Hunspell class invalidate cache and create new object. Otherwise, user cause a JVM crash (segmentation fault) by  accessing to freed JNA object. 

Here is an issue on a user project, OmegaT that report crash when reloading a session.
https://sourceforge.net/p/omegat/bugs/1182/

A log message from JVM is here
https://gist.github.com/mohad12211/fe2ebfd71469b876c41a32e84c661e12