### PR TITLE
[pt] Add APs to ACCENTUATED_PARONYMS_DE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -21918,6 +21918,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
         <rulegroup id="ACCENTUATED_PARONYMS_DE" name="Confusão De - Dê">
+            <antipattern>
+                <token>de</token>
+                <token regexp="yes">qualquer|nenhum|algum</token>
+                <token>jeito</token>
+                <example>Não quero que de jeito nenhum ele fique.</example>
+            </antipattern>
+            <antipattern>
+                <token>de</token>
+                <token>jeito</token>
+                <token regexp="yes">qualquer|nenhum|algum</token>
+                <example>Não queria que o usasse de qualquer jeito.</example>
+            </antipattern>
             <rule>
                 <pattern>
                     <token regexp="yes">


### PR DESCRIPTION
Addressing a couple of temp disables for stuff like `que de jeito nenhum`. Technically those should be surrounded by commas but that's a different problem.