### PR TITLE
[fr] Rule linking OS CW22

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -23266,7 +23266,7 @@ USA
                 <example correction="afin de|pour|de façon à|ainsi">Il le dit <marker>de manière à</marker> réussir son projet.</example>
             </rule>
         </rulegroup>
-        <rulegroup id="REP_CONCEQUENCE" name="conséquence (style)" min_prev_matches="1">
+        <rulegroup id="REP_CONSEQUENCE" name="conséquence (style)" min_prev_matches="1">
             <antipattern>
                 <token regexp="yes">voies?</token>
                 <token>de</token>

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -22974,6 +22974,7 @@ USA
             </pattern>
             <message>Une virgule est conseillée avant cette expression afin d'apporter du rythme à votre phrase.</message>
             <suggestion>, \2</suggestion>
+            <url>https://languagetool.org/insights/fr/poste/synonyme-par-consequent/</url>
             <example correction=", par">Marie<marker> par</marker> ailleurs n'a pas pu répondre à la question.</example>
           </rule>
           <rule>
@@ -26064,7 +26065,7 @@ USA
             <suggestion>ainsi</suggestion>
             <suggestion>donc</suggestion>
             <suggestion>alors</suggestion>
-            <url>https://languagetool.org/insights/fr/poste/ainsi-9-synonymes-indispensables/</url>
+            <url>https://languagetool.org/insights/fr/poste/synonyme-par-consequent/</url>
             <example correction="ainsi|donc|alors">Il est devenu important <marker>par conséquent</marker> les sondages sont positifs.</example>
         </rule>
         <rulegroup id="REP_IL_S_AGIT" name="il s'agit de (style)" min_prev_matches="1" tags="picky">

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -23266,7 +23266,7 @@ USA
                 <example correction="afin de|pour|de façon à|ainsi">Il le dit <marker>de manière à</marker> réussir son projet.</example>
             </rule>
         </rulegroup>
-        <rulegroup id="REP_CONSEQUENCE" name="conséquence (style)" min_prev_matches="1">
+        <rulegroup id="REP_CONCEQUENCE" name="conséquence (style)" min_prev_matches="1" tags="picky">
             <antipattern>
                 <token regexp="yes">voies?</token>
                 <token>de</token>


### PR DESCRIPTION
To address: https://github.com/languagetooler-gmbh/languagetool-premium/issues/5043

4 rules have been linked to blog posts, one of the rules already had an blog article url, but the new blog article seems to fit better.

Typo in rule ID fixed