### PR TITLE
[fr] Francophonie/Afrique dic additions

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
@@ -2553,3 +2553,17 @@ digestat;digestat;N m s
 digestats;digestat;N m p
 Hymoov;Hymoov;Z e s
 Iremia;Iremia;Z e s
+parkwa;parkwa;N m s
+mandara;mandara;N m s
+kanouri;kanouri;N m s
+béti;béti;N m s
+bassa;bassa;N m s
+bankon;bankon;N m s
+boulou;boulou;N m s
+ewondo;ewondo;N m s
+douala;douala;N m s
+camfranglais;camfranglais;N m s
+moundang;moundang;N m s
+bamikélé;bamikélé;N m s
+dioula;dioula;N m s
+bamikélées;bamikélées;J f p

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/hunspell/spelling.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/hunspell/spelling.txt
@@ -808,3 +808,87 @@ Pietro Fiorentini
 Diehl Metering
 Jérôme Chambin
 Prisma Media
+Kaïs Saïed
+Zine el-Abidine Ben Ali
+Youssef Chahed
+Elyes Fakhfakh
+Hichem Mechichi
+Najla Bouden
+Ahmed Hachani
+Mohamed Ennaceur
+Béji Caïd Essebsi
+Taïeb Baccouche
+Félix Antoine Tshisekedi Tshilombo
+Bruno Tshibala
+Sylvestre Ilunga
+Sama Lukonde
+Joseph Kabila
+Abdoulaye Yerodia Ndombasi
+Azarias Ruberwa
+Jean-Pierre Bemba
+Arthur Z'ahidi Ngoma
+Antoine Gizenga
+Adolphe Muzito
+Louis Koyagialo
+Augustin Matata Ponyo
+Samy Badibanga
+Bruno Tshibala
+Laurent-Désiré Kabila
+Abdelmadjid Tebboune
+Sabri Boukadoum
+Abdelaziz Djerad
+Aïmene Benabderrahmane
+Mohammed VI
+Aziz Akhannouch
+Akhannouch
+Abbas El Fassi
+Abdelilah Benkirane
+Saad Dine El Otmani
+El Fassi
+Mohand Laenser
+Mohamed Sadiki
+Alassane Ouattara
+Tiémoko Meyliet Koné
+Patrick Achi
+Adama Bictogo
+Jeannot Ahoussou-Kouadio
+Paul Biya
+Joseph Dion Ngute
+Marcel Niat Njifenji
+Christian Ntsay
+Hery Rajaonarimampianina
+Rivo Rakotovao
+Andry Rajoelina
+Olivier Jocelyn Mahafaly Solonandrasana
+Ibrahim Traoré
+Apollinaire Joachim Kyélem de Tambèla
+Paul-Henri Sandaogo Damiba
+Albert Ouédraogo
+Leïla Ben Ali
+Moncef Marzouki
+Patrice Lumumba
+Kah Walla
+Fatou Bensouda
+Djamila Bouhired
+Rama Yade
+Sékou Touré
+Amina Mohamed
+Ellen Johnson Sirleaf
+Paul Kagame
+Yoweri Museveni
+Macky Sall
+Hage Geingob
+Hailemariam Desalegn
+parkwa
+mandara
+kanouri
+béti
+bassa
+bankon
+boulou
+ewondo
+douala
+camfranglais
+moundang
+bamikélé
+dioula

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/multiwords.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/multiwords.txt
@@ -2925,3 +2925,114 @@ Diehl Metering; Z e s
 Jérôme Chambin; Z m s
 loi n°78-17 du 6 janvier 1978; N f s
 Prisma Media; Z e s
