### PR TITLE
[pt-PT] Added rule ID:INVARIABLE_NOUNS_POR_MOMENTO_POR_MOMENTOS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -869,6 +869,22 @@
         <example>Ele se tornou um aluno brilhante mas somente à custa de sua saúde.</example>
         <example>O consumo de gorduras n-6 aumentou à custa das gorduras n-3.</example>
       </rule>
+
+
+      <rule id='INVARIABLE_NOUNS_POR_MOMENTO_POR_MOMENTOS' name="[pt-PT] 'por momento'/'por momentos'" default="temp_off">
+        <pattern>
+          <marker>
+            <token>por</token>
+            <token>momento</token>
+          </marker>
+        </pattern>
+        <message>Esta expressão é invariável.</message>
+        <suggestion>por momentos</suggestion>
+        <example correction="Por momentos"><marker>Por momento</marker> vi a nossa vida a andar para trás.</example>
+        <example correction="Por momentos"><marker>Por momento</marker> a Ana pareceu-me bem.</example>
+      </rule>
+
+
     </rulegroup>
 
 


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart 

Here is a pt-PT only rule.

Ricardo Joseh Lima said it is not common in Brazil, so it is pt-PT only:
https://github.com/languagetool-org/languagetool/issues/9297

I tested it against 900 000 sentences and it had 0 hits.

It went all through the br.txt sentences file.

```
Portuguese (Portugal): 0 total matches
Portuguese (Portugal): 811110 total sentences considered
Portuguese (Portugal): ø0.00 rule matches per sentence
```

[0_900000sentences.txt](https://github.com/languagetool-org/languagetool/files/12590047/0_900000sentences.txt)

Thanks!