### PR TITLE
[pt] Improve agreement of new scientific rules

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -38800,7 +38800,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example>A vizinha bota fora a comida.</example>
         </rule>
 
-        <rule id="DEUS_DARA" name="Composição de Deus-dará" default="temp_off">
+        <rule id="DEUS_DARA" name="Composição de Deus-dará">
             <pattern>
                 <token>a</token>
                 <marker>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -10698,7 +10698,7 @@ USA
     </category>
 
     <category id="SCIENTIFIC" name="Linguagem científica" type="style" tone_tags="scientific">
-        <rule id="NUMERO_DE_MOLS" name="Número de mols -> massa molecular" default="temp_off" tags="picky" is_goal_specific="true">
+        <rule id="NUMERO_DE_MOLS" name="Número de mols -> massa molecular" tags="picky" is_goal_specific="true">
             <pattern>
                 <token>número</token>
                 <token>de</token>
@@ -10708,7 +10708,7 @@ USA
             <example correction="quantidade de matéria">Uma amostra com alto <marker>número de mols</marker>.</example>
         </rule>
 
-        <rule id="PESO_MOLECULAR" name="Peso molecular -> massa molecular" default="temp_off" tags="picky" is_goal_specific="true">
+        <rule id="PESO_MOLECULAR" name="Peso molecular -> massa molecular" tags="picky" is_goal_specific="true">
             <pattern>
                 <token>peso</token>
                 <token>molecular</token>
@@ -10727,7 +10727,7 @@ USA
             <example correction="constante de Avogadro">Calculamos com o <marker>número de Avogadro</marker>.</example>
         </rule>
 
-        <rule id="GRAU_CENTIGRADO" name="Preferir 'grau Celius' a 'grau centígrado'." default="temp_off">
+        <rule id="GRAU_CENTIGRADO" name="Preferir 'grau Celius' a 'grau centígrado'.">
             <pattern>
                 <token regexp="yes">graus?</token>
                 <marker>
@@ -18386,7 +18386,7 @@ USA
     </category>
 
     <category id="GENERAL" name="Regras gerais de estilo" type="style" tone_tags="general">
-        <rule id="GRAU_KELVIN" name="Evitar 'grau' antes da unidade Kelvin" default="temp_off">
+        <rule id="GRAU_KELVIN" name="Evitar 'grau' antes da unidade Kelvin">
             <pattern>
                 <token regexp="yes">graus?</token>
                 <token>kelvin</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -10700,31 +10700,37 @@ USA
     <category id="SCIENTIFIC" name="Linguagem científica" type="style" tone_tags="scientific">
         <rule id="NUMERO_DE_MOLS" name="Número de mols -> massa molecular" tags="picky" is_goal_specific="true">
             <pattern>
+                <token postag_regexp="yes" postag="(SP.+:)?D.+MS.*" min="0"/>
                 <token>número</token>
                 <token>de</token>
                 <token regexp="yes">mol(e?s)?</token>
             </pattern>
-            <message>&scientific_intro; prefira <suggestion>quantidade de matéria</suggestion>.</message>
-            <example correction="quantidade de matéria">Uma amostra com alto <marker>número de mols</marker>.</example>
+            <message>&scientific_intro; prefira &quot;quantidade de matéria&quot;.</message>
+            <suggestion><match no="1" postag_regexp="yes" postag="(.+)MS(.+)" postag_replace="$1FS$2" include_skipped="all"/> quantidade de matéria</suggestion>
+            <example correction="Esta quantidade de matéria"><marker>Este número de mols</marker> da amostra.</example>
         </rule>
 
         <rule id="PESO_MOLECULAR" name="Peso molecular -> massa molecular" tags="picky" is_goal_specific="true">
             <pattern>
+                <token postag_regexp="yes" postag="(SP.+:)?D.+MS.*" min="0"/>
                 <token>peso</token>
                 <token>molecular</token>
             </pattern>
-            <message>&scientific_intro; prefira <suggestion>massa molecular</suggestion>.</message>
-            <example correction="massa molecular">Uma amostra com alto <marker>peso molecular</marker>.</example>
+            <message>&scientific_intro; prefira &quot;massa molecular&quot;.</message>
+            <suggestion><match no="1" postag_regexp="yes" postag="(.+)MS(.+)" postag_replace="$1FS$2"/> massa molecular</suggestion>
+            <example correction="da massa molecular">A compreensão <marker>do peso molecular</marker> do elemento.</example>
         </rule>
 
-        <rule id="NUMERO_DE_AVOGADRO" name="Número de Avogadro -> constante" default="temp_off" tags="picky" is_goal_specific="true">
+        <rule id="NUMERO_DE_AVOGADRO" name="Número de Avogadro -> constante" tags="picky" is_goal_specific="true">
             <pattern>
+                <token postag_regexp="yes" postag="(SP.+:)?D.+MS.*" min="0"/>
                 <token>número</token>
                 <token>de</token>
                 <token>Avogadro</token>
             </pattern>
-            <message>&scientific_intro; prefira <suggestion>constante de Avogadro</suggestion>.</message>
-            <example correction="constante de Avogadro">Calculamos com o <marker>número de Avogadro</marker>.</example>
+            <message>&scientific_intro; prefira &quot;constante de Avogadro&quot;.</message>
+            <suggestion><match no="1" postag_regexp="yes" postag="(.+)MS(.+)" postag_replace="$1FS$2"/> constante de Avogadro</suggestion>
+            <example correction="a constante de Avogadro">Calculamos com <marker>o número de Avogadro</marker>.</example>
         </rule>
 
         <rule id="GRAU_CENTIGRADO" name="Preferir 'grau Celius' a 'grau centígrado'.">


### PR DESCRIPTION
No FPs, per nightlies (below), but I thought we might also improve the agreement only of determiners adjacent to the expressions. Not handling adjectives and other stuff requiring more complex logic, as it doesn't look those will be very frequent.

https://regression.languagetoolplus.com/via-http/2023-09-01/pt-BR_full/result_style_PESO_MOLECULAR%5B1%5D.html
https://regression.languagetoolplus.com/via-http/2023-09-01/pt-BR_full/result_style_NUMERO_DE_AVOGADRO%5B1%5D.html