### PR TITLE
[pt] Fixed warnings in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -214,7 +214,7 @@
   </rulegroup>
   <rule id="TAO_ADV" name="disambiguate tão as an adverb">
     <pattern>
-      <token postag="V.+" regexp="yes"/>
+      <token postag="VMIP3P0" postag_regexp="no"/>
       <marker>
         <token>tão</token>
       </marker>
@@ -2952,7 +2952,7 @@
     </rule>
     <rule>
       <pattern>
-          <token regexp='yes'>Monte|&precede_nome_proprio_M;</token>
+          <token regexp='yes'>&precede_nome_proprio_M;</token>
           <token postag='NP.+' postag_regexp='yes' regexp='yes' case_sensitive='yes'>\p{Lu}.+</token>
       </pattern>
       <disambig action="replace"><wd pos="NPMS000"/><wd pos="NPMS000_"/></disambig>


### PR DESCRIPTION
Heya, @p-goulart and @susanaboatto 

I have fixed the warnings in the disambiguator while using `TESTRULES PT`.
