### PR TITLE
[sv] Adding the WordCoherencyRule for Swedish

### DIFF
--- a/languagetool-language-modules/sv/src/main/java/org/languagetool/language/Swedish.java
+++ b/languagetool-language-modules/sv/src/main/java/org/languagetool/language/Swedish.java
@@ -100,9 +100,15 @@ public class Swedish extends Language {
             new DoublePunctuationRule(messages),
             new GenericUnpairedBracketsRule(messages),
             new HunspellRule(messages, this, userConfig, altLanguages),
+            // fixme! - A suitable paragraph length should be tuned automatically per text type,
+            // so make sure to get the type from LO and COOL
+            new LongParagraphRule(messages, this, userConfig, 150),
             new UppercaseSentenceStartRule(messages, this),
+            new LongSentenceRule(messages, userConfig, 40),
             new WordRepeatRule(messages, this),
+            new WordCoherencyRule(messages),
             new MultipleWhitespaceRule(messages, this),
+            new SentenceWhitespaceRule(messages),
             new CompoundRule(messages, this, userConfig)
     );
   }

--- a/languagetool-language-modules/sv/src/main/java/org/languagetool/rules/sv/WordCoherencyRule.java
+++ b/languagetool-language-modules/sv/src/main/java/org/languagetool/rules/sv/WordCoherencyRule.java
@@ -1,0 +1,64 @@
+/* LanguageTool, a natural language style checker 
+ * Copyright (C) 2005 Daniel Naber (http://www.danielnaber.de)
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.sv;
+
+import org.languagetool.rules.AbstractWordCoherencyRule;
+import org.languagetool.rules.Example;
+import org.languagetool.rules.WordCoherencyDataLoader;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.Set;
+
+/**
+ * Swedish version of {@link AbstractWordCoherencyRule}.
+ */
+public class WordCoherencyRule extends AbstractWordCoherencyRule {
+
+  private static final Map<String, Set<String>> wordMap = new WordCoherencyDataLoader().loadWords("/sv/coherency.txt");
+
+  public WordCoherencyRule(ResourceBundle messages) throws IOException {
+    super(messages);
+    addExamplePair(Example.wrong("Det är en blandning av <marker>mejl</marker> och <marker>mail</marker> i det du skriver."),
+                   Example.fixed("Om du använder enbart <marker>mejl</marker> när du skriver <marker>mejl</marker> blir det mer konsekvent."));
+  }
+
+  @Override
+  protected Map<String, Set<String>> getWordMap() {
+    return wordMap;
+  }
+
+  @Override
+  protected String getMessage(String word1, String word2) {
+    return "Använd endast en av stavningsvarianterna '" + word1 + "' och '" + word2 + "' i en och samma text.";
+  }
+
+  @Override
+  public String getId() {
+    return "SV_WORD_COHERENCY";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Enhetlig och konsekvent stavning av ord när det finns stavningsvarianter att välja på.";
+  }
+
+}
+


### PR DESCRIPTION
Adding the WordCoherencyRule class for Swedish to start using the pairs in /sv/coherency.txt.