### PR TITLE
[fr] new French variants: CH, BE, CA

### DIFF
--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/BelgianFrench.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/BelgianFrench.java
@@ -1,3 +1,21 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2023 Daniel Naber (http://www.danielnaber.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
 package org.languagetool.language;
 
 import java.util.Arrays;

--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/BelgianFrench.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/BelgianFrench.java
@@ -1,0 +1,24 @@
+package org.languagetool.language;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class BelgianFrench extends French {
+  @Override
+  public String getName() {
+    return "French (Belgium)";
+  }
+
+  @Override
+  public String[] getCountries() {
+    return new String[] { "BE"
+    };
+  }
+
+  @Override
+  public List<String> getDefaultDisabledRulesForVariant() {
+    List<String> rules = Arrays.asList("DOUBLER_UNE_CLASSE");
+    return Collections.unmodifiableList(rules);
+  }
+}

--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/CanadianFrench.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/CanadianFrench.java
@@ -1,0 +1,25 @@
+package org.languagetool.language;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class CanadianFrench extends French {
+  @Override
+  public String getName() {
+    return "French (Canada)";
+  }
+
+  @Override
+  public String[] getCountries() {
+    return new String[] { "CA"
+    };
+  }
+
+  @Override
+  public List<String> getDefaultDisabledRulesForVariant() {
+    List<String> rules = Arrays.asList("DOUBLER_UNE_CLASSE");
+    return Collections.unmodifiableList(rules);
+  }
+}

--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/CanadianFrench.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/CanadianFrench.java
@@ -1,3 +1,21 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2023 Daniel Naber (http://www.danielnaber.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
 package org.languagetool.language;
 
 import java.util.ArrayList;

--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
@@ -61,10 +61,14 @@ public class French extends Language implements AutoCloseable {
 
   @Override
   public String[] getCountries() {
-    return new String[]{"FR", "", "BE", "CH", "CA", "LU", "MC", "CM",
-            "CI", "HT", "ML", "SN", "CD", "MA", "RE"};
+    return new String[]{"FR", "", "LU", "MC", "CM",  "CI", "HT", "ML", "SN", "CD", "MA", "RE"};
+    //  "BE", "CH", "CA",
   }
 
+  @Override
+  public Language getDefaultLanguageVariant() {
+    return Languages.getLanguageForShortCode("fr");
+  }
   @NotNull
   @Override
   public Tagger createDefaultTagger() {

--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/SwissFrench.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/SwissFrench.java
@@ -1,0 +1,25 @@
+package org.languagetool.language;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class SwissFrench extends French {
+  @Override
+  public String getName() {
+    return "French (Switzerland)";
+  }
+
+  @Override
+  public String[] getCountries() {
+    return new String[] { "CH"
+    };
+  }
+
+  @Override
+  public List<String> getDefaultDisabledRulesForVariant() {
+    List<String> rules = Arrays.asList("DOUBLER_UNE_CLASSE");
+    return Collections.unmodifiableList(rules);
+  }
+}

--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/SwissFrench.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/SwissFrench.java
@@ -1,3 +1,21 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2023 Daniel Naber (http://www.danielnaber.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
 package org.languagetool.language;
 
 import java.util.ArrayList;

--- a/languagetool-language-modules/fr/src/main/resources/META-INF/org/languagetool/language-module.properties
+++ b/languagetool-language-modules/fr/src/main/resources/META-INF/org/languagetool/language-module.properties
@@ -1,1 +1,1 @@
-languageClasses=org.languagetool.language.French
+languageClasses=org.languagetool.language.French,org.languagetool.language.CanadianFrench,org.languagetool.language.SwissFrench,org.languagetool.language.BelgianFrench


### PR DESCRIPTION
The new variants (fr-CH, fr-BE, fr-CA) extend the default variant (fr, fr-FR) with disabled and enabled rules by default. 
