### PR TITLE
[pt] Enable PARA_MIM_FAZER

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -285,7 +285,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <rulegroup id="PARA_MIM_FAZER" name="Para mim fazer -> para eu fazer" default="temp_off">
+        <rulegroup id="PARA_MIM_FAZER" name="Para mim fazer -> para eu fazer">
             <rule id="PARA_MIM_FAZER_SENT_START">
                 <pattern>
                     <token postag_regexp="yes" postag="SENT_START|_PUNCT"/>


### PR DESCRIPTION
We've improved the [nightly results](https://internal1.languagetool.org/regression-tests/via-http/2023-09-15/pt-BR/result_grammar_PARA_MIM_FAZER_GERAL%5B4%5D.html) and I think this rule should be ready for production.