### PR TITLE
[pt] Improve DET_FEM_MAS_A_O grammar rule

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -1711,7 +1711,7 @@
     <!-- Verbo + Preposição: p.ex. 'a' como preposição depois do verbo	-->
     <!-- Created by Tiago F. Santos, Portuguese rule, 2016-11-15  	-->
     <!-- https://pt.wikipedia.org/wiki/A_(preposi%C3%A7%C3%A3o)		-->
-    <rule>
+    <rule> <!-- #1 -->
       <pattern>
         <marker>
           <token>a</token>
@@ -1720,7 +1720,7 @@
       </pattern>
       <disambig action="filter" postag="S.+"/>
     </rule>
-    <rule>
+    <rule> <!-- #2 -->
       <pattern>
         <marker>
           <token>a</token>
@@ -1729,7 +1729,7 @@
       </pattern>
       <disambig action="filter" postag="S.+"/>
     </rule>
-    <rule>
+    <rule> <!-- #3 -->
       <pattern>
         <marker>
           <token>a</token>
@@ -1739,7 +1739,7 @@
       </pattern>
       <disambig action="filter" postag="S.+"/>
     </rule>
-    <rule>
+    <rule> <!-- #4 -->
       <pattern>
         <token inflected='yes' regexp='yes'>caminhar|correr|explicar|inaugurar|ver|comprar</token>
         <token min='0' postag='R.' postag_regexp='yes'/>
@@ -1749,34 +1749,46 @@
       </pattern>
       <disambig action="remove" postag="S.+"/>
     </rule>
-    <rule>
+    <rule> <!-- #5 -->
       <pattern>
         <token postag="V.+" postag_regexp="yes" inflected="yes" regexp="yes">começar|levar|ir|chegar|feder</token>
         <token min="0" postag="R." postag_regexp="yes"/>
         <marker>
-          <token>a</token>
+          <!-- when followed by a simple fem. noun in the singular, always allow for it to be an article -->
+            <token>a
+                <exception scope="next" postag_regexp="yes" postag="N.F[SN]..."/>
+                <exception scope="next" regexp="yes" postag_regexp="yes" postag="N.M[SN]...">&masc_nouns_mistaken_for_fem;</exception>
+            </token>
         </marker>
       </pattern>
       <disambig action="filter" postag="S.+"/>
       <example type="untouched">...desde que foi inaugurada a República de Itália, em 1946,...</example>
+      <example type="untouched">Chegou a menina.</example>
     </rule>
-    <rule><!-- TODO too agressive. try disabling this rule in a day without many changes and see regression results -->
+    <rule><!-- #6; TODO too agressive. try disabling this rule in a day without many changes and see regression results -->
       <pattern>
         <token postag="V.+" postag_regexp="yes">
           <exception postag="VMP.+" postag_regexp="yes"/>
           <exception regexp="yes">para|como</exception>
           <exception inflected='yes' regexp='yes'>caminhar|correr|explicar|inaugurar|ver|ele|comprar|abrir|ser|estar</exception></token>
+           <!-- TODO: add a list of common, relatively unambiguous *transitive* verbs here -->
         <token min='0' postag='R.' postag_regexp='yes'/>
         <marker>
-          <token>a</token>
+            <!-- when followed by a simple fem. noun in the singular, always allow for it to be an article -->
+            <token>a
+                <exception scope="next" postag_regexp="yes" postag="N.F[SN]..."/>
+                <exception scope="next" regexp="yes" postag_regexp="yes" postag="N.M[SN]...">&masc_nouns_mistaken_for_fem;</exception>
+            </token>
         </marker>
       </pattern>
       <disambig action="filter" postag="S.+"/>
       <example type='untouched'>...desde que foi inaugurada a República de Itália, em 1946,...</example>
       <example type='untouched'>É proibido a entrada de pessoas não autorizadas</example>
       <example type="untouched">Quero saber quem é a agente que atende.</example>
+      <example type="untouched">Temos que curar a gripe.</example>  <!-- tagged as fem -->
+      <example type="untouched">Temos que curar a herpes.</example>  <!-- tagged as masc, but commonly used in the fem -->
     </rule>
-    <rule>
+    <rule> <!-- #7 -->
       <pattern>
         <token postag='V.+' postag_regexp='yes' regexp='yes' inflected='yes'>&requer_crase_verbos;|a(?:plicar|ssemelhar)|comprometer|d(?:edicar|irigir)|e(?:levar|stender)|ir|limitar|observar|p(?:[ôo]r|ertencer)|r(?:eagir|ecorrer|eferir|estringir)|sobrep[ôo]r|ver</token><!-- XXX ambiguous: juntar|alagar -->
         <token regexp='yes' spacebefore='no'>&hifen;</token>
@@ -1788,7 +1800,7 @@
       </pattern>
       <disambig action='filter' postag='S.+'/>
     </rule>
-    <rule>
+    <rule> <!-- #8 -->
       <pattern>
         <token regexp='yes'>&requer_crase;</token>
         <marker>
@@ -1797,7 +1809,7 @@
       </pattern>
       <disambig action="filter" postag="S.+"/>
     </rule>
-    <rule>
+    <rule> <!-- #9 -->
       <pattern>
         <token inflected='yes'>ser</token>
         <token postag='A.+' postag_regexp='yes'/>
@@ -1807,7 +1819,7 @@
       </pattern>
       <disambig action="filter" postag="S.+"/>
     </rule>
-    <rule>
+    <rule> <!-- #10 -->
       <pattern>
         <token postag_regexp="yes" postag="SENT_START|_PUNCT|V.+"/>
         <token>não</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/misc.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/misc.ent
