### PR TITLE
Update RemoteRuleFilters.java

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleFilters.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRuleFilters.java
@@ -141,7 +141,7 @@ public final class RemoteRuleFilters {
     Language lang = Languages.getLanguageForShortCode(langCode);
     List<AbstractPatternRule> rules = RemoteRuleFilters.load(lang)
       .values().stream().flatMap(Collection::stream).collect(Collectors.toList());
-    Stream<String> lines = Files.lines(Paths.get(matchesFile), StandardCharsets.UTF_8);
+    String content = Files.readString(Paths.get(matchesFile), StandardCharsets.UTF_8);
     ObjectMapper mapper = new ObjectMapper();
     JLanguageTool lt = new JLanguageTool(lang);
 
@@ -149,8 +149,8 @@ public final class RemoteRuleFilters {
       .map(s -> {
         try {
           return mapper.readValue(s, ExpectedMatches.class);
-        } catch (JsonProcessingException e) {
-          throw new RuntimeException(e);
+        } catch (JsonProcessingException | IOException e) {
+          throw new RuntimeException("Error processing JSON or IO", e);
         }
       })
       .flatMap(matches -> {


### PR DESCRIPTION
If you are using Java 11 or later, I used Files.readString to read the file more simply.I modified the exceptions by catching more specific exceptions and providing meaningful error messages