### PR TITLE
[pt] antipattern added to DNA[2] (#6083)

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -1368,6 +1368,11 @@
       <example type="untouched">Um <marker>mal trabalhador</marker> reclama de suas ferramentas.</example><!-- triggers MAL_MAU_CONFUSION -->
     </rule>
     <rule>
+      <antipattern>
+        <token postag="D.+" postag_regexp="yes"/>
+        <token postag="R.+|D.+" postag_regexp="yes"/>
+        <token postag="CC"/>
+      </antipattern>
       <pattern>
         <marker>
           <unify>


### PR DESCRIPTION
- Trying to address [this error](https://github.com/languagetooler-gmbh/languagetool-premium/issues/6083).
- It appears the disambiguator is generating non-existent postags (`D.+`, `R.+`) due to an overlapping of postags in the rule pattern:

```
<pattern>
        <marker>
          <unify>
            <feature id="gender"/>
            <feature id="number"/>
          <token postag="D.+" postag_regexp="yes"/>
        <unify-ignore>
          <token postag="R.+" postag_regexp="yes"/>
        </unify-ignore>
          <token postag="A.+" postag_regexp="yes"><exception>bem</exception></token>
          </unify>
        </marker>
      </pattern>
```

<img width="784" alt="image" src="https://github.com/languagetool-org/languagetool/assets/108675843/b5b29aa8-38cb-4c75-901d-2079f267f302">

- As we can see, `mesmo` and `conforme` appear twice in the disambiguator because they include more than one postag from the pattern; the antipattern added tries to fix this.