### PR TITLE
[pt] Fix DEGREE disambiguation rule

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -25,7 +25,6 @@
 <!-- Contribuintes opensource, deem uma olhada aqui: https://dev.languagetool.org/#portuguese -->
 
 <!DOCTYPE rules [
-        <!ENTITY % messages  SYSTEM "../../resource/pt/entities/messages.ent" >
         <!ENTITY % datetime  SYSTEM "../../resource/pt/entities/datetime.ent" >
         <!ENTITY % misc      SYSTEM "../../resource/pt/entities/misc.ent"     >
         <!ENTITY % abbrev    SYSTEM "../../resource/pt/entities/abbrev.ent"   >
@@ -33,8 +32,7 @@
         <!ENTITY % verbs     SYSTEM "../../resource/pt/entities/verbs.ent"    >
         <!ENTITY % languages SYSTEM "../../resource/pt/entities/languages.ent">
         <!ENTITY % postal    SYSTEM "../../resource/pt/entities/postal.ent"   >
-        <!ENTITY % chars     SYSTEM "../../../resource/pt/entities/chars.ent"    >
-        %messages;
+        <!ENTITY % chars     SYSTEM "../../resource/pt/entities/chars.ent"    >
         %datetime;
         %misc;
         %abbrev;
@@ -43,7 +41,7 @@
         %languages;
         %postal;
         %chars;
-        ]>
+]>
 
 <rules lang="pt" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/resource/disambiguation.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
@@ -2889,22 +2887,22 @@
     <!-- Created by Tiago F. Santos, Portuguese rule  	-->
     <rule>
       <pattern>
-        <token regexp="yes">1[&deg;′″‴] ?[CFKNSEWO]?
+        <token regexp="yes">1[°′″‴] ?[CFKNSEWO]?
           <exception>1º</exception></token>
       </pattern>
       <disambig action="replace"><wd pos="NCMS000"/></disambig>
     </rule>
     <rule>
       <pattern>
-        <token regexp="yes">[\d,. ]+[&deg;′″‴][CFKNSEWO]?
-          <exception regexp='yes'>1[&deg;′″‴].?</exception>
-          <exception regexp='yes'>\d+&ordm;</exception></token>
+        <token regexp="yes">[\d,. ]+[°′″‴][CFKNSEWO]?
+          <exception regexp='yes'>1[°′″‴].?</exception>
+          <exception regexp='yes'>\d+º</exception></token> <!-- ordm! -->
       </pattern>
       <disambig action="replace"><wd pos="NCMP000"/></disambig>
     </rule>
     <rule>
       <pattern>
-        <token regexp="yes">1[&deg;′″‴]</token>
+        <token regexp="yes">1[°′″‴]</token>
         <token regexp="yes" spacebefore='yes'>[CFKNSEWO]
           <exception case_sensitive='yes' regexp='yes'>[eo]</exception></token>
       </pattern>
@@ -2912,7 +2910,7 @@
     </rule>
     <rule>
       <pattern>
-        <token regexp="yes">[\d,. ]+[&deg;′″‴]</token>
+        <token regexp="yes">[\d,. ]+[°′″‴]</token>
         <token regexp="yes" spacebefore='yes'>[CFKNSEWO]
           <exception case_sensitive='yes' regexp='yes'>[eo]</exception></token>
       </pattern>
@@ -2920,15 +2918,22 @@
     </rule>
     <rule>
       <pattern>
-        <token regexp="yes">[&deg;][CFKNSEWO]</token>
+        <token regexp="yes">[°][CFKNSEWO]</token>
       </pattern>
       <disambig action="replace"><wd pos="NCMN000"/></disambig>
     </rule>
     <rule>
