### PR TITLE
[pt] Removed "temp_off" from rule ID:MUITO_FRIO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3686,7 +3686,7 @@ USA
         </rule>
 
 
-        <rule id='MUITO_FRIO' name="Muito frio" tags='picky' tone_tags="formal" is_goal_specific="true" default="temp_off">
+        <rule id='MUITO_FRIO' name="Muito frio" tags='picky' tone_tags="formal" is_goal_specific="true">
             <pattern>
                 <marker>
                     <token>um</token>


### PR DESCRIPTION
The four hits seem valid:
https://internal1.languagetool.org/regression-tests/via-http/2023-11-23/pt-BR_full/result_style_MUITO_FRIO%5B1%5D.html