@@ -199,3 +199,7 @@ limpo">
 
 <!-- Must be the same adverbs as the ones found in PortugueseWordRepeatRule.REDUPLICATED_ADVERBS -->
 <!ENTITY reduplicated_adverbs "logo|já|fácil">
+
+<!ENTITY masc_nouns_mistaken_for_fem_inanimate "herpes|mármore|espécime|bracelete">
+<!ENTITY masc_nouns_mistaken_for_fem_animate "cônjuge|neném">
+<!ENTITY masc_nouns_mistaken_for_fem "&masc_nouns_mistaken_for_fem_animate;|&masc_nouns_mistaken_for_fem_inanimate;">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -16655,18 +16655,43 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <!-- TODO Merge specific concordance rules in rulegroup to compact options -->
-        <!-- DET_FEM_MAS words that use "o" instead of "a" -->
-        <rule id='DET_FEM_MAS_A_O' name="Palavras a-o">
-            <pattern case_sensitive="no">
-                <marker>
-                    <token>a</token>
-                </marker>
-                <token regexp="yes">herpes|mármore|cônjuge|espécime|bracelete</token>
-            </pattern>
-            <message>Erro de concordância. Usar: <suggestion>o</suggestion>.</message>
-            <example correction="o">Temos de curar <marker>a</marker> herpes.</example>
-        </rule>
+        <!-- This rule used to be needed because of a disambiguator rule that meant "a" was frequently tagged only as a preposition. -->
+        <!-- This has since been fixed, but I do think it's important to have a separate message for words that are commonly used -->
+        <!-- in the 'wrong' gender by native speakers. -->
+        <rulegroup id='DET_FEM_MAS_A_O' name="Palavras masculinas frequentemente usadas no feminino." default="temp_off">
+            <short>Possível erro de concordância: substantivo masculino.</short>
+            <rule>
+                <pattern>
+                    <marker>
+                        <token postag_regexp="yes" postag="(SP.+:)?D..F.."/>
+                    </marker>
+                    <token regexp="yes" inflected="yes">&masc_nouns_mistaken_for_fem_inanimate;</token>
+                </pattern>
+                <message>Embora frequentemente usado como se fosse feminino, o substantivo &quot;\2&quot; é, de fato, masculino.</message>
+                <suggestion><match no="1" postag_regexp="yes" postag="((?:SP.+:)?D..)F(..)" postag_replace="$1M$2"/></suggestion>
+                <example correction="o">Temos de curar <marker>a</marker> herpes.</example>
+                <example correction="deste">Gostou <marker>desta</marker> mármore?</example>
+                <example correction="aqueles">Me agradaram <marker>aquelas</marker> braceletes.</example>
+            </rule>
+        </rulegroup>
+
+        <!-- Usage here is strongly on the side of accepting "a cônjuge", which makes sense, so this is picky. -->
+        <rulegroup id="SUBST_SOBRECOMUM_MASCULINO" name="Palavras sobrecomuns frequentmente usadas no feminino" tags="picky" default="temp_off">
+            <url>https://www.normaculta.com.br/substantivo-sobrecomum/</url>
+            <short>Possível erro de concordância: substantivo sobrecomum.</short>
+            <rule>
+                <pattern>
+                    <marker>
+                        <token postag_regexp="yes" postag="(SP.+:)?D..F.."/>
+                    </marker>
+                    <token regexp="yes" inflected="yes">&masc_nouns_mistaken_for_fem_animate;</token>
+                </pattern>
+                <message>Em gramáticas tradicionais, há quem insista que, na norma culta, a palavra &quot;\2&quot;, mesmo quando em referência a pessoas do sexo feminino, seja usada no masculino.</message>
+                <suggestion><match no="1" postag_regexp="yes" postag="((?:SP.+:)?D..)F(..)" postag_replace="$1M$2"/></suggestion>
+                <example correction="seu">Quanto ao estado civil, ela é <marker>sua</marker> cônjuge.</example>
+            </rule>
+        </rulegroup>
+
 
         <rule id='A_COMO_É_AS_OS' name="A como são as/os">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -3801,7 +3801,8 @@ USA
             <example>Mais do que a web, o governo hoje tem em sua defesa várias emissoras de rádio e TV, sites, agencias de notícias etc.</example>
             <example>IRMÃOS, rOGO A VÓS QUE OREM POR MIM POR BENÇAOS, GRAÇAS E VITORIAS NESSA SEMANA QUE SE INICIA.</example>
             <example>isso é muito pouco pra ele hahahh eu acabei de adquirir dois volumes das cronicas de gelo e fogo e pretendo ler em breve, se eu gostar (provalvemente vou, todo mundo fala bem) e aca...</example>
-            <example>Bom, essa parte das musicas a gente mesmo fez.</example>
+            <!-- stopped working once the  "a" in "a gente" started being tagged correctly as a determiner and not a preposition -->
+            <!-- <example>Bom, essa parte das musicas a gente mesmo fez.</example> -->
             <example>Tenho algumas duvidas perante a projeção astral: se eu me projetar e tiver um vampirizador me sugando em meu quarto?</example>
             <example>Com isso em mente, a OCP atribui tarefas aos policias para as zonas mais violentas da cidade, à espera que algum morresse no cumprimento do dever.</example>
             <example>O artista havia publicado inúmeras músicas e remixes de outros artistas.</example>


### PR DESCRIPTION
 - split it, so we also have SUBT_SOBRECOMUM_MASCULINO, which takes care of nouns used in the 'wrong' gender but that make reference to animate entities;

 - improve the disambiguator slightly to never lose the determiner tag of "a" before a feminine singular noun;

 - add entities for commonly misused nouns wrt gender (can be expanded);

 - comment out one example in pt-PT/style that's been affected by the recent change of the disambiguator (@marcoagpinto, you may need to have a look at this).