### PR TITLE
[pt] change priority of COLOCAÇÃO_ADVÉRBIO, temp off INIMIGO_ADVERSÁRIO_ALIADO_OPONENTE

### DIFF
--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
@@ -258,6 +258,7 @@ public class Portuguese extends Language implements AutoCloseable {
       case "GENERAL_GENDER_NUMBER_AGREEMENT_ERRORS":           return -56;
       case "FINAL_STOPS":               return -75;
       case "EU_NÓS_REMOVAL":            return -90;
+      case "COLOCAÇÃO_ADVÉRBIO":            return -90;
       case "FAZER_USO_DE-USAR-RECORRER":            return -90;
       case "T-V_DISTINCTION":           return -100;
       case "T-V_DISTINCTION_ALL":       return -101;

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -12705,7 +12705,7 @@ USA
         </rulegroup>
 
 
-        <rulegroup id='INIMIGO_ADVERSÁRIO_ALIADO_OPONENTE' name="[Simplificar] 'do inimigo/adversário/aliado/oponente' → inimig[ao](s)/adversári[ao](s)/aliad[ao](s)/oponente(s)" type="style" tags='picky'>
+        <rulegroup id='INIMIGO_ADVERSÁRIO_ALIADO_OPONENTE' name="[Simplificar] 'do inimigo/adversário/aliado/oponente' → inimig[ao](s)/adversári[ao](s)/aliad[ao](s)/oponente(s)" type="style" tags='picky' default="temp_off">
             <!--IDEA shorten_it-->
 
             <!-- #1: Number/gender agreement depends on using "às?|[ao]s?" -->


### PR DESCRIPTION
- changed priority of COLOCAÇÃO_ADVÉRBIO based on [these results](https://internal1.languagetool.org/regression-tests/via-http/2023-10-18/pt-BR/) and the removal of some more important matches (like crase errors), I'm changing the priority of this rule
- [This rule](https://internal1.languagetool.org/regression-tests/via-http/2023-10-18/pt-BR/result_style_INIMIGO_ADVERS%C3%81RIO_ALIADO_OPONENTE%5B2%5D.html) also seems to match more FNs than TPs, so I will temp it off for now and ask Marco to review it