### PR TITLE
[fr] AI_FR_GGEC_REPLACEMENT_ORTHOGRAPHY prio change in French.java

### DIFF
--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
@@ -369,6 +369,10 @@ public class French extends Language implements AutoCloseable {
     if (id.startsWith("AI_FR_HYDRA_LEO")) { // prefer more specific rules (also speller)
       return -101;
     }
+
+    if (id.startsWith("AI_FR_GGEC_REPLACEMENT_ORTHOGRAPHY")) { // prefer more specific rules (also speller)
+      return -11;
+    }
     return super.getPriorityForId(id);
   }
   


### PR DESCRIPTION
We saw that some matches previously handled by some XML rules are now diverted by gGEC rules.
This example `Cette année, Avril a été chaud.` is from rulegroup id="MOIS" name="mois de l’année" (src/main/resources/org/languagetool/rules/fr/grammar.xml).
It's now AI_FR_GGEC_REPLACEMENT_ORTHOGRAPHY_UPPE handling it. That's not conveniant, as the xml rules have antipatterns already (see second screen shot about Mai 68).
**This PR lowers the prio of AI_FR_GGEC_REPLACEMENT_ORTHOGRAPHY.**
![capture_d___cran_2023-11-10_141046_720](https://github.com/languagetool-org/languagetool/assets/114988314/e75c0094-4eb1-487e-8dda-962e21736c36)
![image_480](https://github.com/languagetool-org/languagetool/assets/114988314/32345ab0-1607-45cf-b8c5-08610858817c)
