### PR TITLE
[pt] Added the same AP to two rules to fix the wrong suggestion "pôr"

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -16477,6 +16477,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       -->
             <url>https://pt.wiktionary.org/wiki/Ap%C3%AAndice:Combina%C3%A7%C3%B5es_e_contra%C3%A7%C3%B5es_do_portugu%C3%AAs</url>
 
+            <antipattern>
+                <token postag='V.+' postag_regexp='yes'/>
+                <token regexp='no'>por</token>
+                <token postag='DA.+' postag_regexp='yes'/>
+                <token postag='DP.+' postag_regexp='yes'/>
+                <example>Tenho ECTS que os alunos de hoje não têm por a minha licenciatura e mestrado serem pré-Bolonha.</example>
+            </antipattern>
+
             <!-- MARCOAGPINTO 2023-04-25 + 2023-05-21 (Checked/Enhanced) (2-MAR-2023+) *START* -->
             <!-- It has zero hits in 600 000 sentences, it just removes two false positives in my thesis -->
             <antipattern>
@@ -32929,6 +32937,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <token postag='VMN03.+' postag_regexp='yes'/>
                 <example>O operador não terá a perceção disto por a imagem só ser refrescada no final.</example>
                 <example>Durante longos anos dizia-se que eu fazia batota por o meu dinheiro bater certo ao cêntimo.</example>
+            </antipattern>
+
+            <antipattern>
+                <token postag='V.+' postag_regexp='yes'/>
+                <token regexp='no'>por</token>
+                <token postag='DA.+' postag_regexp='yes'/>
+                <token postag='DP.+' postag_regexp='yes'/>
+                <example>Tenho ECTS que os alunos de hoje não têm por a minha licenciatura e mestrado serem pré-Bolonha.</example>
             </antipattern>
 
             <!-- Subrule #1: -->


### PR DESCRIPTION
The same AP for two rules that suggest “pôr” wrongly.