### PR TITLE
Replace File.separator w/ hardcoded forward slash

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/XmlRuleDisambiguator.java
+++ b/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/rules/XmlRuleDisambiguator.java
@@ -53,7 +53,7 @@ public class XmlRuleDisambiguator extends AbstractDisambiguator {
 
   public XmlRuleDisambiguator(Language language, boolean useGlobalDisambiguation) {
     Objects.requireNonNull(language);
-    String disambiguationFile = language.getShortCode() + File.separator + DISAMBIGUATION_FILE;
+    String disambiguationFile = language.getShortCode() + "/" + DISAMBIGUATION_FILE;
     List<DisambiguationPatternRule> disambiguationRulesList;
     try {
       disambiguationRulesList = loadPatternRules(disambiguationFile, language);

--- a/languagetool-core/src/test/java/org/languagetool/tagging/disambiguation/rules/DisambiguationRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/tagging/disambiguation/rules/DisambiguationRuleTest.java
@@ -73,8 +73,8 @@ public class DisambiguationRuleTest {
         long startTime = System.currentTimeMillis();
         // this distinction is needed before the logic for the disambiguation
         // file in core does something odd with the paths
-        String nameWithLocale = lang.getShortCode() + File.separator + "disambiguation.xml";
-        String nameInResourceDir = getDataBroker().getResourceDir() + File.separator + nameWithLocale;
+        String nameWithLocale = lang.getShortCode() + "/" + "disambiguation.xml";
+        String nameInResourceDir = getDataBroker().getResourceDir() + "/" + nameWithLocale;
         validateRuleFile(nameInResourceDir);
         List<DisambiguationPatternRule> rules = ruleLoader.getRules(
           ruleLoader.getClass().getResourceAsStream(nameInResourceDir),


### PR DESCRIPTION
 - in XmlRuleDisambiguator and DisambiguationRuleTest;
 - Windows might be windowsing.

It apparently resolves @tatigf20 's problem and doesn't hurt anyone, so... whatever.

In the past I've always specifically attempted **not** to hardcode path separators, but oh well.