### PR TITLE
[fr] Grammalecte deactivation

### DIFF
--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/rules/fr/GrammalecteRule.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/rules/fr/GrammalecteRule.java
@@ -505,7 +505,8 @@ public class GrammalecteRule extends Rule {
     "g2__pleo_verbes__b4_a1_1",
     "g2__pleo_verbes__b8_a1_1",
     "g2__pleo_locutions__b7_a1_1",
-    "g2__pleo_verbes__b7_a1_1"
+    "g2__pleo_verbes__b7_a1_1",
+    "g2__conf_de_du_d__b1_a1_1"
   ));
 
   public GrammalecteRule(ResourceBundle messages, GlobalConfig globalConfig) {


### PR DESCRIPTION
For this Grammalecte check run, will close https://github.com/languagetooler-gmbh/recurring-issues/issues/10
Deactivation of rule g2__conf_de_du_d__b1_a1_1, replaced by xml rule [DE_DU_D](https://github.com/languagetool-org/languagetool/pull/9497)