### PR TITLE
[es] added AP to AI_ES_HYDRA_LEO_MISSING_COMMA

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/remote-rule-filters.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/remote-rule-filters.xml
@@ -76,6 +76,15 @@ To ignore a remote rule match, set the <marker> so that it exactly covers the te
             </rule>
         </rulegroup>
         <rulegroup id="AI_ES_HYDRA_LEO_MISSING_COMMA" name="">
+            <rule>
+                <pattern>
+                    <marker>
+                        <token postag="SPS.*" postag_regexp="yes"/>
+                    </marker>
+                    <token regexp="yes">\d.*</token>
+                </pattern>
+                <example correction="">El aforo proyectado es de <marker>entre</marker> 9500 y 10 200 personas.</example>
+            </rule>
             <!-- ignore noun + adj if there is agreement -->
             <rule>
                 <pattern>


### PR DESCRIPTION
![image](https://github.com/languagetool-org/languagetool/assets/125255396/73dd8278-b779-4d32-9042-41c88fe03752)
@jaumeortola Added AP to solve this issue.