### PR TITLE
[fr] Loop-fix-various

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/style.xml
@@ -1134,6 +1134,19 @@ Pour en savoir plus sur les tone tags, suivez le lien vers notre documentation (
                 <example><marker>Qu'est-ce que tu y trouves</marker> ?</example>
             </rule>
         </rulegroup>
+        <rule id="TOMBER_DANS_LES_POMMES" name="tomber dans les pommes">
+            <pattern>
+                <token inflected="yes" skip="2">tomber</token>
+                <token>dans</token>
+                <token>les</token>
+                <token>pommes</token>
+            </pattern>
+            <message>« Tomber dans les pommes » est une expression fautive.</message>
+            <suggestion>tomber dans les pâmes</suggestion>
+            <suggestion>perdre connaissance</suggestion>
+            <example correction="tomber dans les pâmes|perdre connaissance"><marker>tomber dans les pommes</marker></example>
+            <example><marker>tomber dans les pâmes</marker></example>
+        </rule>
     </category>
     <category id="CAT_PLEONASMES" name="Pléonasmes" type="style" tone_tags="clarity">
         <!--The following rules were created by Hugo Voisard


### PR DESCRIPTION
To address: https://github.com/languagetooler-gmbh/task-force-french/issues/90

This will probably be the final commit for the above issue. We'll re-run the loop-finder once [this](https://github.com/languagetooler-gmbh/languagetool-premium/issues/6746) actually takes effect.

- AGREEMENT_POSTPONED_ADJ exception added to the already existing list of exceptions
- QUI_VCONJ[5] exception added
GENTILE[12], [17] and [1] OFF due to FPs (https://internal1.languagetool.org/grafana/d/O09LTDNMz/rule-events-summary?orgId=1&var-rule_id=GENTILE&var-language=fr&var-rule_category=All&var-minOpen=0)
- TRES[8] AP added with example