### PR TITLE
checkallable: use default parameters when parameters is empty

### DIFF
--- a/languagetool-dev/src/main/java/org/languagetool/dev/httpchecker/CheckCallable.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/httpchecker/CheckCallable.java
@@ -90,13 +90,15 @@ class CheckCallable implements Callable<File> {
       for (String text : texts) {
         URL url = Tools.getUrl(baseUrl + "/v2/check");
         String postData = "language=" + langCode +
-            "&text=" + URLEncoder.encode(text, "UTF-8") +
-            "&toneTags=" + ToneTag.ALL_TONE_RULES.name() +
-            "&level=picky" +
-            "&enableTempOffRules=true";
+            "&text=" + URLEncoder.encode(text, "UTF-8");
         postData += token != null ? "&token=" + URLEncoder.encode(token, "UTF-8"): "";
         if (parameters != null) {
           postData += "&" + parameters;
+        } else {
+          // default values
+          postData += "&toneTags=" + ToneTag.ALL_TONE_RULES.name() +
+            "&level=picky" +
+            "&enableTempOffRules=true"
         }
         String tokenInfo = token != null ? " with token" : " without token";
         float progress = (float)i++ / texts.size() * 100.0f;

--- a/languagetool-dev/src/main/java/org/languagetool/dev/httpchecker/CheckCallable.java
+++ b/languagetool-dev/src/main/java/org/languagetool/dev/httpchecker/CheckCallable.java
@@ -98,7 +98,7 @@ class CheckCallable implements Callable<File> {
           // default values
           postData += "&toneTags=" + ToneTag.ALL_TONE_RULES.name() +
             "&level=picky" +
-            "&enableTempOffRules=true"
+            "&enableTempOffRules=true";
         }
         String tokenInfo = token != null ? " with token" : " without token";
         float progress = (float)i++ / texts.size() * 100.0f;


### PR DESCRIPTION
This seems a better alternative to https://github.com/languagetool-org/languagetool/pull/9167

This way we can use this method for different purposes, and we can keep the default parameters. 