### PR TITLE
[pt] Removed "temp_off" from rule ID:DIFERENTES

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3663,7 +3663,7 @@ USA
         </rule>
 
 
-        <rule id='DIFERENTES' name="Ser diferente → Diferir" tags='picky' default="temp_off">
+        <rule id='DIFERENTES' name="Ser diferente → Diferir" tags='picky'>
             <pattern>
                 <token postag='NC.+|AQ.+|NP.+|[DP].+' postag_regexp='yes'/>
                 <token min='0' max='1' postag='_PUNCT' postag_regexp='no'/>


### PR DESCRIPTION
Heya,

I see no better way of improving it:
https://internal1.languagetool.org/regression-tests/via-http/2023-11-27/pt-BR_full/result_style_DIFERENTES%5B1%5D.html

37 hits in the nightly diffs.

If there is something that can be improved, tell me.

Thanks!