### PR TITLE
[pt] Added antipattern to rule ID:LINKING_VERB_PREDICATE_AGREEMENT

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -7327,6 +7327,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       -->
             <url>https://pt.wikipedia.org/wiki/Verbo_de_liga%C3%A7%C3%A3o</url>
 
+            <antipattern>
+                <token inflected='yes' regexp='no'>ser</token> <!-- Add more verbs here when/if found. -->
+                <token postag='AQ..P.+|NC.P.+' postag_regexp='yes'/>
+                <token postag='_PUNCT_COMMA' postag_regexp='no'/>
+                <token postag='AQ.+|NC.+' postag_regexp='yes'/>
+                <example>Eu sou letras, prazer, poesia, pecado, redenção.</example>
+                <example>Ele é letras, prazer, poesia, pecado, redenção.</example>
+            </antipattern>
+
             <!-- MARCOAGPINTO 2022-09-24 (Checked/Enhanced) (25-JUL-2022+) *START* -->
             <!-- Zero hits in 600 000 sentences, except my thesis. -->
             <antipattern>


### PR DESCRIPTION
Heya, Susana and Pedro,

Here is an antipattern.

In a 900 000-sentence check, it didn't remove a single hit.

This raises the question:
`<token inflected='yes' regexp='no'>ser</token> <!-- Add more verbs here when/if found. -->`

Should it accept all verbs, or just verb “ser” and others we may find?

https://github.com/languagetool-org/languagetool/issues/9299

Thanks!

