### PR TITLE
[pt] Improve performance of MELHOR_EDUCADO and MAIS_BEM_MELHORES

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/misc.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/misc.ent
@@ -126,12 +126,10 @@ educado|
 encarado|
 ensinado|
 fadado|
-falante|
 fazente|
 humorado|
 ido|
 intencionado|
-lançado|
 mandado|
 merecido|
 nascido|

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -175,20 +175,31 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <pattern>
                     <token regexp="yes">melhor(es)?</token>
                     <token regexp="yes" min="0" spacebefore="no">&hifen;</token>
-                    <token regexp="yes" inflected="yes" postag="V.P.+|A.+|RG" postag_regexp="yes">&compounds_with_bem;</token>
+                    <token regexp="yes" inflected="yes" postag="V.P.+|A.+|RG" postag_regexp="yes">
+                            &compounds_with_bem;
+                        <exception postag_regexp="yes" postag="N.+"/>
+                        <exception>vista</exception>
+                    </token>
                 </pattern>
                 <message>O superlativo e comparativo de adjetivos compostos se formam com &quot;mais&quot;.</message>
                 <suggestion>mais bem-\3</suggestion>
                 <example correction="mais bem-educada">Ela era a menina <marker>melhor educada</marker>.</example>
                 <example correction="mais bem-dotados">Os <marker>melhor-dotados</marker> da classe.</example>
                 <example correction="mais bem-acabadas">As casas estão <marker>melhores acabadas</marker> que os jardins.</example>
+                <example>Ele é o melhor falante de russo da classe.</example>
+                <example>Ponha o seu melhor vestido!</example>
+                <example>Melhor vista e quartos mais agradáveis.</example>
             </rule>
 
             <rule>
                 <pattern>
                     <token regexp="yes">pior(es)?</token>
                     <token regexp="yes" min="0" spacebefore="no">&hifen;</token>
-                    <token regexp="yes" inflected="yes" postag="V.P.+|A.+|RG" postag_regexp="yes">&compounds_with_mal;</token>
+                    <token regexp="yes" inflected="yes" postag="V.P.+|A.+|RG" postag_regexp="yes">
+                            &compounds_with_mal;
+                        <exception postag_regexp="yes" postag="N.+"/>
+                        <exception>vista</exception>
+                    </token>
                 </pattern>
                 <message>O superlativo e comparativo de adjetivos compostos se formam com &quot;mais&quot;.</message>
                 <suggestion>mais mal-\3</suggestion>
@@ -197,15 +208,33 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
         <rulegroup id="MAIS_BEM_MELHORES" name="Melhores colocados -> melhor/mais bem colocados" default="temp_off">
+            <antipattern> <!-- TODO: list of adjectives that cannot be compared (or don't make sense in the comparative) -->
+                <token regexp="yes">(pior|melhor)es</token>
+                <token regexp="yes">causados</token>
+                <example>Os danos causados pelos ventos fortes foram os piores causados por qualquer furacão.</example>
+            </antipattern>
+
             <rule>
                 <pattern>
                     <token>melhores</token>
-                    <token postag_regexp="yes" postag="V.P..P."/>
+                    <token postag_regexp="yes" postag="V.P..P.">
+                        <exception postag_regexp="yes" postag="N.+"/>
+                    </token>
                 </pattern>
                 <message>Se &quot;\1&quot; estiver formando o comparativo ou superlativo da expressão &quot;bem \2&quot;, trata-se de um advérbio e é, portanto, invariável.</message>
                 <suggestion>melhor \2</suggestion>
                 <suggestion>mais bem \2</suggestion>
                 <example correction="melhor colocados|mais bem colocados">Os <marker>melhores colocados</marker> ganharam um prêmio.</example>
+                <example correction="melhor qualificados|mais bem qualificados">Qualificação: 2 atletas de cada bateria (Q) mais os 5 <marker>melhores qualificados</marker> (q).</example>
+                <example correction="melhor vistos|mais bem vistos">Tão altos quantos alguns dos <marker>melhores vistos</marker> no jogo principal.</example>
+                <example>Ela é a melhor advogada da firma.</example>
+                <example>Esse é um dos melhores conjuntos que a Lego já produziu.</example>
+                <example>Aquele restaurante tem a melhor comida da cidade.</example>
+                <example>Confira aqui as melhores pousadas em Ourolândia.</example>
+                <example>A equação de estado de van der Waals foi uma das primeiras a obter melhores resultados que a lei dos gases ideais.</example>
+                <example>Os trabalhos de J. Carlos apareceriam nas melhores revistas de sua época.</example>
+                <example>Ver ao vivo deve ser super borbulhante nos melhores sentidos.</example>
+                <example>Para presentear os melhores soldados com presentes imperiais.</example>
             </rule>
 
             <rule> <!-- disambig issues -->
@@ -222,12 +251,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <rule>
                 <pattern>
                     <token>piores</token>
-                    <token postag_regexp="yes" postag="V.P..P."/>
+                    <token postag_regexp="yes" postag="V.P..P.">
+                        <exception postag_regexp="yes" postag="N.+"/>
+                    </token>
                 </pattern>
                 <message>Se &quot;\1&quot; estiver formando o comparativo ou superlativo da expressão &quot;mal \2&quot;, trata-se de um advérbio e é, portanto, invariável.</message>
                 <suggestion>pior \2</suggestion>
                 <suggestion>mais mal \2</suggestion>
                 <example correction="pior colocados|mais mal colocados">Os <marker>piores colocados</marker> voltaram para Taubaté.</example>
+                <example>A disputa hoje é sobre os melhores e piores vestidos, sapatos, acessórios.</example>
             </rule>
 
             <rule> <!-- disambig issues -->


### PR DESCRIPTION
Logic and AP updates based on [diff results](https://regression.languagetoolplus.com/via-http/2023-09-01/pt-BR/):
- remove adj/pctp that are also nouns (and a couple of other words separately due to disambiguation issues);
- add a bunch of examples for testing.