### PR TITLE
[pt-PT] Removed "temp_off" from rule ID:SIMPLIFICAR_A_SER_PP_A_INF

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -3332,7 +3332,7 @@ USA
         </rule>
 
 
-        <rule id='SIMPLIFICAR_A_SER_PP_A_INF' name="[pt-PT] Simplificar: há + Adv. intensidade + 'a ser Part.P.' → 'a Inf.'" type="style" default="temp_off">
+        <rule id='SIMPLIFICAR_A_SER_PP_A_INF' name="[pt-PT] Simplificar: há + Adv. intensidade + 'a ser Part.P.' → 'a Inf.'" type="style">
             <!-- IDEA shorten_it -->
             <pattern>
                 <token inflected='yes'>haver</token>


### PR DESCRIPTION
Heya,

It only has 5 hits in pt-PT, and they all look fine to me:
https://internal1.languagetool.org/regression-tests/via-http/2023-11-27/pt-PT_full/result_style_SIMPLIFICAR_A_SER_PP_A_INF%5B1%5D.html

Thanks!