### PR TITLE
[pt] Enable MILHARES_DE_PESSOAS and DUAS_MILHÕES rules

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -3037,7 +3037,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <rule id="AS_MILHARES_DE_PESSOAS" name="Concordância tecnicamente incorreta entre numerais como 'milhares' e substantivos femininos" default="temp_off" tags="picky">
+        <rule id="AS_MILHARES_DE_PESSOAS" name="Concordância tecnicamente incorreta entre numerais como 'milhares' e substantivos femininos" tags="picky">
             <pattern>
                 <marker>
                     <token postag="(SPS00:)?[DP][ADIPR].FP.+" postag_regexp="yes"/>
@@ -3053,7 +3053,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
         <!-- Will keep this separate from AS_MILHARES_DE_PESSOAS as usage patterns are different for these two, give users more control. -->
-        <rule id="DUAS_MILHOES" name="Concordância tecnicamente incorreta de 'milhão' com substantivos femininos" default="temp_off" tags="picky">
+        <rule id="DUAS_MILHOES" name="Concordância tecnicamente incorreta de 'milhão' com substantivos femininos" tags="picky">
             <pattern>
                 <marker>
                     <token postag="Z0FP0"/>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -12141,7 +12141,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <rule id="MEIO_DIA_E_MEIO" name="Meio-dia e meio -> meia" default="temp_off">
+        <rule id="MEIO_DIA_E_MEIO" name="Meio-dia e meio -> meia">
             <pattern>
                 <token>meio</token>
                 <token regexp="yes" min="0" spacebefore="no">&hifen;</token>


### PR DESCRIPTION
Per latest [diff](https://regression.languagetoolplus.com/via-http/2023-09-01/pt-BR/), no FPs on either rule.