### PR TITLE
[pt] Update ESPERA_QUE_INDICATIVO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/verbs.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/verbs.ent
@@ -3,7 +3,7 @@
 <!ENTITY verbos_auxiliares_modais "(?:dever|poder|querer|conseguir|pretender|tentar|chegar)">
 <!ENTITY verbos_auxiliares_part_passado "(?:ser|estar|ter|haver|ficar)">
 <!ENTITY verbos_de_ligacao "(?:andar|continuar|estar|ficar|parecer|permanecer|assemelhar|semelhar|ser|virar|viver)">
-<!ENTITY verbos_muito_incomuns "gravidar|fossar|memoriar|propositar|missar|maquinar|politicar|azar|amanhar|aliançar|mear|aquarelar|arvorar|asneirar|antar|aulir|barracar|bobear|bonecar|camar|cortinar|deputar|elar|empresar|estivar|falsar|farar|festar|florestar|luzir|maravilhar|mechar|melodiar|oferendar|palavrar|pelar|roupar|salar|segundar|surpresar|trançar|unhar">
+<!ENTITY verbos_muito_incomuns "gravidar|fossar|memoriar|propositar|missar|maquinar|politicar|azar|amanhar|aliançar|mear|aquarelar|arvorar|asneirar|antar|aulir|barracar|bobear|bonecar|camar|cortinar|deputar|elar|empresar|estivar|falsar|farar|festar|florestar|luzir|maravilhar|mechar|melodiar|oferendar|palavrar|pelar|roupar|salar|segundar|surpresar|trançar|unhar|acimar">
 <!ENTITY verbos_nao_impessoais "acabar|bastar|chegar|entrar|existir|faltar|ficar|restar|sair|sobrar|acontecer|ocorrer">
 <!ENTITY verbos_pronominais "apelidar|chamar|denominar">
 <!ENTITY verbos_que_infinitivo "dizer|observar|perceber|considerar|parecer|concluir|deduzir|responder|informar|constatar|argumentar|decidir|afirmar|contar|relatar|simular|fingir|revelar|admitir|pensar|declarar|alegar">
@@ -25,3 +25,7 @@
                           juntar|tornar|virar|despachar|apressar|calar|alegrar|unir|aplicar|certificar|ajoelhar|vestir|
                           despir"
 >
+
+<!-- Need to find a way to add 'gostaria' here 🤔 -->
+<!ENTITY subjunctive_verbs "esperar|evitar|acreditar|crer|supor|pressupor|permitir|duvidar|negar|suspeitar|temer|imaginar|
+                            propor|aconselhar|impedir|proibir|sugerir|suplicar|recomendar|desmentir|preferir|querer|desejar">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -12304,80 +12304,276 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <rule id="ESPERA_QUE_INDICATIVO" name="Concordância Verbal: Esperar que + Indicativo">
-            <!-- Localized from Catalan grammar.xml by Tiago F. Santos, 2018-07-13 -->
-            <antipattern>
+        <!-- ESPERA_QUE_INDICATIVO -->
+        <rulegroup id="ESPERA_QUE_INDICATIVO" name="Concordância Verbal: Esperar que + Indicativo" default="temp_off">
+            <antipattern> <!-- #1 -->
                 <marker>
                     <token>que</token>
                     <token postag="P.+" postag_regexp="yes"/>
-                    <token inflected="yes" regexp="yes">esperar|evitar</token>
+                    <token inflected="yes" regexp="yes">&subjunctive_verbs;</token>
                     <token>que</token>
                 </marker>
             </antipattern>
-            <antipattern>
+            <antipattern> <!-- #2 -->
                 <token skip='2'>espera</token>
                 <token skip='2'>que</token>
                 <token>já</token>
                 <token>volto</token>
                 <example>Espera aqui que já volto</example>
             </antipattern>
-            <pattern>
-                <token postag='V.IP.+|V.[NG].+' postag_regexp='yes' inflected='yes' skip='4' regexp="yes">esperar|evitar
-                    <exception>como</exception>
+            <antipattern> <!-- #3: rare verbs -->
+                <token postag='V.IP.+|V.[NG].+' postag_regexp='yes' inflected='yes' regexp="yes">&subjunctive_verbs;
                     <exception scope="next" postag="CC|N.+|DI.+|NP.+|V.[^P].*" postag_regexp="yes"/>
                     <exception scope="next" regexp="yes">[;,«“”»]|&quot;</exception>
