### PR TITLE
[de] improve GermanSpeller

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanSpellerRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanSpellerRule.java
@@ -2183,9 +2183,11 @@ public class GermanSpellerRule extends CompoundAwareHunspellRule {
       boolean compound1ok = false;
       if (germanPrefixes.contains(part2)) {
         compound1ok = 
-          ((!isMisspelled(part1) && !isMisspelled(part1+parts.get(2))) ||  // Weinkühlschrank gets split into Wein, kühl, schrank
+          (((!isMisspelled(part1) && !isMisspelled(part1+parts.get(2))) ||  // Weinkühlschrank gets split into Wein, kühl, schrank
           ignorePotentiallyMisspelledWord(part1+parts.get(2))) &&
-          parts.get(2).length() >= 3;  //Vorraus --> Vor, rau, s
+          parts.get(2).length() >= 3) ||  //Vorraus --> Vor, rau, s
+          (!isMisspelled(compound1) || ignorePotentiallyMisspelledWord(compound1) ||   //Menschenrechtsdemos as 'rechts' is in germanPrefixes
+          !isMisspelled(compound1noS) || ignorePotentiallyMisspelledWord(compound1noS)); 
       } else {
         compound1ok =
           !isMisspelled(compound1) || ignorePotentiallyMisspelledWord(compound1) ||

--- a/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/GermanSpellerRuleTest.java
+++ b/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/GermanSpellerRuleTest.java
@@ -60,6 +60,8 @@ public class GermanSpellerRuleTest {
   @Test
   public void testIgnoreMisspelledWord() throws IOException {
     GermanSpellerRule rule = new GermanSpellerRule(TestTools.getMessages("de"), GERMAN_DE);
+    assertTrue(rule.ignorePotentiallyMisspelledWord("Menschenrechtsdemos")); 
+    assertTrue(rule.ignorePotentiallyMisspelledWord("Ausleihstelle")); 
     assertFalse(rule.ignorePotentiallyMisspelledWord("Vorraus")); 
     assertTrue(rule.ignorePotentiallyMisspelledWord("Weinkühlschrank")); 
     assertFalse(rule.ignorePotentiallyMisspelledWord("Weinskühlschrank")); 


### PR DESCRIPTION
- fix for e.g. `Menschenrechtsdemos` as germanPrefixes contains prefixes that can also function as nouns, e.g.`rechts`