### PR TITLE
[fr] AP in PAS_DE_VIRGULE_STYLE and VIRG_NON_TROUVEE

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -21537,6 +21537,19 @@ Pour en savoir plus sur les tone tags, suivez le lien vers notre documentation (
             </rule>
             <rule tags="picky">
                 <antipattern>
+                    <token>Un</token>
+                    <token>jour</token>
+                    <token>je</token>
+                    <token>m'en</token>
+                    <token>irai</token>
+                    <token>,</token>
+                    <token>sans</token>
+                    <token>en</token>
+                    <token>avoir</token>
+                    <token>tout</token>
+                    <token>dit</token>
+                </antipattern>
+                <antipattern>
                     <token postag="V.* (ind|con|sub).*" postag_regexp="yes"/>
                     <token postag="A" min="0" max="3"/>
                     <token>,</token>


### PR DESCRIPTION
Adding AP to PAS_DE_VIRGULE_STYLE and VIRG_NON_TROUVEE for `Un jour je m’en irai, sans en avoir tout dit`
(book by Jean D'Ormesson) see https://github.com/languagetooler-gmbh/languagetool-premium/issues/5240