### PR TITLE
[pt] Enable CONCORDANCIA_SOBRESCRITO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -854,7 +854,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <rulegroup id="CONCORDANCIA_SOBRESCRITO" name="Problema de concordância no sobrescrito de ordinais" default="temp_off">
+        <rulegroup id="CONCORDANCIA_SOBRESCRITO" name="Problema de concordância no sobrescrito de ordinais">
             <rule> <!-- fem superscript, masc. NP -->
                 <pattern>
                     <token postag_regexp="yes" postag="(SP.+:)?D..MS."/>


### PR DESCRIPTION
Per [nightlies](https://regression.languagetoolplus.com/via-http/2023-09-01/pt-BR_full/index.html), no FPs.