-      <pattern>
-        <token regexp="yes">[\d,. ]*[&deg;′″‴][CFKNSEWO]</token>
-      </pattern>
-      <disambig action="ignore_spelling"/>
+        <pattern>
+            <!-- p-goulart@2023-12-19 - DESC: explicitly case-sensitive (fix lettercase in XML) -->
+            <token regexp="yes" case_sensitive="no">(?:\d+[\d,.]*)?[°′″‴][CFKNSEWO]?</token>
+        </pattern>
+        <disambig action="ignore_spelling"/>
+    </rule>
+    <rule>
+        <pattern>
+            <token regexp="yes" case_sensitive="no">(?:&number_token;)?º&degree_abbrevs;?</token>
+        </pattern>
+        <disambig action="ignore_spelling"/>
     </rule>
   </rulegroup>
 
@@ -3994,8 +3999,8 @@
     </rule>
 
     <rule id="ORDINAL_SUPERSCRIPT_IGNORE">
-         <pattern>
-            <token regexp="yes">\d+[&ordf;&ordm;&sup_a;&sup_o;&deg;][&sup_s;]?\d*</token>
+        <pattern> <!-- // ordf, ordm, sup_a, sup_o, deg, sup_s -->
+            <token regexp="yes">\d+[ªºᵃᵒ°][ˢ]?\d*</token>
         </pattern>
         <disambig action="ignore_spelling"/>
     </rule>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/chars.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/chars.ent
@@ -10,6 +10,9 @@
 <!ENTITY minus_sign "−">
 
 <!-- ORDINALS, SUPERSCRIPTS, DEGREE SIGNS, AND OTHER NONSENSE 😩 -->
+<!-- For some reason, entities with special characters do NOT work in the disambiguation.xml file 
+I've tried making explicit reference to the hex or decimal entities, and that also fails, incl. when used
+in the disambiguation file directly. There might be something off with the encoding, but idk where.-->
 <!ENTITY ordf "ª">
 <!ENTITY ordm "º">
 
@@ -28,6 +31,7 @@
 <!ENTITY operadores_matematicos "[-x\.·\*\/\^\|~¬±×÷ϐϑϒϕϰϱϴϵ϶؆؇‖′″‴⁀⁄⁒⁺⁻⁼⁽⁾₊₋₌₍₎∀∁∂∃∄∅∆∇∈∉∊∋∌∍∎∏∐∑−∓∔∕∖∗∘∙√∛∜∝∞∟∠∡∢∣∤∥∦∧∨∩∪∫∬∭∮∯∰∱∲∳∴∵∶∷∸∹∺∻∼∽∾∿≀≁≂≃≄≅≆≇≈≉≊≋≌≍≎≏≐≑≒≓≔≕≖≗≘≙≚≛≜≝≞≟≠≡≢≣≤≥≦≧≨≩≪≫≬≭≮≯≰≱≲≳≴≵≶≷≸≹≺≻≼≽≾≿⊀⊁⊂⊃⊄⊅⊆⊇⊈⊉⊊⊋⊌⊍⊎⊏⊐⊑⊒⊓⊔⊕⊖⊗⊘⊙⊚⊛⊜⊝⊞⊟⊠⊡⊢⊣⊤⊥⊦⊧⊨⊩⊪⊫⊬⊭⊮⊯⊰⊱⊲⊳⊴⊵⊶⊷⊸⊹⊺⊻⊼⊽⊾⊿⋀⋁⋂⋃⋄⋅⋆⋇⋈⋉⋊⋋⋌⋍⋎⋏⋐⋑⋒⋓⋔⋕⋖⋗⋘⋙⋚⋛⋜⋝⋞⋟⋠⋡⋢⋣⋤⋥⋦⋧⋨⋩⋪⋫⋬⋭⋮⋯⋰⋱⋲⋳⋴⋵⋶⋷⋸⋹⋺⋻⋼⋽⋾⋿→⇋]|\=|\+">
 
 <!ENTITY currency_symbols "\p{Lu}*[฿₿₵¢₡$₫֏€ƒ₲₴₭₾₺₼₦₱£៛₽₹₪৳₸₮₩¥¤]">
+<!ENTITY degree_abbrevs "[CFKNSEWO]">
 
 <!-- Convenience entity, should encompass all valid numbers that the PT tokeniser doesn't split. -->
 <!ENTITY number_token "&minus_sign;?\d+[\d,.]*">
