### PR TITLE
[fr] Adding new words entering dics in 2023-24

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
@@ -2397,3 +2397,39 @@ flash-back;flash-back;N m sp
 flashback;flashback;N m s
 flashbacks;flashback;N m p
 AEMO;AEMO;N f s
+phytochimique;phytochimique;J e s
+phytochimiques;phytochimique;J e p
+Brindisi;Brindisi;Z e s
+guideline;guideline;N f s
+guidelines;guideline;N f p
+Idir;Idir;Z m s
+touchpad;touchpad;N m sp
+espresso;espresso;N m s
+flash-mob;flash-mob;N f s
+flash-mobs;flash-mob;N f p
+flashmob;flashmob;N f s
+flashmobs;flashmob;N f p
+MerciApp;MerciApp;Z e sp
+bader;bader;V inf
+badant;bader;V ppr
+badant;bader;V ppa m s
+badante;bader;V ppa f s
+badants;bader;V ppa m p
+badantes;bader;V ppa f p
+klette;klette;N f s
+klettes;klette;N f p
+clette;clette;N f s
+clettes;clette;N f p
+instagrammable;instagrammable;J e s
+instagrammables;instagrammable;J e p
+vélorution;vélorution;N f s
+vélorutions;vélorution;N f p
+bibimbap;bibimbap;N m s
+bibimbaps;bibimbap;N m p
+nutri-score;nutri-score;N m s
+nutri-scores;nutri-score;N m p
+flexoffice;flexoffice;N m s
+flexoffices;flexoffice;N m p
+flex-office;flex-office;N m s
+flex-offices;flex-office;N m p
+cododo;cododo;N m s

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
@@ -1976,7 +1976,8 @@ ghosteur;ghosteur;N m s
 ghosteurs;ghosteur;N m p
 ghosting;ghosting;N m s
 GitHub;GitHub;Z m s
-glottophobie;glottophobie;N m s
+glottophobie;glottophobie;N f s
+glottophobies;glottophobie;N f s
 greenwashing;greenwashing;N m s
 homestaging;homestaging;N m s
 Macronie;Macronie;N f s


### PR DESCRIPTION
DICO ADD
- these words are entering the new Robert Edition
- words are added with variations if needed

```
phytochimique
Brindisi
guideline
Idir (prénom)
touchpad
espresso
flash-mob
MerciApp
bader
badant
klettes (Belgian word)
instagrammable
greenwashing (est maintenant dans le dico)
vélorution
bibimbap
nutri-score
flexoffice
```