### PR TITLE
[pt] Fix A_PREPOSITION rule 6 in disambiguator

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -1755,7 +1755,7 @@
       <pattern>
           <token postag="V.+" postag_regexp="yes">
             <exception regexp="yes">para|como</exception>
-            <exception inflected='yes' regexp='yes'>caminhar|correr|explicar|inaugurar|ver|ele|comprar|abrir</exception></token>
+            <exception inflected='yes' regexp='yes'>caminhar|correr|explicar|inaugurar|ver|ele|comprar|abrir|ser|estar</exception></token>
           <token min='0' postag='R.' postag_regexp='yes'/>
         <marker>
           <token>a</token>
@@ -1763,6 +1763,7 @@
       </pattern>
       <disambig action="filter" postag="S.+"/>
       <example type='untouched'>...desde que foi inaugurada a República de Itália, em 1946,...</example>
+      <example type="untouched">Quero saber quem é a agente que atende.</example>
     </rule>
     <rule>
       <pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -30936,6 +30936,36 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
         <rulegroup id='CONFUSÃO_E_É' name="[Confusão] e/é">
             <short>Possível erro de acentuação.</short>
+            <antipattern>
+                <token regexp="yes">qu[eê]|quando|qual|quais|a?onde|quem|quant[oa]s?|como|por[ ]?qu[êe]</token>
+                <token case_sensitive="yes">e</token>
+                <token postag_regexp="yes" postag="SP.+|RG" min="0"/>
+                <token regexp="yes">se|qu[eê]|quando|qual|quais|onde|quem|quant[oa]s?|como|por[ ]?qu[êe]</token>
+                <example>Onde e como assinar?</example>
+                <example>Sei onde e com quem você dormiu ontem à noite.</example>
+                <example>A RAF parecia saber sempre quando e para onde enviar as suas aeronaves.</example>
+                <example>Volte aqui quando e se achar que deve.</example>
+                <example>Vender ou alugar quantas e quais ações quiser.</example>
+                <example>Quem, onde, sobre quem e em que medida deve ter poder.</example>
+                <example>Quando e por que o destreinamento começa.</example>
+                <example>Quantos e quais países fazem fronteira com a Bulgária?</example>
+                <example>Mas ainda não se sabe como e se esses dois órgãos têm papéis.</example>
+            </antipattern>
+
+            <antipattern>
+                <token regexp="yes">qu[eê]|quando|qual|quais|a?onde|quem|quant[oa]s?|como|por[ ]?qu[êe]</token>
+                <token case_sensitive="yes">e</token>
+                <token>o</token>
+                <token regexp="yes">qu[eê]</token>
+                <example>Quem e o que é você?</example>
+            </antipattern>
+
+            <antipattern>
+                <token postag="VMIP1S0">como</token>
+                <token case_sensitive="yes">e</token>
+                <token postag_regexp="yes" postag="VM.+"/>
+                <example>Como e leio todo o dia.</example>
+            </antipattern>
 
             <!-- the only consistent false positive here refers to mathematical texts where
                  'e' is used as a variable, or physics where it is a constant;
@@ -30944,11 +30974,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                  anyway... -->
             <rule>
                 <pattern>
-                    <token regexp="yes">qu[eê]|quando|qual|onde|quem|quant[oa]s?|como|por[ ]?qu[êe]</token>
+                    <token regexp="yes">qu[eê]|quando|qual|quais|a?onde|quem|quant[oa]s?|como|por[ ]?qu[êe]</token>
                     <marker>
                         <token case_sensitive="yes">e</token>
                     </marker>
-                    <token negate="yes" regexp="yes">qu[eê]|quando|qual|onde|quem|quant[oa]s?|como|por[ ]?qu[êe]</token>
                 </pattern>
                 <message>Possível erro de acentuação. Verifique se não quis dizer <suggestion>é</suggestion>.</message>
                 <example correction="é">Acha que <marker>e</marker> melhor?</example>
@@ -30958,7 +30987,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="é">Quando <marker>e</marker> a festa?</example>
                 <example correction="é">Quanto <marker>e</marker> a medida ideal?</example>
                 <example correction="é">Por que <marker>e</marker> pior fazer do meu jeito?</example>
-                <example>Onde e como assinar?</example>
+                <example correction="é">Como <marker>e</marker> o amor dela?</example>
             </rule>
 
             <rule>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
@@ -179,6 +179,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example>O treinamento do agente foi árduo.</example>
             <example>Ele era um agente da KGB.</example>
             <example>Esse agente não teve uma boa atuação.</example>
+            <example>Quero saber quem é a agente que vai atender.</example>
         </antipattern>
         <antipattern>
             <token>agente</token>


### PR DESCRIPTION
- issue was affecting performance of grammar rule `AGENTE_BR` (cf. [here](https://analytics.languagetoolplus.com/matomo/index.php?module=Widgetize&action=iframe&secondaryDimension=eventName&moduleToWidgetize=Events&actionToWidgetize=getAction&idSite=18&period=day&date=yesterday&flat=1&filter_column=label&show_dimensions=1&filter_pattern=AGENTE_BR));
- made it slightly less aggressive, but not too much so, hopefully.