### PR TITLE
[pt-PT] Added AP to rule ID:TODOS_FOLLOWED_BY_NOUN_SINGULAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -1632,6 +1632,21 @@
       <!-- FIXME: too many matches -->
       <!-- Created by Tiago F. Santos, 2017-10-12 -->
       <antipattern>
+        <token inflected='yes'>ser
+            <exception scope='previous' postag_regexp='yes' postag='V.+'/></token>
+        <token min='0' max='1' regexp='yes'>de|o|um</token>
+        <token>todo</token>
+        <token postag='AQ.+|NC.+' postag_regexp='yes'>
+            <exception postag_regexp='yes' postag='V.+'/></token>
+        <token postag='_PUNCT|CC|RG|RM' postag_regexp='yes'/>
+        <example>Esta solução não é de todo verdade.</example>
+        <example>Esta solução não é de todo verdade embora seja possível.</example>
+        <example>Esta solução não é de todo verdade certamente como pensámos.</example>
+        <example>O lutador profissional é todo músculos.</example>
+        <example>E DEUS É O TODO PODEROSO, O CRIADOR DE TODAS AS COISAS !!!</example>
+        <example>Devemos nos livrar da ideia falsa de que a África é um todo indivisível.</example>
+      </antipattern>
+      <antipattern>
         <token regexp='yes'>tod[ao]</token>
         <token postag_regexp='yes' postag='A.+'>
           <exception negate_pos='yes' postag_regexp='yes' postag='A.+'/></token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -1628,7 +1628,7 @@
     </rule>
 
 
-    <rule id='TODOS_FOLLOWED_BY_NOUN_SINGULAR' name="[pt-PT] Expressão: Todo + 'nome sem artigo'" default="temp_off">
+    <rule id='TODOS_FOLLOWED_BY_NOUN_SINGULAR' name="[pt-PT] Expressão: Todo + 'nome sem artigo'">
       <!-- FIXME: too many matches -->
       <!-- Created by Tiago F. Santos, 2017-10-12 -->
       <antipattern>


### PR DESCRIPTION
Heya, Susana and Pedro,

I have added an antipattern to fix some false positives.

What is wrong with this rule for being “temp_off” besides the huge number of hits? Maybe using “picky” would fix it?

```
Portuguese (Portugal): 1709 total matches
Portuguese (Portugal): 811110 total sentences considered
Portuguese (Portugal): ø0.00 rule matches per sentence
```

[5.txt](https://github.com/languagetool-org/languagetool/files/13537537/5.txt)

