### PR TITLE
[pt] Enable NUMERO_NEGATIVO_SINAL_DE_MENOS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -41089,7 +41089,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
     </category>
     <category id='TYPOGRAPHY' name="Tipografia" type="typographical">
-        <rulegroup id="NUMERO_NEGATIVO_SINAL_DE_MENOS" name="Usar o sinal de menos com números negativos" default="temp_off">
+        <rulegroup id="NUMERO_NEGATIVO_SINAL_DE_MENOS" name="Usar o sinal de menos com números negativos">
             <antipattern> <!-- #1: NO SPACE BEFORE: number ranges, domain-specific formats, etc. -->
                 <token regexp="yes" spacebefore="no">[-–—]</token> <!-- hyphen, n-dash, m-dash -->
                 <token spacebefore="no" regexp="yes">\d.*</token>


### PR DESCRIPTION
[Nightlies](https://internal1.languagetool.org/regression-tests/via-http/2023-12-13/pt-BR/result_grammar_NUMERO_NEGATIVO_SINAL_DE_MENOS%5B1%5D.html) look very good, I see no reason not to have this live.