### PR TITLE
Improvements

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/ignore.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/ignore.txt
@@ -2273,7 +2273,6 @@ Dyck/S #name
 Grohnde/S #name
 JOVIS #name
 L-Azetidin
-Monte/S #name
 Nowotroizk/S #name
 Neu-Kuppritz #name
 PYD #abk

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/ignore.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/ignore.txt
@@ -2248,6 +2248,7 @@ IOIS #abk
 LOI #abk
 HSPA #abk
 DOI #abk
+doi #abk
 GOI #abk
 HFPA #abk
 HWWI #abk
@@ -2277,3 +2278,15 @@ Nowotroizk/S #name
 Neu-Kuppritz #name
 PYD #abk
 Somnium #lat
+Finanztip/S #Ratgeber; rule for typo created
+Vermögensteuer/N
+Ateneum
+Divisio #lat
+Divisiones #lat
+Divus #lat
+Diviš #name
+EcoTopTen #name
+GOZ #abk
+GOÄ #abk
+Passenger/S #eng
+WoW #abk

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/ignore.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/ignore.txt
@@ -2289,3 +2289,4 @@ GOZ #abk
 GOÄ #abk
 Passenger/S #eng
 WoW #abk
+unidealistisch/A #style rule

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -60023,3 +60023,34 @@ rein_verirren
 hinein_verirren
 Bernstein #komp
 Premiumpanzer/SN
+meistkonsumiert/A
+Monte Generoso #name
+Monte dei Paschi di Siena #name
+Monte Imperiale #name
+Monte Epomeo #name
+Monte Bondone #name
+Monte Troodelöh #name
+Belo Monte #name
+Monte Oliveto #name
+Monte Veritá #name
+Monte Cornacchia #name
+Monte Fontane #name
+Monte Zoncolan #name
+Monte Real #name
+Monte Castellazzo #name
+Monte Verde #name
+Monte Testaccio #name
+Monte Argentario #name
+Castel del Monte #name
+Maria del Monte #name
+Monte Filet #name
+Monte Cinto #name
+Monte Cristo #name
+Monte Bondone #name
+Monte Tre Croci #name
+Monte Ceneri #name
+Monte Darwin #name
+San Miniato al Monte #name
+San Salvatore al Monte #name
+Monte Pedreguer #name
+Monte Davidoff/S #name

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -60021,3 +60021,5 @@ elektroneutral/A
 weiter_düsen
 rein_verirren
 hinein_verirren
+Bernstein #komp
+Premiumpanzer/SN

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/remote-rule-filters.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/remote-rule-filters.xml
@@ -1702,7 +1702,7 @@ To ignore a remote rule match, set the <marker> so that it exactly covers the te
         <rulegroup id="AI_DE_GGEC_REPLACEMENT_ORTHOGRAPHY_OTHERCASE" name="">
             <rule><!--1-->
                 <pattern case_sensitive="yes">
-                    <token regexp="yes">[A-ZÄÖÜ]{1,}</token>
+                    <token regexp="yes">[A-ZÄÖÜ]{1,30}</token>
                 </pattern>
                 <example correction="">Das ist <marker>MEIN</marker> Haus.</example>
                 <example correction="">Er ist Chef der Firma <marker>METACOM</marker>.</example>

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/replace.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/replace.txt
@@ -484,6 +484,4 @@ Luka Jovic=Luka Jović
 Türkisch Airline=Turkish Airlines
 Türkisch Airlines=Turkish Airlines
 Finanztip=Finanztipp	Wenn Sie nicht den Ratgeber "Finanztip" meinen, wird "Finanztipp" mit doppeltem "p" geschrieben.
-Vermögensteuer=Vermögenssteuer
-Vermögensteuern=Vermögenssteuern
 St Germain=St. Germain

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/replace.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/replace.txt
@@ -483,5 +483,4 @@ Ousmane Dembele=Ousmane Dembélé
 Luka Jovic=Luka Jović
 Türkisch Airline=Turkish Airlines
 Türkisch Airlines=Turkish Airlines
-Finanztip=Finanztipp	Wenn Sie nicht den Ratgeber "Finanztip" meinen, wird "Finanztipp" mit doppeltem "p" geschrieben.
 St Germain=St. Germain


### PR DESCRIPTION
1st commit: eventually, I decided not to add it to the `recommendation.csv`, but  added _Vermögensteuer_ to `ignore.txt`, so both variants (_Vermögenssteuer_ and _Vermögensteuer_) are accepted by the speller but only _Vermögenssteuer_ will be suggested (see comments [here](https://github.com/languagetool-org/languagetool/pull/9252))