-                    <exception scope="previous" postag="P0[12].{5}|PP3CN000|PP3NN000|PP3..A00|PP3CP000|PP3CSD00" postag_regexp="yes"/></token>
-                <token skip='5'>que
-                    <exception scope="next">que</exception>
-                    <exception scope="next" postag="CC|V.S.+|V.IF.+|_PUNCT.*" postag_regexp="yes"/>
-                    <exception scope="previous" regexp="yes">até|o</exception></token>
-                <marker>
-                    <token postag='V.IP.+' postag_regexp='yes'>
-                        <exception postag='V.S.+|N.+|V.IC.+|A.+|VMG.+' postag_regexp='yes'/>
-                        <exception regexp='yes'>\p{Lu}.*|&verbos_muito_incomuns;|estar</exception></token> <!-- "estar" must be dealt with in a diacritics rule -->
-                </marker>
-            </pattern>
-            <message>Tempo verbal incorreto.</message> <!-- VMIP3S00 -->
-            <suggestion><match no='3' postag="(V.)I(P.+)" postag_regexp="yes" postag_replace="$1S$2"/></suggestion>
-            <example correction="venhais">Espero que <marker>vindes</marker>.</example>
-            <example correction="produzam">Espera-se que se <marker>produzem</marker> bom resultados.</example>
-            <example correction="possa">Espero que no final <marker>posso</marker> vir.</example>
-            <example correction="vejamos">Estamos à espera que nos <marker>vemos</marker> nesta sexta-feira.</example>
-            <example correction="chegue">Espera-se que a sonda Cassini <marker>chega</marker> cedo.</example>
-            <!--example correction="chegue">Se espera que a sonda <marker>chega</marker> cedo.</example--><!-- TODO disambiguate 'se' CS|PP3CN000 -->
-            <example correction="amplie">Esperam que o gás de lutite <marker>amplia</marker> o fornecimento.</example>
-            <!--example correction="possa">Se espera que no final <marker>posso</marker> vir.</example--><!-- TODO disambiguate 'se' CS|PP3CN000 -->
-            <example correction="levem">...para evitar que as esquerdas <marker>levam</marker> adiante o seu programa.</example>
-            <example>Espera-se que a sonda Cassini chegue cedo.</example>
-            <example>Espera-se que a sonda chegue cedo.</example>
-            <example>Espero que possais vir.</example>
-            <example>Espero que perdoar-me-ás se não venho.</example>
-            <example>Esperamos o bem-estar que a publicidade não se cansa de pregar.</example>
-            <!-- <example>Espero que no deus voler proposar-ho.</example> -->
-            <!--example>Esperando até que fez o mesmo.</example--> <!-- TODO disambiguate 'fez' -->
-            <example>Esperamos que atrás não esteja fechada.</example>
-            <example>Passa as férias à espera que o Marco se una.</example>
-            <example>Esperando uma bastante animada que nunca chega.</example>
-            <example>Esperando uma que nunca chega.</example>
-            <example>Esperam que a capa da capota se abra.</example>
-            <example>A espera o Spiderman que lhe confesse a história.</example>
-            <example>Se espera que a demanda de indemnização seja alta.</example>
-            <example>Se espera que a obra esteja terminada o 2014.</example>
-            <example>Se espera que a esperança de vida seja de 81,7 anos.</example>
-            <example>O comportamento que se espera que tem de ter um indivíduo.</example>
-            <example>Se espera que o novo edifício gere uns gastos anuais.</example>
-            <example>Se espera que novas descobertas possam contribuir.</example>
-            <example>Bach espera que a orquestra realize algum tipo de improviso.</example>
-            <example>Estava a esperar que o terra se secasse depois da chuva.</example>
-            <example>Esperando que seria adoptado.</example> <!-- ?? -->
-            <example>Que alguns esperam pensando que se vende droga.</example>
-            <example>Esperamos que a rosa ‘Peace’ levará os pensamentos humanos.</example>
-            <example>Evitar o que é meramente subjetivo.</example>
-            <example>Se espera que o consumo privado se mantenha.</example>
-            <example>Espero que ela não esteja doente. </example>
-            <example>Espero que nenhum deles esteja envolvido no acidente de trânsito.</example>
-        </rule>
+                    <exception scope="previous" postag="P0[12].{5}|PP3CN000|PP3NN000|PP3..A00|PP3CP000|PP3CSD00" postag_regexp="yes"/>
+                </token>
+                <token postag_regexp="yes" postag="R." min="0" max="2"/>
+                <token>que</token>
+                <token regexp="yes" postag_regexp="yes" postag="V.IP.+">&verbos_muito_incomuns;</token>
+                <example>Espero que acima de tudo saibam o que estão fazendo.</example>
+            </antipattern>
+            <antipattern> <!-- #4: espera que já te digo -->
+                <token postag="SENT_START"/>
+                <token postag_regexp="yes" postag="R." min="0" max="2"/>
+                <token postag_regexp="yes" postag="VMM...." inflected="yes">esperar</token>
+                <token postag_regexp="yes" postag="R." min="0" max="2"/>
+                <token>que</token>
+                <token min="0">eu</token>
+                <token postag_regexp="yes" postag="R." min="0" max="2"/>
+                <token min="0" regexp="yes">&pronomes_obliquos;</token>
+                <token postag="VMIP1S0"/>
+                <example>Agora espera aqui que eu já te digo.</example>
+                <example>Espere que logo lhe informo.</example>
+            </antipattern>
+            <antipattern> <!-- #5: espera que já vou te dar a informação -->
+                <token postag="SENT_START"/>
+                <token postag_regexp="yes" postag="R." min="0" max="2"/>
+                <token postag_regexp="yes" postag="VMM...." inflected="yes">esperar</token>
+                <token postag_regexp="yes" postag="R." min="0" max="2"/>
+                <token>que</token>
+                <token min="0">eu</token>
+                <token postag_regexp="yes" postag="R." min="0" max="2"/>
+                <token>vou</token>
+                <token min="0" regexp="yes">&pronomes_obliquos;</token>
+                <token postag="VMN0000"/>
+                <example>Agora espera aqui que eu já vou te dizer.</example>
+                <example>Espere que vou retornar em um segundo.</example>
+            </antipattern>
+            <antipattern> <!-- #6: espero que ela... -->
+                <token>que</token>
+                <token>ela</token>
+                <token postag_regexp="yes" postag="_PUNCT|SENT_END"/>
+                <example>Espero que ela... venha.</example>
+            </antipattern>
 
