### PR TITLE
[pt] Improved rule ID:TOMAR_ASSUMIR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -8317,13 +8317,15 @@ USA
                     </token>
                 </marker>
                 <token min='0' max='2' postag='SPS00|(SPS00:)?[DP][ADIPRT].+|RG' postag_regexp='yes'/>
-                <token regexp='yes'>cert[ao]s?|determinad[ao]s?|diferentes?|divers[ao]s?|enormes?|imens[ao]s?|inúmer[ao]s|múltipl[ao]s|vári[ao]s|variad[ao]s</token>
-                <token postag='AQ.+|NC.+' postag_regexp='yes'>
+                <token regexp='yes'>cert[ao]s?|determinad[ao]s?|diferentes?|divers[ao]s?|enormes?|formas?|imens[ao]s?|inúmer[ao]s|múltipl[ao]s|vári[ao]s|variad[ao]s</token>
+                <token postag='AQ.+|NC.+|PI.+' postag_regexp='yes'>
                     <exception regexp='yes' inflected='yes'>bebida|café|caneca|cerveja|chá|colher|copo|drink|frasco|garfo|garrafa|garrafão|xícara|shot|su[mc]o|vinho|gelado|sorvete|blíster|caixa|comprimido|contracetivo|embalagem|medicação|medicamento|pílula|remédio|autocarro|automóvel|avião|carrinha|carro|jato|ônibus|táxi|veículo|comboio|trem|voo|barc[ao]|bote|canoa|ferry|banho|duche</exception> <!-- Add more words as they are found -->
                 </token>
             </pattern>
             <message>Num contexto formal/científico, é preferível escrever &quot;assumir&quot;.</message>
             <suggestion><match no='2' postag='V.+' postag_regexp='yes'>assumir</match></suggestion>
+            <example correction="assume">O crime <marker>toma</marker> formas impensáveis.</example>
+            <example correction="assume">O crime <marker>toma</marker> formas diversas.</example>
             <example correction="assume">O crime é perigoso e o seu financiamento <marker>toma</marker> diversas formas.</example>
             <example correction="assume">O crime é perigoso e o seu financiamento <marker>toma</marker> as mais diversas formas.</example>
         </rule>


### PR DESCRIPTION
Heya, Susana and Pedro,

The disambiguator fix I have done yesterday made possible to improve this rule.

However, in 900 000 sentences, this improvement only gave one extra hit.

Ahhhhh… I forgot to mention it yesterday, but `TESTRULES PT` gives disambiguator warnings:

```
*** WARNING: The Portuguese rule: TAO_ADV[1], token [1], contains an empty string "" that is marked as regular expression.
*** WARNING: The Portuguese rule: TAO_ADV[1] (POS tag), token [1], contains "V.+" that is not marked as regular expression but probably is one.
*** WARNING: The Portuguese rule: FILTER_PROPER_NAMES[3], token [1], contains duplicated non case sensitive disjunction part (monte) within "Monte|bairro|café|concurso|curso|designaç?o|designado|designados|estilo|festival|filme|fundo|furac?o|galard?o|género|gênero|grupo|hospital|império|instituto|intitulado|jornal|lago|liceu|livro|monte|museu|nau|navio|partido|prémio|programa|projeto|registo|registro|reino|relatório|rio|teatro|tema|tipo". Did you forget case_sensitive="yes"?
```

Thanks!