@@ -35,3 +39,4 @@
 <!ENTITY degree_token "&number_token;&nnbsp;?&deg;">
 <!-- No decimals or negatives, as that makes no sense, only thousands allowed -->
 <!ENTITY ordinal_token "&number_token_no_decimal;&any_ord;">
+

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -39,7 +39,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <!ENTITY % languages  SYSTEM "../../resource/pt/entities/languages.ent">
         <!ENTITY % postal     SYSTEM "../../resource/pt/entities/postal.ent"   >
         <!ENTITY % hyphenised SYSTEM "../../resource/pt/entities/hyphenised.ent"   >
-        <!ENTITY % chars     SYSTEM "../../../resource/pt/entities/chars.ent"    >
+        <!ENTITY % chars      SYSTEM "../../resource/pt/entities/chars.ent"    >
         %messages;
         %datetime;
         %misc;

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -34,7 +34,7 @@ USA
     <!ENTITY % verbs     SYSTEM "../../resource/pt/entities/verbs.ent"    >
     <!ENTITY % languages SYSTEM "../../resource/pt/entities/languages.ent">
     <!ENTITY % postal    SYSTEM "../../resource/pt/entities/postal.ent"   >
-    <!ENTITY % chars     SYSTEM "../../../resource/pt/entities/chars.ent"    >
+    <!ENTITY % chars     SYSTEM "../../resource/pt/entities/chars.ent"    >
     %messages;
     %datetime;
     %misc;

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
@@ -362,6 +362,15 @@ public class MorfologikPortugueseSpellerRuleTest {
   }
 
   @Test
+  public void testPortugueseSpellerDoesNotCorrectDegreeExpressions() throws Exception {
+    assertNoErrors("1,0°", ltBR, ruleBR);
+    assertNoErrors("2°c", ltBR, ruleBR);
+    assertNoErrors("3°C", ltBR, ruleBR);
+    assertNoErrors("4,0ºc", ltBR, ruleBR);
+    assertNoErrors("5.0ºc", ltBR, ruleBR);
+  }
+
+  @Test
   public void testPortugueseSpellerDoesNotCorrectCopyrightSymbol() throws Exception {
     assertNoErrors("Copyright©", ltBR, ruleBR);
   }

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
@@ -156,8 +156,17 @@ public class PortugueseWordTokenizerTest {
     testTokenise("22.a", new String[]{"22.a"});
     testTokenise("23as", new String[]{"23as"});
     testTokenise("24.as", new String[]{"24.as"});
-    // Degree sign, just to be absolutely sure
+  }
+
+  @Test
+  public void testDoNotTokeniseDegreeExpressions() {
     testTokenise("25°", new String[]{"25°"});
+    testTokenise("26,0°", new String[]{"26,0°"});
+    testTokenise("27.0°", new String[]{"27.0°"});
+    testTokenise("28,0°C", new String[]{"28,0°C"});
+    testTokenise("29.0°C", new String[]{"29.0°C"});
+    testTokenise("30,0°c", new String[]{"30,0°c"});
+    testTokenise("31.0°c", new String[]{"31.0°c"});
   }
 
   @Test


### PR DESCRIPTION
As discussed previously:
- for some reason the `&deg;` (and similar) entities don't work as expected exclusively in the `disambiguation.xml` file 😠 
- so I have:
    - added comments to the relevant entity file to make that clear;
    - replaced the entities with the *literal* characters in affected `disambiguation.xml` rules (the relevant one causing failures here was the `ignore_spelling` sub-rule of `DEGREES`);
    - added comments to the affected rules in `disambiguation.xml` so we know what the characters are (it's really difficult to reliably see the difference between `ºᵒ°`...
- also done:
    - added tokeniser and speller tests to make 100% sure we're doing what we must.
    
    
I'll make another PR in a moment with a rule that upcases `°c` to `°C` (it was a rule that we (a) needed, and (b) was useful to test this, so two birds/one stone).