+            <rule id="ESPERA_QUE_INDICATIVO_AR"> <!-- #1: split to keep the simple message, '-ar' verbs -->
+                <pattern>
+                    <token postag='V.I[PF].+|V.[NG].+' postag_regexp='yes' inflected='yes' skip='4' regexp="yes">&subjunctive_verbs;
+                        <exception scope="next" postag="CC|N.+|DI.+|NP.+|V.[^P].*" postag_regexp="yes"/>
+                        <exception scope="next" regexp="yes">[;,«“”»]|&quot;</exception>
+                        <exception scope="previous" postag="P0[12].{5}|PP3CN000|PP3NN000|PP3..A00|PP3CP000|PP3CSD00" postag_regexp="yes"/>
+                    </token>
+                    <token skip='5'>que
+                        <exception scope="next">que</exception>
+                        <exception scope="next" postag="CC|V.IF.+|_PUNCT.*" postag_regexp="yes"/>
+                        <exception scope="next" postag_regexp="yes" postag="V.S.+" inflected="yes" regexp="yes" negate="yes">&verbos_muito_incomuns;</exception>
+                        <exception scope="previous" regexp="yes">até|o</exception>
+                    </token>
+                    <marker>
+                        <token postag='V.IP.+' postag_regexp='yes' inflected="yes" regexp="yes">.+ar$
+                            <exception postag='V.S.+|N.+|V.IC.+|A.+|VMG.+' postag_regexp='yes'/>
+                            <exception regexp='yes'>\p{Lu}.*|&verbos_muito_incomuns;|estar</exception>
+                        </token> <!-- "estar" must be dealt with in a diacritics rule -->
+                    </marker>
+                </pattern>
+                <message>Modo verbal incorreto.</message> <!-- VMIP3S00 -->
+                <suggestion suppress_misspelled="yes"><match no='3' postag="(V.)I[PF](.+)" postag_regexp="yes" postag_replace="$1SP$2"/></suggestion>
+                <example correction="chegue">Espera-se que a sonda Cassini <marker>chega</marker> cedo.</example>
+                <example correction="amplie">Esperam que o gás de lutite <marker>amplia</marker> o fornecimento.</example>
+                <!--example correction="chegue">Se espera que a sonda <marker>chega</marker> cedo.</example--><!-- TODO disambiguate 'se' CS|PP3CN000 -->
+                <example correction="levem">Evitaremos que as direitas <marker>levam</marker> adiante o seu programa.</example>
+                <example correction="acorde">Proponho que Paulo <marker>acorda</marker> mais cedo.</example>
+                <example correction="precisem">Temo que muitas pessoas ainda <marker>precisam</marker> de algo mais.</example>
+                <example>Espera-se que a sonda Cassini chegue cedo.</example>
+                <example>Espera-se que a sonda chegue cedo.</example>
+                <example>Espero que perdoar-me-ás se não venho.</example>
+                <example>Esperamos o bem-estar que a publicidade não se cansa de pregar.</example>
+                <example>Esperamos que atrás não esteja fechada.</example>
+                <example>Passa as férias à espera que o Marco se una.</example>
+                <example>Esperando uma bastante animada que nunca chega.</example>
+                <example>Esperando uma que nunca chega.</example>
+                <example>Esperam que a capa da capota se abra.</example>
+                <example>A espera o Spiderman que lhe confesse a história.</example>
+                <example>Se espera que a demanda de indemnização seja alta.</example>
+                <example>Se espera que a obra esteja terminada o 2014.</example>
+                <example>Se espera que a esperança de vida seja de 81,7 anos.</example>
+                <example>Se espera que o novo edifício gere uns gastos anuais.</example>
+                <example>Bach espera que a orquestra realize algum tipo de improviso.</example>
+                <example>Estava a esperar que o terra se secasse depois da chuva.</example>
+                <example>Que alguns esperam pensando que se vende droga.</example>
+                <example>Esperamos que a rosa ‘Peace’ levará os pensamentos humanos.</example>
+                <example>Espero que ela não esteja doente. </example>
+                <example>Espero que nenhum deles esteja envolvido no acidente de trânsito.</example>
+            </rule>
+
+            <rule id="ESPERA_QUE_INDICATIVO_ER_IR"> <!-- #2: split to introduce a more detailed message, '-er' and '-ir' verbs -->
+                <pattern>
+                    <token postag='V.I[PF].+|V.[NG].+' postag_regexp='yes' inflected='yes' skip='4' regexp="yes">&subjunctive_verbs;
+                        <exception scope="next" postag="CC|N.+|DI.+|NP.+|V.[^P].*" postag_regexp="yes"/>
+                        <exception scope="next" regexp="yes">[;,«“”»]|&quot;</exception>
+                        <exception scope="previous" postag="P0[12].{5}|PP3CN000|PP3NN000|PP3..A00|PP3CP000|PP3CSD00" postag_regexp="yes"/>
+                    </token>
+                    <token skip='5'>que
+                        <exception scope="next">que</exception>
+                        <exception scope="next" postag="CC|V.IF.+|_PUNCT.*" postag_regexp="yes"/>
+                        <exception scope="next" postag_regexp="yes" postag="V.S.+" inflected="yes" regexp="yes" negate="yes">&verbos_muito_incomuns;</exception>
+                        <exception scope="previous" regexp="yes">até|o</exception>
+                    </token>
+                    <marker>
+                        <token postag='V.IP.+' postag_regexp='yes' inflected="yes" regexp="yes">.+[ei]r$
+                            <exception postag='V.S.+|N.+|V.IC.+|A.+|VMG.+' postag_regexp='yes'/>
+                            <exception regexp='yes'>\p{Lu}.*|&verbos_muito_incomuns;|estar</exception>
+                        </token> <!-- "estar" must be dealt with in a diacritics rule -->
+                    </marker>
+                </pattern>
+                <message>Após verbos que expressam dúvidas, desejos e hipóteses, como &quot;<match no="1" postag_regexp="yes" postag=".+" postag_replace="VMN0000"/>&quot;, prefira usar o subjuntivo.</message> <!-- VMIP3S00 -->
+                <suggestion><match no='3' postag="(V.)I[PF](.+)" postag_regexp="yes" postag_replace="$1SP$2"/></suggestion>
+                <example correction="venhais">Sugiro que <marker>vindes</marker>.</example>
+                <example correction="produzam">Espera-se que se <marker>produzem</marker> bom resultados.</example>
+                <example correction="possa">Desejam que no final <marker>posso</marker> vir.</example>
+                <example correction="vejamos">Estamos à espera que nos <marker>vemos</marker> nesta sexta-feira.</example> <!-- this is hacky, that's not a verb -->
+                <example correction="bebam">Proíbo que <marker>bebem</marker> café depois das cinco da tarde!</example>
+                <example correction="saiba">Não acredito que ele realmente <marker>sabe</marker> a verdade.</example>
+                <!--example correction="possa">Se espera que no final <marker>posso</marker> vir.</example--><!-- TODO disambiguate 'se' CS|PP3CN000 -->
+                <example>Espero que possais vir.</example>
+                <!--example>Esperando até que fez o mesmo.</example--> <!-- TODO disambiguate 'fez' -->
+                <example>O comportamento que se espera que tem de ter um indivíduo.</example>
+                <example>Se espera que novas descobertas possam contribuir.</example>
+                <example>Esperando que seria adoptado.</example> <!-- ?? -->
+                <example>Evitar o que é meramente subjetivo.</example>
+                <example>Se espera que o consumo privado se mantenha.</example>
+            </rule>
+
+            <rule id="ESPEREI_QUE_INDICATIVO_AR"> <!-- #3: split to keep the simple message, '-ar' verbs -->
+                <pattern>
+                    <token postag='V.IS.+' postag_regexp='yes' inflected='yes' skip='4' regexp="yes">&subjunctive_verbs;
+                        <exception scope="next" postag="CC|N.+|DI.+|NP.+|V.[^P].*" postag_regexp="yes"/>
+                        <exception scope="next" regexp="yes">[;,«“”»]|&quot;</exception>
+                        <exception scope="previous" postag="P0[12].{5}|PP3CN000|PP3NN000|PP3..A00|PP3CP000|PP3CSD00" postag_regexp="yes"/>
+                    </token>
+                    <token skip='5'>que
+                        <exception scope="next">que</exception>
+                        <exception scope="next" postag="CC|V.IF.+|_PUNCT.*" postag_regexp="yes"/>
+                        <exception scope="next" postag_regexp="yes" postag="V.S.+" inflected="yes" regexp="yes" negate="yes">&verbos_muito_incomuns;</exception>
+                        <exception scope="previous" regexp="yes">até|o</exception>
+                    </token>
+                    <marker>
+                        <token postag='V.IP.+' postag_regexp='yes' inflected="yes" regexp="yes">.+ar$
+                            <exception postag='V.S.+|N.+|V.IC.+|A.+|VMG.+' postag_regexp='yes'/>
+                            <exception regexp='yes'>\p{Lu}.*|&verbos_muito_incomuns;|estar</exception>
+                        </token> <!-- "estar" must be dealt with in a diacritics rule -->
+                    </marker>
+                </pattern>
+                <message>Modo verbal incorreto.</message> <!-- VMIP3S00 -->
+                <suggestion suppress_misspelled="yes"><match no='3' postag="(V.)IP(.+)" postag_regexp="yes" postag_replace="$1SP$2"/></suggestion>
+                <suggestion suppress_misspelled="yes"><match no='3' postag="(V.)IP(.+)" postag_regexp="yes" postag_replace="$1SI$2"/></suggestion>
+                <example correction="chegue|chegasse">Desejei que a sonda Cassini <marker>chega</marker> cedo.</example>
+                <example correction="amplie|ampliasse">Pressupusemos que o gás de lutite <marker>amplia</marker> o fornecimento.</example>
+                <!--example correction="chegue">Se espera que a sonda <marker>chega</marker> cedo.</example--><!-- TODO disambiguate 'se' CS|PP3CN000 -->
+                <example correction="levem|levassem">Evitamos que as direitas <marker>levam</marker> adiante o seu programa.</example>
+                <example correction="acorde|acordasse">Propus que Paulo <marker>acorda</marker> mais cedo.</example>
+                <example correction="precisem|precisassem">Temi que muitas pessoas ainda <marker>precisam</marker> de algo mais.</example>
+            </rule>
+
+            <rule id="ESPEREI_QUE_INDICATIVO_ER_IR"> <!-- #4: split to introduce a more detailed message, '-er' and '-ir' verbs -->
+                <pattern>
+                    <token postag='V.IS.+' postag_regexp='yes' inflected='yes' skip='4' regexp="yes">&subjunctive_verbs;
+                        <exception scope="next" postag="CC|N.+|DI.+|NP.+|V.[^P].*" postag_regexp="yes"/>
+                        <exception scope="next" regexp="yes">[;,«“”»]|&quot;</exception>
+                        <exception scope="previous" postag="P0[12].{5}|PP3CN000|PP3NN000|PP3..A00|PP3CP000|PP3CSD00" postag_regexp="yes"/>
+                    </token>
+                    <token skip='5'>que
+                        <exception scope="next">que</exception>
+                        <exception scope="next" postag="CC|V.IF.+|_PUNCT.*" postag_regexp="yes"/>
+                        <exception scope="next" postag_regexp="yes" postag="V.S.+" inflected="yes" regexp="yes" negate="yes">&verbos_muito_incomuns;</exception>
+                        <exception scope="previous" regexp="yes">até|o</exception>
+                    </token>
+                    <marker>
+                        <token postag='V.IP.+' postag_regexp='yes' inflected="yes" regexp="yes">.+[ei]r$
+                            <exception postag='V.S.+|N.+|V.IC.+|A.+|VMG.+' postag_regexp='yes'/>
+                            <exception regexp='yes'>\p{Lu}.*|&verbos_muito_incomuns;|estar</exception>
+                        </token> <!-- "estar" must be dealt with in a diacritics rule -->
+                    </marker>
+                </pattern>
+                <message>Após verbos que expressam dúvidas, desejos e hipóteses, como &quot;<match no="1" postag_regexp="yes" postag=".+" postag_replace="VMN0000"/>&quot;, prefira usar o subjuntivo.</message> <!-- VMIP3S00 -->
+                <suggestion><match no='3' postag="(V.)IP(.+)" postag_regexp="yes" postag_replace="$1SP$2"/></suggestion>
+                <suggestion><match no='3' postag="(V.)IP(.+)" postag_regexp="yes" postag_replace="$1SI$2"/></suggestion>
+                <example correction="venhais|viésseis">Sugeri que <marker>vindes</marker>.</example>
+                <example correction="produzam|produzissem">Desejei que se <marker>produzem</marker> bom resultados.</example>
+                <example correction="possa|pudesse">Temi que no final não <marker>posso</marker> vir.</example>
+                <example correction="bebam|bebessem">Proibi que <marker>bebem</marker> café depois das cinco da tarde!</example>
+                <example correction="saiba|soubesse">Não acreditei que ele realmente <marker>sabe</marker> a verdade.</example>
+            </rule>
+
+            <rule id="ESPERAVA_QUE_INDICATIVO_AR"> <!-- #5: split to keep the simple message, '-ar' verbs -->
+                <pattern>
+                    <token postag='V.I[CIM].+' postag_regexp='yes' inflected='yes' skip='4' regexp="yes">&subjunctive_verbs;
+                        <exception scope="next" postag="CC|N.+|DI.+|NP.+|V.[^P].*" postag_regexp="yes"/>
+                        <exception scope="next" regexp="yes">[;,«“”»]|&quot;</exception>
+                        <exception scope="previous" postag="P0[12].{5}|PP3CN000|PP3NN000|PP3..A00|PP3CP000|PP3CSD00" postag_regexp="yes"/>
+                    </token>
+                    <token skip='5'>que
+                        <exception scope="next">que</exception>
+                        <exception scope="next" postag="CC|V.IF.+|_PUNCT.*" postag_regexp="yes"/>
+                        <exception scope="next" postag_regexp="yes" postag="V.S.+" inflected="yes" regexp="yes" negate="yes">&verbos_muito_incomuns;</exception>
+                        <exception scope="previous" regexp="yes">até|o</exception>
+                    </token>
+                    <marker>
+                        <token postag='V.IP.+' postag_regexp='yes' inflected="yes" regexp="yes">.+ar$
+                            <exception postag='V.S.+|N.+|V.IC.+|A.+|VMG.+' postag_regexp='yes'/>
+                            <exception regexp='yes'>\p{Lu}.*|&verbos_muito_incomuns;|estar</exception>
+                        </token> <!-- "estar" must be dealt with in a diacritics rule -->
+                    </marker>
+                </pattern>
+                <message>Modo e tempo verbais incorretos.</message> <!-- VMIP3S00 -->
+                <suggestion suppress_misspelled="yes"><match no='3' postag="(V.)IP(.+)" postag_regexp="yes" postag_replace="$1SI$2"/></suggestion>
+                <example correction="chegasse">Desejava que a sonda Cassini <marker>chega</marker> cedo.</example>
+                <example correction="ampliasse">Pressupunha que o gás de lutite <marker>amplia</marker> o fornecimento.</example>
+                <!--example correction="chegue">Se espera que a sonda <marker>chega</marker> cedo.</example--><!-- TODO disambiguate 'se' CS|PP3CN000 -->
+                <example correction="levassem">Evitaríamos que as direitas <marker>levam</marker> adiante o seu programa.</example>
+                <example correction="acordasse">Propunha que Paulo <marker>acorda</marker> mais cedo.</example>
+                <example correction="precisassem">Temia que muitas pessoas ainda <marker>precisam</marker> de algo mais.</example>
+            </rule>
+
+            <rule id="ESPERAVA_QUE_INDICATIVO_ER_IR"> <!-- #2: split to introduce a more detailed message, '-er' and '-ir' verbs -->
+                <pattern>
+                    <token postag='V.I[CIM].+' postag_regexp='yes' inflected='yes' skip='4' regexp="yes">&subjunctive_verbs;
+                        <exception scope="next" postag="CC|N.+|DI.+|NP.+|V.[^P].*" postag_regexp="yes"/>
+                        <exception scope="next" regexp="yes">[;,«“”»]|&quot;</exception>
+                        <exception scope="previous" postag="P0[12].{5}|PP3CN000|PP3NN000|PP3..A00|PP3CP000|PP3CSD00" postag_regexp="yes"/>
+                    </token>
+                    <token skip='5'>que
+                        <exception scope="next">que</exception>
+                        <exception scope="next" postag="CC|V.IF.+|_PUNCT.*" postag_regexp="yes"/>
+                        <exception scope="next" postag_regexp="yes" postag="V.S.+" inflected="yes" regexp="yes" negate="yes">&verbos_muito_incomuns;</exception>
+                        <exception scope="previous" regexp="yes">até|o</exception>
+                    </token>
+                    <marker>
+                        <token postag='V.IP.+' postag_regexp='yes' inflected="yes" regexp="yes">.+[ei]r$
+                            <exception postag='V.S.+|N.+|V.IC.+|A.+|VMG.+' postag_regexp='yes'/>
+                            <exception regexp='yes'>\p{Lu}.*|&verbos_muito_incomuns;|estar</exception>
+                        </token> <!-- "estar" must be dealt with in a diacritics rule -->
+                    </marker>
+                </pattern>
+                <message>Após verbos que expressam dúvidas, desejos e hipóteses, como &quot;<match no="1" postag_regexp="yes" postag=".+" postag_replace="VMN0000"/>&quot;, prefira usar o subjuntivo.</message> <!-- VMIP3S00 -->
+                <suggestion><match no='3' postag="(V.)IP(.+)" postag_regexp="yes" postag_replace="$1SI$2"/></suggestion>
+                <example correction="viésseis">Sugeria que <marker>vindes</marker>.</example>
+                <example correction="produzissem">Desejava que se <marker>produzem</marker> bom resultados.</example>
+                <example correction="pudesse">Queria que no final <marker>posso</marker> vir.</example>
+                <example correction="bebessem">Proibiria que <marker>bebem</marker> café depois das cinco da tarde!</example>
+                <example correction="soubesse">Não acreditava que ele realmente <marker>sabe</marker> a verdade.</example>
+            </rule>
+        </rulegroup>
 
         <rule id='SEGUIR_SINGULAR_PLURAL' name="Verbo 'seguir' singular + sujeito plural → Verbo plural">
             <!-- Created by Ricardo Joseh Lima and improved by Marco A.G.Pinto, Portuguese rule 2022-12-07 (25-JUL-2022+) -->


### PR DESCRIPTION
 - add more verbs that generally require its subclauses to have a subjunctive;

 - add more tense combinations ("espero que faça", "sugeri que faça/fizesse", "sugeria que fizesse");

 - split the messages between -ar verbs and -ir/-er verbs;
 - the former keep the terse message from before;
 - the latter have a more detailed explanation.