### PR TITLE
fix[en]: run expensive initalizations only once in UpperCaseNgramRule

### DIFF
--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/UpperCaseNgramRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/UpperCaseNgramRule.java
@@ -49,14 +49,14 @@ import static org.languagetool.rules.patterns.PatternRuleBuilderHelper.csRegex;
 public class UpperCaseNgramRule extends Rule {
 
   public static final int THRESHOLD = 50;
-  private static MorfologikAmericanSpellerRule spellerRule;
+  private static MorfologikAmericanSpellerRule spellerRule = null;
   private static LinguServices linguServices = null;
   private static final Set<String> exceptions = new HashSet<>(Arrays.asList(
     "Bin", "Spot",  // names
     "Go",           // common usage, as in "Go/No Go decision"
     "French", "Roman", "Hawking", "Square", "Japan", "Premier", "Allied"
   ));
-  private static final AhoCorasickDoubleArrayTrie<String> exceptionTrie = new AhoCorasickDoubleArrayTrie<>();
+  private static AhoCorasickDoubleArrayTrie<String> exceptionTrie = null;
   private static final List<List<PatternToken>> ANTI_PATTERNS = Arrays.asList(
     Arrays.asList(
       token("Hugs"), token("and"), token("Kisses")
@@ -541,6 +541,7 @@ public class UpperCaseNgramRule extends Rule {
     if (exceptionTrie == null) {
       synchronized (UpperCaseNgramRule.class) {
         if (exceptionTrie == null) {
+          exceptionTrie = new AhoCorasickDoubleArrayTrie<>();
           CachingWordListLoader cachingWordListLoader = new CachingWordListLoader();
           List<String> words = new ArrayList<>();
           words.addAll(cachingWordListLoader.loadWords("en/specific_case.txt"));


### PR DESCRIPTION
This caused many unnecessary allocations when new instances of the rule are frequently created