### PR TITLE
[pt] Removed "temp_off" from rule ID:MADRUGADA_MATINAL

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -12851,7 +12851,7 @@ USA
         </rule>
 
 
-        <rule id='MADRUGADA_MATINAL' name="Simplificar: da madrugada/manhã → matinal" type="style" default='temp_off'>
+        <rule id='MADRUGADA_MATINAL' name="Simplificar: da madrugada/manhã → matinal" type="style">
             <!--IDEA shorten_it-->
             <pattern>
                 <token postag='V.+' postag_regexp='yes'/>


### PR DESCRIPTION
I guess all 4 results are okay?

https://internal1.languagetool.org/regression-tests/via-http/2023-11-23/pt-BR_full/result_style_MADRUGADA_MATINAL%5B1%5D.html

If there is the need to remove a word or two from the rule, feel free to do it.