### PR TITLE
[fr] ESPACE_UNITES improved

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -855,15 +855,14 @@ Pour en savoir plus sur les tone tags, suivez le lien vers notre documentation (
             <example correction="de la Covid">Les répercussions économiques <marker>du Covid</marker> ne se sauront pas avant 2022.</example>
             <example correction="à la COVID">Les dommages humains et économiques dus <marker>au COVID</marker> sont considérables.</example>
         </rule>
-        <rule id="CELLES_CEUX" name="celles et ceux" tone_tags="clarity">
+        <rule id="TOTALEMENT" name="totalement" tone_tags="formal" is_goal_specific="true">
             <pattern>
-                <token>ceux</token>
-                <token>et</token>
-                <token>celles</token>
+                <token>totalement</token>
             </pattern>
-            <message>En français, la politesse place le féminin devant le masculin.</message>
-            <suggestion>celles et ceux</suggestion>
-            <example correction="celles et ceux">Ainsi, <marker>ceux et celles</marker> qui ont un pull doivent sortir.</example>
+            <message>Cet adverbe peut sembler familier dans la langue formelle.</message>
+            <suggestion>complètement</suggestion>
+            <suggestion>réellement</suggestion>
+            <example correction="complètement|réellement">C'est <marker>totalement</marker> inhabituel.</example>
         </rule>
     </category>
     <category id="CAT_PLEONASMES" name="Pléonasmes" type="style" tone_tags="clarity">

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -856,7 +856,7 @@ Pour en savoir plus sur les tone tags, suivez le lien vers notre documentation (
             <example correction="à la COVID">Les dommages humains et économiques dus <marker>au COVID</marker> sont considérables.</example>
         </rule>
         <rule id="CELLES_CEUX" name="celles et ceux" tone_tags="clarity">
-        <pattern>
+            <pattern>
                 <token>ceux</token>
                 <token>et</token>
                 <token>celles</token>

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -855,6 +855,16 @@ Pour en savoir plus sur les tone tags, suivez le lien vers notre documentation (
             <example correction="de la Covid">Les répercussions économiques <marker>du Covid</marker> ne se sauront pas avant 2022.</example>
             <example correction="à la COVID">Les dommages humains et économiques dus <marker>au COVID</marker> sont considérables.</example>
         </rule>
+        <rule id="CELLES_CEUX" name="celles et ceux" tone_tags="clarity">
+        <pattern>
+                <token>ceux</token>
+                <token>et</token>
+                <token>celles</token>
+            </pattern>
+            <message>En français, la politesse place le féminin devant le masculin.</message>
+            <suggestion>celles et ceux</suggestion>
+            <example correction="celles et ceux">Ainsi, <marker>ceux et celles</marker> qui ont un pull doivent sortir.</example>
+        </rule>
         <rule id="TOTALEMENT" name="totalement" tone_tags="formal" is_goal_specific="true">
             <pattern>
                 <token>totalement</token>


### PR DESCRIPTION
Related to: https://github.com/languagetooler-gmbh/task-force-french/issues/43

- ESPACE_UNITES some FPs have been fixed, mostly related to postal codes
- TOTALEMENT rule moved to style (temp_off removed)