### PR TITLE
[pt] Add minor fix to UNIDADES_METRICAS

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractUnitConversionRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractUnitConversionRule.java
@@ -419,7 +419,8 @@ public abstract class AbstractUnitConversionRule extends Rule {
     return numberRangePart.matcher(textBefore).find();
   }
 
-  private void tryConversion(AnalyzedSentence sentence, List<RuleMatch> matches, Pattern unitPattern, Double customValue, Unit customUnit, Matcher unitMatcher, List<Map.Entry<Integer, Integer>> ignoreRanges) {
+  private void tryConversion(AnalyzedSentence sentence, List<RuleMatch> matches, Pattern unitPattern, Double customValue,
+                             Unit customUnit, Matcher unitMatcher, List<Map.Entry<Integer, Integer>> ignoreRanges) {
     Map.Entry<Integer, Integer> range = new AbstractMap.SimpleImmutableEntry<>(
       unitMatcher.start(), unitMatcher.end());
     ignoreRanges.add(range);
@@ -481,6 +482,12 @@ public abstract class AbstractUnitConversionRule extends Rule {
         .findFirst();
       if (convertedUnitPattern.isPresent()) { // known unit used for conversion
         Unit convertedUnit = unitPatterns.get(convertedUnitPattern.get());
+        // If the unit before and after conversion is the same, e.g. "22.3 cm (20.4 cm)", assume users either:
+        // 1. know what they're doing; or
+        // 2. there's a more complex expression at play here, which we can't parse
+        if (unit.equals(convertedUnit)) {
+          return;
+        }
         Double convertedValueInText;
         try {
           convertedValueInText = getNumberFormat().parse(convertedMatcher.group(1)).doubleValue();

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseUnitConversionRule.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseUnitConversionRule.java
@@ -48,54 +48,59 @@ public class PortugueseUnitConversionRule extends AbstractUnitConversionRule {
     addUnit("grama", KILOGRAM, "gramas", 1e-3, true);
     addUnit("toneladas?", KILOGRAM, "toneladas", 1e3, true);
     addUnit("libras?", POUND, "libras", 1, false);
+    addUnit("onças?", OUNCE, "onças", 1, false);
 
     addUnit("milhas?", MILE, "milhas", 1, false);
     addUnit("jardas?", YARD, "jardas", 1, false);
     addUnit("pés?", FEET, "pés", 1, false);
     addUnit("polegadas?", INCH, "polegadas", 1, false);
 
-    addUnit("(Kilometros por Hora)", KILOMETRE_PER_HOUR, "quilómetros por hora", 1, true);
-    addUnit("milhas por hora", MILE.divide(HOUR), "milhas por hora", 1, false);
+    addUnit("(qu|k)ilômetros? por hora", KILOMETRE_PER_HOUR, "quilômetros por hora", 1, true);
+    addUnit("milhas? por hora", MILE.divide(HOUR), "milhas por hora", 1, false);
 
     addUnit("metros?", METRE, "metros", 1, true);
-    addUnit("Quilómetros?", METRE, "quilómetros", 1e3, true);
-    addUnit("kilómetros?", METRE, "quilómetros", 1e3, true);
+    addUnit("(qu|k)ilômetros?", METRE, "quilômetros", 1e3, true);
     addUnit("decímetros?", METRE, "decímetros", 1e-1, false); // metric, but should not be suggested
     addUnit("centímetros?", METRE, "centímetros", 1e-2, true);
     addUnit("milímetros?", METRE, "milímetros", 1e-3, true);
-    addUnit("micrómetros?", METRE, "micrómetros", 1e-6, true);
-    addUnit("nanómetros?", METRE, "nanómetros", 1e-9, true);
-    addUnit("picómetros?", METRE, "picómetros", 1e-12, true);
-    addUnit("fentometros?", METRE, "fectometros", 1e-15, true);
+    addUnit("micrômetros?", METRE, "micrômetros", 1e-6, true);
+    addUnit("nanômetros?", METRE, "nanômetros", 1e-9, true);
+    addUnit("picômetros?", METRE, "picômetros", 1e-12, true);
+    addUnit("fentômetros?", METRE, "fentômetros", 1e-15, true);
 
     addUnit("metros? quadrados?", SQUARE_METRE, "metros quadrados", 1, true);
-    addUnit("hectár(es)?", SQUARE_METRE, "héctares", 1e4, true);
-    addUnit("area?", SQUARE_METRE, "ares", 1e2, true);
-    addUnit("(kilómetros?|quilómetros?) quadrados?", SQUARE_METRE,  "quilómetros quadrados",  1e6, true);
-    addUnit("decímetros?", SQUARE_METRE,  "decímetros quadrados",  1e-2,  false/*true*/); // Metric, but not commonly used
+    addUnit("hectar(es)?", SQUARE_METRE, "hectares", 1e4, true);
+    addUnit("ares?", SQUARE_METRE, "ares", 1e2, true);
+    addUnit("(k|qui)ilômetros? quadrados?", SQUARE_METRE,  "quilômetros quadrados",  1e6, true);
+    addUnit("decímetros? quadrados?", SQUARE_METRE,  "decímetros quadrados",  1e-2,  false/*true*/); // Metric, but not commonly used
     addUnit("centímetros? quadrados?", SQUARE_METRE, "centímetros quadrados", 1e-4, true);
     addUnit("milímetros? quadrados?", SQUARE_METRE, "milímetros quadrados", 1e-6, true);
-    addUnit("micrómetros? quadrados?", SQUARE_METRE, "micrómetros quadrados", 1e-12, true);
-    addUnit("nanómetros? quadrados?", SQUARE_METRE,  "nanómetros quadrados",  1e-18, true);
+    addUnit("micrômetros? quadrados?", SQUARE_METRE, "micrômetros quadrados", 1e-12, true);
+    addUnit("nanômetros? quadrados?", SQUARE_METRE,  "nanômetros quadrados",  1e-18, true);
 
-    addUnit("metros? cúbicos?", CUBIC_METRE,     "metros cúbicos",      1, true);
-    addUnit("quilómetros? cúbicos?", CUBIC_METRE, "quilómetros cúbicos",  1e9, true);
+    addUnit("metros? cúbicos?", CUBIC_METRE,"metros cúbicos",      1, true);
+    addUnit("(k|qu)ilômetros? cúbicos?", CUBIC_METRE, "quilômetros cúbicos",  1e9, true);
     addUnit("decímetros? cúbicos?", CUBIC_METRE, "decímetros cúbicos",  1e-3,  false/*true*/); // Metric, but not commonly used
     addUnit("centímetros? cúbicos?", CUBIC_METRE,"centímetros cúbicos", 1e-6, true);
     addUnit("milímetros? cúbicos?", CUBIC_METRE,"milímetros cúbicos", 1e-9, true);
-    addUnit("micrómetros? cúbicos?", CUBIC_METRE,"micrómetros cúbicos", 1e-18, true);
-    addUnit("nanómetros? cúbicos?", CUBIC_METRE, "nanómetros cúbicos",  1e-27, true);
+    addUnit("micrômetros? cúbicos?", CUBIC_METRE,"micrômetros cúbicos", 1e-18, true);
+    addUnit("nanômetros? cúbicos?", CUBIC_METRE, "nanômetros cúbicos",  1e-27, true);
 
     addUnit("litros?", LITRE, "litros", 1, true);
-    addUnit("milílitros?", LITRE, "milílitros", 1e-3, true);
+    addUnit("mililitros?", LITRE, "mililitros", 1e-3, true);
 
     addUnit( "(?:Graus)? Fahrenheit", FAHRENHEIT, "graus Fahrenheit", 1, false);
-    addUnit( "(?:Graus)? Celsi[ou]s", CELSIUS, "graus Celsios", 1, true);
+    addUnit( "(?:Graus)? (Celsi[ou]s|[cC]entígrados?)", CELSIUS, "graus Celsius", 1, true);
   }
 
   @Override
   public String getId() {
     return "UNIDADES_METRICAS";
+  }
+
+  @Override
+  protected String formatRounded(String s) {
+    return "aprox. " + s;
   }
 
   @Override
@@ -107,13 +112,13 @@ public class PortugueseUnitConversionRule extends AbstractUnitConversionRule {
   protected String getMessage(Message message) {
     switch(message) {
       case CHECK:
-        return "Esta conversão parece estar errada. Quer que isso seja corrigido automaticamente?";
+        return "Esta conversão não parece estar precisa. Gostaria de corrigi-la?";
       case SUGGESTION:
         return "Deseja adicionar automaticamente uma conversão ao sistema métrico?";
       case CHECK_UNKNOWN_UNIT:
         return "A unidade usada nesta conversão não foi reconhecida.";
       case UNIT_MISMATCH:
-        return "Estas unidades não são compatíveis.";
+        return "Estas unidades de medida não são compatíveis.";
       default:
         throw new RuntimeException("Unknown message type." + message);
     }
@@ -123,13 +128,13 @@ public class PortugueseUnitConversionRule extends AbstractUnitConversionRule {
   protected String getShortMessage(Message message) {
     switch(message) {
       case CHECK:
-        return "Conversão errada. Corrigir automaticamente?";
+        return "Conversão incorreta. Corrigir?";
       case SUGGESTION:
-        return "Adicionar equivalência de métrica?";
+        return "Adicionar conversão ao sistema métrico?";
       case CHECK_UNKNOWN_UNIT:
         return "Unidade desconhecida.";
       case UNIT_MISMATCH:
-        return "Unidade não relacionada.";
+        return "Unidade incompatível.";
       default:
         throw new RuntimeException("Unknown message type." + message);
     }

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/PortugueseUnitConversionRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/PortugueseUnitConversionRuleTest.java
@@ -55,15 +55,22 @@ public class PortugueseUnitConversionRuleTest {
     PortugueseUnitConversionRule rule = new PortugueseUnitConversionRule(JLanguageTool.getMessageBundle(lang));
     assertMatches("Eu tenho 6 pés de altura.", 1, "1,83 metros", rule, lt);
     assertMatches("Eu tenho 6 pés (2,02 m) de altura.", 1, "1,83 metros", rule, lt);
-    assertMatches("Eu tenho 6 pés (1,82 m) de altura.", 0, null, rule, lt);assertMatches("A via tem 100 milhas de comprimento.", 1, "160,93 quilómetros", rule, lt);
+    assertMatches("Eu tenho 6 pés (1,82 m) de altura.", 0, null, rule, lt);
+    assertMatches("A via tem 100 milhas de comprimento.", 1, "160,93 quilômetros", rule, lt);
     assertMatches("A via tem 10 km (20 milhas) de comprimento.", 1, "6,21", rule, lt);
     assertMatches("A via tem 10 km (6,21 milhas) de comprimento.", 0, null, rule, lt);
-    assertMatches("A via tem 100 milhas (160,93 quilómetros) de comprimento.", 0, null, rule, lt);
+    assertMatches("A via tem 100 milhas (160,93 quilômetros) de comprimento.", 0, null, rule, lt);
     assertMatches("A carga é de 10.000 libras.", 1, "4,54 toneladas", rule, lt);
     assertMatches("Isto tem 5'6\" de altura.", 1, "1,68 m", rule, lt);
     assertMatches("O meu novo apartamento tem 500 sq ft de área.", 1, "46,45 metros quadrados", rule, lt);
     assertMatches("Sendo a latitude 8º 32' 00\" e a longitude 39º 22' 49\".", 0, null, rule, lt);
     assertMatches("Sendo a latitude 8º32'00\" e a longitude 39º22'49\".", 0, null, rule, lt);
+    // Same unit, assume something shady, but don't suggest conversion to the same one!
+    assertMatches("Com altura de 4,8 cm (22,08 cm).", 0, null, rule, lt);
+    // Composite expression (squaring); should work properly at some point, but at least now it doesn't fail
+    assertMatches("Com altura de 4,8 mm x 5,2 cm (2,5 cm²).", 0, null, rule, lt);
+    assertMatches("Com altura de 4,8 mm × 5,2 cm (2,5 cm²).", 0, null, rule, lt);
+
   }
 
   private void assertMatches(String input, int expectedMatches, String converted, AbstractUnitConversionRule rule, JLanguageTool lt) throws IOException {


### PR DESCRIPTION
@susanaboatto I had to change the default spellings of the units to `pt-BR`, but also made some changes to the messages so they're less awkward.

---

@danielnaber there is an issue with this rule in that it fails to parse composite expressions like `2.3cm x 2.3cm`. In `pt-BR`, this appears as a frequent `temp_disable` context, and I believe that's also a reason why its apply rate is so low. The same seems to be true in other locales that have a unit conversion rule implemented.

It's prob. not a huge issue right now, so I'm just adding a simple hotfix to get rid of same-unit conversions, which takes care of many of the squaring/cubing FPs. But we might want to rethink the unit conversion rule, esp. for complex dimensions (2.5 x 2.3 x 6.9 cm).

![Screenshot 2023-12-04 at 5 07 24 PM](https://github.com/languagetool-org/languagetool/assets/50704700/8f52869f-0eb1-4a15-8880-7e4e0d27dbf6)

![Screenshot 2023-12-04 at 5 12 50 PM](https://github.com/languagetool-org/languagetool/assets/50704700/5c620c18-db4d-437d-ab98-5ae23bf65982)

![Screenshot 2023-12-04 at 5 13 18 PM](https://github.com/languagetool-org/languagetool/assets/50704700/ab8c815c-9765-405b-80ed-0014cfece4fa)

