### PR TITLE
[pt] Removed "temp_off" from rule ID:DE_FORA_EXTERNO_DE_DENTRO_INTERNO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -11207,7 +11207,7 @@ USA
         </rulegroup>
 
 
-        <rulegroup id='DE_FORA_EXTERNO_DE_DENTRO_INTERNO' name="Simplificar: de dentro/fora → interno/externo" default="temp_off">
+        <rulegroup id='DE_FORA_EXTERNO_DE_DENTRO_INTERNO' name="Simplificar: de dentro/fora → interno/externo">
             <!--IDEA shorten_it-->
 
             <!-- #1: de dentro → interno -->


### PR DESCRIPTION
Heya, Susana and Pedro,

I have removed the "temp_off":
https://internal1.languagetool.org/regression-tests/via-http/2023-10-06/pt-BR/result_style_DE_FORA_EXTERNO_DE_DENTRO_INTERNO%5B2%5D.html

Thanks!