### PR TITLE
refactor: make classes accessed from language-* to public

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/chunking/TokenExpressionFactory.java
+++ b/languagetool-core/src/main/java/org/languagetool/chunking/TokenExpressionFactory.java
@@ -25,14 +25,14 @@ import edu.washington.cs.knowitall.regex.ExpressionFactory;
 /**
  * @since 2.9
  */
-final class TokenExpressionFactory extends ExpressionFactory<ChunkTaggedToken> {
+public final class TokenExpressionFactory extends ExpressionFactory<ChunkTaggedToken> {
 
   private final boolean caseSensitive;
 
   /**
    * @param caseSensitive whether word tokens should be compared case-sensitively - also used for regular expressions
    */
-  TokenExpressionFactory(boolean caseSensitive) {
+  public TokenExpressionFactory(boolean caseSensitive) {
     this.caseSensitive = caseSensitive;
   }
 

--- a/languagetool-core/src/main/java/org/languagetool/language/Contributor.java
+++ b/languagetool-core/src/main/java/org/languagetool/language/Contributor.java
@@ -32,12 +32,12 @@ public final class Contributor {
    * @param name full name
    * @param url URL to homepage or similar (optional)
    */
-  Contributor(String name, String url) {
+  public Contributor(String name, String url) {
     this.name = Objects.requireNonNull(name, "name cannot be null");
     this.url = url;
   }
 
-  Contributor(String name) {
+   public Contributor(String name) {
     this(name, null);
   }
   

--- a/languagetool-core/src/main/java/org/languagetool/language/Contributors.java
+++ b/languagetool-core/src/main/java/org/languagetool/language/Contributors.java
@@ -21,13 +21,13 @@ package org.languagetool.language;
 /**
  * Constants for contributors who contribute to more than one language (use to avoid duplication).
  */
-final class Contributors {
+public final class Contributors {
 
   private Contributors() {
   }
 
-  static final Contributor MARCIN_MILKOWSKI = new Contributor("Marcin Miłkowski", "http://marcinmilkowski.pl");
-  static final Contributor DANIEL_NABER = new Contributor("Daniel Naber", "http://www.danielnaber.de");
-  static final Contributor DOMINIQUE_PELLE = new Contributor("Dominique Pellé", "http://dominiko.livejournal.com/tag/lingvoilo");
+  public static final Contributor MARCIN_MILKOWSKI = new Contributor("Marcin Miłkowski", "http://marcinmilkowski.pl");
+  public static final Contributor DANIEL_NABER = new Contributor("Daniel Naber", "http://www.danielnaber.de");
+  public static final Contributor DOMINIQUE_PELLE = new Contributor("Dominique Pellé", "http://dominiko.livejournal.com/tag/lingvoilo");
 
 }


### PR DESCRIPTION
# Purpose and motivation

Preparation for "Support Java9 Platform Module System(JPMS)" #9406

Circle CI in #9406 failed to build because it uses a snapshot version of "languagetool-core" library.
So I propose a preparation change for the JPMS support.

# What problem is resolved?

#9406 changes packages from o.l.language to o.l.language.(lang) to support JPMS.
It asks "language-core" expose  some classes to see from another package. 


# What is changes?

- escalate o.l.c.TokenExpressionFactory and o.l.language.Contributor(s) to public

# Further information

 we can control visibility by module-info.java in future when languagetool support fully JPMS even when we escalate class to public.
