### PR TITLE
[pt] Removed "temp_off" from rules

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -32171,7 +32171,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='CONFUSÃO_APROXIMA_A_PRÓXIMA' name="Confusão de termos: aproxima/'a próxima'/'aproximar'" default="temp_off">
+        <rule id='CONFUSÃO_APROXIMA_A_PRÓXIMA' name="Confusão de termos: aproxima/'a próxima'/'aproximar'">
             <pattern>
                 <token>para</token>
                 <marker>
@@ -32185,7 +32185,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='ARREAR_ARRIAR' name="Confusão de termos: arrear/arriar" default="temp_off">
+        <rule id='ARREAR_ARRIAR' name="Confusão de termos: arrear/arriar">
             <pattern>
                 <marker>
                     <token skip="4" inflected='yes'>arrear</token>
@@ -32198,7 +32198,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='CONFUSÃO_ASSERTO_ACERTO_DE_CONTAS' name="Confusão de termos: asserto/acerto" default="temp_off">
+        <rule id='CONFUSÃO_ASSERTO_ACERTO_DE_CONTAS' name="Confusão de termos: asserto/acerto">
             <pattern>
                 <marker>
                     <token skip="4">asserto</token>


### PR DESCRIPTION
Heya, @susanaboatto  and @p-goulart ,

No hits in the nightly diffs:

ARREAR_ARRIAR
no hits

CONFUSÃO_APROXIMA_A_PRÓXIMA
no hits

CONFUSÃO_ASSERTO_ACERTO_DE_CONTAS
no hits

HÁS_VEZES
no hits
