### PR TITLE
[pt] Pare back EM_CASE_DE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -189,19 +189,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
         <rulegroup id="EM_CASE_EM_CASO_CONFUSAO" name="Confusão entre 'case' e 'caso'">
-            <!-- If annoying marketing execs get annoyed as they're trying to use 'case', GOOD 😈. What an obnoxious word. -->
+            <!-- If annoying marketing execs get annoyed as they're trying to use 'case', GOOD 😈. What an obnoxious word. They did... paring it back. -->
             <rule id="EM_CASE_DE">
                 <pattern>
-                    <token postag_regexp="yes" postag="SP.+" regexp="yes">em|n.+</token>
+                    <token>em</token>
                     <marker>
                         <token>case</token>
                     </marker>
+                    <token>de</token>
                 </pattern>
                 <message>Possível erro de digitação.</message>
                 <suggestion>caso</suggestion>
                 <example correction="caso">Em <marker>case</marker> de incêndio...</example>
-                <example correction="caso">No <marker>case</marker> do outro menino...</example>
-                <example correction="caso">Bem, nesse <marker>case</marker>...</example>
+                <example>No case do outro menino...</example>
+                <example>Bem, nesse case...</example>
             </rule>
 
             <rule id="CASE_ALGO_ACONTECA">


### PR DESCRIPTION
Lots of 'nesse case, o cliente...' I hate this word with a passion, but whatever, the users win 😭 Now it'll only work with `em case de`.

![Screenshot 2023-12-11 at 11 23 48 AM](https://github.com/languagetool-org/languagetool/assets/50704700/c8b3176c-fc5d-4a7e-8e70-d7b6c04bd237)
