### PR TITLE
[pt] Removed "temp_off" from rule ID:PELO_QUAL_PELA_QUAL

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -7833,7 +7833,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>Deixei o local um pouco irritada.</example>
             </antipattern>
 
-            <rule id='PELO_QUAL_PELA_QUAL' name="Concordância: 'pelo' → 'pela'" default="temp_off">
+            <rule id='PELO_QUAL_PELA_QUAL' name="Concordância: 'pelo' → 'pela'">
                 <antipattern>
                     <token postag='AQ.M.+|NCM.+' postag_regexp='yes'/>
                     <token min='0' max='1' postag='CC|RG' postag_regexp='yes'/>


### PR DESCRIPTION
Heya,

Only one hit in the nightly results:
https://internal1.languagetool.org/regression-tests/via-http/2023-11-23/pt-BR_full/result_grammar_PELO_QUAL_PELA_QUAL%5B1%5D.html
