### PR TITLE
[sv] Fixes the missing entries for the Swedish language module

### DIFF
--- a/languagetool-office-extension/src/main/resources/Addons.xcu
+++ b/languagetool-office-extension/src/main/resources/Addons.xcu
@@ -99,6 +99,7 @@
                     <value xml:lang="gl">Erro ortográfico ou gramatical seguinte</value>
                     <value xml:lang="ru">Следующая грамматическая или орфографическая ошибка</value>
 					<value xml:lang="pt">Próximo erro ortográfico ou gramatical</value>
+		        <value xml:lang="sv">Nästa grammatik- eller stavningskontrollpunkt</value>
                     </prop>
                 </node>
                 <node oor:name="T2" oor:op="replace">
@@ -137,6 +138,7 @@
                     <value xml:lang="ca">Revisa el text</value>
                     <value xml:lang="ta">உரையைச் சரிபார்</value>
                     <value xml:lang="sr">Провера правописа</value>
+                    <value xml:lang="sv">Språkgranska dokumentet</value>
                     </prop>
                 </node>
                 <node oor:name="T3" oor:op="replace">
@@ -173,6 +175,7 @@
                     <value xml:lang="ca">Revisa el text de nou</value>
                     <value xml:lang="ta">ஆவணத்தை மீண்டும் சரிபார்</value>
                     <value xml:lang="sr">Поново проверити документ</value>
+                    <value xml:lang="sv">Språkgranska dokumentet igen</value>
                     </prop>
                 </node>
                 <node oor:name="T4" oor:op="replace">
@@ -189,6 +192,7 @@
                     <value xml:lang="en-US">Refresh Check Results</value>
                     <value xml:lang="de">Prüfergebnisse erneuern</value>
                     <value xml:lang="ru">Обновить результаты проверки</value>
+                    <value xml:lang="sv">Uppdatera språkgranskningspunkterna</value>
                     </prop>
                 </node>
                 <node oor:name="T5" oor:op="replace">
@@ -227,6 +231,7 @@
                     <value xml:lang="ca">Configuració...</value>
                     <value xml:lang="ta">தேர்வுகள்...</value>
                     <value xml:lang="sr">Подешавања ...</value>
+                    <value xml:lang="sv">Inställningar ...</value>
                     </prop>
                 </node>
                 <node oor:name="T6" oor:op="replace">
@@ -263,6 +268,7 @@
                     <value xml:lang="ca">Sobre...</value>
                     <value xml:lang="ta">எங்களைப் பற்றி...</value>
                     <value xml:lang="sr">О програму LanguageTool ...</value>
+                    <value xml:lang="sv">Om LanguageTool ...</value>
                     </prop>
                 </node>
             </node>
@@ -285,6 +291,7 @@
                     <value xml:lang="gl">Erro ortográfico ou gramatical seguinte</value>
                     <value xml:lang="ru">Следующая грамматическая или орфографическая ошибка</value>
 					<value xml:lang="pt">Próximo erro ortográfico ou gramatical</value>
+			<value xml:lang="sv">Nästa grammatik- eller stavningskontrollpunkt</value>
                     </prop>
                 </node>
                 <node oor:name="T2" oor:op="replace">
@@ -323,6 +330,7 @@
                     <value xml:lang="ca">Revisa el text</value>
                     <value xml:lang="ta">உரையைச் சரிபார்</value>
                     <value xml:lang="sr">Провера правописа</value>
+                    <value xml:lang="sv">Språkgranska dokumentet</value>
                     </prop>
                 </node>
                 <node oor:name="T3" oor:op="replace">
@@ -359,6 +367,7 @@
                     <value xml:lang="ca">Revisa el text de nou</value>
                     <value xml:lang="ta">ஆவணத்தை மீண்டும் சரிபார்</value>
                     <value xml:lang="sr">Поново проверити документ</value>
+                    <value xml:lang="sv">Språkgranska dokumentet igen</value>
                     </prop>
                 </node>
                 <node oor:name="T4" oor:op="replace">
@@ -375,6 +384,7 @@
                     <value xml:lang="en-US">Refresh Check Results</value>
                     <value xml:lang="de">Prüfergebnisse erneuern</value>
                     <value xml:lang="ru">Обновить результат проверки</value>
+                    <value xml:lang="sv">Uppdatera språkgranskningspunkterna</value>
                     </prop>
                 </node>
                 <node oor:name="T5" oor:op="replace">
@@ -413,6 +423,7 @@
                     <value xml:lang="ca">Configuració...</value>
                     <value xml:lang="ta">தேர்வுகள்...</value>
                     <value xml:lang="sr">Подешавања ...</value>
+                    <value xml:lang="sv">Inställningar ...</value>
                     </prop>
                 </node>
                 <node oor:name="T6" oor:op="replace">
