### PR TITLE
[fr] CONFUSION_CE_L_ON deleted and added to replace.txt

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/replace.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/replace.txt
@@ -30,3 +30,4 @@ dair=d'air|air|pair
 #june=juin
 malgrés=malgré
 parmis=parmi|partis|permis|Paris
+ce l'on=selon


### PR DESCRIPTION
For some reason, the rule CONFUSION_CE_L_ON isn't working, the rule can be handled in the replace.txt.