+Frédéric Thiollier; Z m s
+La Barillais; Z m s
+Dominique Tristant; Z m s
+Green Solutions Awards; Z m sp
+Pietro Fiorentini; Z m s
+Diehl Metering; Z e s
+Jérôme Chambin; Z m s
+loi n°78-17 du 6 janvier 1978; N f s
+Prisma Media; Z e s
+Kaïs Saïed; Z m s
+Zine el-Abidine Ben Ali; Z m s
+Youssef Chahed; Z m s
+Elyes Fakhfakh; Z m s
+Hichem Mechichi; Z m s
+Najla Bouden; Z f s
+Ahmed Hachani; Z m s
+Mohamed Ennaceur; Z m s
+Béji Caïd Essebsi; Z m s
+Taïeb Baccouche; Z m s
+Félix Antoine Tshisekedi Tshilombo; Z m s
+Bruno Tshibala; Z m s
+Sylvestre Ilunga; Z m s
+Sama Lukonde; Z m s
+Joseph Kabila; Z m s
+Abdoulaye Yerodia Ndombasi; Z m s
+Azarias Ruberwa; Z m s
+Jean-Pierre Bemba; Z m s
+Arthur Z'ahidi Ngoma; Z m s
+Antoine Gizenga; Z m s
+Adolphe Muzito; Z m s
+Louis Koyagialo; Z m s
+Augustin Matata Ponyo; Z m s
+Samy Badibanga; Z m s
+Bruno Tshibala; Z m s
+Laurent-Désiré Kabila; Z m s
+Abdelmadjid Tebboune; Z m s
+Sabri Boukadoum; Z m s
+Abdelaziz Djerad; Z m s
+Aïmene Benabderrahmane; Z m s
+Mohammed VI; Z m s
+Aziz Akhannouch; Z m s
+Abbas El Fassi; Z m s
+Abdelilah Benkirane; Z m s
+Saad Dine El Otmani; Z m s
+El Fassi; Z m s
+Mohand Laenser; Z m s
+Mohamed Sadiki; Z m s
+Alassane Ouattara; Z m s
+Tiémoko Meyliet Koné; Z m s
+Patrick Achi; Z m s
+Adama Bictogo; Z m s
+Jeannot Ahoussou-Kouadio; Z m s
+Paul Biya; Z m s
+Joseph Dion Ngute; Z m s
+Marcel Niat Njifenji; Z m s
+Christian Ntsay; Z m s
+Hery Rajaonarimampianina; Z m s
+Rivo Rakotovao; Z m s
+Andry Rajoelina; Z m s
+Olivier Jocelyn Mahafaly Solonandrasana; Z m s
+Ibrahim Traoré; Z m s
+Apollinaire Joachim Kyélem de Tambèla; Z m s
+Paul-Henri Sandaogo Damiba; Z m s
+Albert Ouédraogo; Z m s
+Leïla Ben Ali; Z f s
+Moncef Marzouki; Z f s
+Patrice Lumumba; Z f s
+Kah Walla; Z f s
+Fatou Bensouda; Z f s
+Djamila Bouhired; Z f s
+Rama Yade; Z f s
+Sékou Touré; Z f s
+Amina Mohamed; Z f s
+Ellen Johnson Sirleaf; Z f s
+Paul Kagame; Z m s
+Yoweri Museveni; Z m s
+Macky Sall; Z m s
+Hage Geingob; Z m s
+Hailemariam Desalegn; Z m s
+Léopold Sédar Senghor; Z m s
+Nawal El Saadawi; Z f s
+Leïla Slimani; Z f s
+Chinua Achebe; Z m s
+Amin Maalouf; Z m s
+Assia Djebar; Z f s
+Maryse Condé; Z f s
+Alain Mabanckou; Z m s
+Dany Laferrière; Z m s
+Tahar Ben Jelloun; Z m s
+Yasmina Reza; Z f s
+Marie NDiaye; Z f s
+Hicham Saïed; Z m s
+Ichraf Chebil; Z f s
+Rachid Taha; Z m s
+Raouf Bouzaiene; Z m s
+Latifa Arfaoui; Z m s
+Taoufik Ben Brik; Z m s
+Ons Jabeur; Z f s
+Youssef Msakni; Z m s
+Néjib Belkadhi; Z m s
+Amina Sboui; Z f s
+Fally Ipupa; Z m s
+Cédric Bakambu; Z m s
+Denis Mukwege; Z m s
+Dieudonné M'bala M'bala; Z m s
+Evelyne Dhéliat; Z f s
+Makaya Ntshayi; Z m s
+Angélique Kidjo; Z f s
+Aïssa Maïga; Z f s
+Assia Djebar; Z f s
+Rokia Traoré; Z f s


### PR DESCRIPTION
In the context of https://github.com/languagetooler-gmbh/languagetool-premium/issues/6467
- Adding 100 names (politicians, authors, footballer players, etc.) from African continent. 
- Adding also 15 languages