@@ -449,6 +460,7 @@
                     <value xml:lang="ca">Sobre...</value>
                     <value xml:lang="ta">எங்களைப் பற்றி...</value>
                     <value xml:lang="sr">О програму LanguageTool ...</value>
+                    <value xml:lang="sv">Om LanguageTool ...</value>
                     </prop>
                 </node>
             </node>
@@ -501,6 +513,7 @@
                 <value xml:lang="ca">Gramàtica (LanguageTool)</value>
                 <value xml:lang="ta">லேங்குவேஜ் டூல்</value>
                 <value xml:lang="sr">Правопис (LanguageTool)</value>
+                <value xml:lang="sv">Grammatik (LanguageTool)</value>
                 </prop>
               <node oor:name="Submenu">
                 <node oor:name="M1" oor:op="replace">
@@ -513,6 +526,7 @@
                     <value xml:lang="de">Nächster Rechtschreib- oder Grammatikfehler</value>                    
                     <value xml:lang="gl">Erro ortográfico ou gramatical seguinte</value>
                     <value xml:lang="ru">Следующая ошибка</value>
+                    <value xml:lang="sv">Nästa grammatik- eller stavningskontrollpunkt</value>
                   </prop>
                   <prop oor:name="Target" oor:type="xs:string">
                     <value>_self</value>
@@ -553,6 +567,7 @@
                     <value xml:lang="ca">Revisa el text</value>
                     <value xml:lang="ta">உரையைச் சரிபார்</value>
                     <value xml:lang="sr">Провера правописа</value>
+                    <value xml:lang="sv">Språkgranska dokumentet</value>
                   </prop>
                   <prop oor:name="Target" oor:type="xs:string">
                     <value>_self</value>
@@ -591,6 +606,7 @@
                     <value xml:lang="ca">Revisa el text de nou</value>
                     <value xml:lang="ta">ஆவணத்தை மீண்டும் சரிபார்</value>
                     <value xml:lang="sr">Поново проверити документ</value>
+                    <value xml:lang="sv">Språkgranska dokumentet igen</value>
                   </prop>
                   <prop oor:name="Target" oor:type="xs:string">
                     <value>_self</value>
@@ -609,6 +625,7 @@
                     <value xml:lang="en-US">Refresh Check Results</value>
                     <value xml:lang="de">Prüfergebnisse erneuern</value>
                     <value xml:lang="ru">Обновить результат проверки</value>
+                    <value xml:lang="sv">Uppdatera språkgranskningspunkterna</value>
                   </prop>
                   <prop oor:name="Target" oor:type="xs:string">
                     <value>_self</value>
@@ -648,6 +665,7 @@
                     <value xml:lang="ca">Configuració...</value>
                     <value xml:lang="ta">தேர்வுகள்...</value>
                     <value xml:lang="sr">Подешавања ...</value>
+                    <value xml:lang="sv">Inställningar ...</value>
                   </prop>
                   <prop oor:name="Target" oor:type="xs:string">
                     <value>_self</value>
@@ -685,6 +703,7 @@
                     <value xml:lang="ca">Sobre...</value>
                     <value xml:lang="ta">எங்களைப் பற்றி...</value>
                     <value xml:lang="sr">О програму LanguageTool ...</value>
+                    <value xml:lang="sv">Om LanguageTool ...</value>
                   </prop>
                   <prop oor:name="Target" oor:type="xs:string">
                     <value>_self</value>

--- a/languagetool-office-extension/src/main/resources/description.xml
+++ b/languagetool-office-extension/src/main/resources/description.xml
@@ -25,6 +25,7 @@
 		<src xlink:href="description/desc_sk.txt" lang="sk" />
 		<src xlink:href="description/desc_sl.txt" lang="sl" />
 		<src xlink:href="description/desc_sr.txt" lang="sr" />
+		<src xlink:href="description/desc_sv.txt" lang="sv" />
 		<src xlink:href="description/desc_ta.txt" lang="ta" />
 		<src xlink:href="description/desc_ru.txt" lang="ru" />
 		<src xlink:href="description/desc_uk.txt" lang="uk" />

--- a/languagetool-office-extension/src/main/resources/description/desc_sv.txt
+++ b/languagetool-office-extension/src/main/resources/description/desc_sv.txt
@@ -1,0 +1,3 @@
+Språkgranskning med grammatik- och stavningskontoll.
+LanguageTool stöttar ditt skrivande på mer än 20 språk.
+


### PR DESCRIPTION
Fixes the missing entries for the Swedish language module according to the checklist for adding a new language.

- Adding translations to languagetool-office-extension/src/main/resources/Addons.xcu
- Adding entry for sv in languagetool-office-extension/src/main/resources/description.xml
- Adding new file languagetool-office-extension/src/main/resources/description/desc_sv.txt