### PR TITLE
[pt] Added rule ID:PARA_SER_MELHORADA_A_MELHORAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -2590,6 +2590,21 @@ USA
             <example correction="finda|termina|acaba">Outro ano que <marker>chega ao fim</marker>.</example>
         </rule>
 
+        <rule id='PARA_SER_MELHORADA_A_MELHORAR' name="Para/a ser melhorad(a/o) → a melhorar" default="temp_off">
+            <!-- IDEA shorten_it -->
+            <pattern>
+                <token postag="NC.+|AQ.+" postag_regexp='yes'/>
+                <marker>
+                    <token regexp='yes'>a|para</token>
+                    <token regexp='yes'>ser(em)?</token>
+                    <token regexp='yes'>melhorad[ao]s?</token>
+                </marker>
+            </pattern>
+            <message>&simplify_msg;</message>
+            <suggestion>a melhorar</suggestion>
+            <example correction="a melhorar">Outra limitação <marker>para ser melhorada</marker> passa pela inclusão de novas equações.</example>
+            <example correction="a melhorar">Outro ponto <marker>a ser melhorado</marker> é a inclusão de novas equações.</example>
+        </rule>
 
         <!-- VERB + A + ELE(S)/ELA(S) verb + lhe -->
         <rulegroup id='SIMPLIFICAR_PP_OBJ_IND_V2' name="[pt-PT][Simplificar] Pronome pessoal no dativo" type='style' tone_tags="objective">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -11984,6 +11984,25 @@ USA
             <message>Substitua por <suggestion>nada vai</suggestion>.</message>
             <example correction="nada vai">Em princípio <marker>as coisas não vão</marker> melhorar.</example>
         </rule>
+
+
+        <rule id='PARA_SER_MELHORADA_A_MELHORAR' name="Para/a ser melhorad(a/o) → a melhorar">
+            <!-- IDEA shorten_it -->
+            <pattern>
+                <token postag="NC.+|AQ.+" postag_regexp='yes'/>
+                <marker>
+                    <token regexp='yes'>a|para</token>
+                    <token regexp='yes'>ser(em)?</token>
+                    <token regexp='yes'>melhorad[ao]s?</token>
+                </marker>
+            </pattern>
+            <message>&simplify_msg;</message>
+            <suggestion>a melhorar</suggestion>
+            <example correction="a melhorar">Outra limitação <marker>para ser melhorada</marker> passa pela inclusão de novas equações.</example>
+            <example correction="a melhorar">Outro ponto <marker>a ser melhorado</marker> é a inclusão de novas equações.</example>
+        </rule>
+
+
         <!-- É NECESSÁRIO ESTAR PRESENTE é presencial -->
         <!--      Created by Marco A.G.Pinto, Portuguese rule 2020-12-02 (21-OCT-2020+)  *START*   -->
         <rulegroup id='PRESENTE_PRESENCIAL' name="é presencial">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -11986,7 +11986,7 @@ USA
         </rule>
 
 
-        <rule id='PARA_SER_MELHORADA_A_MELHORAR' name="Para/a ser melhorad(a/o) → a melhorar">
+        <rule id='PARA_SER_MELHORADA_A_MELHORAR' name="Para/a ser melhorad(a/o) → a melhorar" default="temp_off">
             <!-- IDEA shorten_it -->
             <pattern>
                 <token postag="NC.+|AQ.+" postag_regexp='yes'/>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -11985,24 +11985,6 @@ USA
             <example correction="nada vai">Em princípio <marker>as coisas não vão</marker> melhorar.</example>
         </rule>
 
-
-        <rule id='PARA_SER_MELHORADA_A_MELHORAR' name="Para/a ser melhorad(a/o) → a melhorar" default="temp_off">
-            <!-- IDEA shorten_it -->
-            <pattern>
-                <token postag="NC.+|AQ.+" postag_regexp='yes'/>
-                <marker>
-                    <token regexp='yes'>a|para</token>
-                    <token regexp='yes'>ser(em)?</token>
-                    <token regexp='yes'>melhorad[ao]s?</token>
-                </marker>
-            </pattern>
-            <message>&simplify_msg;</message>
-            <suggestion>a melhorar</suggestion>
-            <example correction="a melhorar">Outra limitação <marker>para ser melhorada</marker> passa pela inclusão de novas equações.</example>
-            <example correction="a melhorar">Outro ponto <marker>a ser melhorado</marker> é a inclusão de novas equações.</example>
-        </rule>
-
-
         <!-- É NECESSÁRIO ESTAR PRESENTE é presencial -->
         <!--      Created by Marco A.G.Pinto, Portuguese rule 2020-12-02 (21-OCT-2020+)  *START*   -->
         <rulegroup id='PRESENTE_PRESENCIAL' name="é presencial">


### PR DESCRIPTION
Heya, Pedro and Susana,

Here is a simple rule which I came up with while revising my thesis.

I tried to replace:
`<token regexp='yes'>a|para</token>`
with:
`<token/>`
just to see the difference, but it only had two hits and only one was a real positive.

Here are the results:
```
Portuguese (Portugal): 1 total matches
Portuguese (Portugal): 811110 total sentences considered
Portuguese (Portugal): ø0.00 rule matches per sentence
```

[_2.txt](https://github.com/languagetool-org/languagetool/files/12732193/_2.txt)

Thanks!

