### PR TITLE
[fr] Dictionary additions onomatopoeias

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/multiwords.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/multiwords.txt
@@ -3129,3 +3129,5 @@ Rune Söderqvist; Z m s
 Raymond Loewy; Z m s
 SNCF inOui; Z e sp
 Under Armour; Z e sp
+ding dong; I
+toc toc; I


### PR DESCRIPTION
To fix [[fr] Onomatopée Ding Dong#5583](https://github.com/languagetooler-gmbh/languagetool-premium/issues/5583)
Onomatop are behaving as normal nouns (see https://dictionnaire.lerobert.com/guide/interjections-et-typographie.). 
PoS tag **I** (interjection) is perfect (tested on dare-dare and mama-mia, that are already in multiwords.txt). 

![image](https://github.com/languagetool-org/languagetool/assets/114988314/d2b59bce-be58-41a4-b13c-c43cb2b6c66d)
