### PR TITLE
[pt] Add PARA_MIM_FAZER rule

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -171,6 +171,101 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
     <category id='GRAMMAR' name="Gramática Geral" type="grammar">
+        <rulegroup id="PARA_MIM_FAZER" name="Para mim fazer -> para eu fazer" default="temp_off">
+
+            <rule>
+                <pattern>
+                    <token postag_regexp="yes" postag="SENT_START|_PUNCT"/>
+                    <token regexp="yes">pa?ra</token>
+                    <marker>
+                        <token skip="1">
+                            mim
+                            <exception scope="next" postag_regexp="yes" postag="SP.+|_PUNCT|C.|N.+"/>
+                            <exception scope="next">a</exception> <!-- issues with disambiguation of 'a' -->
+                            <exception negate="yes" scope="next" postag_regexp="yes" postag="V.+" regexp="yes">.+[eaioô]r$</exception>
+                        </token>
+                    </marker>
+                    <token postag_regexp="yes" postag="V.N0000"/>
+                </pattern>
+                <message>Na posição de sujeito, use <suggestion>eu</suggestion> no lugar de &quot;mim&quot;. Se não for o caso, talvez seja possível inserir uma vírgula.</message>
+                <suggestion>mim,</suggestion>
+                <example correction="eu|mim,">Para <marker>mim</marker> abrir a porta será difícil.</example>
+                <example correction="eu|mim,">Pra <marker>mim</marker> fechar o portão, não sei.</example>
+                <example correction="eu|mim,">2006 (UTC) Para <marker>mim</marker> dirigir para além de Braga é muito.</example>
+            </rule>
+
+            <rule>
+                <pattern>
+                    <token inflected="yes">dar</token>
+                    <token regexp="yes">pa?ra</token>
+                    <marker>
+                        <token skip="1">
+                            mim
+                            <exception scope="next" postag_regexp="yes" postag="SP.+|_PUNCT|C.|N.+"/>
+                            <exception scope="next">a</exception> <!-- issues with disambiguation of 'a' -->
+                            <exception negate="yes" scope="next" postag_regexp="yes" postag="V.+" regexp="yes">.+[eaioô]r$</exception>
+                        </token>
+                    </marker>
+                    <token postag_regexp="yes" postag="V.N0000"/>
+                </pattern>
+                <message>Na posição de sujeito, use <suggestion>eu</suggestion> no lugar de &quot;mim&quot;.</message>
+                <example correction="eu">Não dá para <marker>mim</marker> vir em janeiro.</example>
+                <example correction="eu">Vai dar pra <marker>mim</marker> pedir um novo?</example>
+                <example correction="eu">Ainda não deu para <marker>mim</marker> entrar em contato.</example>
+            </rule>
+
+            <rule>
+                <antipattern>
+                    <token inflected="yes" regexp="yes">ser|torna|ficar</token>
+                    <token postag_regexp="yes" postag="R." min="0" max="-1"/>
+                    <token postag_regexp="yes" postag="A.+"/>
+                    <token regexp="yes">pa?ra</token>
+                    <token>mim</token>
+                    <example>É difícil para mim ver o que está acontecendo.</example>
+                    <example>Seria incrivelmente natural para mim ler em russo.</example>
+                    <example>Ele pode ver que seria perfeitamente natural para mim dizer algo do gênero.</example>
+                    <example>Sem meus óculos se torna impossível para mim enxergar.</example>
+                    <example>Está ficando mais fácil para mim ouvir esse tipo de música.</example>
+                </antipattern>
+                <antipattern>
+                    <token regexp="yes">sonho|honra|importância|prazer|prioridade</token>
+                    <token postag_regexp="yes" postag="R." min="0" max="-1"/>
+                    <token min="0" postag_regexp="yes" postag="A.+"/>
+                    <token regexp="yes">pa?ra</token>
+                    <token>mim</token>
+                    <example>É um sonho para mim jogar neste time.</example>
+                    <example>É uma honra imensa para mim lhes dar essa ajuda.</example>
+                </antipattern>
+                <antipattern>
+                    <token inflected="yes">sobrar</token>
+                    <token postag_regexp="yes" postag="R." min="0" max="-1"/>
+                    <token regexp="yes">pa?ra</token>
+                    <token>mim</token>
+                    <example>Sobra para mim novamente explicar.</example>
+                </antipattern>
+                <pattern>
+                    <marker>
+                        <token negate_pos="yes" postag_regexp="yes" postag="_PUNCT|SENT_START"/>
+                        <token regexp="yes">pa?ra</token>
+                        <token skip="1">
+                            mim
+                            <exception scope="next" postag_regexp="yes" postag="SP.+|_PUNCT|C.|N.+"/>
+                            <exception scope="next">a</exception> <!-- issues with disambiguation of 'a' -->
+                            <exception negate="yes" scope="next" postag_regexp="yes" postag="V.+" regexp="yes">.+[eaioô]r$</exception>
+                        </token>
+                    </marker>
+                    <token postag_regexp="yes" postag="V.N0000"/>
+                </pattern>
+                <message>Na posição de sujeito, use &quot;eu&quot; no lugar de &quot;mim&quot;. Se não for o caso, talvez seja melhor pôr entre vírgulas.</message>
+                <suggestion>\1 \2 eu</suggestion>
+                <suggestion>\1, \2 mim,</suggestion>
+                <example correction="desafio para eu|desafio, para mim,">Será um <marker>desafio para mim</marker> entrar lá sozinho.</example>
+                <example correction="suficiente para eu|suficiente, para mim,">Acho que passamos tempo o <marker>suficiente para mim</marker> lhe dizer que eu dormi.</example>
+                <example correction="desbloqueada pra eu|desbloqueada, pra mim,">Gostaria que ela fosse <marker>desbloqueada pra mim</marker> recuperar minha página.</example>
+                <example>Outros sites para mim parecem agir normalmente.</example>
+            </rule>
+        </rulegroup>
+
         <rule id="CONFUSAO_MAIS_MAS_VIRGULA" name="Confusão de mais e mas após a vírgula" default="on">
             <antipattern>
                 <token postag='SENT_START'/>


### PR DESCRIPTION
This is one of those things that's really stigmatised in pt-BR for some reason, so it'd be nice to cover at least the most obvious cases.

Deciding when the `mim` stands for a 1SG subject and when it doesn't is not that trivial, so there might be a handful of false negatives to iron out later, but for now I think what we have here should introduce more TPs than FPs.

Since this is formality-agnostic, we're not transforming 'pra' into 'para'.