### PR TITLE
[de] add SoSe/WiSe to spelling ignorelist

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/ignore.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/ignore.txt
@@ -1961,3 +1961,5 @@ Snatch #name
 INDOOR
 OUTDOOR
 into #eng
+SoSe #abk
+WiSe #abk


### PR DESCRIPTION
Der Ist-Zustand:

> SoSe 2024 [true-negative]
> **WiSe** 2024 [false-positive]

Ich habe direkt beide hinzugefügt, nur um sicherzugehen.

Falls das nicht allgemein bekannt ist:
SoSe = Sommersemester, WiSe = Wintersemester