### PR TITLE
only obtain the language tool and speller rule once to make the test faster

### DIFF
--- a/languagetool-language-modules/uk/src/test/java/org/languagetool/rules/uk/MorfologikUkrainianSpellerRuleTest.java
+++ b/languagetool-language-modules/uk/src/test/java/org/languagetool/rules/uk/MorfologikUkrainianSpellerRuleTest.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.languagetool.JLanguageTool;
 import org.languagetool.TestTools;
@@ -33,11 +33,11 @@ import org.languagetool.language.Ukrainian;
 import org.languagetool.rules.RuleMatch;
 
 public class MorfologikUkrainianSpellerRuleTest {
-  private JLanguageTool lt;
-  private MorfologikUkrainianSpellerRule rule;
+  private static JLanguageTool lt;
+  private static MorfologikUkrainianSpellerRule rule;
   
-  @Before
-  public void init() throws IOException {
+  @BeforeClass
+  public static void init() throws IOException {
     rule = new MorfologikUkrainianSpellerRule (TestTools.getMessages("uk"), new Ukrainian(), null, Collections.emptyList());
     lt = new JLanguageTool(new Ukrainian());
   }


### PR DESCRIPTION
For the test class `MorfologikUkrainianSpellerRuleTest`, there are 5 tests. The `JLanguageTool lt` and `MorfologikUkrainianSpellerRule rule` are only accessed but not modified among these tests. Repeatedly getting `lt` and `rule` in the testing code can make tests run slower.

By only obtaining the language tool and speller rule once, the time to run this test class can jump from 4.571 s to 2.5 s on our local machine after applying the change.