### PR TITLE
[pt] Enable new scientific rules

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -38800,7 +38800,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example>A vizinha bota fora a comida.</example>
         </rule>
 
-        <rule id="DEUS_DARA" name="Composição de Deus-dará" default="temp_off">
+        <rule id="DEUS_DARA" name="Composição de Deus-dará">
             <pattern>
                 <token>a</token>
                 <marker>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -10698,7 +10698,7 @@ USA
     </category>
 
     <category id="SCIENTIFIC" name="Linguagem científica" type="style" tone_tags="scientific">
-        <rule id="NUMERO_DE_MOLS" name="Número de mols -> massa molecular" default="temp_off" tags="picky" is_goal_specific="true">
+        <rule id="NUMERO_DE_MOLS" name="Número de mols -> massa molecular" tags="picky" is_goal_specific="true">
             <pattern>
                 <token>número</token>
                 <token>de</token>
@@ -10708,7 +10708,7 @@ USA
             <example correction="quantidade de matéria">Uma amostra com alto <marker>número de mols</marker>.</example>
         </rule>
 
-        <rule id="PESO_MOLECULAR" name="Peso molecular -> massa molecular" default="temp_off" tags="picky" is_goal_specific="true">
+        <rule id="PESO_MOLECULAR" name="Peso molecular -> massa molecular" tags="picky" is_goal_specific="true">
             <pattern>
                 <token>peso</token>
                 <token>molecular</token>
@@ -10727,7 +10727,7 @@ USA
             <example correction="constante de Avogadro">Calculamos com o <marker>número de Avogadro</marker>.</example>
         </rule>
 
-        <rule id="GRAU_CENTIGRADO" name="Preferir 'grau Celius' a 'grau centígrado'." default="temp_off">
+        <rule id="GRAU_CENTIGRADO" name="Preferir 'grau Celius' a 'grau centígrado'.">
             <pattern>
                 <token regexp="yes">graus?</token>
                 <marker>
@@ -18386,7 +18386,7 @@ USA
     </category>
 
     <category id="GENERAL" name="Regras gerais de estilo" type="style" tone_tags="general">
-        <rule id="GRAU_KELVIN" name="Evitar 'grau' antes da unidade Kelvin" default="temp_off">
+        <rule id="GRAU_KELVIN" name="Evitar 'grau' antes da unidade Kelvin">
             <pattern>
                 <token regexp="yes">graus?</token>
                 <token>kelvin</token>


### PR DESCRIPTION
Kelvin rule has no hits, centigrade one has [no FPs](https://regression.languagetoolplus.com/via-http/2023-09-01/pt-BR_full/result_style_GRAU_CENTIGRADO%5B1%5D.html).