### PR TITLE
[fr] couleur_invariable-AI-AP

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/remote-rule-filters.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/remote-rule-filters.xml
@@ -29,14 +29,14 @@ To ignore a remote rule match, set the <marker> so that it exactly covers the te
 <!ENTITY unites_temps "matinée|journée|an|année|veille|décade|décennie|h(eure)?|j(our)?|lustre|millénaire|min(ute)?|mois|quadrimestre|seconde|semaine|semestre|siècle|trimestre|secs?">
 <!ENTITY unites_de_mesure "min|(centi|milli|déci|déca|hecto|kilo|atto|exa|mega|giga|tera|peta|zetta|yotta|micro|nano|pico|femto|zepto|yocto)?[mètre|gramme|litre]|degré|[mchkd][wglm]|dag|dal|dam|volt|watt|hz|hertz|bits?|ms|s|cs|cc|dB|go|kw">
 <!ENTITY monnaies "afghani|rand|lek|d[ie]nar|euro|kwanza|dollar|florin|riyal|peso|dram|manat|taka|rouble|franc|r(h)?oupie|boliviano|mark|pula|couronne|real|(bulgarian)? lev|riel|peso|escudo|yuan|livre|won|kuna|colon|dirham|birr|dalasi|lari|ghana cedi|quetzal|gourde|lempira|forint|rupiah|rial|yen|tenge|shilling|som|kip|rans|loti|lats|litas|pataca|malagasy|ringgit|kwacha|rufiyaa|ouguija|leu|tugrik|metical|kyat|rand|cordoba|naira|soum|balboa|kina|guarani|(nouveau)? sol|zloty|tala|dobra|leone|lilangeni|somoni|baht|pa'anga|manat|hryvnia|vatu|bolivar|dong|kwacha">
-        <!ENTITY couleur_invariable "abricot|absinthe|acajou|acier|océan|aigue-marine|albâtre|amadou|amande|amarante|ambre|améthyste|andrinople|anis|anthracite|ardoise|argent|argile|asperge|aubergine|auburn|aurore|avocat|azur|banane|basane|basque|bistre|bitume|bonbon|bordeaux|bourgogne|bouteille|brique|bronze|bulle|cacao|cachou|café|canari|cannelle|capucine|caramel|carmin|carmélite|carotte|cassis|cerise|chair|chamois|champagne|chaudron|chocolat|châtaigne|ciel|citron|cognac|coquelicot|corail|crevette|crème|cuivre|cyclamen|céladon|denim|ébène|émeraude|étain|feu|filasse|fluo|fraise|framboise|fuchsia|garance|grenat|groseille|géranium|havane|indigo|isabelle|ivoire|jade|jonquille|kaki|klein|lagon|lavande|lie-de-vin|lilas|magenta|mangue|marengo|marron|mastic|maïs|melon|menthe|miel|moutarde|muscade|myrtille|n[âa]cre|nacarat|nacre|noisette|ocre|olive|or|orange|outremer|paille|pastel|pastèque|perle|pervenche|pie|piment|pistache|pivoine|pomme|ponceau|porto|prune|puce|pétrole|pêche|romarin|rouille|sable|safran|sang|saumon|sépia|tabac|taupe|tilleul|tomate|turquoise|vanille|verdâtre|vermillon">
-        <!-- |tendance indien|plastique|tendre nuit?? -->
-        <!ENTITY couleur_invariable_m "noyer|canard"> <!-- fem: marine -->
-        <!ENTITY couleur_variable "alezan|blanhâtre|pourpré|violacé|ambré|aubère|bai|baillet|basané|beige|bis|blafard|blond|blême|châtain|chiné|cramoisi|dense|doré|écarlate|écru|fauve|fluorescent|foncé|glauque|incarnat|intense|livide|louvet|lumineux|mat|mauve|métallique|mordoré|opalin|orangé|pâle|perse|pourpre|profond|rosé|rose|rouan|rousse|roux|tourdille|tropical|vairon|vermeil|vernissé|vif|violet|zain|zinzolin">
-        <!ENTITY couleur "blanc|bleu|brun|gris|jaune|noir|rouge|vert">
-        <!-- only on the second position: -->
-        <!ENTITY couleur_variable2 "brillant|paillette|pailleté|cassé|bigarré|clair|sombre">
-        ]>
+<!ENTITY couleur_invariable "abricot|absinthe|acajou|acier|océan|aigue-marine|albâtre|amadou|amande|amarante|ambre|améthyste|andrinople|anis|anthracite|ardoise|argent|argile|asperge|aubergine|auburn|aurore|avocat|azur|banane|basane|basque|bistre|bitume|bonbon|bordeaux|bourgogne|bouteille|brique|bronze|bulle|cacao|cachou|café|canari|cannelle|capucine|caramel|carmin|carmélite|carotte|cassis|cerise|chair|chamois|champagne|chaudron|chocolat|châtaigne|ciel|citron|cognac|coquelicot|corail|crevette|crème|cuivre|cyclamen|céladon|denim|ébène|émeraude|étain|feu|filasse|fluo|fraise|framboise|fuchsia|garance|grenat|groseille|géranium|havane|indigo|isabelle|ivoire|jade|jonquille|kaki|klein|lagon|lavande|lie-de-vin|lilas|magenta|mangue|marengo|marron|mastic|maïs|melon|menthe|miel|moutarde|muscade|myrtille|n[âa]cre|nacarat|nacre|noisette|ocre|olive|or|orange|outremer|paille|pastel|pastèque|perle|pervenche|pie|piment|pistache|pivoine|pomme|ponceau|porto|prune|puce|pétrole|pêche|romarin|rouille|sable|safran|sang|saumon|sépia|tabac|taupe|tilleul|tomate|turquoise|vanille|verdâtre|vermillon">
+<!-- |tendance indien|plastique|tendre nuit?? -->
+<!ENTITY couleur_invariable_m "noyer|canard"> <!-- fem: marine -->
+<!ENTITY couleur_variable "alezan|blanhâtre|pourpré|violacé|ambré|aubère|bai|baillet|basané|beige|bis|blafard|blond|blême|châtain|chiné|cramoisi|dense|doré|écarlate|écru|fauve|fluorescent|foncé|glauque|incarnat|intense|livide|louvet|lumineux|mat|mauve|métallique|mordoré|opalin|orangé|pâle|perse|pourpre|profond|rosé|rose|rouan|rousse|roux|tourdille|tropical|vairon|vermeil|vernissé|vif|violet|zain|zinzolin">
+<!ENTITY couleur "blanc|bleu|brun|gris|jaune|noir|rouge|vert">
+<!-- only on the second position: -->
+<!ENTITY couleur_variable2 "brillant|paillette|pailleté|cassé|bigarré|clair|sombre">
+]>
 <rules lang="fr" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/remote-rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <category name="Machine learning rules" id="AI_RULES">
         <rulegroup id="AI_FR_HYDRA_LEO_MISSING_COMMA" name="">
