### PR TITLE
disambiguation: add chunktags

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/DisambiguationPatternRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/DisambiguationPatternRule.java
@@ -41,7 +41,7 @@ public class DisambiguationPatternRule extends AbstractTokenBasedRule {
 
   /** Possible disambiguator actions. **/
   public enum DisambiguatorAction {
-    ADD, FILTER, REMOVE, REPLACE, UNIFY, IMMUNIZE, IGNORE_SPELLING, FILTERALL
+    ADD, FILTER, REMOVE, REPLACE, UNIFY, IMMUNIZE, IGNORE_SPELLING, FILTERALL, ADDCHUNK
   }
 
   private final String disambiguatedPOS;
@@ -71,7 +71,8 @@ public class DisambiguationPatternRule extends AbstractTokenBasedRule {
         && disambAction != DisambiguatorAction.IMMUNIZE
         && disambAction != DisambiguatorAction.REPLACE
         && disambAction != DisambiguatorAction.FILTERALL
-        && disambAction != DisambiguatorAction.IGNORE_SPELLING) {
+        && disambAction != DisambiguatorAction.IGNORE_SPELLING
+        && disambAction != DisambiguatorAction.ADDCHUNK) {
       throw new NullPointerException("disambiguated POS cannot be null with posSelect == null and " + disambAction);
     }
     this.disambiguatedPOS = disambiguatedPOS;

--- a/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/DisambiguationPatternRuleReplacer.java
+++ b/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/DisambiguationPatternRuleReplacer.java
@@ -22,6 +22,7 @@ package org.languagetool.tagging.disambiguation.rules;
 import org.languagetool.AnalyzedSentence;
 import org.languagetool.AnalyzedToken;
 import org.languagetool.AnalyzedTokenReadings;
+import org.languagetool.chunking.ChunkTag;
 import org.languagetool.rules.RuleMatch;
 import org.languagetool.rules.patterns.*;
 import org.languagetool.tools.StringTools;
@@ -29,6 +30,7 @@ import org.languagetool.tools.StringTools;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -210,6 +212,22 @@ class DisambiguationPatternRuleReplacer extends AbstractPatternRulePerformer {
           AnalyzedToken newTok = new AnalyzedToken(token,
               newTokenReadings[i].getPOSTag(), lemma);
           whTokens[position].addReading(newTok, rule.getFullId());
+        }
+      }
+      break;
+    case ADDCHUNK:
+      if (newTokenReadings != null && newTokenReadings.length == matchingTokensWithCorrection
+            - startPositionCorrection + endPositionCorrection) {
+        for (int i = 0; i < newTokenReadings.length; i++) {
+          int position = sentence.getOriginalPosition(firstMatchToken + correctedStPos + i);
+          List<ChunkTag> listChunkTag = new ArrayList<>();
+          listChunkTag.addAll(whTokens[position].getChunkTags());
+          // the POStag is added to the ChunkTag
+          ChunkTag newChunkTag = new ChunkTag(newTokenReadings[i].getPOSTag());
+          if (!listChunkTag.contains(newChunkTag)) {
+            listChunkTag.add(newChunkTag);  
+          }
+          whTokens[position].setChunkTags(listChunkTag);
         }
       }
       break;

