### PR TITLE
[pt] Removed "temp_off" from rule ID:CONFUSÃO_AO_OU

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -30737,7 +30737,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='CONFUSÃO_AO_OU' name="Confusão de termos: ao/ou" default="temp_off">
+        <rule id='CONFUSÃO_AO_OU' name="Confusão de termos: ao/ou">
             <pattern>
                 <token postag='NC.+|AQ.+|SENT_START' postag_regexp='yes'>
                     <exception postag_regexp='yes' postag='SP[0S]00|RG|CC|VMP00.+'/>


### PR DESCRIPTION
Zero hits in the nightly results.