### PR TITLE
[fr] Adding instruction on Tone_Tags and WG to OS style file

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -21,6 +21,15 @@ You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
 USA
+
+⚠️  Contributeurs Open Source - votre attention ! ⚠️
+Depuis juin 2023, il est possible d’utiliser des TONE TAGS pour les règles de style.
+Ces étiquettes permettent de mieux contrôler plus précisément dans quels contextes les règles vont s’activer.
+Cette nouvelle option est encore en développement !
+On aimerait beaucoup que, pour le moment, vous nous ajoutiez en tant que reviewers de vos pull requests quand vous créez des règles de style : @GillouLT et/ou @LucieSteib
+Pour le moment, les tone_tags disponibles sont les suivants : clarity, formal, professional, confident, academic, povrem, scientific, objective, persuasive, povadd, et positive.
+
+Pour en savoir plus sur les tone tags, suivez le lien vers notre documentation (en anglais) : https://dev.languagetool.org/style_tone_tags.
 -->
 <!DOCTYPE rules [
         <!ENTITY dashes "[–—―‒-]">


### PR DESCRIPTION
Adding instructions for OS contributors to use tone_tags, as per https://github.com/languagetooler-gmbh/languagetool-premium/issues/5761.