### PR TITLE
[pt] Rewrote rule ID:MADRUGADA_MATINAL

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -12810,43 +12810,21 @@ USA
         </rule>
 
 
-        <!-- MADRUGADA matinal -->
-        <rule id='MADRUGADA_MATINAL' name="[Simplificar] De madrugada → matinal" type="style" default='off'>
+        <rule id='MADRUGADA_MATINAL' name="Simplificar: da madrugada/manhã → matinal" type="style" default='temp_off'>
             <!--IDEA shorten_it-->
-            <!--      Created by Marco A.G.Pinto, Portuguese rule 2021-07-22 + 2021-07-23 + 2022-09-14 (25-JUN-2021+)      -->
-            <!--
-      Vamos fazer exercício de madrugada. → Vamos fazer exercício matinal.
-      -->
-            <antipattern>
-                <token regexp='yes' inflected='yes'>haver|escovar|ir|trazer</token>  <!-- 2022-09-14: Add exception verbs here -->
-                <token min="0" max="1" postag='DA.+' postag_regexp='yes'/>
-                <token postag='AQ.+|NC.+' postag_regexp='yes'/>
-                <token regexp='no'>de</token>
-                <token regexp='yes'>madrugada|manhã</token>
-                <example>Eles disseram para eu lá ir terça de manhã com o documento.</example>
-                <example>Treinei meu cachorro para que me trouxesse o jornal de manhã.</example>
-                <example>Havia névoa de manhã.</example>
-                <example>Ela escova o cabelo de manhã.</example>
-            </antipattern>
-
             <pattern>
-                <token postag='V.+' postag_regexp='yes'>
-                    <exception postag_regexp='yes' postag='AQ0.+|NC.+'/>
-                </token>
-                <token min="0" max="1" postag='DI.+|DA.+' postag_regexp='yes'/>
-                <token postag='AQ0.S.+|NC.S.+' postag_regexp='yes'>
-                    <exception>amanhã</exception>
-                    <exception postag='RG'/>
-                </token>
+                <token postag='V.+' postag_regexp='yes'/>
+                <token regexp='yes'>[ao]s?</token>
+                <token regexp='yes' inflected='yes'>banho|café|chá|exercício|leite|névoa|orvalho|passeio|sexo|sol</token> <!-- Add more words as found -->
                 <marker>
-                    <token regexp='yes'>d[ae]</token>
-                    <token regexp='yes'>madrugada|manhã</token>
+                    <token regexp='yes'>das?</token>
+                    <token regexp='yes'>madrugadas?|manhãs?</token>
                 </marker>
             </pattern>
             <message>&simplify_msg;</message>
-            <suggestion>matinal</suggestion>
-            <example correction="matinal">Vamos fazer exercício <marker>de madrugada</marker>.</example>
-            <example correction="matinal">Eu sempre tomo um banho <marker>de manhã</marker>.</example>
+            <suggestion><match no='5' postag='NCF(.)000' postag_replace='AQ0C$10'>matinal</match></suggestion>
+            <example correction="matinal">Vamos fazer o exercício <marker>da madrugada</marker>.</example>
+            <example correction="matinal">Eu sempre tomo o banho <marker>da manhã</marker>.</example>
             <example correction="matinal">Eu tinha o costume de dar o passeio <marker>da manhã</marker>.</example>
         </rule>
 


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart 

Proceeding with my plan of converting many “off” rules to “on”, I have rewritten this rule.

Basically, almost all the hits happen with `“café da manhã”`, but I have added other entries.

This is now a stricter rule to avoid the tons of false positives from before.

Thanks!

```
Portuguese (Portugal): 87 total matches
Portuguese (Portugal): 811110 total sentences considered
Portuguese (Portugal): ø0.00 rule matches per sentence
```
[7.txt](https://github.com/languagetool-org/languagetool/files/13392948/7.txt)

```
        <rule id='MADRUGADA_MATINAL' name="Simplificar: da madrugada/manhã → matinal" type="style" default='temp_off'>
            <!--IDEA shorten_it-->
            <pattern>
                <token postag='V.+' postag_regexp='yes'/>
                <token regexp='yes'>[ao]s?</token>
                <token regexp='yes' inflected='yes'>banho|café|chá|exercício|leite|névoa|orvalho|passeio|sexo|sol</token> <!-- Add more words as found -->
                <marker>
                    <token regexp='yes'>das?</token>
                    <token regexp='yes'>madrugadas?|manhãs?</token>
                </marker>
            </pattern>
            <message>&simplify_msg;</message>
            <suggestion><match no='5' postag='NCF(.)000' postag_replace='AQ0C$10'>matinal</match></suggestion>
            <example correction="matinal">Vamos fazer o exercício <marker>da madrugada</marker>.</example>
            <example correction="matinal">Eu sempre tomo o banho <marker>da manhã</marker>.</example>
            <example correction="matinal">Eu tinha o costume de dar o passeio <marker>da manhã</marker>.</example>
        </rule>
```

😋 😛 😛 😛 😛 😛 😛 ❤️ ❤️ ❤️ ❤️ 