### PR TITLE
[fr] OS from Premium grammar -> style AND grammar rules migration

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -23164,18 +23164,6 @@ USA
             <suggestion>—</suggestion>
             <example correction="—">Il est grand <marker>--</marker> fort intelligent.</example>
           </rule>
-          <rule>
-            <pattern>
-              <token>-
-                <exception scope="previous">-</exception></token>
-              <token>-</token>
-              <token>-
-                <exception scope="next">-</exception></token>
-            </pattern>
-            <message>Un tiret long peut sembler plus approprié.</message>
-            <suggestion>—</suggestion>
-            <example correction="—">Il est grand <marker>---</marker> fort intelligent.</example>
-          </rule>
         </rulegroup>
     </category>
     <category id="REPETITIONS_STYLE" name="repetitions style" type="style" tone_tags="clarity">

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -23116,6 +23116,67 @@ USA
             <example correction="Marie.|Marie,">Bonjour, <marker>Marie ;</marker></example>
           </rule>
         </rulegroup>
+        <rulegroup id="TIRET_LONG" name="tiret long" tone_tags="formal">
+          <rule>
+            <antipattern>
+              <token regexp="yes">sainte?</token>
+              <token>-</token>
+              <token postag="Z.*" postag_regexp="yes"/>
+            </antipattern>
+            <pattern>
+              <marker>
+                <token regexp="yes">[a-z].*
+                  <exception postag="UNKNOWN"/></token>
+                <token spacebefore="yes">-</token>
+                <token spacebefore="yes" regexp="yes" case_sensitive="yes">[A-Z].*
+                  <exception postag="UNKNOWN"/></token>
+              </marker>
+            </pattern>
+            <message>Un tiret long ou un autre signe de ponctuation plus approprié, car le trait d'union ne s'utilise que pour former un mot.</message>
+            <suggestion>\1 — \3</suggestion>
+            <suggestion>\1 – \3</suggestion>
+            <suggestion>\1 : \3</suggestion>
+            <suggestion>\1. \3</suggestion>
+            <suggestion>\1 (\3</suggestion>
+            <suggestion>\1) \3</suggestion>
+            <url>https://www.academie-francaise.fr/tiret-pour-trait-dunion</url>
+            <example correction="ange — Bleu|ange – Bleu|ange : Bleu|ange. Bleu|ange (Bleu|ange) Bleu">Il a vu un <marker>ange - Bleu</marker>, je crois — passé devant lui.</example>
+            <example>Puis il se rendit à Saint - Louis.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token>-
+                <exception scope="previous">-</exception></token>
+              <token>-</token>
+              <token>-
+                <exception scope="next">-</exception></token>
+            </pattern>
+            <message>Un tiret long peut sembler plus approprié.</message>
+            <suggestion>—</suggestion>
+            <example correction="—">Il est grand <marker>---</marker> fort intelligent.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token>-<exception scope="previous">-</exception></token>
+              <token>-<exception scope="next">-</exception></token>
+            </pattern>
+            <message>Un tiret long peut sembler plus approprié.</message>
+            <suggestion>—</suggestion>
+            <example correction="—">Il est grand <marker>--</marker> fort intelligent.</example>
+          </rule>
+          <rule>
+            <pattern>
+              <token>-
+                <exception scope="previous">-</exception></token>
+              <token>-</token>
+              <token>-
+                <exception scope="next">-</exception></token>
+            </pattern>
+            <message>Un tiret long peut sembler plus approprié.</message>
+            <suggestion>—</suggestion>
+            <example correction="—">Il est grand <marker>---</marker> fort intelligent.</example>
+          </rule>
+        </rulegroup>
     </category>
     <category id="REPETITIONS_STYLE" name="repetitions style" type="style" tone_tags="clarity">
     <!--This category has been tagged as clarity, but "picky" tag will likely be replaced by "formal" tone tag in the near future-->


### PR DESCRIPTION
In the context of:https://github.com/languagetooler-gmbh/languagetool-premium/issues/5842
More details in https://docs.google.com/spreadsheets/d/18ZEBC_s8MxBW4HwIi_TIoRfLU2UM8ih8Kwg4Gr4H3I0/edit?usp=sharing

Moving Premium **grammar** rules to OS **style** rules
- TIRET ([⚠️](https://emojipedia.org/fr/symbole-d-avertissement/)now **TIRET_LONG**) subrules 12,17,18 about "tiret long"

Moving Premium **grammar** rules to OS **grammar** rules
- TIRET all other subrules

PR for Premium:
https://github.com/languagetooler-gmbh/languagetool-premium-modules/pull/668