### PR TITLE
[fr] FETE_SAINT and NOUVEL_AN rules creations

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -97,6 +97,14 @@ Pour en savoir plus sur les tone tags, suivez le lien vers notre documentation (
         ]>
 <rules lang="fr" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <category id="STYLE" name="style rules" type="style">
+        <rule id="NOUVEL_AN" name="Nouvel An" tone_tags="general" default="temp_off">
+            <pattern case_sensitive="yes">
+                <token>nouvel</token>
+                <token regexp="yes">an</token>
+            </pattern>
+            <message>Si vous parlez de la fête, il faut deux majuscules : <suggestion>Nouvel An</suggestion>. Bonne année !</message>
+            <example correction="Nouvel An">Tu fais quoi pour <marker>nouvel an</marker> cette année ?</example>
+        </rule>
         <rulegroup id="NOMBRES_EN_LETTRES" name="nombres en lettres" type="style" tone_tags="formal">
             <antipattern>
                 <token postag="Y"/>


### PR DESCRIPTION
In the context of  https://github.com/languagetooler-gmbh/languagetool-premium/issues/6602.
- The recommendations for _Nouvel An_ are unclear (most sources recommend uppercase, see [Larousse](https://www.larousse.fr/dictionnaires/francais/Saint-Sylvestre/186735), but the _Académie Française_ [uses lowercase](https://www.dictionnaire-academie.fr/article/A9F0578)), and so does the [TLF/CNRTL](http://stella.atilf.fr/Dendien/scripts/tlfiv5/search.exe?23;s=1019470875;cat=1;m=nouvel+an;). Therefore, the rule is created in Style and not Grammar. We need to monitor the apply/disable rate of that rule in the future even more carefully than usual.
- Saint-XXX is handled through feminine determiner _la_ which should naturally avoid FP on masculine uses of "saint Jean, Saint André" etc. as a regular names. 