### PR TITLE
[pt] Removed "temp_off" from rule ID:INIMIGO_ADVERSÁRIO_ALIADO_OPONENTE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -12653,7 +12653,7 @@ USA
         </rulegroup>
 
 
-        <rulegroup id='INIMIGO_ADVERSÁRIO_ALIADO_OPONENTE' name="[Simplificar] 'do inimigo/adversário/aliado/oponente' → inimig[ao](s)/adversári[ao](s)/aliad[ao](s)/oponente(s)" type="style" tags='picky' default="temp_off">
+        <rulegroup id='INIMIGO_ADVERSÁRIO_ALIADO_OPONENTE' name="[Simplificar] 'do inimigo/adversário/aliado/oponente' → inimig[ao](s)/adversári[ao](s)/aliad[ao](s)/oponente(s)" type="style" tags='picky'>
             <!--IDEA shorten_it-->
 
             <!-- #1: Number/gender agreement depends on using "às?|[ao]s?" -->


### PR DESCRIPTION
Heya, Susana and Pedro,

I have removed the “temp_off”.

I removed the false positives reported by Susana in the previous week or so, and I can't focus right now to see if there are any additional enhancements required.

Here is the total results:
https://internal1.languagetool.org/regression-tests/via-http/2023-11-06/pt-BR_full/result_style_INIMIGO_ADVERS%C3%81RIO_ALIADO_OPONENTE%5B1%5D.html

https://internal1.languagetool.org/regression-tests/via-http/2023-11-06/pt-BR_full/result_style_INIMIGO_ADVERS%C3%81RIO_ALIADO_OPONENTE%5B2%5D.html

Any feedback is welcome!

Thanks!

