### PR TITLE
[pt] Require upcasing after initial dashes

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/UppercaseSentenceStartRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/UppercaseSentenceStartRule.java
@@ -217,7 +217,20 @@ public class UppercaseSentenceStartRule extends TextLevelRule {
   }
 
   private boolean isQuoteStart(String word) {
-    return StringUtils.equalsAny(word, "\"", "'", "„", "»", "«", "“", "‘", "¡", "¿");
+    String[] baseQuoteStrings = { "\"", "'", "„", "»", "«", "“", "‘", "¡", "¿" };
+    // pt-BR uses dashes to introduce dialogue >:(
+    // will keep it separate as other locales may expect line-initial m-dashes
+    // in enumerations not to introduce capital letters
+    String[] searchStrings;
+    if (language.getShortCode().equals("pt")) {
+      String[] portugueseDialogueDashes = { "-", "–", "—" };
+      searchStrings = new String[baseQuoteStrings.length + portugueseDialogueDashes.length];
+      System.arraycopy(baseQuoteStrings, 0, searchStrings, 0, baseQuoteStrings.length);
+      System.arraycopy(portugueseDialogueDashes, 0, searchStrings, baseQuoteStrings.length, portugueseDialogueDashes.length);
+    } else {
+      searchStrings = baseQuoteStrings;
+    }
+    return StringUtils.equalsAny(word, searchStrings);
   }
 
   @Override

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/UppercaseSentenceStartRuleTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/UppercaseSentenceStartRuleTest.java
@@ -40,6 +40,8 @@ public class UppercaseSentenceStartRuleTest {
     assertEquals(1, lt.check("languagetool.org is a website.").size());
     assertEquals(1, lt.check("a sentence.").size());
     assertEquals(1, lt.check("a sentence!").size());
+    assertEquals(0, lt.check("— Dash introducing enumeration item!").size());
+    assertEquals(0, lt.check("— dash introducing enumeration item!").size());
     lt.disableRule("EN_CASE_AFTER_SALUTATION");
     assertEquals(0, lt.check("Hi Mr. Miller,\n\n\u00A0\n\nhow are you?").size());  // special case for paste from e.g. Outlook
   }

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/UppercaseSentenceStartRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/UppercaseSentenceStartRuleTest.java
@@ -1,0 +1,62 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2005 Daniel Naber (http://www.danielnaber.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.pt;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.languagetool.JLanguageTool;
+import org.languagetool.Languages;
+import org.languagetool.TestTools;
+
+public class UppercaseSentenceStartRuleTest {
+
+  @Test
+  public void testUppercaseRule() throws IOException {
+    JLanguageTool lt = new JLanguageTool(Languages.getLanguageForShortCode("pt"));
+    TestTools.disableAllRulesExcept(lt, "UPPERCASE_SENTENCE_START");
+
+    assertEquals(1, lt.check("hora de começar").size());
+
+    assertEquals(0, lt.check("palavra").size());  // not a real sentence
+    assertEquals(0, lt.check("Frase").size());
+
+    assertEquals(0, lt.check("Começamos uma frase. E agora vem a outra.").size());
+    assertEquals(0, lt.check("Mais outra frase. Âmbar é meu álbum favorito da Bethânia.").size());
+    assertEquals(0, lt.check("Agora com abreviaturas, p. ex. esta.").size());
+    assertEquals(0, lt.check("Agora com aspas. \"Essas aqui!\".").size());
+    assertEquals(0, lt.check("\"Aspas desde o começo!\"").size());
+    assertEquals(0, lt.check("— Esta, com travessão (M), é nova!").size());
+    assertEquals(0, lt.check("– Esta, com travessão (N), é nova!").size());
+    assertEquals(0, lt.check("- Esta, com travessão (H), é nova!").size());
+    assertEquals(0, lt.check("Prezado Dr. Stein,\ngostaria de marcar uma nova data.").size());
+
+    assertEquals(1, lt.check("legal!").size());
+    assertEquals(1, lt.check("Começamos uma frase. e agora vem a outra.").size());
+    assertEquals(1, lt.check("Mais outra frase. âmbar é meu álbum favorito da Bethânia.").size());
+    assertEquals(1, lt.check("Agora com aspas. \"essas aqui!\".").size());
+    assertEquals(1, lt.check("\"aspas desde o começo!\"").size());
+    assertEquals(1, lt.check("— esta, com travessão, é nova!").size());
+    assertEquals(1, lt.check("– esta, com travessão, é nova!").size());
+    assertEquals(1, lt.check("- esta, com travessão, é nova!").size());
+  }
+
+}


### PR DESCRIPTION
 - pt-BR introduces dialogue with dash chars, so we need to check if the first char after a sentence-initial dash is uppercase;

 - add hyphen, n-dash, and m-dash to `UppercaseSentenceStartRule` logic *only if* the locale is Portuguese (must add all three because the rule to convert them to m-dashes is (and should be) `picky`);

 - we recognise other locales may not want that behaviour, so that's PT-only, which requires some goofy logic, but I always prefer goofiness to repeating strings, where applicable;

 - add a PT test class for this, and add a couple of tests to EN just to be sure everything is as it should be.