### PR TITLE
[pt] Added rule ID:CONFUSÃO_AO_OU

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -30540,7 +30540,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='CONFUSÃO_AO_OU' name="[Confusão] ao/ou" default="temp_off">
+        <rule id='CONFUSÃO_AO_OU' name="Confusão de termos: ao/ou" default="temp_off">
             <pattern>
                 <token postag='NC.+|AQ.+|SENT_START' postag_regexp='yes'>
                     <exception postag_regexp='yes' postag='SP[0S]00|RG|CC|VMP00.+'/>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -30540,6 +30540,29 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
+        <rule id='CONFUSÃO_AO_OU' name="[Confusão] ao/ou" default="temp_off">
+            <pattern>
+                <token postag='NC.+|AQ.+' postag_regexp='yes'>
+                    <exception postag_regexp='yes' postag='SP[0S]00|RG|CC|VMP00.+'/>
+                </token>
+                <token min='0' max='1' postag='_PUNCT'/>
+                <marker>
+                    <token>ao</token>
+                </marker>
+                <token postag='VM[IMS].+' postag_regexp='yes'>
+                    <exception postag_regexp='yes' postag='VMN.+|VMIP1S0|RG|CC|SPS00'/>
+                </token>
+                <token postag='D[AIP].+|SPS00' postag_regexp='yes'/>
+            </pattern>
+            <message>Possível confusão de termos.</message>
+            <suggestion>ou</suggestion>
+            <example correction="ou">Venda o monitor <marker>ao</marker> parta o porquinho mealheiro.</example>
+            <example correction="ou">Vendam o monitor <marker>ao</marker> partam o porquinho mealheiro.</example>
+            <example correction="ou">Venda o monitor <marker>ao</marker> quebre um mealheiro.</example>
+            <example correction="ou">Vendam o monitor <marker>ao</marker> quebrem uns mealheiros.</example>
+        </rule>
+
+
         <!-- APROXIMA a próxima -->
         <rule id='CONFUSÃO_APROXIMA_A_PRÓXIMA' name="[Confusão] aproxima/'a próxima'">
             <!--      Created by Marco A.G.Pinto, Portuguese 2021-10-05 (25-JUN-2021+)      -->

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -30542,7 +30542,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
         <rule id='CONFUSÃO_AO_OU' name="[Confusão] ao/ou" default="temp_off">
             <pattern>
-                <token postag='NC.+|AQ.+' postag_regexp='yes'>
+                <token postag='NC.+|AQ.+|SENT_START' postag_regexp='yes'>
                     <exception postag_regexp='yes' postag='SP[0S]00|RG|CC|VMP00.+'/>
                 </token>
                 <token min='0' max='1' postag='_PUNCT'/>


### PR DESCRIPTION
Heya, Susana and Pedro,

Here is a new rule.

It only had one hit in 900 000 sentences, and the hit seems inconclusive but a valid structure for the rule (well triggered).

```
Portuguese (Portugal): 1 total matches
Portuguese (Portugal): 811110 total sentences considered
Portuguese (Portugal): ø0.00 rule matches per sentence
```


[6.txt](https://github.com/languagetool-org/languagetool/files/13198030/6.txt)

