### PR TITLE
[pt] enable PT_MULTITOKEN_SPELLING_TWO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -43871,7 +43871,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>Sucre de caña</example>
             </rule>
         </rulegroup>
-        <!--
         <rulegroup id="PT_MULTITOKEN_SPELLING_TWO" name="erros ortográficos em nomes próprios (2 tokens)" default="temp_off">
             <antipattern>
                 <token/>
@@ -43985,7 +43984,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>RMN-GP Foto</example>
             </rule>
         </rulegroup>
-        -->
         <rulegroup id="PT_MULTITOKEN_SPELLING_HYPHEN" name="erros ortográficos em nomes próprios hifenizados" default="temp_off">
             <antipattern>
                 <token regexp="yes">.+</token>


### PR DESCRIPTION
There was an obsolete spelling rule in Premium that caused an error in tests. Fixed here: https://github.com/languagetooler-gmbh/languagetool-premium-modules/commit/a475f7f2fdbd335b56370dcb225cf14d5448438e