### PR TITLE
[pt] add tags to "abraçadinho" and its variants

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
@@ -9184,3 +9184,7 @@ masturbatório	masturbatório	AQ0MS0
 masturbatórios	masturbatório	AQ0MP0
 masturbatória	masturbatório	AQ0FS0
 masturbatórias	masturbatório	AQ0FP0
+abraçadinho	abraçadinho	AQ0MS0
+abraçadinha	abraçadinho	AQ0FS0
+abraçadinhos	abraçadinho	AQ0MP0
+abraçadinhas	abraçadinho	AQ0FP0


### PR DESCRIPTION
The diminutive forms of "abraçado" were not tagged.  Plus: the only way to mark them as diminutives is to tag them as nouns. I wonder if we should add D to adjective attributes.