--- a/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/DisambiguationRuleHandler.java
+++ b/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/DisambiguationRuleHandler.java
@@ -285,7 +285,8 @@ class DisambiguationRuleHandler extends XMLRuleHandler {
 
         int matchedTokenCount = endPos - startPos;
         if (newWdList != null) {
-          if (disambigAction == DisambiguationPatternRule.DisambiguatorAction.ADD || disambigAction == DisambiguationPatternRule.DisambiguatorAction.REMOVE
+          if (disambigAction == DisambiguationPatternRule.DisambiguatorAction.ADDCHUNK || 
+              disambigAction == DisambiguationPatternRule.DisambiguatorAction.ADD || disambigAction == DisambiguationPatternRule.DisambiguatorAction.REMOVE
                   || disambigAction == DisambiguationPatternRule.DisambiguatorAction.REPLACE) {
             if ((!newWdList.isEmpty() && disambigAction == DisambiguationPatternRule.DisambiguatorAction.REPLACE)
                     && newWdList.size() != matchedTokenCount) {

--- a/languagetool-core/src/main/resources/org/languagetool/resource/disambiguation.xsd
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/disambiguation.xsd
@@ -132,7 +132,8 @@
 			<xs:simpleType>
 					<xs:restriction base="xs:NMTOKEN">
 						<xs:enumeration value="add" />						
-						<xs:enumeration value="filter" />
+					    <xs:enumeration value="addchunk" />
+					    <xs:enumeration value="filter" />
 						<xs:enumeration value="remove" />
 						<xs:enumeration value="replace" />
 						<xs:enumeration value="unify" />

--- a/languagetool-language-modules/ca/src/main/resources/org/languagetool/resource/ca/disambiguation.xml
+++ b/languagetool-language-modules/ca/src/main/resources/org/languagetool/resource/ca/disambiguation.xml
@@ -19844,4 +19844,71 @@ Copyright (C) 2012 Jaume Ortolà i Font
         </pattern>
         <disambig action="ignore_spelling"/>
     </rule>
+    <!-- CHUNKER -->
+    <rulegroup id="PERIFRASIS_VERBALS" name="perífrasis verbals">
+        <rule>
+            <pattern>
+                <token inflected="yes">haver</token>
+                <token regexp="yes">de|d'</token>
+                <token postag="V.N.*" postag_regexp="yes"/>
+            </pattern>
+            <disambig action="addchunk">
+                <wd pos="GV"/>
+                <wd pos="GV"/>
+                <wd pos="GV"/>
+            </disambig>
+        </rule>
+        <rule>
+            <pattern>
+                <token inflected="yes">haver</token>
+                <token postag="V.P.*" postag_regexp="yes"><exception postag="[NA].*"/></token>
+            </pattern>
+            <disambig action="addchunk">
+                <wd pos="GV"/>
+                <wd pos="GV"/>
+            </disambig>
+        </rule>
+        <rule>
+            <pattern>
+                <token postag="VA.*" postag_regexp="yes" inflected="yes">anar</token>
+                <token postag="V.N.*" postag_regexp="yes"/>
+            </pattern>
+            <disambig action="addchunk">
+                <wd pos="GV"/>
+                <wd pos="GV"/>
+            </disambig>
+        </rule>
+        <rule>
+            <pattern>
+                <token postag="V.*" postag_regexp="yes" inflected="yes" regexp="yes">continuar|seguir|estar|anar|prosseguir</token>
+                <token postag="V.G.*" postag_regexp="yes"/>
+            </pattern>
+            <disambig action="addchunk">
+                <wd pos="GV"/>
+                <wd pos="GV"/>
+            </disambig>
+        </rule>
+        <rule>
+            <pattern>
+                <token postag="V.*" postag_regexp="yes" inflected="yes" regexp="yes">poder|voler|desitjar|deure</token>
+                <token postag="V.N.*" postag_regexp="yes"/>
+            </pattern>
+            <disambig action="addchunk">
+                <wd pos="GV"/>
+                <wd pos="GV"/>
+            </disambig>
+        </rule>
+        <rule>
+            <pattern>
+                <token postag="V.*" postag_regexp="yes" inflected="yes">tornar</token>
+                <token>a</token>
+                <token postag="V.N.*" postag_regexp="yes"/>
+            </pattern>
+            <disambig action="addchunk">
+                <wd pos="GV"/>
+                <wd pos="GV"/>
+                <wd pos="GV"/>
+            </disambig>
+        </rule>
+    </rulegroup>
 </rules>

--- a/languagetool-language-modules/ca/src/test/java/org/languagetool/JLanguageToolTest.java
+++ b/languagetool-language-modules/ca/src/test/java/org/languagetool/JLanguageToolTest.java
@@ -40,6 +40,15 @@ public class JLanguageToolTest {
     matches = tool.check("Potser siga el millor");
     assertEquals(1, matches.size());
     assertEquals("POTSER_SIGUI", matches.get(0).getRule().getId());
+    
+    //ChunkTags
+ 
+    assertEquals("[<S> Ho[ho/PP3NN000] deu[deure/VMIP3S00,GV] haver[haver/VAN00000,haver/_GV_,haver/_perfet,GV] tornat[tornar/VMP00SM0,GV] a[a/SPS00,GV] fer[fer/VMN00000,fer/complement,GV].[</S>./_PUNCT,<P/>]]",
+        tool.analyzeText("Ho deu haver tornat a fer.").toString());
+
+    
+    assertEquals("[<S> Ho[ho/PP3NN000] he[haver/VAIP1S00,haver/_obligacio,GV] de[de/SPS00,GV] continuar[continuar/VMN00000,continuar/_GV_,GV] fent[fer/VMG00000,fent/_GV_,GV] així[així/RG].[</S>./_PUNCT,<P/>]]",
+        tool.analyzeText("Ho he de continuar fent així.").toString());
 
   }
 


### PR DESCRIPTION
An easy way of adding chunk tags from disambiguation.xml.
This will be very useful for all Romance languages.

`action="addchunk"` will be similar to `action="add"` but the tag will be added to the chunk tags.