### PR TITLE
Fix Mötley Crüe in global spelling

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/resource/spelling_global.txt
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/spelling_global.txt
@@ -5763,7 +5763,7 @@ Family Guy
 Navy CIS
 Costco Wholesale
 Metro Group
-Motley Crue
+Mötley Crüe
 Hank Moody
 Black Friday
 King’s College


### PR DESCRIPTION
Their [official name](https://en.wikipedia.org/wiki/Mötley_Crüe) *does* have metal umlauts, it's not just a decoration.