### PR TITLE
[de] removing isOnlyPluralNoun from as a condition for non-infix-s

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanSpellerRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanSpellerRule.java
@@ -2234,7 +2234,7 @@ public class GermanSpellerRule extends CompoundAwareHunspellRule {
         part1.length() >= 3 && part2.length() >= 4 &&
         !part2.contains("-") &&
         startsWithLowercase(part2) &&
-        (wordsWithoutInfixS.contains(part1) || (compoundPatternSpecialEnding.matcher(part1).matches() && isNoun(part2uc)) || isOnlyPluralNoun(part1)) &&
+        (wordsWithoutInfixS.contains(part1) || (compoundPatternSpecialEnding.matcher(part1).matches() && isNoun(part2uc))) &&
         !isMisspelled(part1) &&
         !isMisspelled(part2uc) &&
         isMisspelled(part2) // don't accept e.g. "Azubikommt"

--- a/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/GermanSpellerRuleTest.java
+++ b/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/GermanSpellerRuleTest.java
@@ -60,7 +60,7 @@ public class GermanSpellerRuleTest {
   @Test
   public void testIgnoreMisspelledWord() throws IOException {
     GermanSpellerRule rule = new GermanSpellerRule(TestTools.getMessages("de"), GERMAN_DE);
-    assertTrue(rule.ignorePotentiallyMisspelledWord("Atmosphärenkonzept"));
+    assertFalse(rule.ignorePotentiallyMisspelledWord("Atmosphärenkonzept"));
     assertFalse(rule.ignorePotentiallyMisspelledWord("Abschlussgruße"));  // probably "...grüße"
     assertTrue(rule.ignorePotentiallyMisspelledWord("Offenlegungsfrist"));
     assertFalse(rule.ignorePotentiallyMisspelledWord("Offenlegungsfirst"));


### PR DESCRIPTION
as discussed – removal of `isOnlyPluralNoun` 