### PR TITLE
[pt] Removed "temp_off" from rule ID:ESTAR_NO_ECRA

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -12275,7 +12275,7 @@ USA
         </rulegroup>
 
 
-        <rule id='ESTAR_NO_ECRA' name="Estar no ecrã" default="temp_off">
+        <rule id='ESTAR_NO_ECRA' name="Estar no ecrã">
             <!--IDEA shorten_it-->
             <pattern>
                 <token postag='(SPS00:)?PD.+' postag_regexp='yes'/>


### PR DESCRIPTION
Heya,

During the weekend, I am going to dedicate some time to removing “temp_off” from some rules.

This one, for example, had zero hits in the nightly results.