### PR TITLE
[fr] OS from Premium grammar -> style rules migration

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -21832,6 +21832,1290 @@ USA
             <example correction="">Alors, qu'est-ce que ça veut dire d'<marker>«</marker> être aimé.</example>
           </rule>
         </rulegroup>
+        <rulegroup name="virgule expressions figées" id="VIRGULE_EXPRESSIONS_FIGEES">
+          <rule>
+            <antipattern>
+              <token>en</token>
+              <token>conclusion</token>
+              <token postag="[PJ].*" postag_regexp="yes"/>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>en</token>
+              <token regexp="yes">somme|outre|conclusion</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor|V.*" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">En outre<marker> le</marker> policier allait bien.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token>c'</token>
+              <token>est</token>
+              <token>à</token>
+              <token>dire</token>
+              <token>vrai</token>
+            </antipattern>
+            <pattern>
+              <token>à</token>
+              <token>dire</token>
+              <token>vrai</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor|M fin.*|R pers suj.*" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">Il faut, à  dire vrai<marker> le</marker> faire bien.</example>
+            <example>C'est un risque risque important, c'est-à-dire vrai risque d'avalanche.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token>c'</token>
+              <token>est</token>
+              <token>à</token>
+              <token>dire</token>
+              <token>vrai</token>
+            </antipattern>
+            <pattern>
+              <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor"/></token>
+              <marker>
+                <token>à</token>
+              </marker>
+              <token>dire</token>
+              <token>vrai</token>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \2</suggestion>
+            <example correction=", à">Il faut<marker> à</marker> dire vrai, le faire bien.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token>pour</token>
+              <token>ce</token>
+              <token>que</token>
+              <token>ça</token>
+              <token>vaut</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \6</suggestion>
+            <example correction=", le">Pour ce que ça vaut<marker> le</marker> garçon s'est excusé.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token>c'</token>
+              <token>est</token>
+              <token>exact</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor|M fin.*" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">C'est exact<marker> le</marker> colis arrivera demain.</example>
+            <example>C'est exact !</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token>bon</token>
+              <token postag="[DV].*" postag_regexp="yes"/>
+              <token>,</token>
+            </antipattern>
+            <antipattern>
+              <token>bon</token>
+              <token regexp="yes">les|mon|ma|mes</token>
+              <token regexp="yes">gars|filles|garçons|enfants|grande?|petite?|mecs</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>bon</token>
+              <marker>
+                <token postag="[DV].*" postag_regexp="yes">
+                  <exception regexp="yes">voilà|est|était</exception>
+                  <exception postag="N.*|V ind pres 3 s" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cet adverbe afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \3</suggestion>
+            <example correction=", le">Bon<marker> le</marker> médecin va bien.</example>
+            <example>Bon ride à tous.</example>
+            <example>Bon les gars, maitenant il faut assurer.</example>
+            <example>Bon allez, profitez bien de votre journée.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token>sur</token>
+              <token>ce</token>
+              <token postag="J.*" postag_regexp="yes"><exception regexp="yes">bon(ne)?s?</exception></token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>sur</token>
+              <token>ce</token>
+              <marker>
+                <token postag="[DJ].*" postag_regexp="yes"/>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">Sur ce<marker> le</marker> garçon s'excusa.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>puis</token>
+              <marker>
+                <token postag="P.*" postag_regexp="yes"/>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après un adverbe placé en début de phrase afin d'apporter du rythme à celle-ci.</message>
+            <suggestion>, \3</suggestion>
+            <example correction=", en">Puis<marker> en</marker> arrivant, il tomba.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token>d'</token>
+              <token>une</token>
+              <token>part</token>
+              <token>de</token>
+              <token postag="R pers suj.*|N.*" postag_regexp="yes"/>
+            </antipattern>
+            <pattern>
+              <token>d'<exception scope="previous">,</exception></token>
+              <token>une</token>
+              <token>part</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="J.*|C coor" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", de">Il a suggéré d'une part<marker> de</marker> construire une maison et d'autre part, de laisser les enfants la décorer.</example>
+            <example>Nous nous amputons aussi d’une part de nous-mêmes.</example>
+            <example>Je te téléphone, d'une part pour t'inviter à manger, d'autre part pour te dire que ton frère est parti.</example>
+            <example>Il a mangé une part de gâteau.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token>d'</token>
+              <token>autre</token>
+              <token>part</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+
+                  <exception scope="next">,</exception>
+                  <exception postag="J.*|Y" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", de">Il a suggéré d'une part de construire une maison et d'autre part<marker> de</marker> laisser les enfants la décorer.</example>
+            <example>D'autre part et, pour la première fois, elle a largement mis son grain de sel dans les textes.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor"/></token>
+              <marker>
+                <token>à</token>
+              </marker>
+              <token>vrai</token>
+              <token>dire</token>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \2</suggestion>
+            <example correction=", à">Il faut<marker> à</marker> vrai dire le faire bien.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token>à</token>
+              <token>vrai</token>
+              <token>dire</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor|M fin.*|R pers suj.*" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">Il faut, à vrai dire<marker> le</marker> faire bien.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token>de</token>
+              <token>nos</token>
+              <token>jours</token>
+              <token postag="V.*" postag_regexp="yes"><exception postag="V ppa.*" postag_regexp="yes"/></token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token>de</token>
+              <token>nos</token>
+              <token>jours</token>
+              <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+</token>
+              <token>,</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>de</token>
+              <token>nos</token>
+              <token>jours</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor|M fin.*|R pers suj.*|[ANP].*" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \5</suggestion>
+            <example correction=", le">De nos jours<marker> le</marker> cours de la bourse est en chute libre.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token>contre</token>
+              <token regexp="yes">toutes?</token>
+              <token>attente</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">Contre toute attente<marker> le</marker> poisson va bien.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor"/></token>
+              <marker>
+                <token case_sensitive="yes">contre</token>
+              </marker>
+              <token regexp="yes">toutes?</token>
+              <token>attente</token>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \2</suggestion>
+            <example correction=", contre">Il lui a dit<marker> contre</marker> toute attente, que le poisson allait bien.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token>en</token>
+              <token>l'</token>
+              <token regexp="yes">occ?urr?ence</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor"/>
+                <exception scope="next">,</exception>
+              </token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">En l'occurrence<marker> le</marker> poisson allait bien.</example>
+            <example>Ils choisissent de devenir parrain et marraine d'un enfant en difficulté, en l'occurrence Mila, dont la mère fait des séjours réguliers à l'hôpital.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>à</token>
+              <token regexp="yes">[tms]on</token>
+              <token>avis</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor|M fin.*" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \5</suggestion>
+            <example correction=", le">À mon avis<marker> le</marker> poisson allait bien.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token>quoi</token>
+              <token>qu'</token>
+              <token>il</token>
+              <token>en</token>
+              <token>soit</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \6</suggestion>
+            <example correction=", le">Quoi qu'il en soit<marker> le</marker> poisson va bien.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token>attention</token>
+              <token postag="D.*" postag_regexp="yes"/>
+              <token postag="N.*" postag_regexp="yes"/>
+              <token regexp="yes">[,‘’–)\[—."\/;\]\|:(\…'«»“”-]+|[/?!]</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>attention</token>
+              <marker>
+                <token postag="D.*|R dem.*" postag_regexp="yes"/>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après ce terme afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \3</suggestion>
+            <example correction=", le">Attention<marker> le</marker> poisson va bien.</example>
+            <example>Attention les yeux !</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token>ma</token>
+              <token>foi</token>
+              <token postag="V.*" postag_regexp="yes"><exception postag="V inf"/></token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>ma</token>
+              <token>foi</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor|M fin.*|R pers suj.*|P.*" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">Ma foi<marker> le</marker> poisson va bien.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor|M fin.*|R pers obj.*" postag_regexp="yes"/></token>
+              <marker>
+                <token>dis</token>
+              </marker>
+              <token>donc</token>
+              <token postag="SENT_END"/>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \2</suggestion>
+            <example correction=", dis">Le poisson va bien<marker> dis</marker> donc.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>bonté</token>
+              <token>divine</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+<exception postag="C coor|M fin.*" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">Bonté divine<marker> le</marker> chat est revenu !</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token postag="A" min="0" max="1"/>
+              <token min="0" max="1">tout</token>
+              <token>d'</token>
+              <token>abord</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+|[!?]<exception postag="Y|V.*|C coor" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \6</suggestion>
+            <example correction=", il">D'abord<marker> il</marker> fera beau demain.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token>pour</token>
+              <token>le</token>
+              <token>reste</token>
+              <token postag="[AZ].*" postag_regexp="yes"/>
+              <token min="0" max="1">,</token>
+              <token postag="R pers suj.*" postag_regexp="yes"/>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>pour</token>
+              <token>le</token>
+              <token>reste</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+
+                  <exception>des</exception>
+                  <exception  postag="SENT_END"/>
+                  <exception  postag="R pers suj.*|P.*" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \5</suggestion>
+            <example correction=", le">Pour le reste<marker> le</marker> poisson va bien.</example>
+            <example>Pour le reste aussi, nous avons fait l'impossible.</example>
+            <example>Pour le reste des gens, je suis invisible.</example>
+            <example>Pour le reste ?</example>
+            <example>Pour le reste de la population, c'est incroyable.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token>à</token>
+              <token>la</token>
+              <token>réflexion</token>
+              <marker>
+                <token postag="D.*|R dem.*" postag_regexp="yes">
+                  <exception postag="K"/>
+                  <exception>des</exception></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">Selon lui, à la réflexion<marker> le</marker> poisson va bien.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token postag="A" regexp="yes">&jours_semaine;</token>
+              <token regexp="yes">les?|des</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token postag="A"/>
+              <token postag="D.*" postag_regexp="yes" min="0" max="1"/>
+              <token postag="[NZ].*" postag_regexp="yes"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token postag="A"/>
+              <token postag="V.*|[YK]" postag_regexp="yes"/>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token postag="A"/>
+              <token regexp="yes">midi|matin|soir</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token postag="A" regexp="yes">donc|enfin|aussi|ensemble|certes|ici|déjà|bientôt|ailleurs|Ensuite|alors|ainsi|hier|demain|aujourd'hui|là|&jours_semaine;</token>
+              <marker>
+                <token postag="[NZDR].*" postag_regexp="yes" skip="-1">
+                  <exception scope="next">,</exception><exception>quelques</exception></token>
+              </marker>
+              <token postag="M fin"/>
+            </pattern>
+            <message>Une virgule est conseillée afin de mettre en valeur l'adverbe la précédant et d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \3</suggestion>
+            <example correction=", il">Déjà<marker> il</marker> fait beau.</example>
+            <example><marker>Combien il</marker> en a pris ?</example>
+            <example>Enfin quelques possibilités.</example>
+            <example>Dimanche des Reliques.</example>
+            <example>Déjà la nuit.</example>
+            <example>Bientôt Noël.</example>
+            <example>Ainsi danse Jean Petit.</example>
+            <example>Demain matin conviendra.</example>
+            <example>Déjà deux semaines sont passées et je ne vous ai pas vu.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>très</token>
+              <token>bien</token>
+              <marker>
+                <token postag="D.*|R pers suj.*" postag_regexp="yes"/>
+
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après ces adverbes placés en début de phrase afin d'apporter du rythme à celle-ci.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", il">Très bien<marker> il</marker> fait beau.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>bon</token>
+              <token>sang</token>
+              <marker>
+                <token regexp="yes">[^,‘’–)\[—."\/;\]\|:(\…'«»“”-]+
+                  <exception regexp="yes" inflected="yes">de|ne</exception>
+                  <exception postag="M fin excl|UNKNOWN" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", il">Bon sang<marker> il</marker> ne peut pas regarder où il va.</example>
+            <example>Bon sang de bonsoir !</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token postag="A" postag_regexp="yes" regexp="yes">.*ent$</token>
+              <token postag="D.*" postag_regexp="yes"/>
+              <token postag="N.*" postag_regexp="yes"/>
+              <token postag="J.*" postag_regexp="yes" min="0" max="1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token regexp="yes">tellement|exactement</token>
+              <token postag="D.*" postag_regexp="yes"/>
+              <token postag="N.*" postag_regexp="yes"/>
+              <token postag="V.*" postag_regexp="yes" min="0" max="1"/>
+              <token postag="J.*" postag_regexp="yes" min="0" max="1"/>
+              <token inflected="yes">que</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">rarement|vivement|seulement</token>
+              <token postag="D.*" postag_regexp="yes"/>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">rarement|pratiquement|quasiment</token>
+              <token regexp="yes">tous|toute?s?</token>
+            </antipattern>
+            <antipattern>
+              <token postag="A"/>
+              <token postag="R pers obj.*" postag_regexp="yes"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token postag="A"/>
+              <and>
+              <token postag="R pers obj.*" postag_regexp="yes"/>
+              <token postag="SENT_END"/>
+              </and>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START|M fin" postag_regexp="yes"/>
+              <token postag="A" postag_regexp="yes" regexp="yes">.*ent$</token>
+              <marker>
+                <token postag="[DR].*" postag_regexp="yes">
+                  <exception regexp="yes">rien|personne|s'|se</exception>
+                  <exception postag="K"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après un adverbe placé en début de phrase afin d'apporter du rythme à celle-ci.</message>
+            <suggestion>, \3</suggestion>
+            <example correction=", cette">Malheureusement<marker> cette</marker> ville n'est pas belle.</example>
+            <example correction=", j'">Je dois être trop vieux... personnellement<marker> j'</marker>apprécie les conseils des pros.</example>
+            <example>Uniquement des veaux !</example>
+            <example>Seulement moi</example>
+            <example>Certainement rien qui ne révolutionnera le monde.</example>
+            <example>Pratiquement tous les Japonais ont les cheveux foncés.</example>
+            <example>Seulement deux sessions de formations théoriques par an.</example>
+            <example>Exactement la tête que je fais !</example>
+            <example>Tellement la question était difficile que nul ne sut répondre.</example>
+            <example>Vivement la fin de ce cycle.</example>
+            <example>Pratiquement personne ne le vit.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token>après</token>
+              <token regexp="yes">ça|cela</token>
+              <token>ce</token>
+              <token regexp="yes">fait|dit</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>après</token>
+              <token regexp="yes">ça|cela</token>
+              <marker>
+                <token regexp="yes">[a-z].* <exception postag="R pers obj.*|C coor|V.*" postag_regexp="yes"/>
+                <exception inflected="yes">ne</exception>
+              </token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">Après cela<marker> le</marker> garçon sortit jouer avec ses copains.</example>
+            <example>Après ça ce fait souvent.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token>au</token>
+              <token>début</token>
+              <token regexp="yes">comme|des|quelques?|où</token>
+            </antipattern>
+            <antipattern>
+              <token>au</token>
+              <token>début</token>
+              <token postag="P.*" postag_regexp="yes"/>
+            </antipattern>
+            <antipattern>
+              <token>au</token>
+              <token>début</token>
+              <token postag="A"/>
+              <token postag="[JP].*|V ppa.*" postag_regexp="yes"/>
+            </antipattern>
+            <antipattern>
+              <token>au</token>
+              <token>début</token>
+              <token postag="A" regexp="yes">.*ment$</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token regexp="yes">en|au</token>
+              <token regexp="yes">moyenne|début</token>
+              <marker>
+                <token regexp="yes">[a-z].*<exception postag="C coor|[JVN].*|P|UNKNOWN" postag_regexp="yes"/>
+                <exception scope="next" postag="M fin.*|M nonfin" postag_regexp="yes"/>
+              </token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">En moyenne<marker> le</marker> conseil prend deux à trois décisions par jour.</example>
+            <example>En moyenne montagne, les accidents sont nombreux.</example>
+            <example>En moyenne annuelle, le bénéfice est faible.</example>
+            <example>En moyenne sur l'année, le déficit est important.</example>
+            <example>Au début essentiellement de nature régionale, le marché finit par devenir mondial.</example>
+            <example>Au début du siècle dernier, Internet n'existait pas.</example>
+            <example>Au début plus religieux que littéraires, ces cercles devinrent petit à petit plus littéraires que religieux.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token regexp="yes">a|à</token>
+              <token>l'</token>
+              <token>évidence</token>
+              <marker>
+                <token regexp="yes">[a-z].*
+                  <exception postag="C coor|[V].*" postag_regexp="yes"/>
+                  <exception scope="next" postag="M fin.*|M nonfin" postag_regexp="yes"/>
+                </token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \5</suggestion>
+            <example correction=", le">A l'évidence<marker> le</marker> chat avait mangé la souris.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>par</token>
+              <token>la</token>
+              <token>suite</token>
+              <marker>
+                <token regexp="yes">[a-z].*
+                  <exception postag="C coor|[VN].*|R pers obj.*" postag_regexp="yes"/>
+                  <exception scope="next" postag="M fin.*|M nonfin" postag_regexp="yes"/>
+                </token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \5</suggestion>
+            <example correction=", le">Par la suite<marker> le</marker> jeune homme habita en ville.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token regexp="yes">à|a</token>
+              <token>ce</token>
+              <token>propos</token>
+              <marker>
+                <token regexp="yes">[a-z].*
+                  <exception postag="C coor|[V].*" postag_regexp="yes"/>
+                  <exception scope="next" postag="M fin.*|M nonfin" postag_regexp="yes"/>
+                </token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \5</suggestion>
+            <example correction=", le">A ce propos<marker> le</marker> serrurier viendra demain.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>dans</token>
+              <token>l'</token>
+              <token>ensemble</token>
+              <marker>
+                <token regexp="yes">[a-z].*<exception inflected="yes">de</exception></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \5</suggestion>
+            <example correction=", le">Dans l'ensemble<marker> le</marker> texte était correct.</example>
+            <example>Dans l'ensemble de la pièce, les acteurs jouèrent bien.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token>en</token>
+              <token regexp="yes">vérité|fait|revanche</token>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes">[^a-z].*</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token>en</token>
+              <token regexp="yes">vérité|fait|revanche</token>
+              <token inflected="yes">de</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>en</token>
+              <token regexp="yes">vérité|fait|revanche</token>
+              <marker>
+                <token regexp="yes">[a-z].*<exception postag="UNKNOWN"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">En fait<marker> le</marker> chat avait mangé la souris.</example>
+            <example>En fait si.</example>
+            <example>En fait d'intégration, il n'y a que de la désintégration.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token>au</token>
+              <token>fait</token>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes">[^a-z].*</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>au</token>
+              <token>fait</token>
+              <marker>
+                <token regexp="yes">[a-z].*<exception postag="UNKNOWN"/><exception inflected="yes">de</exception></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">Au fait<marker> le</marker> chat a mangé la souris.</example>
+            <example>Au fait de leur victoire, ils allèrent au restaurant.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token>si</token>
+              <token postag="R pers suj.*" postag_regexp="yes"/>
+              <token>le</token>
+              <token postag="V.*" postag_regexp="yes" inflected="yes">dire</token>
+              <marker>
+                <token regexp="yes">[a-z].*<exception postag="UNKNOWN|[JP].*" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \5</suggestion>
+            <example correction=", alors">Si tu le dis<marker> alors</marker> cela doit être vrai.</example>
+            <example>Si tu le dis influencé par ce courant, alors il doit être grandiose.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token regexp="yes">à|a<exception postag="R pers suj.*" postag_regexp="yes"/></token>
+              <token>l'</token>
+              <token>occasion</token>
+              <marker>
+                <token regexp="yes">[a-z].*<exception postag="UNKNOWN|[JPN].*|C coor" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \5</suggestion>
+            <example correction=", le">A l'occasion<marker> le</marker> chapeau volait.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes">à|a</token>
+              <token>défaut</token>
+              <token inflected="yes">de</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token regexp="yes">à|a</token>
+              <token regexp="yes">contrecoeur|contrecœur|défaut</token>
+              <marker>
+                <token regexp="yes">[a-z].*<exception postag="UNKNOWN|C coor" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", le">A contrecœur<marker> le</marker> magicien finit son spectacle.</example>
+            <example>À défaut d'avoir pu déjeuner le matin, j'ai jeûné toute la journée.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes">de|en</token>
+              <token>plus</token>
+              <token regexp="yes">[,‘’–)\[—."\/;\]\|:(\…\='«»“”-]+|[?!]</token>
+            </antipattern>
+            <antipattern>
+              <token>de</token>
+              <token>plus</token>
+              <token>en</token>
+              <token>plus</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" case_sensitive="yes">de|en</token>
+              <token>plus</token>
+              <token postag="[DV].*" postag_regexp="yes"/>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" case_sensitive="yes">de|en</token>
+              <token>plus</token>
+              <token postag="A"/>
+            </antipattern>
+            <antipattern>
+              <token>de</token>
+              <token case_sensitive="yes">Plus</token>
+              <token>belle</token>
+              <token>la</token>
+              <token>vie</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" inflected="yes">que|fois</token>
+              <token regexp="yes">de|en</token>
+              <token>plus</token>
+            </antipattern>
+            <antipattern>
+              <token postag="[DPN].*" postag_regexp="yes"/>
+              <token postag="[NJ].*" postag_regexp="yes"/>
+              <token regexp="yes">de|en</token>
+              <token>plus</token>
+              <token postag="Y"/>
+            </antipattern>
+            <antipattern>
+              <token postag="V.*" postag_regexp="yes"/>
+              <token regexp="yes">de|en</token>
+              <token>plus</token>
+              <token postag="Y"/>
+              <token regexp="yes">[a-z].*</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">de|en</token>
+              <token>plus</token>
+              <token regexp="yes" inflected="yes">ne|ici|qui|,|des?|du|en|que|belle|[nv]ous-même|(eux|elles?|[mt]oi)-mêmes?</token>
+            </antipattern>
+            <pattern>
+              <token regexp="yes">de|en<exception scope="previous">plus</exception></token>
+              <token>plus
+                <exception postag="SENT_END"/>
+                <exception scope="next" postag="V.*|[JNP].*|R pers obj.*|C coor" postag_regexp="yes"/>
+              </token>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>\1 \2,</suggestion>
+            <example correction="en plus,">Il est grand et <marker>en plus</marker> il est intelligent.</example>
+            <example>Dixie peut en plus planer.</example>
+            <example>Une personne de plus se joindra à nous plus tard.</example>
+            <example>On peut y voir le plus gros amortisseur du monde de plus près.</example>
+            <example>Tu ne peux plus faire grand chose de plus toi-même.</example>
+            <example>C'est le spin-off de Plus belle la vie.</example>
+            <example>Il intimide une fois de plus Valentin.</example>
+            <example>Il y a une population plutôt équilibrée 26,7 % de personnes de plus 60 ans.</example>
+            <example>J'ai dû payer en plus 5 dollars.</example>
+            <example>Si tu t'y étais rendu et qu'en plus il ait plu ?</example>
+          </rule>
+          <rule default="off">
+            <antipattern>
+              <token postag="A" regexp="yes">.*ent$</token>
+              <token regexp="yes" skip="-1">[a-z].*</token>
+              <token postag="M fin inte"/>
+            </antipattern>
+            <antipattern>
+              <token postag="A" regexp="yes">.*ent$</token>
+              <token>donc</token>
+            </antipattern>
+            <antipattern>
+              <token>immédiatement</token>
+              <token>après</token>
+            </antipattern>
+            <antipattern>
+              <token>non</token>
+              <token>seulement</token>
+              <token regexp="yes">aux?</token>
+            </antipattern>
+            <antipattern>
+              <token>à</token>
+              <token>proprement</token>
+              <token>parler</token>
+            </antipattern>
+            <antipattern>
+              <token>ce</token>
+              <token>soit</token>
+              <token postag="A" regexp="yes">.*ent$</token>
+              <token regexp="yes">[a-z].*</token>
+            </antipattern>
+            <antipattern>
+              <token>plus</token>
+              <token postag="A" regexp="yes">.*ent$<exception regexp="yes">particulièrement|généralement|largement|couramment|précisement</exception></token>
+              <token regexp="yes">[a-z].*</token>
+            </antipattern>
+            <antipattern>
+              <token>pas</token>
+              <token>encore</token>
+              <token postag="A" regexp="yes">.*ent$</token>
+              <token regexp="yes">[a-z].*</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">[aà]</token>
+              <token>présent</token>
+              <token inflected="yes">que</token>
+            </antipattern>
+            <pattern>
+              <token postag="A">
+                <exception scope="previous" regexp="yes">pas|bien</exception></token>
+              <token postag="A" regexp="yes">.*ent$
+                <exception scope="previous" regexp="yes">pas|ainsi|trop|très|vraiment|aussi|si|donc|toujours|déjà|encore</exception>
+                <exception regexp="yes">souvent|vraiment|vivement</exception>
+              </token>
+              <marker>
+                <token regexp="yes">[a-z].*
+                  <exception scope="next" regexp="yes" inflected="yes">,|qu[ie]|alors</exception>
+                  <exception postag="J.*|V.* pp.*|V.* inf" postag_regexp="yes"/>
+                  <exception regexp="yes" inflected="yes">(?-i)[A-Z].*|ce|moins|avec|pas|plus|sous|trop|comme|jamais|qu[ie]</exception></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée après cet adverbe afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \4</suggestion>
+            <example correction=", ne">Cécile bien malheureusement<marker> ne</marker> pourra pas venir demain.</example>
+            <example>Tu ne peux pas simplement abandonner.</example>
+            <example>Il lui resterait donc seulement deux ans d'éligibilité.</example>
+            <example>C'est un physicien célèbre non seulement au Japon, mais dans le monde entier.</example>
+            <example>Il parle bien plus couramment l'anglais que je ne le peux.</example>
+            <example>Je n'arrive pas à croire que ce soit vraiment vous.</example>
+            <example>À présent que Marie s'en est allée, Tom est beaucoup plus heureux.</example>
+          </rule>
+            <!--
+          <rule default="off">
+            <antipattern>
+              <token postag="[VC].*|SENT_START|R dem.*" postag_regexp="yes"/>
+              <token postag="A" min="0" max="2"/>
+              <token postag="A" postag_regexp="yes" regexp="yes">.*ent$</token>
+            </antipattern>
+            <antipattern>
+              <token postag="A" postag_regexp="yes" regexp="yes" skip="-1">.*ent$</token>
+              <token postag="M fin inte"/>
+            </antipattern>
+            <antipattern>
+              <token postag="V (etre|avoir).*" postag_regexp="yes"/>
+              <token regexp="yes" min="0" max="1">pas|plus|jamais|très</token>
+              <token postag="A" postag_regexp="yes" regexp="yes">.*ent$</token>
+              <token postag="V.* ppa.*" postag_regexp="yes"/>
+            </antipattern>
+            <antipattern>
+              <token postag="V.*" postag_regexp="yes"/>
+              <token regexp="yes">pas|plus|jamais|tous|toute?s?</token>
+              <token postag="A" postag_regexp="yes" regexp="yes" skip="-1">.*ent$</token>
+            </antipattern>
+            <antipattern>
+              <token>,</token>
+              <token postag="A"><exception postag="A" regexp="yes">.*ent$</exception></token>
+              <token postag="A" postag_regexp="yes" regexp="yes">.*ent$</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">à|sans|non</token>
+              <token regexp="yes">présent|seulement</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">pour|à</token>
+              <token regexp="yes">le|proprement</token>
+              <token regexp="yes">moment|parler</token>
+            </antipattern>
+            <antipattern>
+              <token>tout</token>
+              <token>à</token>
+              <token>fait</token>
+              <token postag="A" postag_regexp="yes" regexp="yes">.*ent$</token>
+            </antipattern>
+            <antipattern>
+              <token postag="A" postag_regexp="yes" regexp="yes">(?-i)[A-Z].*ent$</token>
+            </antipattern>
+            <antipattern>
+              <token postag="A" postag_regexp="yes" regexp="yes">.*ent$</token>
+              <token postag="SENT_END|M nonfin|V.*" postag_regexp="yes"/>
+            </antipattern>
+            <antipattern>
+              <token postag="A"/>
+              <token>souvent</token>
+            </antipattern>
+            <pattern>
+              <token postag="A"><exception regexp="yes">ici|encore|n|quasi|peut-être|tantôt|peu|voire|cher|fort|hier|souvent|donc|toujours|si|peine|plutôt|tout|juste|même|jamais|presque|par|déjà|ensuite|pas|près</exception></token>
+              <marker>
+                <token postag="A" regexp="yes">.*ent$
+                  <exception scope="next" regexp="yes" inflected="yes">qu[ei]</exception>
+                  <exception scope="previous" regexp="yes">&unites_de_mesure;|partie|très|plus|moins|aussi|bien|trop|assez</exception></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée avant cet adverbe afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \3</suggestion>
+            <example correction=", quasiment">Lui, finalement<marker> quasiment</marker> mort au cours de la bataille, ne pourra pas venir demain.</example>
+            <example>Absolument !</example>
+            <example>Les hommes pensent tout à fait différemment selon qu'ils sont assis ou debout.</example>
+            <example>Il quitta la pièce sans seulement me dire au revoir.</example>
+            <example>Es-tu absolument sûr que c'était Tom que tu as vu ?</example>
+            <example>Tous les travaux d'agrandissement y sont effectués à peu près exclusivement par des entreprises flamandes.</example>
+            <example>Tu ne dois pas absolument t'y rendre.</example>
+            <example>Il est donc temps de regarder les choses autrement si nous voulons véritablement guérir.</example>
+            <example>Elle mange bien volontiers et abondamment et a l'air replète.</example>
+            <example>Faites-les mousser avec vos doigts et rincez-les abondamment !</example>
+            <example>Cet album abondamment illustré revient sur l'histoire de cette création originale.</example>
+          </rule>
+          -->
+          <rule>
+            <pattern>
+              <token postag="[NZ].*" postag_regexp="yes"><exception postag="V pp.*|V.* inf" postag_regexp="yes"/></token>
+              <marker>
+                <token regexp="yes" case_sensitive="yes">cependant|ainsi|enfin|pourtant|certes|néanmoins|toutefois|nonobstant</token>
+              </marker>
+              <token min="0" max="1" inflected="yes">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="2"><exception regexp="yes">[a-z]$</exception></token>
+              <token postag="V.*" postag_regexp="yes"><exception postag="V pp.*|V.* inf|J.*|M nonfin" postag_regexp="yes"/></token>
+            </pattern>
+            <message>Une virgule est conseillée avant cet adverbe afin de le mettre en valeur et d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \2</suggestion>
+            <example correction=", ainsi">Marie<marker> ainsi</marker> ne pourra pas venir demain.</example>
+            <example>Le roi ayant ainsi assez d'argent pour payer son dû.</example>
+            <example>Il a cependant excercé la profession d'avocat pendant diz ans.</example>
+            <example>La droite ainsi S est une tangente.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token postag="[NZ].*" postag_regexp="yes"><exception postag="V pp.*|V.* inf" postag_regexp="yes"/></token>
+              <marker>
+                <token regexp="yes" case_sensitive="yes">cependant|ainsi|enfin|pourtant|certes|néanmoins|toutefois|surtout|nonobstant</token>
+              </marker>
+              <token min="0" max="1" inflected="yes">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="2"><exception regexp="yes">[a-z]$</exception></token>
+              <token postag="V.*" postag_regexp="yes"><exception postag="V pp.*|V.* inf|J.*|M nonfin" postag_regexp="yes"/></token>
+            </pattern>
+            <message>Une virgule est conseillée après cet adverbe afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>\2,</suggestion>
+            <example correction="ainsi,">Marie <marker>ainsi</marker> lui dit de ne pas venir demain.</example>
+            <example>Le roi ayant ainsi assez d'argent pour payer son dû.</example>
+            <example>Il a cependant excercé la profession d'avocat pendant diz ans.</example>
+            <example>La droite ainsi S est une tangente.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes" skip="-1">[,‘’–)\[—."\/;\]\|:(\…'«»“”-]+</token>
+              <token>tantôt</token>
+            </antipattern>
+            <pattern>
+              <token skip="-1">tantôt</token>
+              <marker>
+                <token>tantôt<exception scope="previous" postag="C coor|M nonfin" postag_regexp="yes"/></token>
+              </marker>
+            </pattern>
+            <message>Une virgule est conseillée avant cet adverbe afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \3</suggestion>
+            <example correction=", tantôt">Il a tantôt des puces<marker> tantôt</marker> des tiques.</example>
+            <example correction=", tantôt">Le vent peut être tantôt doux<marker> tantôt</marker> violent dans l'oeuvre de Thiers.</example>
+            <example>Tantôt le ciel lance d'affreux torrents ; / <marker> tantôt</marker> des rocs noircis par ses feux dévorant.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes">en|dans|à</token>
+              <token regexp="yes">ces?|la</token>
+              <token regexp="yes">lieu|suite|conditions|fait</token>
+            </antipattern>
+            <pattern>
+              <token postag="[NZ].*" postag_regexp="yes"><exception postag="V pp.*|V.* inf" postag_regexp="yes"/></token>
+              <marker>
+                <token regexp="yes">dans|tout|en|par|à</token>
+              </marker>
+              <token regexp="yes">ces|compte|premier|la|deuxième|dernier|ce|l'</token>
+              <token regexp="yes">inverse|propos|suite|conditions|fait|lieu</token>
+              <token min="0" max="1" inflected="yes">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="2"/>
+              <token postag="V.*" postag_regexp="yes"><exception postag="V pp.*|V.* inf" postag_regexp="yes"/></token>
+            </pattern>
+            <message>Une virgule est conseillée avant cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \2</suggestion>
+            <example correction=", en">Marie<marker> en</marker> premier lieu a introduit le sujet.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes">en|dans|à</token>
+              <token regexp="yes">ces?|la</token>
+              <token regexp="yes">lieu|suite|conditions|fait</token>
+            </antipattern>
+            <pattern>
+              <token postag="[NZ].*" postag_regexp="yes"><exception postag="V pp.*|V.* inf" postag_regexp="yes"/></token>
+              <token regexp="yes">dans|tout|en|par|à</token>
+              <token regexp="yes">ces|compte|premier|la|deuxième|dernier|ce|l'</token>
+              <marker>
+                <token regexp="yes">inverse|propos|suite|conditions|fait|lieu</token>
+              </marker>
+              <token min="0" max="1" inflected="yes">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="2"/>
+              <token postag="V.*" postag_regexp="yes"><exception postag="V pp.*|V.* inf" postag_regexp="yes"/></token>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>\4,</suggestion>
+            <example correction="inverse,">Vincent à l'<marker>inverse</marker> n'a pas fait ses devoirs.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token>de</token>
+              <token>conclusion</token>
+            </antipattern>
+            <antipattern>
+              <token postag="[NZ].*" postag_regexp="yes"/>
+              <token regexp="yes">pour|de|sans|en</token>
+              <token regexp="yes">tout|même|(?-i)Total|seulement</token>
+              <token min="0" max="1" inflected="yes">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="2"/>
+              <token postag="V.*" postag_regexp="yes"/>
+            </antipattern>
+            <antipattern>
+              <token postag="[NZ].*" postag_regexp="yes"/>
+              <token>en</token>
+              <token>doute</token>
+              <token min="0" max="1" inflected="yes">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="2"/>
+              <token postag="V.*" postag_regexp="yes"/>
+            </antipattern>
+            <pattern>
+              <token postag="[NZ].*" postag_regexp="yes"/>
+              <marker>
+                <token regexp="yes">d'|par|au|en|magré|non|de|sans|pour</token>
+              </marker>
+              <token regexp="yes">ailleurs|total|contre|contraire|revanche|tout|seulement|même|doute|surcroît|conclure|résumé|conclusion|conséquent|définitive</token>
+              <token min="0" max="1" inflected="yes">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="2"/>
+              <token postag="V.*" postag_regexp="yes"/>
+            </pattern>
+            <message>Une virgule est conseillée avant cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \2</suggestion>
+            <example correction=", par">Marie<marker> par</marker> ailleurs n'a pas pu répondre à la question.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token>de</token>
+              <token>conclusion</token>
+            </antipattern>
+            <antipattern>
+              <token postag="[NZ].*" postag_regexp="yes"/>
+              <token regexp="yes">pour|de|sans|en</token>
+              <token regexp="yes">tout|même|(?-i)Total|seulement</token>
+              <token min="0" max="1" inflected="yes">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="2"/>
+              <token postag="V.*" postag_regexp="yes"/>
+            </antipattern>
+            <antipattern>
+              <token postag="[NZ].*" postag_regexp="yes"/>
+              <token>en</token>
+              <token>doute</token>
+              <token min="0" max="1" inflected="yes">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="2"/>
+              <token postag="V.*" postag_regexp="yes"/>
+            </antipattern>
+            <pattern>
+              <token postag="[NZ].*" postag_regexp="yes"/>
+              <token regexp="yes">d'|par|au|en|magré|non|de|sans|pour</token>
+              <marker>
+                <token regexp="yes">ailleurs|total|contre|contraire|revanche|tout|seulement|même|doute|surcroît|conclure|résumé|conclusion|conséquent|définitive</token>
+              </marker>
+              <token min="0" max="1" inflected="yes">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="2"/>
+              <token postag="V.*" postag_regexp="yes"><exception scope="next">,</exception></token>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>\3,</suggestion>
+            <example correction="ailleurs,">Ce garçon par <marker>ailleurs</marker> a obtenu la meilleure note pour ce devoir.</example>
+            <example>L'excès en tout est un défaut.</example>
+            <example>Quelques-unes de ces peintures mises en doute sont apportées à Moscou.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token postag="[AC].*" postag_regexp="yes"/>
+              <marker>
+                <token regexp="yes">dans|en</token>
+              </marker>
+              <token regexp="yes">un|d'</token>
+              <token regexp="yes">premier|deuxième|dernier|second|autres</token>
+              <token regexp="yes">temps|termes</token>
+              <token min="0" max="1">,</token>
+              <token min="0" max="1" inflected="yes">ne</token>
+              <token postag="R pers.*" postag_regexp="yes" min="0" max="2"/>
+              <token postag="V.*" postag_regexp="yes"/>
+            </pattern>
+            <message>Une virgule est conseillée avant cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>, \2</suggestion>
+            <example correction=", dans">Ainsi<marker> dans</marker> un premier temps, nous allons étudier les batraciens.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token postag="[AC].*" postag_regexp="yes" min="0" max="1"/>
+              <token min="0" max="1">,</token>
+              <token regexp="yes">dans|en</token>
+              <token regexp="yes">un|d'</token>
+              <token regexp="yes">premier|deuxième|dernier|second|autres</token>
+              <marker>
+                <token regexp="yes">temps|termes</token>
+              </marker>
+              <token min="0" max="1" inflected="yes">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="2"/>
+              <token postag="V.*" postag_regexp="yes"/>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>\7,</suggestion>
+            <example correction="temps,">Ainsi, dans un premier <marker>temps</marker> lisez attentivement le texte.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token>qui</token>
+              <token>plus</token>
+              <token>est</token>
+              <token>,</token>
+              <token postag="A"/>
+              <token postag="V.* ppa.*" postag_regexp="yes"/>
+            </antipattern>
+            <antipattern>
+              <token postag="V (etre|avoir).*" postag_regexp="yes" regexp="yes">(?-i)[A-Z].*</token>
+              <token>,</token>
+              <token postag="A"/>
+              <token postag="V.* ppa.*" postag_regexp="yes"/>
+            </antipattern>
+            <pattern>
+              <token postag="V (etre|avoir).*" postag_regexp="yes"><exception postag="V.* inf" postag_regexp="yes"/></token>
+              <marker>
+                <token>,</token>
+                <token postag="A"><exception regexp="yes">non|pas|plus|jamais</exception></token>
+              </marker>
+              <token postag="V.* ppa.*" postag_regexp="yes"><exception scope="next">,</exception></token>
+            </pattern>
+            <message>Il est déconseillé de placer des virgules à l'intérieur du groupe verbal.</message>
+            <suggestion> \3</suggestion>
+            <example correction=" ainsi">Il a<marker>, ainsi</marker> gagné les élections.</example>
+            <example>Câble A, précédemment dénommé Téléval.</example>
+            <example>Il y avait, profondément plantée, un arbre dans le jardin.</example>
+            <example>Martin Chuzzlewit, il est vrai, figure parmi les exceptions, de façon, qui plus est, assez outrée.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token>pour</token>
+              <token>se</token>
+              <token>faire</token>
+              <token postag="[NZD].*" postag_regexp="yes"/>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token>pour</token>
+              <token regexp="yes">se|ce</token>
+              <marker>
+                <token>faire</token>
+              </marker>
+              <token postag="R pers suj.*|[NZD].*" postag_regexp="yes"/>
+            </pattern>
+            <message>Une virgule est conseillée après cette expression afin d'apporter du rythme à votre phrase.</message>
+            <suggestion>\4,</suggestion>
+            <example correction="faire,">Pour ce <marker>faire</marker> il faudra que tu appelles ta tante demain.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token>bonjour</token>
+              <token min="0">,</token>
+              <marker>
+                <token postag="[TZ].*" postag_regexp="yes"/>
+                <token regexp="yes">[:;]</token>
+              </marker>
+            </pattern>
+            <message>Une virgule ou un point doit suivre l'expression de la salutation.</message>
+            <suggestion>\3.</suggestion>
+            <suggestion>\3,</suggestion>
+            <example correction="Marie.|Marie,">Bonjour, <marker>Marie ;</marker></example>
+          </rule>
+        </rulegroup>
     </category>
     <category id="REPETITIONS_STYLE" name="repetitions style" type="style" tone_tags="clarity">
     <!--This category has been tagged as clarity, but "picky" tag will likely be replaced by "formal" tone tag in the near future-->

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -20059,6 +20059,1779 @@ USA
             <example>Mais peu importe.</example>
             <example>Mais bon Sophie est rentré à nouveau chez elle.</example>
         </rule>
+        <rulegroup id="POINT_MAIS" name="point mais (. Pourtant,)">
+          <antipattern>
+            <token regexp="yes">comme|non|pas</token>
+            <token regexp="yes" skip="-1">pas|si|seulement</token>
+            <token>,</token>
+            <token>mais</token>
+            <token min="10" skip="-1"/>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token skip="-1">mais</token>
+            <token><exception postag="V.*" postag_regexp="yes"/></token>
+            <token postag="M nonfin|C coor" postag_regexp="yes" skip="-1"/>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token skip="1">mais</token>
+            <token>ne</token>
+            <token>pas</token>
+            <token postag="V.* inf" postag_regexp="yes" skip="-1"/>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token>-</token>
+            <token regexp="yes" spacebefore="yes" skip="-1">[a-z].*</token>
+            <token>,</token>
+            <token skip="-1">mais</token>
+            <token regexp="yes">[a-z].*</token>
+            <token skip="-1" spacebefore="yes">-</token>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token>—</token>
+            <token>,</token>
+            <token>mais</token>
+          </antipattern>
+          <antipattern>
+            <token regexp="yes" skip="-1">[;:]</token>
+            <token>,</token>
+            <token skip="-1">mais</token>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token skip="3">mais</token>
+            <token regexp="yes" skip="-1">[;:]</token>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token postag="SENT_START"/>
+            <token>s'</token>
+            <token regexp="yes" skip="-1">[àâaêèéeiîoôòóöŌuœä].*</token>
+            <token>,</token>
+            <token skip="3">mais</token>
+            <token postag="V.*" postag_regexp="yes"/>
+          </antipattern>
+          <antipattern>
+            <token postag="SENT_START"/>
+            <token>si</token>
+            <token regexp="yes" skip="-1">[a-z].*</token>
+            <token>,</token>
+            <token>mais</token>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token>mais</token>
+            <token postag="N.*" postag_regexp="yes" skip="2"/>
+            <token>,</token>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token skip="-1">mais</token>
+            <token regexp="yes" skip="-1">[a-z].*</token>
+            <token spacebefore="no">)</token>
+          </antipattern>
+          <antipattern>
+            <token postag="SENT_START"/>
+            <token inflected="yes" skip="-1">que</token>
+            <token>,</token>
+            <token skip="3">mais</token>
+            <token postag="V.*" postag_regexp="yes"/>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token>mais</token>
+            <token>le</token>
+            <token>fait</token>
+            <token inflected="yes">que</token>
+          </antipattern>
+          <antipattern>
+            <token regexp="yes" skip="-1">[\(]</token>
+            <token>,</token>
+            <token skip="-1">mais</token>
+            <token regexp="yes">[\)]</token>
+          </antipattern>
+          <antipattern>
+            <token skip="-1">(</token>
+            <token skip="-1"><exception>)</exception></token>
+            <token>,</token>
+            <token skip="-1">mais</token>
+          </antipattern>
+          <antipattern>
+            <token regexp="yes" skip="-1">["«…]</token>
+            <token>,</token>
+            <token>mais</token>
+            <token min="10" skip="-1"/>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token skip="5">mais</token>
+            <token regexp="yes">;</token>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token skip="-1">mais</token>
+            <token spacebefore="no">.</token>
+            <token regexp="yes" spacebefore="no">(?-i)[A-Z].*</token>
+          </antipattern>
+          <antipattern>
+            <token skip="5">,</token>
+            <token>,</token>
+            <token>mais<exception scope="next" regexp="yes">aussi|également|même|lors</exception></token>
+            <token regexp="yes">[a-z].*</token>
+            <token min="20" skip="-1"/>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token postag="P.*" postag_regexp="yes"/>
+            <token postag="[ANJV].*" postag_regexp="yes" skip="-1"/>
+            <token>,</token>
+            <token skip="-1">mais<exception scope="next" regexp="yes">aussi|également|même|lors</exception></token>
+            <token postag="P.*" postag_regexp="yes"/>
+            <token><match no="1"/></token>
+            <token min="20" skip="-1"/>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token min="5" skip="-1"/>
+            <token skip="-1">qui</token>
+            <marker>
+              <token>,</token>
+              <token>mais<exception scope="next" regexp="yes">aussi|également|même|lors</exception></token>
+            </marker>
+            <token min="20" skip="-1"/>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token postag="SENT_START"/>
+            <token min="1" max="19"/>
+            <token>,</token>
+            <token skip="3">mais</token>
+            <token postag="V.* 3 p" postag_regexp="yes"/>
+            <token min="15" skip="-1"/>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token postag="SENT_START" skip="8"/>
+            <token>,</token>
+            <token>mais</token>
+            <token>elles</token>
+            <token min="0" skip="4"/>
+            <token postag="V.* 3 p" postag_regexp="yes"/>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token>mais</token>
+            <token>elles</token>
+            <token min="0" skip="4"/>
+            <token postag="V.* 3 p" postag_regexp="yes" skip="8"/>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token>mais</token>
+            <token>pas</token>
+            <token>seulement</token>
+            <token postag="V.* 3 p" postag_regexp="yes"/>
+          </antipattern>
+          <antipattern>
+            <token postag="SENT_START"/>
+            <token postag="V.*" postag_regexp="yes" skip="-1"><exception postag="V.* inf" postag_regexp="yes"/></token>
+            <token>,</token>
+            <token skip="3">mais</token>
+          </antipattern>
+          <antipattern>
+            <token postag="SENT_START"/>
+            <token inflected="yes" skip="-1">si</token>
+            <token>,</token>
+            <token>mais</token>
+          </antipattern>
+          <antipattern>
+            <token><exception postag="SENT_START"/></token>
+            <token skip="-1">certes</token>
+            <token>,</token>
+            <token skip="3">mais</token>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token skip="2">mais</token>
+            <token inflected="yes">si</token>
+            <token postag="V.* 3 p" postag_regexp="yes"/>
+          </antipattern>
+          <antipattern>
+            <token><exception inflected="yes">que</exception></token>
+            <token><exception postag="[DN].*" postag_regexp="yes"/></token>
+            <token skip="-1">soit</token>
+            <token>,</token>
+            <token skip="3">mais</token>
+          </antipattern>
+          <antipattern>
+            <token>non</token>
+            <token postag="C coor" skip="-1"/>
+            <token>,</token>
+            <token skip="3">mais</token>
+          </antipattern>
+          <antipattern>
+            <token>non</token>
+            <token>parce</token>
+            <token inflected="yes" skip="-1">que</token>
+            <token>,</token>
+            <token skip="3">mais</token>
+          </antipattern>
+          <antipattern>
+            <token postag="SENT_START" skip="8"/>
+            <token>,</token>
+            <token>mais</token>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token skip="3">mais</token>
+            <token postag="V.* 3 p" postag_regexp="yes"/>
+            <token>c'</token>
+            <token postag="V etre.*" postag_regexp="yes" skip="-1"/>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token regexp="yes">c'|ce</token>
+            <token postag="V etre.*" postag_regexp="yes" skip="-1"/>
+            <token>,</token>
+            <token skip="3">mais</token>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token skip="3">mais</token>
+            <token postag="V.* 3 p" postag_regexp="yes" skip="-1"/>
+            <token skip="-1">soit</token>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token skip="3">mais</token>
+            <token>,</token>
+            <token postag="V.* 3 p" postag_regexp="yes"/>
+            <token min="20" skip="-1"/>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token skip="3">mais</token>
+            <token postag="V.* 3 p" postag_regexp="yes" skip="-1"/>
+            <token>mais</token>
+          </antipattern>
+          <antipattern>
+            <token>,</token>
+            <token skip="3">mais</token>
+            <token postag="V.* 3 p" postag_regexp="yes" skip="-1"/>
+            <token skip="-1" regexp="yes">[-–;]</token>
+            <token><exception regexp="yes" spacebefore="no">(?-i)[A-Z].*</exception></token>
+            <token postag="SENT_END"/>
+          </antipattern>
+          <rule>
+            <antipattern>
+              <token min="5" skip="-1"/>
+              <token>,</token>
+              <token>mais</token>
+              <token min="0" max="3">
+                <exception inflected="yes">ne</exception>
+                <exception postag="R pers obj.*" postag_regexp="yes"/></token>
+              <token postag="V.* 3 p" postag_regexp="yes"/>
+              <token min="20" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token>,<exception scope="previous">.</exception></token>
+                <token>mais
+                  <exception scope="next" postag="R pers obj.*" postag_regexp="yes"/>
+                  <exception scope="next" regexp="yes">que|qu'|dont|aussi|également|même|lors|ils|elles|ne|n'|qui</exception></token>
+                <token min="0" skip="3"/>
+                <token postag="V.* 3 p" postag_regexp="yes"><exception postag="[NJ].*" postag_regexp="yes"/></token>
+              </marker>
+              <token min="20" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut apporter une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>. <match no="3" include_skipped="all" case_conversion="startupper"/> \4 cependant</suggestion>
+            <suggestion>. Pourtant, <match no="3" include_skipped="all"/> \4</suggestion>
+            <suggestion>. <match no="3" include_skipped="all" case_conversion="startupper"/> \4</suggestion>
+            <example correction=". Des activités sont cependant|. Pourtant, des activités sont|. Des activités sont">La plupart de ses membres ont un lien avec l'Université Laval<marker>, mais  des activités sont</marker> conduites en collaboration avec des collègues d'autres universités, entre autres, à travers la réalisation de projets de recherche.</example>
+            <example>J'ai fait tout mon possible pour cela, et je pense que vous avez manifesté le plus grand intérêt à appréhender non seulement ces règles, mais également « l'esprit » de cette merveilleuse création du Maître, Zamenhof.</example>
+            <example> L'idée de ruse n'est pas ici à entendre au sens de tromperie ou de fourberie, mais au sens de souplesse épousant la souplesse du monde, de chatoiement se fondant dans le chatoiement.</example>
+            <example>Une toile de selle ou une couverture sert de doublure sous la selle, absorbe la transpiration, mais dans certains cas, les cavaliers mettent plusieurs selles afin de placer une selle trop large sous un dos étroit.</example>
+            <example>L'enfant est retrouvé en fin de soirée sain et sauf, en compagnie de son père, qui n'avait plus la garde de l'enfant, mais un simple droit de visite, et est donc l'auteur de l'enlèvement de l'enfant et de l'assassinat de la mère d'Ibrahim.</example>
+            <example>Il semble donc qu'ils soient descendus de la crête vers le glacier du Trône, mais qu'ils n'aient pas encore atteint les plateaux, situés à une altitude d'environ 6 500 m.Le vent ne s'est pas gêné aujourd'hui, mais la visibilité était mauvaise.</example>
+            <example>Peut-etre pour certains batons en 2 brins...., mais les miens sont en 3 et le perdrais bcp en faisant ainsi.... quoi que.... ca merite d'y regarder de plus pres... mais bon, comme j'ai tjrs mon leathermann...</example>
+            <example>Cet algorithme permet à tous les utilisateurs, mais pas seulement ceux qui suivent, d'avoir une chance que leurs photos soient figurées sur la page des tendances, augmentant ainsi de fait leur popularité.</example>
+            <example>D'autres formats de jeux non sportifs, mais personnalisables, sont pratiqués, le plus souvent dans le cadre d'associations de joueurs affiliés ou non à la Fédération de paintball sportif.</example>
+            <example>Elle fut déchirée avec des crochets de fer et amenée dans les arènes pour y être la proie des bêtes, mais les lions se couchèrent à ses pieds ; elle fut mise sur un bûcher : les flammes ne l'atteignirent pas mais brûlèrent les spectateurs.</example>
+            <example>Dogons et Bozos se moquent réciproquement, mais parallèlement se doivent assistance, et pratiquent traditionnellement un intense commerce par troc de leurs spécialités respectives (poissons bozos contre oignons et outils forgés dogons).</example>
+            <example>Israël accepta cette requête, mais uniquement si ses cendres étaient jetées en dehors de ses eaux territoriales afin d'éviter qu'elles ne « souillent » le territoire de l'État hébreu.</example>
+            <example>La Côte d’Ivoire est certes un État laïc, mais des fonctionnaires sont souvent désignés pour représenter l'État à des cérémonies religieuses et certaines écoles confessionnelles reçoivent des aides financières de l'État.</example>
+            <example>Arrive le cortège des invités de la noce, mais les réjouissances sont interrompues par des soldats commandés par Lotario qui escortent jusqu’au château un prisonnier masqué qui n’est autre que le malheureux Teobaldo.</example>
+            <example>Il y en a de grandes, mais la plupart ne sont que des îlots qui se pressent sur plusieurs rangs le long de la côte et parfois jusqu'à douze ou quinze milles au large.</example>
+            <example>Quelques autres animaux avaient peut-être des ancêtres quadrupèdes, mais leurs pattes sont devenues des structures vestigiales – c’est-à-dire que leurs membres n'ont plus de fonction contrairement à ceux de leurs ancêtres.</example>
+            <example>Je suis désolé de faire cette requête, mais sinon certains diront que je n'ai pas démenti.--Oguh Rotciv (discuter) 3 mars 2019 à 20:58 (CET)</example>
+            <example>Non dans la main des garçons, mais dans leurs yeux, Brilleront les lueurs sacrées des adieux, La pâleur du front des filles sera leur linceul, Leurs fleurs, la tendresse d'esprits silencieux, Et chaque long crépuscule, un rideau qui se clôt.</example>
+            <example>Quand ils ont découvert que les Yaquis n'utilisaient pas de peyotl, mais que les Huichols le faisaient, ils se sont dirigés vers le territoire des Huichols, dans le sud du Mexique, où, selon Fikes, ils ont provoqué de graves perturbations.</example>
+            <example>Un des personnages explique qu'avant ils étaient toute une bande, mais qu'ils sont tous partis, qu'ensuite un Irrégulier (en fait, Wiggins) se prenait pour le chef, puis est parti, ne laissant que Black Tom, Charlotte et Billy Fletcher.</example>
+            <example>Je ne sais pourquoi, mais voyez: beaucoup nous quittent, et cela est dommage, bonne soirée, cordialement, --Joe La Truite(Courriel | Ma rivière) 18 octobre 2009 à 22:23 (CEST)</example>
+            <example>Sa situation financière devient rapidement difficile, car les caisses de la Roumanie victorieuse, mais exsangue, sont vides (tout l’or national roumain, mis à l’abri à Moscou, a été confisqué par les bolchéviks).</example>
+            <example>S’il n’y a pas de ponctuation, mais des phrases qui s’enchaînent en cascade, évoquant du point de vue de la forme un poème en vers libre, c’est, explique Joseph Ponthus, que</example>
+            <example>Ce texte indique que les noms d'Eärendil n'ont pas de véritable traduction sindarine, mais qu'ils sont rendus par les périphrases mír n'Arðon et Seron Aearon ; des formes erronées, influencées par le sindarin, existent également, comme ou .</example>
+            <example>Souvent, mais pas toujours, ils forment ensuite leurs propres groupes pour faire une carrière en leur nom : par exemple John Lennon, Paul McCartney, George Harrison et Pete Best qui étaient sidemen de Tony Sheridan avant de former le groupe The Beatles.</example>
+            <example>Dans un golf très exclusif dont tous les membres sont très riches et excentriques, mais dont tous les employés sont pauvres, Danny Noonan (Michael O'Keefe), un caddy, désire amasser le plus d'argent possible en vue de s'inscrire à la fac.</example>
+            <example>En créature qui existe, mais imaginairement méchante, ils ont inventé Lula, Chavez, et en partie Sadam Hussein, mais je les vois pas avec des oreilles de lapins.</example>
+            <example>Les individus ayant une forte affinité envers les animaux, mais sans attirance sexuelle, peuvent être qualifiés de zoophiles « non-sexuels » (ou « émotionnels »), mais peuvent rejeter le terme « zoophile ».</example>
+            <example>Pionnière dans la 3D, mais dont les limites sont bien connues maintenant, ce système (N64) va donner des jeux aux graphismes très beau, mais rien de bien marquant.</example>
+            <example>À la fin de l’examen, il propose deux solutions : soit il guérit complètement le blessé, mais les soins dureront une année entière, soit il le remet sur pied rapidement, prêt à combattre, mais dans ce cas il meurt trois jours après.</example>
+            <example>Le seul point indiscutable du Livre Noir, mais les psychanalystes n'ont pas attendu le Livre Noir pour le dire eux-mêmes, c'est que la psychanalyse, malgré les croyances premières de Freud et même de Lacan, n'est pas une science, mais une pratique.</example>
+            <example>Par exemple, sur un sujet donné, je commence avec les pages en français, mais certaines pages sont mieux rédigées dans d'autres langues, mais si je clique sur la langue concernée je sors du livre, et je dois recréer un autre livre.</example>
+            <example>Claude Rostand écrit ironiquement : , mais les réactions sont favorables : on trouve des papiers de Jacques Ibert, Ingelbrecht, Darius Milhaud, Gustave Samazeuilh, Florent Schmitt, Émile Vuillermoz.</example>
+            <example>Il est néanmoins moins critique sur les augures romains, non parce qu’il est lui-même augure, mais parce que ceux-ci ne servent pas à dire l’avenir, mais seulement à obtenir l'avis préalable des dieux lors des actes importants des magistrats.></example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token>,</token>
+              <token>mais</token>
+              <token><exception inflected="yes">ne</exception></token>
+              <token min="0" max="2"><exception postag="R pers obj.*" postag_regexp="yes"/></token>
+              <token postag="V.* 3 p" postag_regexp="yes"/>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token>,</token>
+              <token skip="3">mais</token>
+              <token postag="V.* 3 p" postag_regexp="yes"/>
+              <token>cependant</token>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token>,</token>
+              <token>mais</token>
+              <token min="0" max="1"><exception inflected="yes">ne</exception></token>
+              <token min="1" max="2"><exception postag="R pers obj.*" postag_regexp="yes"/></token>
+              <token postag="V.* 3 p" postag_regexp="yes"/>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token>,</token>
+                <token>mais<exception scope="next" regexp="yes">aussi|également|même|lors|ils|elles</exception></token>
+              </marker>
+              <token inflected="yes" min="0" max="3">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="3"/>
+              <token postag="V.* 3 p" postag_regexp="yes"><exception postag="[NJ].*" postag_regexp="yes"/></token>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut apporter une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>. Cependant, ils</suggestion>
+            <suggestion>. Cependant, elles</suggestion>
+            <suggestion>. Pourtant, ils</suggestion>
+            <suggestion>. Pourtant, elles</suggestion>
+            <suggestion>.</suggestion>
+            <example correction=". Cependant, ils|. Cependant, elles|. Pourtant, ils|. Pourtant, elles|.">Les 22 sujets ont continué à prendre cette préparation n'ont pas continué à perdre du poids<marker>, mais</marker> n'en ont pas repris non progression du bol alimentaire hors de l'estomac, ce qui augmenterait la durée de la sensation de satiété et favoriserait la perte de poids.</example>
+            <example>J'ai fait tout mon possible pour cela, et je pense que vous avez manifesté le plus grand intérêt à appréhender non seulement ces règles, mais également « l'esprit » de cette merveilleuse création du Maître, Zamenhof.</example>
+            <example> L'idée de ruse n'est pas ici à entendre au sens de tromperie ou de fourberie, mais au sens de souplesse épousant la souplesse du monde, de chatoiement se fondant dans le chatoiement.</example>
+            <example>Une toile de selle ou une couverture sert de doublure sous la selle, absorbe la transpiration, mais dans certains cas, les cavaliers mettent plusieurs selles afin de placer une selle trop large sous un dos étroit.</example>
+            <example>L'enfant est retrouvé en fin de soirée sain et sauf, en compagnie de son père, qui n'avait plus la garde de l'enfant, mais un simple droit de visite, et est donc l'auteur de l'enlèvement de l'enfant et de l'assassinat de la mère d'Ibrahim.</example>
+            <example>S'ils ont obtenu leur diplôme d'études secondaires aux États-Unis, mais ne se sont pas inscrits dans un collège ou une université américaine, quatre années se sont écoulées depuis leur diplôme au lycée.</example>
+            <example>Ainsi, les autorités fédérales n'ont par exemple pas formulé d'objectif pour la réduction des émissions de gaz à effet de serre, mais ont cependant indiqué que si l'objectif régional n'était pas atteint, ils prendraient des mesures fédérales complémentaires.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token>,</token>
+              <token>mais</token>
+              <token>elles</token>
+              <token min="0" skip="4"/>
+              <token postag="V.* 3 p" postag_regexp="yes" skip="-1"/>
+              <token>:</token>
+              <token>elles</token>
+              <token postag="V.* 3 p" postag_regexp="yes"/>
+              <token postag="A"/>
+            </antipattern>
+            <antipattern>
+              <token>,</token>
+              <token>mais</token>
+              <token>elles</token>
+              <token min="0" skip="4"/>
+              <token postag="V.* 3 p" postag_regexp="yes" skip="-1"/>
+              <token>c'</token>
+              <token postag="V etre.*" postag_regexp="yes"/>
+              <token min="15"/>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token>,</token>
+                <token>mais</token>
+                <token>elles</token>
+                <token min="0" skip="4"/>
+                <token postag="V.* 3 p" postag_regexp="yes"><exception postag="[NJ].*" postag_regexp="yes"/></token>
+              </marker>
+              <token min="20" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut apporter une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>. Elles <match no="4" include_skipped="all"/> \5 cependant</suggestion>
+            <suggestion>. Pourtant, elles <match no="4" include_skipped="all"/> \5</suggestion>
+            <suggestion>. Elles <match no="4" include_skipped="all"/> \5</suggestion>
+            <example correction=". Elles correspondent cependant|. Pourtant, elles correspondent|. Elles correspondent">Les appellations des différents yogas proposés peuvent paraître compliquées<marker>, mais elles correspondent</marker> aux noms des plus grandes écoles de yoga installées principalement en Inde, en France et aux Etats-Unis.</example>
+            <example>Les débutantes sont dans la majorité des cas issues de familles privilégiées, mais elles doivent posséder des qualités qui leur sont propres : elles sont aussi invitées à participer pour ce qu'elles font et ce à quoi elles se destinent.</example>
+            <example>Ah c'est pas du tout dans mes cordes, mais elles sont vraiment magnifiques tes photos, c'est bien ce qui donne envie d'aller en montagne, avant l'aspect sportif proprement dit !</example>
+          </rule>
+          <rule>
+            <pattern>
+              <marker>
+                <token>,</token>
+                <token>mais</token>
+                <token>ils</token>
+                <token min="0" skip="4"/>
+                <token postag="V.* 3 p" postag_regexp="yes"><exception postag="[NJ].*" postag_regexp="yes"/></token>
+              </marker>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut apporter une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>. Ils <match no="4" include_skipped="all"/> \5 cependant</suggestion>
+            <suggestion>. Pourtant, ils <match no="4" include_skipped="all"/> \5</suggestion>
+            <suggestion>. Ils <match no="4" include_skipped="all"/> \5</suggestion>
+            <example correction=". Ils correspondent cependant|. Pourtant, ils correspondent|. Ils correspondent">Les noms des différents yogas proposés peuvent paraître compliqués<marker>, mais ils correspondent</marker> aux noms des plus grandes écoles de yoga installées principalement en Inde, en France et aux Etats-Unis.</example>
+            <example>Également courtisée par Berlioz, elle épouse Camille Pleyel le 5 avril 1831, mais ils se séparent en 1835 ; Pleyel effectuera encore quelques tournées en Europe avant de s'installer en 1847 à Bruxelles, en tant que pédagogue.</example>
+            <example>En plus ils ont un catalogue commun ,avec en théorie les mêmes prix,mais ils font ce qu'ils veulent dans chaque magasin.Et pas question de discuter,alors moi, je fais la visite ,j'essaie tout ce que j'ai envie,et je m'en vais!!!Dommage pour les employés.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token max="15" skip="-1"/>
+              <token>,</token>
+              <token>mais</token>
+              <token max="15"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">comme|non|pas</token>
+              <token regexp="yes" skip="-1">si|seulement</token>
+              <token>,</token>
+              <token>mais</token>
+              <token min="10" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="-1">["«(…]</token>
+              <token>,</token>
+              <token>mais</token>
+              <token min="10" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token skip="5">,</token>
+              <token>,</token>
+              <token>mais<exception scope="next" regexp="yes">aussi|également|même|lors</exception></token>
+              <token regexp="yes">[a-z].*</token>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token postag="P.*" postag_regexp="yes"/>
+              <token postag="[ANJV].*" postag_regexp="yes" skip="-1"/>
+              <token>,</token>
+              <token skip="-1">mais<exception scope="next" regexp="yes">aussi|également|même|lors</exception></token>
+              <token postag="P.*" postag_regexp="yes"/>
+              <token><match no="1"/></token>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token min="5" skip="-1"/>
+              <token skip="-1">qui</token>
+              <token>,</token>
+              <token>mais</token>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token min="15" skip="-1"/>
+              <token>,</token>
+              <token>mais</token>
+              <token inflected="yes" min="0" max="1">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="3"/>
+              <token postag="V.* 3 s" postag_regexp="yes"/>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token min="5" skip="-1"/>
+              <token>,</token>
+              <token>c'</token>
+              <token min="2" max="10"/>
+              <token>,</token>
+              <token>mais</token>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token min="15" skip="-1"/>
+              <token>,</token>
+              <token>mais</token>
+              <token>à</token>
+              <token postag="V.* inf" postag_regexp="yes"/>
+              <token min="13" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token min="15" skip="-1"/>
+              <token>,</token>
+              <token skip="1">mais</token>
+              <token>,</token>
+              <token min="13" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token postag="P"/>
+              <token postag="[NJ].*" postag_regexp="yes"/>
+              <token>,</token>
+              <token skip="1">mais</token>
+              <token><match no="0"/></token>
+              <token postag="[NJ].*" postag_regexp="yes"/>
+              <token min="10" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token max="14"/>
+              <token>,</token>
+              <token>mais</token>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token>,</token>
+              <token skip="1">mais</token>
+              <token postag="R rel.*" postag_regexp="yes" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token>,</token>
+              <token skip="1">mais</token>
+              <token postag="V.* ppr" postag_regexp="yes"/>
+              <token postag="V.* inf" postag_regexp="yes" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token>,</token>
+              <token>mais</token>
+              <token postag="V.* inf" postag_regexp="yes"/>
+              <token><exception postag="A"/></token>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token>,</token>
+              <token>mais</token>
+              <token inflected="yes">ne</token>
+              <token skip="-1"><exception postag="V.* imp.*" postag_regexp="yes"/></token>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token>,</token>
+              <token>mais</token>
+              <token postag="P.*" postag_regexp="yes" skip="-1"><exception regexp="yes">aux?|pour|pendant</exception></token>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token>,</token>
+              <token>mais</token>
+              <token max="8"/>
+              <token skip="-1">:</token>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token>,</token>
+              <token>mais</token>
+              <token>si</token>
+              <token postag="J.*|V.* ppa.*" postag_regexp="yes" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token>,</token>
+                <token>mais<exception scope="next" regexp="yes">bien|non|sous|combien|pas|que|qu'|aussi|également|même|lors|qui|où|surtout|seulement|plutôt</exception></token>
+                <token regexp="yes">[a-z].*<exception postag="V.*|R rel.*|R pers obj.*|J.*" postag_regexp="yes"/></token>
+              </marker>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut induire une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>. Cependant, \3</suggestion>
+            <suggestion>. Pourtant, \3</suggestion>
+            <suggestion>. En revanche, \3</suggestion>
+            <suggestion>. <match no="3" case_conversion="startupper"/></suggestion>
+            <example correction=". Cependant, ils|. Pourtant, ils|. En revanche, ils|. Ils">Le sujet qui a continué à prendre cette préparation n'a pas continué à perdre du poids<marker>, mais ils</marker> n'en a pas repris non progression du bol alimentaire hors de l'estomac, ce qui augmenterait la durée de la sensation de satiété et favoriserait la perte de poids.</example>
+            <example correction=". Cependant, c'|. Pourtant, c'|. En revanche, c'|. C'">Ces armes posent un gros dilemme pour les Britanniques ; La SDB-II est une arme éprouvée et bien adaptée au F-35, car les États-Unis ont déjà prévu de s'en servir sur leurs F-35<marker>, mais c'</marker>est une bombe planante dont la portée n'excède pas les 40 nautiques, alors que l'arme équivalente en cours d'étude chez MBDA devrait être propulsée par un petit turboréacteur et avoir une portée de 70 nautiques[108].</example>
+            <example correction=". Cependant, son|. Pourtant, son|. En revanche, son|. Son">Cette crise de notre temps s'est manifestée dans les grands mouvements historiques que furent les grandes guerres et les mouvements communistes et fascistes<marker>, mais son</marker> origine est liée à l'ensemble du projet moderne que Strauss s'est attaché à examiner.</example>
+            <example correction=". Cependant, pendant|. Pourtant, pendant|. En revanche, pendant|. Pendant">Il estime que pour ce dernier, on emploie, dans les premiers jours de la fabrication, 3 kilogrammes de chaux environ pour 1,000 litres de jus<marker>, mais pendant</marker> la durée et à la fin de la campagne, cette quantité peut s'élever à 6, 8 et même 10 pour 1,000..</example>
+            <example>J'ai fait tout mon possible pour cela, et je pense que vous avez manifesté le plus grand intérêt à appréhender non seulement ces règles, mais également « l'esprit » de cette merveilleuse création du Maître, Zamenhof.</example>
+            <example>C'est un discours totalement contre-productif, car les premières personnes à convaincre, ce ne sont pas les malades, mais bien les médecins des thérapies conventionnelles, qui ont quand même le dernier mot dans la plupart des cas, et ce à juste titre.</example>
+            <example> L'idée de ruse n'est pas ici à entendre au sens de tromperie ou de fourberie, mais au sens de souplesse épousant la souplesse du monde, de chatoiement se fondant dans le chatoiement.</example>
+            <example>Une toile de selle ou une couverture sert de doublure sous la selle, absorbe la transpiration, mais dans certains cas, les cavaliers mettent plusieurs selles afin de placer une selle trop large sous un dos étroit.</example>
+            <example>L'enfant est retrouvé en fin de soirée sain et sauf, en compagnie de son père, qui n'avait plus la garde de l'enfant, mais un simple droit de visite, et est donc l'auteur de l'enlèvement de l'enfant et de l'assassinat de la mère d'Ibrahim.</example>
+            <example>L'ambiguïté tragique, c'est prosaïquement (pardonnez-moi) l'homme qui a "le cul entre deux chaises" et qui souffre de cette cassure entre un monde qu'il récuse, et qui n'existe déjà plus pour lui, et un autre monde auquel il aspire, mais qui n'existe pas encore.</example>
+            <example>“Là”, c'était la Terre Prime où il n'était supposément pas se trouver, mais où il se trouvait quand même parce qu'il avait des choses à y faire.</example>
+            <example>Même si le message en lui-même n'est pas fixé, il doit inviter à ne pas intervenir soi-même, mais à appeler un numéro de téléphone donné.</example>
+            <example>Alors, celui-ci dit : « Désormais, ton nom ne sera plus Jacob, mais Israël, car tu as combattu avec Dieu et les hommes, et tu as vaincu. »</example>
+            <example>Peu à peu, il va être confronté à des faits qui ne relèveront plus de ses compétences d'agents, mais de sa capacité à lutter contre un mal obscur qui semble s'être emparé des forêts alentour de la ville.</example>
+            <example>Ainsi, les autorités fédérales n'ont par exemple pas formulé d'objectif pour la réduction des émissions de gaz à effet de serre, mais ont cependant indiqué que si l'objectif régional n'était pas atteint, ils prendraient des mesures fédérales complémentaires.</example>
+            <example>En dehors de ça, les changements sont très minimes : les coquilles d'habillage de la colonne de direction recevant les commodos ne sont plus en métal, mais en plastique, comme sur les nouvelles Herald (et peut-être sur les dernières Mk2).</example>
+            <example>En effet, lors de son déroulement on se retrouve rapidement avec des branches proposant les mêmes substitutions, mais avec des probabilités différentes : il n'est pas nécessaire de dérouler celles de plus faible probabilité puisqu'elles ne peuvent plus être candidates pour décrire le message le plus probable.</example>
+            <example>Je ne pense pas utiliser les coings ainsi, pas présentables et un peu secs, mais ajouter à une compote de pommes, je suis certaine que ça va etre un régal.</example>
+            <example>À l'origine la molécule avait été découverte dans les années 1960, mais abandonnée parce qu'elle n'était pas rentable, la maladie affectant la plupart du temps des malades pauvres</example>
+            <example>Le but avoué n'est pas de vous apprendre quoi que ce soit de plus, mais bien plus, de partager, entre nous, un moment de Grâce, et d'Éternité, je l'espère.</example>
+            <example>L'humanité, une nouvelle fois, semble glisser vers des frontières sans doute jamais convenues jusqu'à présent, eu égard à la diversité du potentiel établi, mais combien similaires cependant quant aux piètres résultats lorsqu'il s'agit du bonheur des populations ; héritage inéluctable à n'en pas dou-ter, récurant dans sa transmission et à peine nuancé quant à l'agrégat qui le fomente.</example>
+            <example>En fait, d'après ce que j'ai compris, le Village d'Ipsos invite presque tous les soirs de la semaine ceux des Clubs environnants, moyennant un prix d'entrée amical, pour une immense Grave-party, non pas dans ce que vous m'avez montré hier, mais dans un sous-sol sous la grange, cette dernière n'étant que le hall d'entrée de la véritable discothèque. FA?	,</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes">comme|non|pas</token>
+              <token regexp="yes" skip="-1">si|seulement</token>
+              <token>,</token>
+              <token>mais</token>
+              <token min="10" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="-1">["«(…]</token>
+              <token>,</token>
+              <token>mais</token>
+              <token min="10" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token>,</token>
+              <token postag="V.*" postag_regexp="yes"/>
+              <token postag="[ANJ].*" postag_regexp="yes" min="2" max="5"/>
+              <token>,</token>
+              <token>mais</token>
+              <token regexp="yes">[a-z].*</token>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <pattern>
+              <token min="15" skip="-1"/>
+              <marker>
+                <token>,</token>
+                <token>mais</token>
+                <token>sinon</token>
+              </marker>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut apporter une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>. Dans le cas contraire,</suggestion>
+            <suggestion>. Sinon,</suggestion>
+            <example correction=". Dans le cas contraire,|. Sinon,">Les 22 sujets qui ont continué à prendre cette préparation n'ont pas continué à perdre du poids<marker>, mais sinon</marker> il ont pas repris non progression du bol alimentaire hors de l'estomac, ce qui augmenterait la durée de la sensation de satiété et favoriserait la perte de poids.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes">comme|non|pas</token>
+              <token regexp="yes" skip="-1">si|seulement</token>
+              <token>,</token>
+              <token>mais</token>
+              <token min="10" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="-1">["«(…]</token>
+              <token>,</token>
+              <token>mais</token>
+              <token min="10" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token skip="5">,</token>
+              <token>,</token>
+              <token>mais<exception scope="next" regexp="yes">aussi|également|même|lors</exception></token>
+              <token regexp="yes">[a-z].*</token>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token postag="P.*" postag_regexp="yes"/>
+              <token postag="[ANJV].*" postag_regexp="yes" skip="-1"/>
+              <token>,</token>
+              <token skip="-1">mais<exception scope="next" regexp="yes">aussi|également|même|lors</exception></token>
+              <token postag="P.*" postag_regexp="yes"/>
+              <token><match no="1"/></token>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token min="5" skip="-1"/>
+              <token skip="-1">qui</token>
+              <marker>
+                <token>,</token>
+                <token>mais<exception scope="next" regexp="yes">aussi|également|même|lors</exception></token>
+              </marker>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token postag="V.* 3 s" postag_regexp="yes"/>
+              <token postag="A" min="0" max="3"/>
+              <token inflected="yes" skip="-1">que</token>
+              <token>,</token>
+              <token>mais</token>
+              <token inflected="yes" min="0" max="1">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="3"/>
+              <token postag="V.* 3 s" postag_regexp="yes"/>
+            </antipattern>
+            <pattern>
+              <token min="15" skip="-1"/>
+              <marker>
+                <token>,</token>
+                <token>mais<exception scope="next" regexp="yes">aussi|également|même|lors</exception></token>
+              </marker>
+              <token inflected="yes" min="0" max="1">ne</token>
+              <token postag="R pers obj.*" postag_regexp="yes" min="0" max="3"/>
+              <token postag="V.* 3 s" postag_regexp="yes"/>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut apporter une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>. Cependant, il</suggestion>
+            <suggestion>. Cependant, elle</suggestion>
+            <suggestion>. Pourtant, il</suggestion>
+            <suggestion>. Pourtant, elle</suggestion>
+            <suggestion>.</suggestion>
+            <example correction=". Cependant, il|. Cependant, elle|. Pourtant, il|. Pourtant, elle|.">Ce sujet qui a continué à prendre cette préparation n'a pas continué à perdre du poids<marker>, mais</marker> n'en a pas repris non progression du bol alimentaire hors de l'estomac, ce qui augmenterait la durée de la sensation de satiété et favoriserait la perte de poids.</example>
+            <example>J'ai fait tout mon possible pour cela, et je pense que vous avez manifesté le plus grand intérêt à appréhender non seulement ces règles, mais également « l'esprit » de cette merveilleuse création du Maître, Zamenhof.</example>
+            <example> L'idée de ruse n'est pas ici à entendre au sens de tromperie ou de fourberie, mais au sens de souplesse épousant la souplesse du monde, de chatoiement se fondant dans le chatoiement.</example>
+            <example>Une toile de selle ou une couverture sert de doublure sous la selle, absorbe la transpiration, mais dans certains cas, les cavaliers mettent plusieurs selles afin de placer une selle trop large sous un dos étroit.</example>
+            <example>L'enfant est retrouvé en fin de soirée sain et sauf, en compagnie de son père, qui n'avait plus la garde de l'enfant, mais un simple droit de visite, et est donc l'auteur de l'enlèvement de l'enfant et de l'assassinat de la mère d'Ibrahim.</example>
+            <example>Si c'est le jura français, il y a une via dans le doubs, mais limite jura, à nans-sous-sainte-anne, et une à moirans, mais qui doit être fermée à cette saison.</example>
+            <example>Mais ce navire est lent (voguant généralement à , il bat ses records cette nuit-là en atteignant , mais reste bien plus lent que les autres navires) et la présence de glaces le ralentit encore plus.</example>
+            <example>Toutefois, quand Francesco revend le palace à des étrangers, avec la complicité de son cousin Maxence, Claudia est folle de rage et décide de le tuer, mais le fait qu'Annabelle se fasse arrêter par la police la motive à fuir avec son mari Albert.</example>
+            <example>Il n'a pas besoin non plus d'oublier les états antérieurs : il suffit qu'en se rappelant ces états il ne les juxtapose pas à l'état actuel comme un point à un autre point, mais les organise avec lui, comme il arrive quand nous nous rappelons, fondues pour ainsi dire ensemble, les notes d'une mélodie.</example>
+            <example>On découvre entre-temps que Martinez n'a pas été victime d'un empoisonnement accidentel, mais a été bel et bien tué, ce qui donne l'occasion à Penders de menacer d'attaquer la prison pour les conditions inhumaines de détention à l'isolation.</example>
+          </rule>
+          <rule default="off">
+            <antipattern>
+              <token regexp="yes">comme|non|pas</token>
+              <token regexp="yes" skip="-1">si|seulement</token>
+              <token>,</token>
+              <token>mais</token>
+              <token min="10" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="-1">["«(…]</token>
+              <token>,</token>
+              <token>mais</token>
+              <token min="10" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token skip="5">,</token>
+              <token>,</token>
+              <token>mais</token>
+              <token regexp="yes">[a-z].*</token>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token postag="P.*" postag_regexp="yes"/>
+              <token postag="[ANJV].*" postag_regexp="yes" skip="-1"/>
+              <token>,</token>
+              <token skip="-1">mais</token>
+              <token postag="P.*" postag_regexp="yes"/>
+              <token><match no="1"/></token>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token min="5" skip="-1"/>
+              <token skip="-1">qui</token>
+              <marker>
+                <token>,</token>
+                <token>mais</token>
+              </marker>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START" skip="10"/>
+              <token>,</token>
+              <token skip="3">mais</token>
+              <token postag="V.* ppr" postag_regexp="yes"/>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token>,</token>
+                <token>mais</token>
+                <token postag="R pers obj.*" postag_regexp="yes" min="0" max="3">
+                  <exception>en</exception>
+                </token>
+                <token postag="V.* ppr" postag_regexp="yes"/>
+              </marker>
+              <token min="15" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut apporter une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>. Il \3 <match no="4" postag="V (avoir )?(etre )?(ppr)" postag_regexp="yes" postag_replace="V $1$2ind pres 3 s"/></suggestion>
+            <suggestion>. Elle \3 <match no="4" postag="V (avoir )?(etre )?(ppr)" postag_regexp="yes" postag_replace="V $1$2ind pres 3 s"/></suggestion>
+            <example correction=". Il montre|. Elle montre">Pour Golden Tour, elle est plus pailletée et ne frôle jamais le ridicule<marker>, mais montrant</marker> plutôt que quand le kitsch n'est jamais très loin pour une icône à la longue carrière.</example>
+            <example>Je croyais que je ne supportais pas la vue de mon visage, mais en y réfléchissant bien, c'est l'image que les autres me renvoient que je ne supporte pas.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START" skip="10"/>
+              <token regexp="yes">ainsi|cependant|néanmoins|pourtant|désormais|maintenant|ensuite|toutefois|c'est-à-dire|comme|puis</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START" skip="10"/>
+              <token regexp="yes">ainsi|cependant|néanmoins|pourtant|désormais|maintenant|ensuite|toutefois|c'est-à-dire|comme|puis</token>
+              <token>,</token>
+              <token postag="R pers obj.*|V.* pp.*|[NJ].*" postag_regexp="yes"/>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START" skip="10"/>
+              <token>comme</token>
+              <token postag="D.*" postag_regexp="yes"/>
+              <token postag="N.*" postag_regexp="yes"/>
+              <token>,</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START" skip="10"/>
+              <token>désormais</token>
+              <token regexp="yes">(?-i)[A-Z].*</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token regexp="yes" skip="15">lorsque|quand</token>
+              <token regexp="yes">ainsi|cependant|néanmoins|pourtant|désormais|maintenant|ensuite|toutefois|c'est-à-dire|comme|puis</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START" skip="15"/>
+              <token regexp="yes">ainsi|cependant|néanmoins|pourtant|désormais|maintenant|ensuite|toutefois|c'est-à-dire|comme|puis</token>
+              <token postag="V.*" postag_regexp="yes"/>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START" skip="15"/>
+              <token postag="V.*" postag_regexp="yes"/>
+              <token postag="A" min="0" max="3"/>
+              <token regexp="yes">ainsi|cependant|néanmoins|pourtant|désormais|maintenant|ensuite|toutefois|c'est-à-dire|comme|puis</token>
+              <token inflected="yes">que</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START" skip="15"/>
+              <token regexp="yes">ainsi|cependant|néanmoins|pourtant|désormais|maintenant|ensuite|toutefois|c'est-à-dire|comme|puis</token>
+              <token regexp="yes">[;:\(\]\|\.]</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START" skip="3"/>
+              <token skip="15">si</token>
+              <token>comme</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token regexp="yes">[aà]</token>
+              <token>l'</token>
+              <token skip="15">instar</token>
+              <token>comme</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="-1">[;:\(\"\«]</token>
+              <token regexp="yes">ainsi|cependant|néanmoins|pourtant|désormais|maintenant|ensuite|toutefois|c'est-à-dire|comme|puis</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">ainsi|cependant|néanmoins|pourtant|désormais|maintenant|ensuite|toutefois|c'est-à-dire|comme|puis</token>
+              <token>:</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">et|ou</token>
+              <token min="0" max="1">,</token>
+              <token regexp="yes">ainsi|cependant|néanmoins|pourtant|désormais|maintenant|ensuite|toutefois|c'est-à-dire|comme|puis</token>
+            </antipattern>
+            <antipattern>
+              <token postag="V.*" postag_regexp="yes"/>
+              <token min="0" max="1">,</token>
+              <token regexp="yes">ainsi|cependant|néanmoins|pourtant|désormais|maintenant|ensuite|toutefois|c'est-à-dire|comme|puis</token>
+            </antipattern>
+            <antipattern>
+              <token>,</token>
+              <token>comme</token>
+              <token>elle</token>
+              <token>,</token>
+            </antipattern>
+            <antipattern>
+              <token skip="3">comme</token>
+              <token postag="V.*" postag_regexp="yes" inflected="yes">constater</token>
+            </antipattern>
+            <antipattern>
+              <token>comme</token>
+              <token regexp="yes">partout|suit</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token min="10" skip="-1"/>
+              <marker>
+                <token>,<exception scope="previous" regexp="yes">chacun|.|qui|que|mais|car|qu'|si</exception></token>
+              </marker>
+              <token regexp="yes">ainsi|cependant|néanmoins|pourtant|désormais|maintenant|ensuite|toutefois|c'est-à-dire|comme|puis
+                <exception scope="next" postag="R pers obj.*|V.* pp.*|[NJ].*" postag_regexp="yes"/>
+                <exception scope="next" regexp="yes">que|qu'|ne|n'|qui</exception></token>
+              <token min="20" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut apporter une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>.</suggestion>
+            <example correction=".">La plupart de ses membres ont un lien avec l'Université Laval<marker>,</marker> ainsi des activités sont conduites en collaboration avec des collègues d'autres universités, entre autres, à travers la réalisation de projets de recherche.</example>
+            <example>Six d'entre eux, cependant, résistaient encore, ils étaient désignés à l'époque gaz permanents : oxygène, hydrogène, azote, monoxyde de carbone, méthane, monoxyde d'azote.</example>
+            <example>En se plongeant dans des archives privées, ils ont, ainsi, exhumé de nombreuses images inédites qu'ils ont organisées en différentes séquences : les grandes avenues.</example>
+            <example>La première fois qu'il associa Juan Diego à ce thème, cependant, ce n'était pas lors de son premier voyage apostolique au Mexique en 1979, </example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START" skip="10"/>
+              <token regexp="yes" skip="-1">car|ainsi|donc|cependant|néanmoins|pourtant|désormais|maintenant|ensuite|toutefois</token>
+              <token><exception regexp="yes">car|ainsi|donc|cependant|néanmoins|pourtant|désormais|maintenant|ensuite|toutefois</exception></token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START" skip="10"/>
+              <token regexp="yes">car|donc</token>
+              <token>,</token>
+              <token postag="R pers obj.*|V.* pp.*|[NJ].*" postag_regexp="yes"/>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="-1">[;:\(\"\«]</token>
+              <token regexp="yes">car|donc</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token min="10" skip="-1"/>
+              <marker>
+                <token>,<exception scope="previous" regexp="yes">chacun|.</exception></token>
+                <token regexp="yes">car|donc|puisque
+                  <exception scope="next" postag="R pers obj.*|V.* pp.*|[NJ].*" postag_regexp="yes"/>
+                  <exception scope="next" regexp="yes">que|qu'|ne|n'|qui</exception></token>
+              </marker>
+              <token min="20" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut apporter une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>. Ainsi,</suggestion>
+            <suggestion>. En effet,</suggestion>
+            <example correction=". Ainsi,|. En effet,">La plupart de ses membres ont un lien avec l'Université Laval<marker>, car</marker> des activités sont conduites en collaboration avec des collègues d'autres universités, entre autres, à travers la réalisation de projets de recherche.</example>
+            <example>Six d'entre eux, cependant, résistaient encore, ils étaient désignés à l'époque gaz permanents : oxygène, hydrogène, azote, monoxyde de carbone, méthane, monoxyde d'azote.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START" skip="10"/>
+              <token>puisqu'</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START" skip="10"/>
+              <token>puisqu'</token>
+              <token>,</token>
+              <token postag="R pers obj.*|V.* pp.*|[NJ].*" postag_regexp="yes"/>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="-1">[;:\(\"\«]</token>
+              <token>puisqu'</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token min="10" skip="-1"/>
+              <marker>
+                <token>,<exception scope="previous" regexp="yes">chacun|.</exception></token>
+                <token>puisqu'
+                  <exception scope="next" postag="R pers obj.*|V.* pp.*|[NJ].*" postag_regexp="yes"/>
+                  <exception scope="next" regexp="yes">que|qu'|ne|n'|qui</exception></token>
+              </marker>
+              <token min="20" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut apporter une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>. Ainsi, </suggestion>
+            <suggestion>. En effet, </suggestion>
+            <suggestion>. Effectivement, </suggestion>
+            <example correction=". Ainsi, |. En effet, |. Effectivement, ">La plupart de ses membres ont un lien avec l'Université Laval<marker>, puisqu'</marker>il a des activités conduites en collaboration avec des collègues d'autres universités, entre autres, à travers la réalisation de projets de recherche.</example>
+            <example>Six d'entre eux, cependant, résistaient encore, ils étaient désignés à l'époque gaz permanents : oxygène, hydrogène, azote, monoxyde de carbone, méthane, monoxyde d'azote.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token min="10" skip="-1"/>
+              <token postag="[CV].*|R rel.*" postag_regexp="yes"/>
+              <token postag="A" min="0" max="3"/>
+              <token>,</token>
+              <token>en</token>
+              <token regexp="yes">revanche|conséquence|effet|outre</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="-1">[;:\(\"\«]</token>
+              <token>,</token>
+              <token>en</token>
+              <token regexp="yes">revanche|conséquence|effet|outre</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token min="10" skip="-1"/>
+              <marker>
+                <token>,
+                  <exception scope="previous" postag="V.*" postag_regexp="yes"/>
+                  <exception scope="previous" regexp="yes">chacun|.|et|ou|car|mais|où|auquel|auxque(le)?s?|laquelle|lequel|lesquel(le)s?|dont|qui|pour|dans|par</exception></token>
+              </marker>
+              <token>en</token>
+              <token regexp="yes">revanche|conséquence|effet|outre
+                <exception scope="next" postag="R pers obj.*|V.* pp.*|[NJ].*" postag_regexp="yes"/>
+                <exception scope="next" regexp="yes">que|qu'|ne|n'|qui</exception></token>
+              <token min="20" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut apporter une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>.</suggestion>
+            <example correction=".">La plupart de ses membres ont un lien avec l'Université Laval<marker>,</marker> en effet des activités sont conduites en collaboration avec des collègues d'autres universités, entre autres, à travers la réalisation de projets de recherche.</example>
+            <example>Six d'entre eux, cependant, résistaient encore, ils étaient désignés à l'époque gaz permanents : oxygène, hydrogène, azote, monoxyde de carbone, méthane, monoxyde d'azote.</example>
+            <example>En 1983, en effet, il publie avec de grandes difficultés (notamment pour trouver un label), , qui ne bénéficie de quasiment aucune promotion et, par conséquent, de peu de critiques.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="C.*|V.* (ind|con|sub).*|R rel.*" postag_regexp="yes"/>
+              <token postag="A" min="0" max="3"/>
+              <token min="0" max="1">,</token>
+              <token>parce</token>
+              <token>que</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="-1">[;:\(\"\«]</token>
+              <token min="0" max="1">,</token>
+              <token>parce</token>
+              <token>que</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="1">appelé|nommé|simplement</token>
+              <token min="0" max="1">,</token>
+              <token>parce</token>
+              <token>que</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token postag="A inte" skip="-1"/>
+              <token min="0" max="1">,</token>
+              <token>parce</token>
+              <token>que</token>
+            </antipattern>
+            <antipattern>
+              <token>alors</token>
+              <token skip="-1" inflected="yes">que</token>
+              <token min="0" max="1">,</token>
+              <token>parce</token>
+              <token>que</token>
+            </antipattern>
+            <antipattern>
+              <token>alors</token>
+              <token skip="-1" inflected="yes">que</token>
+              <token>parce</token>
+              <token>que</token>
+            </antipattern>
+            <antipattern>
+              <token>mais</token>
+              <token>aussi</token>
+              <token min="0" max="1">,</token>
+              <token>parce</token>
+              <token>que</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token min="10" skip="-1"/>
+              <marker>
+                <token min="0" max="1">,</token>
+                <token>parce</token>
+                <token>que<exception scope="next" postag="R pers obj.*|V.* pp.*|[NJ].*" postag_regexp="yes"/>
+                <exception scope="next" regexp="yes">que|qu'|ne|n'|qui</exception></token>
+              </marker>
+              <token min="20" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut apporter une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>. En effet</suggestion>
+            <suggestion>. Ainsi</suggestion>
+            <suggestion>. Comme</suggestion>
+            <example correction=". En effet|. Ainsi|. Comme">La plupart de ses membres ont un lien avec l'Université Laval<marker>, parce que</marker> des activités sont conduites en collaboration avec des collègues d'autres universités, entre autres, à travers la réalisation de projets de recherche.</example>
+            <example>Six d'entre eux, cependant, résistaient encore, ils étaient désignés à l'époque gaz permanents : oxygène, hydrogène, azote, monoxyde de carbone, méthane, monoxyde d'azote.</example>
+            <example>En 1983, en effet, il publie avec de grandes difficultés (notamment pour trouver un label), , qui ne bénéficie de quasiment aucune promotion et, par conséquent, de peu de critiques.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="[CV].*|R rel.*" postag_regexp="yes"/>
+              <token postag="A" min="0" max="3"/>
+              <token min="0" max="1">,</token>
+              <token>parce</token>
+              <token>que</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="-1">[;:\(\"\«]</token>
+              <token>parce</token>
+              <token>que</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token min="10" skip="-1"/>
+              <marker>
+                <token min="0" max="1">,</token>
+                <token>parce</token>
+                <token>qu'<exception scope="next" postag="R pers obj.*|V.* pp.*|[NJ].*" postag_regexp="yes"/>
+                <exception scope="next" regexp="yes">que|qu'|ne|n'|qui</exception></token>
+              </marker>
+              <token min="20" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut apporter une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>. En effet </suggestion>
+            <suggestion>. Ainsi </suggestion>
+            <suggestion>. Comme </suggestion>
+            <example correction=". En effet |. Ainsi |. Comme ">La plupart de ses membres ont un lien avec l'Université Laval <marker>parce qu'</marker>il a des activités conduites en collaboration avec des collègues d'autres universités, entre autres, à travers la réalisation de projets de recherche.</example>
+            <example>Six d'entre eux, cependant, résistaient encore, ils étaient désignés à l'époque gaz permanents : oxygène, hydrogène, azote, monoxyde de carbone, méthane, monoxyde d'azote.</example>
+            <example>En 1983, en effet, il publie avec de grandes difficultés (notamment pour trouver un label), , qui ne bénéficie de quasiment aucune promotion et, par conséquent, de peu de critiques.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token max="2"/>
+              <token>,</token>
+              <token>par</token>
+              <token regexp="yes">ailleurs|conséquence</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token max="3"/>
+              <token>,</token>
+              <token>par</token>
+              <token regexp="yes">ailleurs|conséquence</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token min="10" skip="-1"/>
+              <token postag="[CV].*|R rel.*" postag_regexp="yes"/>
+              <token postag="A" min="0" max="3"/>
+              <token>,</token>
+              <token>par</token>
+              <token regexp="yes">ailleurs|conséquence</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="-1">[;:\(\"\«]</token>
+              <token>,</token>
+              <token>par</token>
+              <token regexp="yes">ailleurs|conséquence</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token min="10" skip="-1"/>
+              <marker>
+                <token>,
+                  <exception scope="previous" postag="V.*" postag_regexp="yes"/>
+                  <exception scope="previous" regexp="yes">chacun|.|et|ou|car|mais|où|auquel|auxque(le)?s?|laquelle|lequel|lesquel(le)s?|dont|qui|pour|dans|par</exception></token>
+              </marker>
+              <token regexp="yes">par|de</token>
+              <token regexp="yes">ailleurs|conséquent|conséquence|plus
+                <exception scope="next" postag="R pers obj.*|V.* pp.*|[NJ].*" postag_regexp="yes"/>
+                <exception scope="next" regexp="yes">que|qu'|ne|n'|qui</exception></token>
+              <token  postag="R pers suj.*|[PD].*" postag_regexp="yes">
+                <exception regexp="yes">de|d'</exception></token>
+              <token min="20" skip="-1"/>
+              <token postag="SENT_END"><exception>?</exception></token>
+            </pattern>
+            <message>Une phrase longue peut apporter une perte de sens pour le lecteur. Celle-ci peut donc être divisée afin d'apporter de la clarté et du rythme.</message>
+            <suggestion>.</suggestion>
+            <example correction=".">La plupart de ses membres ont un lien avec l'Université Laval<marker>,</marker> par conséquent des activités sont conduites en collaboration avec des collègues d'autres universités, entre autres, à travers la réalisation de projets de recherche.</example>
+            <example>Six d'entre eux, cependant, résistaient encore, ils étaient désignés à l'époque gaz permanents : oxygène, hydrogène, azote, monoxyde de carbone, méthane, monoxyde d'azote.</example>
+            <example>En 1983, en effet, il publie avec de grandes difficultés (notamment pour trouver un label), , qui ne bénéficie de quasiment aucune promotion et, par conséquent, de peu de critiques.</example>
+          </rule>
+        </rulegroup>
+        <rulegroup id="PONCTUATION_DOUBLE" name="ponctuation double" tags="picky">
+          <rule>
+            <antipattern>
+              <token>…</token>
+              <token>…</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">\p{Lu}</token>
+              <token min="1" max="3">+</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">[?\!]</token>
+              <token min="1" max="1"><match no="0"/></token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">.</token>
+              <token min="5" max="10"><match no="0"/></token>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token regexp="yes">[)-,(\:\;\[\]\…\«\»\“\”\’\´\‛\′\‘\?\!]<exception>*</exception></token>
+                <token min="1" max="10"><match no="0"/></token>
+              </marker>
+            </pattern>
+            <message>Le signe de ponctuation semble être répété.</message>
+            <suggestion>\1</suggestion>
+            <example correction=")">Il est arrivé<marker>)))))))</marker>.</example>
+            <example>Le C++ est sur le point d'être mis à jour.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes">["]</token>
+              <token spacebefore="no">"</token>
+              <token regexp="yes">(?-i)\p{Lu}.*</token>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token>"</token>
+                <token spacebefore="no">"</token>
+              </marker>
+            </pattern>
+            <message>Ce signe de ponctuation semble être répété. Pour mettre en valeur un élément, les guillemets français sont plus adaptés.</message>
+            <suggestion>\1</suggestion>
+            <suggestion>«</suggestion>
+            <suggestion>»</suggestion>
+            <example correction='"|«|»'>"Il est arrivé<marker>""</marker>.</example>
+            <example>"D'où vient cette superstition ?""Appelons-la sagesse populaire".</example>
+          </rule>
+          <rule>
+            <pattern>
+              <marker>
+                <token>"</token>
+                <token>"</token>
+              </marker>
+            </pattern>
+            <message>Les guillemets semblent être répétés. Dans un dialogue, il est possible d'insérer un retour à ligne ou un tiret pour plus de clarté.</message>
+            <suggestion> — </suggestion>
+            <example correction=" — ">"Peux-tu me passer le sucre ?<marker>" "</marker>Le voilà."</example>
+            <example correction=" — ">"As-tu la clé?<marker>""</marker>Oui, je l'ai."</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes">[']</token>
+              <token regexp="yes" spacebefore="no">[']</token>
+              <token regexp="yes">\p{Lu}.*</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">[']</token>
+              <token regexp="yes" spacebefore="no">[']</token>
+              <token min="0" max="1">.</token>
+              <token regexp="yes" spacebefore="yes">[']</token>
+              <token regexp="yes">[']</token>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token regexp="yes">[']<exception scope="previous" postag="Y"/></token>
+                <token min="1" max="50" spacebefore="no">'</token>
+              </marker>
+            </pattern>
+            <message>L'apostrophe semble être répétée. Pour mettre en valeur un élément, les guillemets français sont plus adaptés.</message>
+            <suggestion>\1</suggestion>
+            <suggestion>«</suggestion>
+            <suggestion>»</suggestion>
+            <example correction="'|«|»">'Il est arrivé<marker>''</marker>.</example>
+            <example>'Notes on the U.S. Steamer Vixen.' 'Investigation of the Comparative Merits.'</example>
+            <example>Taille des utilisateurs: 4'3''- 5'1''.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <marker>
+                <token regexp="yes">[']</token>
+                <token min="1" max="50" spacebefore="yes">'</token>
+              </marker>
+            </pattern>
+            <message>Les guillemets semblent être répétés. Dans un dialogue, un retour à ligne peut être inséré pour plus de clarté.</message>
+            <suggestion>\1</suggestion>
+            <suggestion>«</suggestion>
+            <suggestion>»</suggestion>
+            <example correction="'|«|»">'Il est arrivé<marker>' '</marker>.</example>
+            <example>Ils ont l''air de te faire confiance.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes" min="1" max="2">["'«\»\“\”\’\´\‛\′\‘]</token>
+              <token postag="M fin"/>
+              <token postag="SENT_END" regexp="yes">["'«\»\“\”\’\´\‛\′\‘]</token>
+            </antipattern>
+            <pattern>
+              <token regexp="yes" min="1" max="2">["']</token>
+              <token regexp="yes" skip="-1">(?-i)\p{Lu}.*</token>
+              <marker>
+                <token regexp="yes" min="1" max="2">["']</token>
+                <token postag="M fin"/>
+                <token regexp="yes" min="1" max="2">["']</token>
+              </marker>
+            </pattern>
+            <message>Les guillemets semblent être répétés. Dans un dialogue, il est possible d'insérer un retour à ligne ou un tiret pour plus de clarté.</message>
+            <suggestion>. — </suggestion>
+            <example correction=". — ">''Mon père ne boit pas<marker>''. ''</marker>Mon père ne boit pas non plus''.</example>
+            <example>Notre statut indique :"L'ensemble des 6 AG Régionales fera office d'assemblée générale annuelle". "</example>
+          </rule>
+          <rule>
+            <pattern>
+              <marker>
+                <token regexp="yes">["»]</token>
+                <token>—</token>
+                <token regexp="yes">["«]
+                  <exception scope="next" regexp="yes">\p{Lu}</exception>
+                  <exception scope="next">the</exception>
+                </token>
+              </marker>
+            </pattern>
+            <message>Dans un dialogue, il est possible d'insérer un retour à ligne ou un tiret pour plus de clarté.</message>
+            <suggestion> — </suggestion>
+            <example correction=" — ">"Peux-tu me passer le sucre ?<marker>» — «</marker>Le voilà."</example>
+            <example>« A » — « M »</example>
+            <example>Recipient of "China academy Awards" — "The Outstanding Works in Animation Award".</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes" skip="-1">["'«\»\“\”\’\´\‛\′\‘]</token>
+              <token regexp="yes" skip="-1">["'«\»\“\”\’\´\‛\′\‘]</token>
+              <token regexp="yes">["'«\»\“\”\’\´\‛\′\‘]</token>
+              <token postag="M fin"/>
+              <token postag="SENT_END" regexp="yes">["'«\»\“\”\’\´\‛\′\‘]</token>
+            </antipattern>
+            <pattern>
+              <token regexp="yes" min="1" max="2">["'«\»\“\”\’\´\‛\′\‘]</token>
+              <token regexp="yes" skip="-1">(?-i)[A-Z].*</token>
+              <marker>
+                <token regexp="yes" min="1" max="2">["'«\»\“\”\’\´\‛\′\‘]</token>
+                <token postag="M fin"/>
+                <token postag="SENT_END" regexp="yes">["'«\»\“\”\’\´\‛\′\‘]</token>
+              </marker>
+            </pattern>
+            <message>Les guillemets semblent être répétés.</message>
+            <suggestion>.</suggestion>
+            <example correction=".">"Mon père ne boit pas<marker>'. "</marker></example>
+          </rule>
+          <rule>
+            <pattern>
+              <token postag="SENT_START"/>
+              <marker>
+                <token>"</token>
+              </marker>
+              <token regexp="yes" skip="-1">[a-z].*</token>
+              <token>»</token>
+              <token postag="SENT_END"/>
+            </pattern>
+            <message>Les guillemets français semblent plus appropriés.</message>
+            <suggestion>«</suggestion>
+            <example correction="«"><marker>"</marker> J'aurais du retard ».</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token>:</token>
+              <marker>
+                <token>"</token>
+              </marker>
+              <token regexp="yes" skip="-1">[a-z].*</token>
+              <token>»</token>
+              <token postag="SENT_END"/>
+            </pattern>
+            <message>Les guillemets français semblent plus appropriés.</message>
+            <suggestion>«</suggestion>
+            <example correction="«">Il m'a dit : <marker>"</marker> J'aurais du retard ».</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token><exception>:</exception></token>
+              <token>«</token>
+              <token regexp="yes" skip="-1">[a-z].*</token>
+              <token regexp="yes">[a-z].*|[\.\?\!]</token>
+              <token>"</token>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token>«</token>
+              <token regexp="yes" skip="-1">[a-z].*</token>
+              <token><exception regexp="yes">[a-z].*|[\.\?\!]</exception></token>
+              <token>"</token>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <pattern>
+              <token>:</token>
+              <token skip="-1">«</token>
+              <marker>
+                <token>"</token>
+              </marker>
+              <token postag="SENT_END"/>
+            </pattern>
+            <message>Les guillemets français semblent plus appropriés.</message>
+            <suggestion>»</suggestion>
+            <example correction="»">Il m'a dit : « J'aurais du retard.<marker>"</marker>.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token><exception>:</exception></token>
+              <token>«</token>
+              <token regexp="yes" skip="-1">[a-z].*</token>
+              <token regexp="yes">[a-z].*|[\.\?\!]</token>
+              <token>"</token>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <antipattern>
+              <token>«</token>
+              <token regexp="yes" skip="-1">[a-z].*</token>
+              <token><exception regexp="yes">[a-z].*|[\.\?\!]</exception></token>
+              <token>"</token>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <token skip="-1">«</token>
+              <marker>
+                <token>"</token>
+              </marker>
+              <token postag="SENT_END" regexp="yes">[\.\?\!]</token>
+            </pattern>
+            <message>Les guillemets français semblent plus appropriés.</message>
+            <suggestion>»</suggestion>
+            <example correction="»">« J'aurais du retard.<marker>"</marker>.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token><exception postag="SENT_START"/></token>
+              <token regexp="yes">[\«\"]</token>
+              <token regexp="yes" skip="-1">[a-z].*</token>
+              <token regexp="yes">[a-z].*|[\.\?\!]</token>
+              <token>"</token>
+              <token postag="SENT_END"/>
+            </antipattern>
+            <pattern>
+              <token regexp="yes">[a-z].*|[\.\?\!]</token>
+              <marker>
+                <token>"</token>
+              </marker>
+              <token postag="SENT_END"/>
+            </pattern>
+            <message>Les guillemets français semblent plus appropriés.</message>
+            <suggestion>»</suggestion>
+            <example correction="»">« J'aurais du retard.<marker>"</marker>.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes" spacebefore="no">[´‘′`']|"</token>
+              <token regexp="yes" spacebefore="yes">[a-z].*</token>
+            </antipattern>
+            <antipattern>
+              <token spacebefore="no">"</token>
+              <token regexp="yes" spacebefore="yes" skip="-1">[a-z].*</token>
+              <token>"</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" spacebefore="no">[´‘′`']|"</token>
+              <token></token>
+              <token regexp="yes" spacebefore="no">[´‘′`']|"</token>
+              <token regexp="yes" spacebefore="yes">[a-z].*</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">\d.*</token>
+              <token regexp="yes" spacebefore="no">[´‘′`']|"</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="20">"</token>
+              <token regexp="yes" spacebefore="no">[´‘′`']|"</token>
+              <token regexp="yes" spacebefore="yes">[a-z].*</token>
+            </antipattern>
+            <pattern>
+              <token regexp="yes">[´‘′`']|"
+                <exception scope="previous" regexp="yes">\d.*</exception></token>
+              <token regexp="yes" spacebefore="yes">[a-z].*</token>
+            </pattern>
+            <message>L'espace doit être omise.</message>
+            <suggestion>\1\2</suggestion>
+            <example correction="'Ainsi"><marker>' Ainsi</marker>, il est grand'.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token skip="-1">«</token>
+              <token spacebefore="yes" regexp="yes">['"]</token>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes" skip="-1">['"]</token>
+              <token>»</token>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token spacebefore="yes" regexp="yes">['"]</token>
+                <token regexp="yes">[a-z].*
+                  <exception>n</exception>
+                  <exception postag="UNKNOWN"/></token>
+                <token regexp="yes">['"]</token>
+              </marker>
+            </pattern>
+            <message>Utiliser les guillemets français pour un style soigné.</message>
+            <suggestion>« \2 »</suggestion>
+            <example correction="« Charles »">Il s'appelle <marker>" Charles "</marker>.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token skip="-1">«</token>
+              <token spacebefore="yes" regexp="yes">['"]</token>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes" skip="-1">['"]</token>
+              <token>»</token>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token spacebefore="yes" regexp="yes">['"]</token>
+                <token regexp="yes">[a-z].*
+                  <exception regexp="yes">[dlmtscnj]'</exception>
+                  <exception postag="UNKNOWN"/></token>
+                <token regexp="yes">[a-z].*
+                  <exception postag="UNKNOWN"/></token>
+                <token regexp="yes">['"]</token>
+              </marker>
+            </pattern>
+            <message>Utiliser les guillemets français pour un style soigné.</message>
+            <suggestion>« \2 \3 »</suggestion>
+            <example correction="« Charles Dupont »">Il s'appelle <marker>" Charles Dupont "</marker>.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token skip="-1">«</token>
+              <token spacebefore="yes" regexp="yes">['"]</token>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes" skip="-1">['"]</token>
+              <token>»</token>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token spacebefore="yes" regexp="yes">['"]</token>
+                <token regexp="yes">[dlmtscnj]'</token>
+                <token regexp="yes">[a-z].*</token>
+                <token regexp="yes">['"]</token>
+              </marker>
+            </pattern>
+            <message>Utiliser les guillemets français pour un style soigné.</message>
+            <suggestion>« \2\3 »</suggestion>
+            <example correction="« L'hortensia »">Il s'appelle <marker>" L'hortensia "</marker>.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes">['"]</token>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes" min="0" max="1">[a-z].*</token>
+              <token regexp="yes">['"]</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_START"/>
+              <marker>
+                <token regexp="yes">['"]</token>
+                <token regexp="yes">[a-z].*</token>
+              </marker>
+            </pattern>
+            <message>Utiliser les guillemets français pour un style soigné.</message>
+            <suggestion>« \3</suggestion>
+            <example correction="« Bonjour"><marker>"Bonjour</marker>, Monsieur Dupont. »</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes">['"]</token>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes" min="0" max="1">[a-z].*</token>
+              <token regexp="yes">['"]</token>
+            </antipattern>
+            <pattern>
+              <token>(</token>
+              <marker>
+                <token regexp="yes">['"]</token>
+                <token regexp="yes">[a-z].*<exception postag="UNKNOWN"/></token>
+              </marker>
+            </pattern>
+            <message>Utiliser les guillemets français pour un style soigné.</message>
+            <suggestion>« \3</suggestion>
+            <example correction="« Bonjour">(<marker>"Bonjour</marker>, Monsieur Dupont. »)</example>
+          </rule>
+          <rule>
+            <antipattern><!-- smilies: ":-)"-->
+              <token regexp="yes">[;:\)]</token>
+              <token spacebefore="no">
+                <exception>"</exception></token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">['"]</token>
+              <token regexp="yes" skip="-1">[–\-]</token>
+              <token regexp="yes">['"]</token>
+              <example>Il m'a dit : "- Bonjour, Monsieur".</example>
+            </antipattern>
+            <antipattern>
+              <token skip="-1" regexp="yes">['"]</token>
+              <token skip="-1">…</token>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes">['"]</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">['"]</token>
+              <token regexp="yes" min="1" max="2">[a-z].*</token>
+              <token regexp="yes">['"]</token>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token regexp="yes">[a-z].*</token>
+                <token regexp="yes">['"]</token>
+              </marker>
+              <token regexp="yes">[,.;:\)…\!\?\]].*|[–\-]</token>
+            </pattern>
+            <message>Utiliser les guillemets français pour un style soigné.</message>
+            <suggestion>\1 »</suggestion>
+            <example correction="Bonjour »">« <marker>Bonjour "</marker>, voici le mot de salutation français.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes">['"]</token>
+              <token postag="SENT_END" regexp="yes">['"]</token>
+            </antipattern>
+            <pattern>
+              <token postag="SENT_END" regexp="yes">['"]</token>
+            </pattern>
+            <message>Utiliser les guillemets français pour un style soigné.</message>
+            <suggestion>»</suggestion>
+            <example correction="»">« Qui a dit cela ? <marker>"</marker></example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token spacebefore="yes" regexp="yes">['"]</token>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes" min="0" max="1">[a-z].*</token>
+              <token regexp="yes">['"]</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token regexp="yes">['"]</token>
+              <token regexp="yes">[a-z].*</token>
+            </antipattern>
+            <antipattern>
+              <token>(</token>
+              <token regexp="yes">['"]</token>
+              <token regexp="yes">[a-z].*</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes">['"]</token>
+              <token regexp="yes">[,.;:\)…\!\?\]].*|[–\-]</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_END" regexp="yes">['"]</token>
+            </antipattern>
+            <antipattern>
+              <token>"</token>
+              <token>"</token>
+            </antipattern>
+            <antipattern>
+              <token>"</token>
+              <token spacebefore="no" regexp="yes">[a-z].*</token>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token>"</token>
+              </marker>
+            </pattern>
+            <message>Utiliser les guillemets français pour un style soigné.</message>
+            <suggestion>«</suggestion>
+            <suggestion>»</suggestion>
+            <example correction="«|»">Il s'appelle <marker>"</marker> Charles du Château Bleu ".</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token spacebefore="yes" regexp="yes">['"]</token>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes" min="0" max="1">[a-z].*</token>
+              <token regexp="yes">['"]</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_START"/>
+              <token regexp="yes">['"]</token>
+              <token regexp="yes">[a-z].*</token>
+            </antipattern>
+            <antipattern>
+              <token>(</token>
+              <token regexp="yes">['"]</token>
+              <token regexp="yes">[a-z].*</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes">[a-z].*</token>
+              <token regexp="yes">['"]</token>
+              <token regexp="yes">[,.;:\)…\!\?\]].*|[–\-]</token>
+            </antipattern>
+            <antipattern>
+              <token postag="SENT_END" regexp="yes">['"]</token>
+            </antipattern>
+            <antipattern>
+              <token>"</token>
+              <token>"</token>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token>"</token>
+              </marker>
+              <token spacebefore="no" regexp="yes">[a-z].*</token>
+            </pattern>
+            <message>Utiliser les guillemets français pour un style soigné.</message>
+            <suggestion>« </suggestion>
+            <suggestion>» </suggestion>
+            <example correction="« |» ">Il s'appelle <marker>"</marker>Charles du Château Bleu".</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes" skip="-1">[«]</token>
+              <token regexp="yes" skip="-1">[\»\«]</token>
+              <token regexp="yes">[»]</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="-1">[«]</token>
+              <token regexp="yes">[«]</token>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token regexp="yes" skip="-1">[»]</token>
+              </marker>
+              <token regexp="yes">[»]</token>
+            </pattern>
+            <message>Dans un dialogue, il est possible d'insérer un retour à ligne ou un tiret pour plus de clarté.</message>
+            <suggestion>«</suggestion>
+            <example correction="«">C'est le <marker>»</marker> fer de lance » de cette campagne.</example>
+          </rule>
+          <rule>
+            <antipattern>
+              <token regexp="yes" skip="-1">[«"]</token>
+              <token regexp="yes" skip="-1">[»"]</token>
+            </antipattern>
+            <antipattern>
+              <token regexp="yes" skip="-1">[«"]</token>
+              <token>'</token>
+              <token>'</token>
+            </antipattern>
+            <antipattern>
+              <token skip="1">'</token>
+              <token regexp="yes">[«"]</token>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token regexp="yes" skip="-1">[«"]
+                  <exception scope="previous" postag="[YK]" postag_regexp="yes"/>
+                </token>
+              </marker>
+              <token postag="SENT_END"/>
+            </pattern>
+            <message>Ce signe doit être supprimé.</message>
+            <example correction="">Alors, qu'est-ce que ça veut dire d'<marker>«</marker> être aimé.</example>
+          </rule>
+        </rulegroup>
     </category>
     <category id="REPETITIONS_STYLE" name="repetitions style" type="style" tone_tags="clarity">
     <!--This category has been tagged as clarity, but "picky" tag will likely be replaced by "formal" tone tag in the near future-->


### PR DESCRIPTION
In the context of:https://github.com/languagetooler-gmbh/languagetool-premium/issues/5842
More details in https://docs.google.com/spreadsheets/d/18ZEBC_s8MxBW4HwIi_TIoRfLU2UM8ih8Kwg4Gr4H3I0/edit?usp=sharing

Moving Premium **grammar** rules to OS **style** rules
- PONCTUATION_DOUBLE
- POINT_MAIS
- VIRGULE_EXPRESSIONS_FIGEES

PR for Premium:
https://github.com/languagetooler-gmbh/languagetool-premium-modules/pull/667