### PR TITLE
Add annotatorName to SentenceAnnotaor cfg

### DIFF
--- a/languagetool-http-client/src/main/java/org/languagetool/remote/SentenceAnnotator.java
+++ b/languagetool-http-client/src/main/java/org/languagetool/remote/SentenceAnnotator.java
@@ -35,6 +35,7 @@ public class SentenceAnnotator {
       AnnotatorConfig cfg = new AnnotatorConfig();
       cfg.remoteServer = prop.getProperty("remoteServer", "http://localhost:8081").trim();
       cfg.userName = prop.getProperty("userName", "").trim();
+      cfg.annotatorName = prop.getProperty("annotatorName", "").trim();
       cfg.apiKey = prop.getProperty("apiKey", "").trim();
       cfg.inputFilePath = prop.getProperty("inputFile", "").trim();
       cfg.outputFilePath = prop.getProperty("outputFile", "").trim();
@@ -385,7 +386,7 @@ public class SentenceAnnotator {
                                       int suggestionsTotal, String ruleId, String ruleCategory, String ruleType) {
     String[] rowFields = {
       sentenceHash,
-      cfg.userName,
+      cfg.annotatorName,
       timestamp,
       errorSentence,
       correctedSentence,
@@ -576,6 +577,7 @@ public class SentenceAnnotator {
   static private class AnnotatorConfig {
     String remoteServer;
     String userName;
+    String annotatorName;
     String apiKey;
     String inputFilePath;
     String outputFilePath;


### PR DESCRIPTION
@AzadehSafakish: this should work.

@jaumeortola, already updated this [on Confluence](https://languagetooler.atlassian.net/wiki/spaces/DEV/pages/2134016018/SentenceAnnotator+instructions). Needed because we want to add the annotator's name to the output but the `userName` is used for something else.