### PR TITLE
[pt] Add ABREVIATURAS_FEMININAS_COM_SOBRESCRITO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -18972,6 +18972,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="et al.">SANTOS, T.F. <marker>et al</marker> (2005),…</example>
         </rule>
 
+        
         <rulegroup id='ABREVIATIONS_PUNCTUATION' name="Abreviaturas: Pontuação">
             <!--       Based on the Catalan version, Tiago F. Santos,  2017-02-18      -->
             <!--          Wordlist from https://gerrit.libreoffice.org/#/c/29277/      -->
@@ -38788,6 +38789,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </category>
     <category id='TYPOGRAPHY' name="Tipografia" type="typographical">
 
+        <rule id="ABREVIATURAS_FEMININAS_COM_SOBRESCRITO" name="Prefira o sobrescrito em abreviaturas femininas." type="typographical" tags="picky" default="temp_off">
+            <pattern>
+                <token regexp="yes">profa|dra|exa|enga|sra|reva|srta</token>
+                <token regexp='yes' spacebefore='no'>\.</token>
+            </pattern>
+            <message>Determinadas abreviaturas exigem um sobrescrito após o ponto. No lugar de &quot;\1.&quot;, prefira <suggestion><match no="1" regexp_match="(.+)a$" regexp_replace="$1.ª"/></suggestion>.</message>
+            <example correction="Prof.ª">Gostaria de ir com a <marker>Profa.</marker> Goldberg.</example>
+        </rule>
 
         <rulegroup id='GENERAL_NUMBER_FORMAT' name="Matemático: Formatação de números: 10 341 330" default='off'>
             <!-- Created by Tiago F. Santos, 2017-03-05 -->


### PR DESCRIPTION
I've finally got fed up with all the `profa` and `dra` in the logs. This should address it. The list of abbreviations is relatively small and unambiguous, to keep things simple. A good candidate for a picky typography rule.

We can, in the future, add sister rules for stuff like `Engo.`, but I feel those will be much rarer anyway.

---

There are other abbreviations that might require the superscript in some situations, but there is very limited support for other superscript characters in most fonts (despite some [Unicode support](https://en.wikipedia.org/wiki/Unicode_subscripts_and_superscripts), though do note the caveat with regards to their size and position). I'd steer clear of adding support for those more obscure cases for now.