### PR TITLE
[DE] GermanUnpairedBracketsRule: single french quotes added

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanUnpairedBracketsRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanUnpairedBracketsRule.java
@@ -30,8 +30,8 @@ import java.util.function.Supplier;
 
 public class GermanUnpairedBracketsRule extends GenericUnpairedBracketsRule {
 
-  private static final List<String> DE_START_SYMBOLS = Arrays.asList("[", "(", "{", "„", "»", "«", "\"");
-  private static final List<String> DE_END_SYMBOLS   = Arrays.asList("]", ")", "}", "“", "«", "»", "\"");
+  private static final List<String> DE_START_SYMBOLS = Arrays.asList("[", "(", "{", "„", "»", "«", "\"", "›", "‹");
+  private static final List<String> DE_END_SYMBOLS   = Arrays.asList("]", ")", "}", "“", "«", "»", "\"", "‹", "›");
 
   public GermanUnpairedBracketsRule(ResourceBundle messages, Language language) {
     super(messages, DE_START_SYMBOLS, DE_END_SYMBOLS);


### PR DESCRIPTION
The GermanUnpairedBracketsRule function does not accept single quotation marks. The standard quotation marks result in errors. However, the "French" single quotation marks used in German-language literature can be added without errors. That's what was done in this amendment.