### PR TITLE
[pt] Removed "temp_off" from rules, they seem solid enough in the results

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -1224,7 +1224,7 @@ USA
             <url>https://pt.wikipedia.org/wiki/V%C3%ADcio_de_linguagem#Prolixidade_ou_preciosismo</url>
             <short>Expressão prolixa</short>
 
-            <rule default='temp_off'>
+            <rule>
                 <pattern>
                     <marker>
                         <token regexp='yes'>considerad[ao]s?</token>
@@ -9987,7 +9987,7 @@ USA
         </rulegroup>
 
 
-        <rule id='CIENTÍFICO_DAR_CONFERIR' name="[Universitário][Científico] dar → conferir" type="style" tags="picky" tone_tags="academic" default='temp_off'>
+        <rule id='CIENTÍFICO_DAR_CONFERIR' name="[Universitário][Científico] dar → conferir" type="style" tone_tags="academic">
             <!--
             It uses filters:
               -de → velocidade, integridade, etc.


### PR DESCRIPTION
Heya,

I was looking at the results:
https://internal1.languagetool.org/regression-tests/via-http

And they seem solid enough to remove the temp_off.

I also removed the picky from the academic rule.

There may a false positive or two, but they can be easily removed in future builds.