### PR TITLE
[pt] Enable ABREVIATURAS_FEMININAS_COM_SOBRESCRITO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -38907,7 +38907,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="XLIV">A história se passa no século <marker>44</marker>.</example>
         </rule>
 
-        <rule id="ABREVIATURAS_FEMININAS_COM_SOBRESCRITO" name="Prefira o sobrescrito em abreviaturas femininas." type="typographical" tags="picky" default="temp_off">
+        <rule id="ABREVIATURAS_FEMININAS_COM_SOBRESCRITO" name="Prefira o sobrescrito em abreviaturas femininas." type="typographical" tags="picky">
             <pattern>
                 <token regexp="yes">profa|dra|exa|enga|sra|reva|srta</token>
                 <token regexp='yes' spacebefore='no'>\.</token>


### PR DESCRIPTION
[Results](https://internal1.languagetool.org/regression-tests/via-http/2023-08-25/pt-BR/result_grammar_ABREVIATURAS_FEMININAS_COM_SOBRESCRITO%5B1%5D.html) are solid.