### PR TITLE
[pt] Removed "temp_off" from rule ID:PELA_QUAL_PELO_QUAL

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -8161,7 +8161,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="pelas">Esta foi uma das razões <marker>pelos</marker> quais ele concebeu a equação.</example>
             </rule>
 
-            <rule id='PELA_QUAL_PELO_QUAL' name="Concordância: 'pela' → 'pelo'" default="temp_off">
+            <rule id='PELA_QUAL_PELO_QUAL' name="Concordância: 'pela' → 'pelo'">
                 <antipattern>
                     <token postag='AQ.F.+|NCF.+' postag_regexp='yes'/>
                     <token min='0' max='1' postag='CC|RG' postag_regexp='yes'/>


### PR DESCRIPTION
0 hits in the nightly diff.

I forgot that there were two rules (pela → pelo & pelo →pela) and the other week I only removed the “temp_off” from one of them.