### PR TITLE
[de] changed prio over gGEC

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
@@ -296,6 +296,7 @@ public class German extends Language implements AutoCloseable {
       case "DA_DURCH": return 2; // prefer over SUBSTANTIVIERUNG_NACH_DURCH and DURCH_SCHAUEN and DURCH_WACHSEN
       case "BEI_GOOGLE" : return 2;   // prefer over agreement rules and VOR_BEI
       case "EINE_ORIGINAL_RECHNUNG_TEST" : return 2;   // prefer over agreement rules
+      case "VON_SEITEN_RECOMMENDATION" : return 2;   // prefer over AI_DE_GGEC_UNNECESSARY_ORTHOGRAPHY_SPACE
       case "VONSTATTEN_GEHEN" : return 2;   // prefer over EINE_ORIGINAL_RECHNUNG
       case "VERWECHSLUNG_MIR_DIR_MIR_DIE": return 1; // prefer over MIR_DIR
       case "ERNEUERBARE_ENERGIEN": return 1; // prefer over VEREINBAREN


### PR DESCRIPTION
gGEC takes away the match, gives a correct suggestion, but the message is not helpful and it is marked as a spelling error, when in fact it is just the recommended spelling. The xml style rule has a good apply rate in grafana and there is no data on matomo so no disables (last 30 days).  

![image](https://github.com/languagetool-org/languagetool/assets/115984740/24057368-2a45-492a-83cb-18781d9cac0f)

![image](https://github.com/languagetool-org/languagetool/assets/115984740/fa6044be-25c9-472f-9411-b73982ac4e8d)
[Grafana 30 days view ](https://internal1.languagetool.org/grafana/d/j4ReLa87z/rule-events-summary-with-types?orgId=1&var-rule_id=VON_SEITEN_RECOMMENDATION&var-language=All&var-rule_category=All&var-rule_type=All&var-filename=All&var-rule_tags=All&var-tone_tags=All&var-minOpen=0&from=now-30d&to=now)