@@ -606,6 +606,20 @@ To ignore a remote rule match, set the <marker> so that it exactly covers the te
                     </marker>
                 </pattern>
                 <example correction="">Bonjour <marker>monsieur</marker>.</example>
+            </rule>
+        </rulegroup>
+        <rulegroup id="AI_FR_GGEC_REPLACEMENT_NOUN_FORM.*" name="">
+            <rule>
+                <pattern>
+                    <token postag="D . s?p" postag_regexp="yes"/>
+                    <token postag="N . p" postag_regexp="yes">
+                        <exception regexp="yes">grosses|dernières|premières|petits</exception></token>
+                    <marker>
+                        <token regexp="yes" inflected="yes" postag="[JN].* s" postag_regexp="yes">&couleur_invariable;
+                            <exception regexp="yes">cassée?s?|briques?|tendue?s?|nuits?|perles?|plastiques?|oranges</exception></token>
+                    </marker>
+                </pattern>
+                <example correction="">Elle avait les yeux <marker>marron</marker>.</example>
             </rule>
         </rulegroup>
     </category>


### PR DESCRIPTION
To address the looping issue: https://github.com/languagetooler-gmbh/task-force-french/issues/90
But also GEMA 23D gGEC FPs, so: https://github.com/languagetooler-gmbh/task-force-french/issues/85

- AI_FR_GGEC_REPLACEMENT_NOUN_FORM.*: AP added in remote-rule-filter to avoid FPs and loops with grammalecte_g3__gn_couleurs_invariables__b1_a1_1 and ACCORD_COULEUR[1] on, for example, "Elle avait les yeux marron"

AP tested and working :) it's actually the pattern from XML ACCORD_COULEUR[1], I only changed the token from the marker from plural to singular (`[JN].* p` to `[JN].* s`)