### PR TITLE
[en] add ignore_spelling to multiwords in global_spelling.txt

### DIFF
--- a/languagetool-language-modules/en/src/main/java/org/languagetool/tagging/en/EnglishHybridDisambiguator.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/tagging/en/EnglishHybridDisambiguator.java
@@ -43,12 +43,14 @@ import java.util.List;
 public class EnglishHybridDisambiguator extends AbstractDisambiguator {
 
   private final MultiWordChunker chunker = new MultiWordChunker("/en/multiwords.txt", true, true);
+  private final MultiWordChunker chunkerGlobal = new MultiWordChunker("/spelling_global.txt", true, true, MultiWordChunker.tagForNotAddingTags);
   private final Disambiguator disambiguator;
 
   public EnglishHybridDisambiguator(Language lang) {
     disambiguator = new XmlRuleDisambiguator(lang, true);
     chunker.setIgnoreSpelling(true);
     chunker.setRemovePreviousTags(true);
+    chunkerGlobal.setIgnoreSpelling(true);
   }
 
   @Override
@@ -67,7 +69,7 @@ public class EnglishHybridDisambiguator extends AbstractDisambiguator {
    */
   @Override
   public AnalyzedSentence disambiguate(AnalyzedSentence input, @Nullable JLanguageTool.CheckCancelledCallback checkCanceled) throws IOException {
-    return disambiguator.disambiguate(chunker.disambiguate(input, checkCanceled), checkCanceled);
+    return disambiguator.disambiguate(chunker.disambiguate(chunkerGlobal.disambiguate(input, checkCanceled), checkCanceled), checkCanceled);
   }
 
 }

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/tokenizers/en/TokenizeMultiwordsTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/tokenizers/en/TokenizeMultiwordsTest.java
@@ -36,12 +36,13 @@ public class TokenizeMultiwordsTest {
 
   private final static String MULTIWORDS_FILE = "/en/multiwords.txt";
 
-  private final List<String> filesToTest = Arrays.asList("spelling_global.txt", "/en/added.txt", "/en/removed.txt",
+  private final List<String> filesToTest = Arrays.asList("/en/added.txt", "/en/removed.txt",
       "/en/hunspell/ignore.txt", "/en/hunspell/prohibit.txt", "/en/hunspell/prohibit_custom.txt",
       "/en/hunspell/spelling.txt", "/en/hunspell/spelling_custom.txt", "/en/hunspell/spelling_en-AU.txt",
       "/en/hunspell/spelling_en-CA.txt", "/en/hunspell/spelling_en-GB.txt", "/en/hunspell/spelling_en-NZ.txt",
       "/en/hunspell/spelling_en-US.txt", "/en/hunspell/spelling_en-ZA.txt", "/en/hunspell/spelling_merged.txt");
-
+  // "spelling_global.txt",
+  
   @Test
   public void testTokenize() {
     final EnglishWordTokenizer wordTokenizer = new EnglishWordTokenizer();


### PR DESCRIPTION
This way, we don't need to tokenize the phrases or add antipatterns to the speller. 
This does not seem to have any noticeable effect on speed. Do you have some way to test it better,  @fabrichter? We can test it on a server. But similar things are already done in other languages.