### PR TITLE
[pt] Fix message for PT/BR replace rule

### DIFF
--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/BrazilianPortugueseReplaceRule.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/BrazilianPortugueseReplaceRule.java
@@ -69,12 +69,12 @@ public class BrazilianPortugueseReplaceRule extends AbstractSimpleReplaceRule2 {
 
   @Override
   public String getShort() {
-    return "Palavra de português de Portugal";
+    return "Palavra do português de Portugal";
   }
 
   @Override
   public String getMessage() {
-    return "'$match' é uma expressão de Portugal, em português do Brasil utiliza-se: $suggestions";
+    return "\"$match\" é uma expressão usada sobretudo em Portugal. No português brasileiro diz-se $suggestions";
   }
 
   @Override

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
@@ -1487,7 +1487,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
       <pattern>
         <token postag="VMIS1P0P" regexp="yes">.*ámos</token>
       </pattern>
-      <message>Em português do Brasil, se escreve sem acento.</message>
+      <message>No português do Brasil, escreve-se sem acento.</message>
       <suggestion><match no="1" postag="VMIS1P0P" postag_regexp="yes" postag_replace="VMIS1P0"/></suggestion>
       <example correction="provamos"><marker>provámos</marker></example>
     </rule>


### PR DESCRIPTION
The original message was a little janky. 'Em português de Portugal' is ungrammatical.