### PR TITLE
[pt] enable rules, add disambiguation rule for "tão", make TOMAR_ASSUMIR goal specific

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -210,7 +210,7 @@
       </disambig>
     </rule>
   </rulegroup>
-  <rule id="TAO_ADV" name="rare POS tags">
+  <rule id="TAO_ADV" name="disambiguate tão as an adverb">
     <pattern>
       <token postag="V.+" regexp="yes"/>
       <marker>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -210,7 +210,16 @@
       </disambig>
     </rule>
   </rulegroup>
-
+  <rule id="TAO_ADV" name="rare POS tags">
+    <pattern>
+      <token postag="V.+" regexp="yes"/>
+      <marker>
+        <token>tão</token>
+      </marker>
+    </pattern>
+    <disambig action="remove" postag="V.*"/>
+    <example type="untouched">Ela ficou tão bonita!</example>
+  </rule>
   <rulegroup id="RARE_POS" name="rare POS tags">
     <rule>
       <antipattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -30197,7 +30197,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="há">Namoro um cara <marker>a</marker> quase nove meses.</example>
                 <example correction="há">Eu conheci Isabella <marker>a</marker> alguns anos</example>
             </rule>
-            <rule default="temp_off">
+            <rule>
                 <pattern>
                     <token regexp="yes">daqui|dali</token>
                     <marker>
@@ -33973,7 +33973,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="aderência">A <marker>adesão</marker> do pneu é boa.</example>
         </rule>
 
-        <rule id='EMIGRAR_DE' name="Confusão: Emigrar + de" default="temp_off">
+        <rule id='EMIGRAR_DE' name="Confusão: Emigrar + de">
             <pattern>
                 <token inflected='yes'>emigrar</token>
                 <token regexp='yes'>pa?ra</token>
@@ -33983,7 +33983,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="imigraram para">Muitos <marker>emigraram para</marker> a França nos anos 60.</example>
         </rule>
 
-        <rule id='IMIGRAR_PARA' name="Confusão: Imigrar + para" default="temp_off">
+        <rule id='IMIGRAR_PARA' name="Confusão: Imigrar + para">
             <pattern>
                 <token inflected='yes'>imigrar</token>
                 <token postag="SPS.+" postag_regexp="yes" regexp='yes'>d.*</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -8314,7 +8314,7 @@ USA
     </category>
     <category id='ACADEMIC' name='Linguagem acadêmica' type='style' tone_tags="academic">
 
-        <rule id='TOMAR_ASSUMIR' name="[Universitário][Científico] V. Tomar → V. Assumir" tone_tags="academic">
+        <rule id='TOMAR_ASSUMIR' name="[Universitário][Científico] V. Tomar → V. Assumir" tone_tags="academic" is_goal_specific="true">
             <pattern>
                 <token postag='SENT_START|AQ.+|NC.+|NP.+|CS|CC' postag_regexp='yes'/>
                 <marker>


### PR DESCRIPTION
- Enable subrule in CONFUSAO_À_HÁ
- Enable IMIGRAR_PARA and EMIGRAR_DE
- Add disambiguation rule for tão to avoid confusion (rule should be expanded at some point)
- Make TOMAR_ASSUMIR goal specific