### PR TITLE
feat: allow loading language-* module as plugins in application

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/Languages.java
+++ b/languagetool-core/src/main/java/org/languagetool/Languages.java
@@ -116,9 +116,8 @@ public final class Languages {
     List<Language> staticLanguages = new ArrayList<>();
     Set<String> languageClassNames = new HashSet<>();
     try {
-      Enumeration<URL> propertyFiles = Language.class.getClassLoader().getResources(PROPERTIES_PATH);
-      while (propertyFiles.hasMoreElements()) {
-        URL url = propertyFiles.nextElement();
+      List<URL> propertyFiles = JLanguageTool.getDataBroker().getAsURLs(PROPERTIES_PATH);
+      for (URL url: propertyFiles) {
         try (InputStream inputStream = url.openStream()) {
           // We want to be able to read properties file with duplicate key, as produced by
           // Maven when merging files:


### PR DESCRIPTION
There are many language modules LanguageTool project provided. It is benefitical that langaugetool allow language-* module to be loaded dynimically before calling languagetool core functions.

Currently language list is built in static **initialization** context. 

This is a proposal that the creation of languages list is happened **when requested.** This allows applications to load language-* modules after a launch of the application, aka. classLoader load them after static initialization.

Here is a client example which loading language-en in dynamic way, and implements `brokers`. 
https://github.com/miurahr/languagetool-dynamic-loading-client-example