### PR TITLE
[pt] Removed "temp_off" from rule ID:QUASE_QUE_PRONOME

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3759,7 +3759,7 @@ USA
         </rule>
 
 
-        <rule id='QUASE_QUE_PRONOME' name="'quase que + pronome' → 'quase pronome'" type="style" default="temp_off">
+        <rule id='QUASE_QUE_PRONOME' name="'quase que + pronome' → 'quase pronome'" type="style">
             <pattern>
                 <marker>
                     <token>quase</token>


### PR DESCRIPTION
Heya,

All the six hits seem valid to me:
https://internal1.languagetool.org/regression-tests/via-http/2023-11-23/pt-BR_full/result_style_QUASE_QUE_PRONOME%5B1%5D.html
