### PR TITLE
[pt] Removed "temp_off" from rule ID:INIMIGO_ADVERSÁRIO_ALIADO_OPONENTE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -12734,7 +12734,7 @@ USA
         </rulegroup>
 
 
-        <rulegroup id='INIMIGO_ADVERSÁRIO_ALIADO_OPONENTE' name="[Simplificar] 'do inimigo/adversário/aliado/oponente' → inimig[ao](s)/adversári[ao](s)/aliad[ao](s)/oponente(s)" type="style" tags='picky' default="temp_off">
+        <rulegroup id='INIMIGO_ADVERSÁRIO_ALIADO_OPONENTE' name="[Simplificar] 'do inimigo/adversário/aliado/oponente' → inimig[ao](s)/adversári[ao](s)/aliad[ao](s)/oponente(s)" type="style" tags='picky'>
             <!--IDEA shorten_it-->
 
             <!-- #1: Number/gender agreement depends on using "às?|[ao]s?" -->


### PR DESCRIPTION
Heya, Susana and Pedro,

It seems stable enough:
https://internal1.languagetool.org/regression-tests/via-http/2023-10-25/pt-PT_full/result_style_INIMIGO_ADVERS%C3%81RIO_ALIADO_OPONENTE%5B1%5D.html
https://internal1.languagetool.org/regression-tests/via-http/2023-10-25/pt-PT_full/result_style_INIMIGO_ADVERS%C3%81RIO_ALIADO_OPONENTE%5B1%5D.html

Thanks!