### PR TITLE
[pt] Broaden AP for CONC_NUM_GEN_O_SUAS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -8162,24 +8162,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <!-- The contraction postags make this difficult to do using the AdvancedSynthesizerFilter. For now, we just need a quickfix, so this silly rule will do. -->
         <rulegroup id="CONC_NUM_GEN_O_SUAS" name="Possível erro de digitação causando erro de concordância entre artigo e possessivo.">
             <antipattern>
-                <token regexp="yes" postag="(SP.+:)?DA.+" postag_regexp="yes">[nd]?o</token>
-                <token case_sensitive="yes">SUAS</token>
-            </antipattern>
-
-            <antipattern>
-                <token regexp="yes" postag="(SP.+:)?DA.+" postag_regexp="yes">[nd]?o</token>
-                <token case_sensitive="yes">Tua</token>
+                <token regexp="yes" postag="(SP.+:)?DA.+" postag_regexp="yes">[nd]?[oa]s?</token>
+                <token case_sensitive="yes" regexp="yes">\p{Lu}.+</token>
                 <example>própria operação da CP na Linha do Tua.</example>
-            </antipattern>
-
-            <antipattern>
-                <token regexp="yes" postag="(SP.+:)?DA.+" postag_regexp="yes">[nd]?o</token>
-                <token case_sensitive="yes">Minha</token>
-                <token case_sensitive="yes">Casa</token>
-                <token regexp="yes" min="0" spacebefore="no">,</token>
-                <token case_sensitive="yes">Minha</token>
-                <token case_sensitive="yes">Vida</token>
                 <example>três condomínios do Minha Casa, Minha Vida, do Rio Grande do Sul.</example>
+                <example>eles são do SUAS</example>
+                <example>energia solar da Meu Gerador</example>
             </antipattern>
 
             <rule> <!-- masc->fem.pl. -->


### PR DESCRIPTION
The disable contexts for this rule are always something to do with some named entity, so I've decided to merge the APs into a blanket block of the rule before anything starting with a capital letter. Let's see.