### PR TITLE
[fr] Dics addition

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
@@ -2518,3 +2518,7 @@ Seb;Seb;Z m s
 Stéph;Stéph;Z e s
 Gillou;Gillou;Z m s
 Nath;Nath;Z f s
+pédosexuel;pédosexuel;J m s
+pédosexuels;pédosexuel;J m p
+pédosexuelle;pédosexuel;J f s
+pédosexuelles;pédosexuel;J f p

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/hunspell/spelling.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/hunspell/spelling.txt
@@ -768,3 +768,5 @@ Seb
 Stéph
 Gillou
 Nath
+pédosexuel
+pédosexuels


### PR DESCRIPTION
Addition to dictionary files 

Even if the word "_pédosexuels_" isn't in the main dictionaries (Larousse, Robert, TLFi) the Cordial has [an entry for it ](https://www.cordial.fr/dictionnaire/definition/p%C3%A9dosexuel.php#:~:text=D%C3%A9finition%20de%20p%C3%A9dosexuel&text=Personne%20qui%20manifeste%20une%20attirance%20sexuelle%20pour%20les%20enfants.). Also  the suggestion displayed by LT convey a social judgement that's not acceptable. 

See https://twitter.com/Vince_NXi/status/1700148798985519264  
![image](https://github.com/languagetool-org/languagetool/assets/114988314/e0392190-0ea5-4afb-968d-2359652a95aa)
