### PR TITLE
[pt] Enable SAIR_AS_RUAS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -12390,7 +12390,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="meia">Chegamos meio-dia e <marker>meio</marker>.</example>
         </rule>
 
-       <rulegroup id="SAIR_AS_RUAS" name="Erro de crase em 'sair as ruas' -> 'às'" default="temp_off">
+       <rulegroup id="SAIR_AS_RUAS" name="Erro de crase em 'sair as ruas' -> 'às'">
            <rule>
                <pattern>
                    <token postag_regexp="yes" postag="V.+" inflected="yes">sair</token>


### PR DESCRIPTION
[Looks solid](https://internal1.languagetool.org/regression-tests/via-http/2023-09-19/pt-BR/result_grammar_SAIR_AS_RUAS%5B1%5D.html).