### PR TITLE
[fr] anglicisms cleanup

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -18496,6 +18496,44 @@ Pour en savoir plus sur les tone tags, suivez le lien vers notre documentation (
             <suggestion>crise cardiaque</suggestion>
             <example correction="crise cardiaque"><marker>attaque cardiaque</marker></example>
         </rule>
+        <rule id="ANGLICISME_FAKE_NEWS" name="fake news">
+            <pattern>
+                <token>fakes</token>
+                <token>news</token>
+            </pattern>
+            <message>L'expression anglaise est <suggestion>fake news</suggestion>.</message>
+            <example correction="fake news"> Ce sont des <marker>fakes news</marker>.</example>
+        </rule>
+        <rule id="ANGLICISME_BABY_SHOWER" name="baby shower">
+             <pattern>
+                <token>baby</token>
+                <token>-</token>
+                <token regexp="yes">showers?</token>
+             </pattern>
+             <message>Ce nom s'écrit sans trait d'union.</message>
+             <suggestion>\1 \3</suggestion>
+             <example correction="baby shower">Il a organisé une <marker>baby-shower</marker>.</example>
+        </rule>
+        <rule id="ANGLICISME_SEX_TOYS" name="sex toys">
+           <pattern>
+             <token>sexe</token>
+             <token min="0">-</token>
+             <token regexp="yes">toys?</token>
+           </pattern>
+           <message>Ce mot est un anglicisme non francisé.</message>
+           <suggestion>sex \3</suggestion>
+           <example correction="sex toys">Il utilise des <marker>sexe toys</marker>.</example>
+        </rule>
+        <rule id="ANGLICISME_MOBILE_HOME" name="mobile home">
+           <pattern>
+              <token regexp="yes">mobiles?</token>
+              <token regexp="yes">homes?</token>
+           </pattern>
+           <message>Ce terme est un anglicisme et peut être remplacé par son équivalent français.</message>
+           <suggestion>mobil-\2</suggestion>
+           <url>https://www.larousse.fr/dictionnaires/francais/mobil-home/51878</url>
+           <example correction="mobil-home">Il vit dans un <marker>mobiles home</marker>.</example>
+        </rule>
     </category>
     <category id="CAT_REGLES_DE_BASE" name="Règles de base" type="style">
         <rulegroup id="C_EST_QUOI" name="c'est quoi" tone_tags="general">


### PR DESCRIPTION
In the context of: https://github.com/languagetooler-gmbh/task-force-french/issues/33.
→ Anglicisms replacement rules should be moved to Style. This is the PR for OS.

# grammar_os
## Impacted rules
<html>
<head>
	

	
</head>

<body>


Old name | New name | Other change
-- | -- | --
FAKE_NEWS | ANGLICISME_FAKE_NEWS |  
MEDIA |   |  
PAS_DE_TRAIT_UNION | ANGLICISME_SEX_TOY |  
TRAIT_UNION | ANGLICISME_MOBILE_HOME |  
HEURES |   | Message changed
HEURES |   | Message changed
HEURES |   | Message changed
TITRE_M |   | Message changed


</body>

</html>

## Comments
### Rules not moved, since they apply to word use in French and are not anglicisms _per se_:
- MEDIA wasn't moved, since the rule really concerns the word media in French.
- HEURES subrules were not moved, and the error message was modified from `<message>Cette écriture peut être considérée comme un anglicisme.</message>` to `<message>Cette notation correspond à l'usage dans les pays anglo-saxons.</message>`
- TITRE_M rule were not moved, and the error message was modified from `<message>Ce titre anglais doit être traduit en français.</message>` to `<message>Mr correspond à "mister" en anglais. Monsieur s'abrège M.</message>`

### The moved rules got a new name, starting with **ANGLICISME**. That should maybe be generalized to new anglicisms rules (and maybe even extended to legacy rules(?). 
