### PR TITLE
fix: AdaptSuggestionFilter only considered the first reading

### DIFF
--- a/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/AdaptSuggestionFilterTest.java
+++ b/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/AdaptSuggestionFilterTest.java
@@ -75,6 +75,8 @@ public class AdaptSuggestionFilterTest {
     runAcceptRuleMatch("Hier steht ihre Roadmap.", "Roadmap",   "Verfahren", "[ihr Verfahren]");
     runAcceptRuleMatch("Hier steht unsere Roadmap.", "Roadmap", "Verfahren", "[unser Verfahren]");
     runAcceptRuleMatch("Hier steht eure Roadmap.", "Roadmap",   "Verfahren", "[euer Verfahren]");
+
+    runAcceptRuleMatch("Ein Asylant.", "Asylant", "Asylberechtigter", "[Ein Asylberechtigter]");
   }
 
   @Ignore("WIP")


### PR DESCRIPTION
Maybe this was wrong all the time and we just didn't notice it? After updating the external jwordsplitter dependency, some tests started to fail (https://github.com/languagetooler-gmbh/languagetool-premium-modules/commit/c2ee720ae219f78bb6c411398f257b95039e5a17).