### PR TITLE
[pt] Added exceptions and removed "temp_off" from rule ID:IR_CONTRACTION_NOUN

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -14160,7 +14160,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='IR_CONTRACTION_NOUN' name="Ir + 'na/no' + nome → à/ao" default="temp_off">
+        <rule id='IR_CONTRACTION_NOUN' name="Ir + 'na/no' + nome → à/ao">
             <!-- To do: remove verb "mercar" ("mercado") POS? It removes all valid entries using "mercado" -->
             <!-- This is a very hard to code rule. It will require further enhancements in the future (2023-10-31). -->
 
@@ -14304,7 +14304,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 </marker>
                 <token min='0' max='1' postag='DP.+' postag_regexp='yes'/>
                 <token postag='NC.+|AQ.+' postag_regexp='yes'>
-                    <exception regexp='yes'>almas?|braços?|cabeças?|carros?|comboios?|comédias?|contramão|conversas?|direc?ç(ão|ões)|embalage(m|ns)|encalços?|episódios?|fígados?|filmes?|formas?|futuros?|instintos?|listas?|lugar(es)?|malas?|mentes?|mesas?|metr[oô]s?|novelas?|partes?|postos?|pr[éê]mios?|propósitos?|recompensas?|rodas?|rostos?|sentidos?|simultâne[ao]s?|thrillers?|tre(m|ns)|vidas?</exception> <!-- List of words that antipatterns can't deal with, using the logic: "vou/vai + na/no + word" -->
+                    <exception regexp='yes'>almas?|braços?|cabeças?|carros?|comboios?|comédias?|contramão|conversas?|direc?ç(ão|ões)|embalage(m|ns)|encalços?|episódios?|férias?|fígados?|filmes?|formas?|futuros?|instintos?|listas?|lugar(es)?|malas?|mentes?|mesas?|metr[oô]s?|novelas?|partes?|postos?|pr[éê]mios?|propósitos?|recompensas?|rodas?|rostos?|sentidos?|simultâne[ao]s?|thrillers?|tre(m|ns)|vidas?</exception> <!-- List of words that antipatterns can't deal with, using the logic: "vou/vai + na/no + word" -->
                     <exception regexp='yes'>&dias_semana;|&dias_semana_abrev;|&expressoes_de_tempo;</exception>
                     <exception postag='(AO|Z).+|V.+|SPS0.+|[DP].+|CC|CS|RG|I|RM|RN' postag_regexp='yes'/>
                 </token>
@@ -14329,6 +14329,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example>Sua estreia no oeste foi na Ópera de Nice com A Rainha de Espadas em 1989.</example>
             <example>O único lugar onde Kellan Kyle sempre se sentiu em casa foi no centro de um palco.</example>
             <example>Minha primeira escolha vai ser alguém que eu sei que vai ser confortável fora no deserto.</example>
+            <example>"Aonde vocês gostariam de ir nas férias?" "À Rússia."</example>
         </rule>
 
 


### PR DESCRIPTION
Heya, Susana and Pedro,

This rule can't become much better than already is.

I have removed a FP and the “temp_off”.

https://internal1.languagetool.org/regression-tests/via-http/2023-12-02/pt-BR_full/result_grammar_IR_CONTRACTION_NOUN%5B1%5D.html

❤️ ❤️ ❤️ ❤️ 