### PR TITLE
[pt-PT] Added AP to rule ID:SIMPLIFICAR_À_VERBO_DE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -2876,6 +2876,22 @@ USA
             <!--
             O Rui anda à procura de material científico. → O Rui anda a procurar material científico.
             -->
+
+            <antipattern>
+                <token postag_regexp='yes' postag='VMSI.+|VMG0000|VMP00.+'/>
+                <token>à</token>
+                <token postag_regexp='yes' postag='NC.+|AQ.+|NP.+'/>
+                <token>de</token>
+                <token postag_regexp='yes' postag='NC.+|AQ.+|NP.+|DI.+|CS|V.+'/>
+                <example>Ele pediu que o adicionasse à lista de acesso da sala de chat.</example>
+                <example>A vida das pessoas, a autoestima e seus relacionamentos estão totalmente atrelados à forma de como se mostram ao mundo.</example>
+                <example>Esta ação evita que problemas e gastos excessivos ligados à falta de lubrificação, apareçam futuramente.</example>
+                <example>São tantas as páginas do meu livro marcadas à espera de serem lidas, que me perco sem saber qual delas ler primeiro.</example>
+                <example>Nós estamos indo à festa de aniversário do filho de Tom.</example>
+                <example>Conceitos fundamentais associados à obra de Bakhtin incluem o dialogismo, a polifonia (linguística), a heteroglossia e o carnavalesco.</example>
+                <example>A calorimetria é uma ramificação da termologia que analisa os problemas relacionados à troca de calor em sistemas de temperaturas diversas.</example>
+            </antipattern>
+
             <!--
             Em maio de 1863, submeteu-se à prova de admissão para o ingresso na Faculdade de Direito do Recife sendo reprovado.
             E, ao se referir-se à visita de Lula, informou que "Lula honra Berlim e Hamburgo" com sua visita.


### PR DESCRIPTION
An antipattern to fix a ton of false positives:

BEFORE:
```
Portuguese (Portugal): 110 total matches
Portuguese (Portugal): 599999 total sentences considered
Portuguese (Portugal): ø0.00 rule matches per sentence
```

AFTER:
```
Portuguese (Portugal): 98 total matches
Portuguese (Portugal): 599999 total sentences considered
Portuguese (Portugal): ø0.00 rule matches per sentence
```

