### PR TITLE
[pt] Improve recognition of reduplicated adverbs

### DIFF
--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseWordRepeatRule.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseWordRepeatRule.java
@@ -43,6 +43,8 @@ public class PortugueseWordRepeatRule extends WordRepeatRule {
 
   private static final Pattern PRONOUNS = Pattern.compile("mas|n?[ao]s?|se");
 
+  private static final Pattern REDUPLICATED_ADVERBS = Pattern.compile("já|logo|fácil", Pattern.CASE_INSENSITIVE);
+
   public PortugueseWordRepeatRule(ResourceBundle messages, Language language) {
     super(messages, language);
     super.setCategory(Categories.REPETITIONS.getCategory(messages));
@@ -76,6 +78,9 @@ public class PortugueseWordRepeatRule extends WordRepeatRule {
     if (isHyphenated(tokens, position) && isPronoun(tokens[position])) {
       return true;   // e.g. "Coloquem-na na sala."
     }
+    if (isReduplicatedAdverb(tokens[position])) {
+      return true; // e.g. "Logo logo" => we need another rule to suggest a comma.
+    }
     return super.ignore(tokens, position);
   }
 
@@ -93,5 +98,9 @@ public class PortugueseWordRepeatRule extends WordRepeatRule {
 
   private boolean isSpecies(AnalyzedTokenReadings token) {
     return TAUTONYMS_SPECIES.matcher(token.getToken()).matches();
+  }
+
+  private boolean isReduplicatedAdverb(AnalyzedTokenReadings token) {
+    return REDUPLICATED_ADVERBS.matcher(token.getToken()).matches();
   }
 }

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/misc.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/misc.ent
@@ -197,3 +197,5 @@ limpo">
 
 <!ENTITY numeros_masculinos "milhares|(m|b|tr|quatr|quinqu|sext|sept|oct|non)ilhões">
 
+<!-- Must be the same adverbs as the ones found in PortugueseWordRepeatRule.REDUPLICATED_ADVERBS -->
+<!ENTITY reduplicated_adverbs "logo|já|fácil">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -18583,6 +18583,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
     <category id='PUNCTUATION' name="Pontuação">
+        <rulegroup id="LOCUCOES_ADVERBIAIS_REDUPLICADAS" name="Sugerir vírgula em locuções adverbiais formadas por reduplicação, como 'logo logo' => 'logo, logo'.">
+            <rule>
+                <pattern>
+                    <token regexp="yes">&reduplicated_adverbs;</token>
+                    <token><match no="0"/></token>
+                </pattern>
+                <message>As palavras em locuções formadas por reduplicação, via de regra, separam-se por vírgula.</message>
+                <suggestion>\1, \2</suggestion>
+                <example correction="Logo, logo"><marker>Logo logo</marker> vamos ao mercado.</example>
+                <example correction="já, já">Ele chega <marker>já já</marker>.</example>
+            </rule>
+        </rulegroup>
+
         <rulegroup id='FINAL_STOPS' name="Pontuação: pontuação final em falta" default='on' tags="picky">
             <!-- Created by Tiago F. Santos, Portuguese rule, -->
             <antipattern>

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/PortugueseWordRepeatRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/PortugueseWordRepeatRuleTest.java
@@ -33,16 +33,16 @@ public class PortugueseWordRepeatRuleTest {
     Language lang = Languages.getLanguageForShortCode("pt");
     JLanguageTool lt = new JLanguageTool(lang);
     PortugueseWordRepeatRule rule = new PortugueseWordRepeatRule(TestTools.getEnglishMessages(), lang);
-    assertFalse(ignore("no repetition", lt, rule));
-    assertTrue(ignore("blá blá", lt, rule));
-    assertTrue(ignore("Aaptos aaptos", lt, rule));
-    // assertTrue(ignore("Coloquem-na na sala.", lt, rule)); XXX passes tests. TODO improve ignore function
+    assertFalse(ignore("no repetition", lt, rule, 2));
+    assertTrue(ignore("blá blá", lt, rule, 2));
+    assertTrue(ignore("Aaptos aaptos", lt, rule, 2));
+    assertTrue(ignore("Logo logo vamos ao mercado", lt, rule, 2));
+    assertTrue(ignore("Coloquem-na na sala.", lt, rule, 4)); // the hyphen is a token
   }
 
-  private boolean ignore(String input, JLanguageTool lt, PortugueseWordRepeatRule rule) throws IOException {
+  private boolean ignore(String input, JLanguageTool lt, PortugueseWordRepeatRule rule, int position) throws IOException {
     AnalyzedSentence sentence = lt.getAnalyzedSentence(input);
     AnalyzedTokenReadings[] tokens = sentence.getTokensWithoutWhitespace();
-    return rule.ignore(tokens, 2);
+    return rule.ignore(tokens, position);
   }
-
 }


### PR DESCRIPTION
For cases like:

<img width="401" alt="Screenshot 2023-12-07 at 3 09 28 PM" src="https://github.com/languagetool-org/languagetool/assets/50704700/7c85ef4b-8929-4ca2-bae4-6a16f5333a65">

This is wrong, but not because of repetition, but because there's a comma missing.