### PR TITLE
[pt] Removed "temp_off" from rule ID:REMOÇÃO_SUBSTANTIVO_APÓS_MESMO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -11339,7 +11339,7 @@ USA
         </rule>
 
 
-        <rulegroup id="REMOÇÃO_SUBSTANTIVO_APÓS_MESMO" name="Redação Avançada: remoção de substantivos após 'mesmo'" tone_tags="objective" default="temp_off">
+        <rulegroup id="REMOÇÃO_SUBSTANTIVO_APÓS_MESMO" name="Redação Avançada: remoção de substantivos após 'mesmo'" tone_tags="objective">
             <!-- IDEA shorten_it -->
 
             <!-- #1: 1 noun -->


### PR DESCRIPTION
Only one result, and it seems valid to me:
https://internal1.languagetool.org/regression-tests/via-http/2023-11-23/pt-BR_full/result_style_REMO%C3%87%C3%83O_SUBSTANTIVO_AP%C3%93S_MESMO%5B1%5D.html