### PR TITLE
[pt] Improve degree sign and ordinal indicator detection rules

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -2884,17 +2884,16 @@
   </rulegroup>
 
   <rulegroup id="DEGREES" name="Graus">
-    <!-- Created by Tiago F. Santos, Portuguese rule  	-->
     <rule>
       <pattern>
-        <token regexp="yes">1[°′″‴] ?[CFKNSEWO]?
+        <token regexp="yes">1[°′″‴] ?(?:&follow_degree_sign;)?
           <exception>1º</exception></token>
       </pattern>
       <disambig action="replace"><wd pos="NCMS000"/></disambig>
     </rule>
     <rule>
       <pattern>
-        <token regexp="yes">[\d,. ]+[°′″‴][CFKNSEWO]?
+        <token regexp="yes">(?:&number_token;)[°′″‴](?:&follow_degree_sign;)?
           <exception regexp='yes'>1[°′″‴].?</exception>
           <exception regexp='yes'>\d+º</exception></token> <!-- ordm! -->
       </pattern>
@@ -2903,35 +2902,35 @@
     <rule>
       <pattern>
         <token regexp="yes">1[°′″‴]</token>
-        <token regexp="yes" spacebefore='yes'>[CFKNSEWO]
+        <token regexp="yes" spacebefore='yes'>&follow_degree_sign;
           <exception case_sensitive='yes' regexp='yes'>[eo]</exception></token>
       </pattern>
       <disambig action="replace"><wd pos="NCMS000"/><wd pos="NCMN000"/></disambig>
     </rule>
     <rule>
       <pattern>
-        <token regexp="yes">[\d,. ]+[°′″‴]</token>
-        <token regexp="yes" spacebefore='yes'>[CFKNSEWO]
+        <token regexp="yes">(?:&number_token;)[°′″‴]</token>
+        <token regexp="yes" spacebefore='yes'>&follow_degree_sign;
           <exception case_sensitive='yes' regexp='yes'>[eo]</exception></token>
       </pattern>
       <disambig action="replace"><wd pos="NCMP000"/><wd pos="NCMN000"/></disambig>
     </rule>
     <rule>
       <pattern>
-        <token regexp="yes">[°][CFKNSEWO]</token>
+        <token regexp="yes">[°](?:&follow_degree_sign;)</token>
       </pattern>
       <disambig action="replace"><wd pos="NCMN000"/></disambig>
     </rule>
     <rule>
         <pattern>
             <!-- p-goulart@2023-12-19 - DESC: explicitly case-sensitive (fix lettercase in XML) -->
-            <token regexp="yes" case_sensitive="no">(?:\d+[\d,.]*)?[°′″‴][CFKNSEWO]?</token>
+            <token regexp="yes" case_sensitive="no">(?:&number_token;)?[°′″‴](?:&follow_degree_sign;)?</token>
         </pattern>
         <disambig action="ignore_spelling"/>
     </rule>
     <rule>
         <pattern>
-            <token regexp="yes" case_sensitive="no">(?:&number_token;)?º&degree_abbrevs;?</token>
+            <token regexp="yes" case_sensitive="no">(?:&number_token;)?º(?:&follow_degree_sign;)?</token>
         </pattern>
         <disambig action="ignore_spelling"/>
     </rule>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/chars.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/chars.ent
@@ -21,6 +21,7 @@ in the disambiguation file directly. There might be something off with the encod
 <!ENTITY sup_s "ˢ">
 
 <!ENTITY deg "°">
+<!ENTITY deg_r "\u00BA">
 
 <!ENTITY any_masc_ord "[o&ordm;&sup_o;]">
 <!ENTITY any_fem_ord "[a&ordf;&sup_a;]">
@@ -31,7 +32,15 @@ in the disambiguation file directly. There might be something off with the encod
 <!ENTITY operadores_matematicos "[-x\.·\*\/\^\|~¬±×÷ϐϑϒϕϰϱϴϵ϶؆؇‖′″‴⁀⁄⁒⁺⁻⁼⁽⁾₊₋₌₍₎∀∁∂∃∄∅∆∇∈∉∊∋∌∍∎∏∐∑−∓∔∕∖∗∘∙√∛∜∝∞∟∠∡∢∣∤∥∦∧∨∩∪∫∬∭∮∯∰∱∲∳∴∵∶∷∸∹∺∻∼∽∾∿≀≁≂≃≄≅≆≇≈≉≊≋≌≍≎≏≐≑≒≓≔≕≖≗≘≙≚≛≜≝≞≟≠≡≢≣≤≥≦≧≨≩≪≫≬≭≮≯≰≱≲≳≴≵≶≷≸≹≺≻≼≽≾≿⊀⊁⊂⊃⊄⊅⊆⊇⊈⊉⊊⊋⊌⊍⊎⊏⊐⊑⊒⊓⊔⊕⊖⊗⊘⊙⊚⊛⊜⊝⊞⊟⊠⊡⊢⊣⊤⊥⊦⊧⊨⊩⊪⊫⊬⊭⊮⊯⊰⊱⊲⊳⊴⊵⊶⊷⊸⊹⊺⊻⊼⊽⊾⊿⋀⋁⋂⋃⋄⋅⋆⋇⋈⋉⋊⋋⋌⋍⋎⋏⋐⋑⋒⋓⋔⋕⋖⋗⋘⋙⋚⋛⋜⋝⋞⋟⋠⋡⋢⋣⋤⋥⋦⋧⋨⋩⋪⋫⋬⋭⋮⋯⋰⋱⋲⋳⋴⋵⋶⋷⋸⋹⋺⋻⋼⋽⋾⋿→⇋]|\=|\+">
 
 <!ENTITY currency_symbols "\p{Lu}*[฿₿₵¢₡$₫֏€ƒ₲₴₭₾₺₼₦₱£៛₽₹₪৳₸₮₩¥¤]">
-<!ENTITY degree_abbrevs "[CFKNSEWO]">
+
+<!-- A previous version of this entity included NSEW, which are north/norte/south/sul/east/leste/west/oeste. -->
+<!-- We're also adding °D (Delisle), °Ré (Réamur), °Ra (Rankine), °Rø (Rømer). Specifically skipping °N (degrees Newton). -->
+<!-- Accepting Kelvin, even though not a degree; this will be fixed by a style rule. -->
+<!ENTITY degree_abbrevs "[CFKD]|R[éaø]">
+
+<!ENTITY cardinal_points "[NSEWO]">
+
+<!ENTITY follow_degree_sign "&degree_abbrevs;|&cardinal_points;">
 
 <!-- Convenience entity, should encompass all valid numbers that the PT tokeniser doesn't split. -->
 <!ENTITY number_token "&minus_sign;?\d+[\d,.]*">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/chars.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/chars.ent
@@ -21,13 +21,17 @@ in the disambiguation file directly. There might be something off with the encod
 <!ENTITY sup_s "ˢ">
 
 <!ENTITY deg "°">
-<!ENTITY deg_r "\u00BA">
 
 <!ENTITY any_masc_ord "[o&ordm;&sup_o;]">
 <!ENTITY any_fem_ord "[a&ordf;&sup_a;]">
 <!ENTITY any_pl_ord "[s&sup_s;]">
 <!ENTITY any_ord "[o&ordm;&sup_o;a&ordf;&sup_a;]&any_pl_ord;?">
 <!-- END -->
+
+<!-- More degree stuff -->
+<!ENTITY prime "′">
+<!ENTITY double_prime "″|&prime;{2}">
+<!ENTITY triple_prime "‴|&prime;{3}">
 
 <!ENTITY operadores_matematicos "[-x\.·\*\/\^\|~¬±×÷ϐϑϒϕϰϱϴϵ϶؆؇‖′″‴⁀⁄⁒⁺⁻⁼⁽⁾₊₋₌₍₎∀∁∂∃∄∅∆∇∈∉∊∋∌∍∎∏∐∑−∓∔∕∖∗∘∙√∛∜∝∞∟∠∡∢∣∤∥∦∧∨∩∪∫∬∭∮∯∰∱∲∳∴∵∶∷∸∹∺∻∼∽∾∿≀≁≂≃≄≅≆≇≈≉≊≋≌≍≎≏≐≑≒≓≔≕≖≗≘≙≚≛≜≝≞≟≠≡≢≣≤≥≦≧≨≩≪≫≬≭≮≯≰≱≲≳≴≵≶≷≸≹≺≻≼≽≾≿⊀⊁⊂⊃⊄⊅⊆⊇⊈⊉⊊⊋⊌⊍⊎⊏⊐⊑⊒⊓⊔⊕⊖⊗⊘⊙⊚⊛⊜⊝⊞⊟⊠⊡⊢⊣⊤⊥⊦⊧⊨⊩⊪⊫⊬⊭⊮⊯⊰⊱⊲⊳⊴⊵⊶⊷⊸⊹⊺⊻⊼⊽⊾⊿⋀⋁⋂⋃⋄⋅⋆⋇⋈⋉⋊⋋⋌⋍⋎⋏⋐⋑⋒⋓⋔⋕⋖⋗⋘⋙⋚⋛⋜⋝⋞⋟⋠⋡⋢⋣⋤⋥⋦⋧⋨⋩⋪⋫⋬⋭⋮⋯⋰⋱⋲⋳⋴⋵⋶⋷⋸⋹⋺⋻⋼⋽⋾⋿→⇋]|\=|\+">
 
@@ -37,14 +41,17 @@ in the disambiguation file directly. There might be something off with the encod
 <!-- We're also adding °D (Delisle), °Ré (Réamur), °Ra (Rankine), °Rø (Rømer). Specifically skipping °N (degrees Newton). -->
 <!-- Accepting Kelvin, even though not a degree; this will be fixed by a style rule. -->
 <!ENTITY degree_abbrevs "[CFKD]|R[éaø]">
+<!-- for correction -->
+<!ENTITY degree_abbrevs_lower "[cfkd]|r[éaø]">
 
 <!ENTITY cardinal_points "[NSEWO]">
 
 <!ENTITY follow_degree_sign "&degree_abbrevs;|&cardinal_points;">
 
 <!-- Convenience entity, should encompass all valid numbers that the PT tokeniser doesn't split. -->
-<!ENTITY number_token "&minus_sign;?\d+[\d,.]*">
-<!ENTITY number_token_no_decimal "\d+(\.\d{3})*">
+<!-- Due to the really liberal regexp, do NOT use this in <regexp> keys, only in <token> keys with regexp mode. -->
+<!ENTITY number_token "&minus_sign;?\d+(?:[,. ]\d+)*">
+<!ENTITY number_token_no_decimal "\d+([. ]\d{3})*">
 <!ENTITY degree_token "&number_token;&nnbsp;?&deg;">
 <!-- No decimals or negatives, as that makes no sense, only thousands allowed -->
 <!ENTITY ordinal_token "&number_token_no_decimal;&any_ord;">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -41238,29 +41238,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <rulegroup id="SIMBOLO_DE_GRAU_ESPACAMENTO" name="Dar espaçamento antes do símbolo de grau em escalas com nomes.">
-            <!--Our strategy was to suggest a narrow non-breaking space even when
-            users manually input a regular whitespace. Now we will only
-            trigger when users skip the space altogether. Trust their word
-            processing software to know what to do; LT can't do that reliably.-->
-            <rule id="SIMBOLO_DE_GRAU_ESPACAMENTO_NENHUM" default="on">
-                <pattern>
-                    <token regexp="yes" case_sensitive="yes">&degree_token;[CFNSEW]</token>
-                </pattern>
-                <message>Neste caso, põe-se um espaço estreito entre o número e o símbolo de grau.</message>
-                <suggestion><match no="1" regexp_match="^(.+)(&deg;[CFNSEW])$" regexp_replace="$1&nnbsp;$2"/></suggestion>
-                <example correction="22&nnbsp;&deg;C">Faz <marker>22&deg;C</marker> à sombra.</example>
-            </rule>
-            <rule id="SIMBOLO_DE_GRAU_ESPACAMENTO_GRAU_E_UNIDADE" default="temp_off">
-                <pattern>
-                    <token regexp="yes">&degree_token;</token>
-                    <token regexp="yes" spacebefore="yes" case_sensitive="yes">[CFNSEW]</token>
-                </pattern>
-                <message>Não se põe espaço entre o símbolo de grau e a abreviatura da escala.</message>
-                <suggestion><match no="1" regexp_match="^(.+)&deg;$" regexp_replace="$1&nnbsp;&deg;"/>\2</suggestion>
-                <example correction="22&nnbsp;&deg;C">Faz <marker>22&deg; C</marker> à sombra.</example>
-            </rule>
-        </rulegroup>
+        <!-- SIMBOLO_DE_GRAU_ESPACAMENTO -->
 
         <rulegroup id="SIMBOLO_DE_GRAU_ORDINAL" name="Símbolo de grau usado no lugar de um indicator ordinal." default="on" tags="picky">
             <rule> <!-- singular, dot-separated -->

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -41146,12 +41146,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <rulegroup id="SIMBOLO_DE_GRAUS_COM_UNIDADE_EM_MINUSCULA" name="Pôr em maiúscula o símbolo da escala em graus nomeados (e.g. &deg;c => &deg;C)." default="temp_off">
             <!-- p-goulart@2023-12-19 - DESC: the rules to fix the spacing are elsewhere. The capitalisation should be prioritised. -->
             <rule>
-                <regexp case_sensitive="yes" mark="1">°([cfknsewo])\b</regexp>
+                <regexp case_sensitive="yes" mark="1">&deg;(&degree_abbrevs_lower;)\b</regexp>
                 <message>Ponha o símbolo da escala em maiúscula.</message>
-                <suggestion><match no="1" case_conversion='allupper' regexp_match="(\p{Ll})" regexp_replace="$1"/></suggestion>
-                <example correction="W">Fez 69,5&deg;<marker>w</marker> ontem.</example>
+                <suggestion><match no="1" case_conversion='startupper' regexp_match="(\p{Ll}+)" regexp_replace="$1"/></suggestion>
+                <example correction="Rø">Fez 69,5&deg;<marker>rø</marker> ontem.</example>
                 <example correction="C">Fez 22,5&deg;<marker>c</marker> ontem.</example>
                 <example>Fez 40&deg;C ontem.</example>
+                <example>Via de regra, a temperatura oscila entre 15°e 22°C.</example> <!-- not right, but should be a different rule -->
             </rule>
         </rulegroup>
 
@@ -41159,33 +41160,39 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <rule id="DEGREE_SYMBOL_WITH_DEGREE_TYPE">
                 <!-- This rule, unlike SIMBOLO_DE_GRAU_ESPACAMENTO, preserves the user's spaces.
                 This is only here to turn the ordinal into a degree sign. That's the rule that fixes spaces.-->
-                <regexp type="exact">(?-i)[&ordm;&sup_o;](\s?[CFNSEW])\b</regexp>
+                <regexp case_sensitive="yes">&any_masc_ord;(\s?(?:&degree_abbrevs;|&cardinal_points;))\b</regexp>
+                <filter class="org.languagetool.rules.patterns.RegexAntiPatternFilter" args="antipatterns:&any_masc_ord;\s?e|\.&any_masc_ord;"/>
                 <message>&degree_ordinal_msg;</message>
                 <suggestion>&deg;\1</suggestion>
                 <example correction="&deg; C">Faz 22<marker>&ordm; C</marker> à sombra.</example>
                 <example correction="&deg;C">Faz 25<marker>&ordm;C</marker> à sombra.</example>
                 <example>Faz 25&deg;.</example>
                 <example>Faz 25&ordm;.</example> <!-- must be dealt with some other way -->
-                <example>…o da União, conforme estabelecido nos artigos 349.º e 355.º do Tratado sobre o Funcionamento da União E…</example>
-                <example>…que pôs fim à República Velha, depondo seu 13º e último presidente Washington Luís e impedindo a…</example>
+                <example>Faz 25o.</example>
+                <example>O 25.&ordm; F de sua carreira escolar.</example>
+                <example correction="&deg;C">A temperatura da superfície chega a 21 000 <marker>&ordm;C</marker>.</example>
+                <example>Conforme estabelecido nos artigos 349.&ordm; e 355.&ordm; do Tratado sobre o Funcionamento da União.</example>
+                <example>Depondo seu 13&ordm; e último presidente.</example>
+                <example correction="&deg; N">Está a 55<marker>o N</marker> daqui.</example>
             </rule>
             <rule id="DEGREE_SYMBOL_WITH_CONTEXT_POST">
                 <pattern>
                     <marker>
-                        <token regexp="yes">&number_token;[&ordm;&sup_o;]</token>
+                        <token regexp="yes">&number_token;&any_masc_ord;</token>
                     </marker>
                     <token>de</token>
                     <token regexp="yes">&degree_collocates;</token>
                 </pattern>
                 <message>&degree_ordinal_msg;</message>
-                <suggestion><match no="1" regexp_match="^(&minus_sign;?\d+[\d.,]*).+" regexp_replace="$1&deg;"/></suggestion>
+                <suggestion><match no="1" regexp_match="^(&number_token;)&any_masc_ord;" regexp_replace="$1&deg;"/></suggestion>
                 <example correction="40&deg;">O bebê está com <marker>40&ordm;</marker> de febre!</example>
+                <example correction="39&deg;">Sofria com <marker>39o</marker> de calor!</example>
             </rule>
             <rule id="DEGREE_SYMBOL_WITH_CONTEXT_PRE">
                 <pattern>
                     <token regexp="yes" inflected="yes" skip="2">&degree_collocates;</token>
                     <marker>
-                        <token regexp="yes">&number_token;[&ordm;&sup_o;]</token>
+                        <token regexp="yes">&number_token;&any_masc_ord;</token>
                     </marker>
                 </pattern>
                 <message>&degree_ordinal_msg;</message>
@@ -41198,7 +41205,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <pattern>
                     <token inflected="yes">fazer</token>
                     <marker>
-                        <token regexp="yes">&number_token;[&ordm;&sup_o;]</token>
+                        <token regexp="yes">&number_token;&any_masc_ord;</token>
                     </marker>
                     <token postag_regexp="yes" postag="R." min="0" max="2"/>
                     <token postag_regexp="yes" postag="SENT_END|_PUNCT_PERIOD"/>
@@ -41208,20 +41215,45 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="25&deg;">Ontem fez <marker>25&ordm;</marker>.</example>
                 <example correction="38,8&deg;">Fará <marker>38,8&ordm;</marker> amanhã.</example>
             </rule>
-            <rule id="DEGREE_SYMBOL_COORDINATES">
+            <rule id="DEGREE_SYMBOL_COORDINATES_SINGLE_TOKEN">
                 <pattern>
-                    <token regexp="yes">\d+[&ordm;&sup_o;]\d+[&ordm;&sup_o;]</token>
+                    <token regexp="yes">\d+&any_masc_ord;\d+&any_masc_ord;</token>
                 </pattern>
                 <message>&degree_ordinal_msg;</message>
                 <suggestion><match no="1" regexp_match="^(\d+)[&ordm;&sup_o;](\d+)[&ordm;&sup_o;]" regexp_replace="$1&deg;$2&deg;"/></suggestion>
                 <example correction="90&deg;45&deg;">Coordenadas: <marker>90&ordm;45&sup_o;</marker></example>
+            </rule>
+            <rule id="DEGREE_SYMBOL_COORDINATES_MULTIPLE_TOKENS">
+                <pattern>
+                    <marker>
+                        <token regexp="yes">\d+&any_masc_ord;</token>
+                    </marker>
+                    <token regexp="yes">\d+</token>
+                    <token spacebefore="no">&prime;</token>
+                </pattern>
+                <message>&degree_ordinal_msg;</message>
+                <suggestion><match no="1" regexp_match="^(\d+)&any_masc_ord;" regexp_replace="$1&deg;"/></suggestion>
+                <example correction="90&deg;">Coordenadas: <marker>90o</marker> 45&prime;.</example>
+            </rule>
+            <rule id="DEGREE_SYMBOL_COORDINATES_EXPLICIT">
+                <pattern>
+                    <marker>
+                        <token regexp="yes">\d+&any_masc_ord;</token>
+                    </marker>
+                    <token min="0">ao</token>
+                    <token regexp="yes">norte|sul|leste|oeste</token>
+                </pattern>
+                <message>&degree_ordinal_msg;</message>
+                <suggestion><match no="1" regexp_match="^(\d+)&any_masc_ord;" regexp_replace="$1&deg;"/></suggestion>
+                <example correction="17&deg;">Fica <marker>17o</marker> ao leste daqui.</example>
+                <example correction="18&deg;">Fica <marker>18&ordm;</marker> norte de lá.</example>
             </rule>
             <rule id="DEGREE_SYMBOL_RANGES">
                 <pattern>
                     <token regexp="yes" spacebefore="yes">&number_token;</token>
                     <token spacebefore="no">–</token> <!-- n-dash -->
                     <marker>
-                        <token regexp="yes" spacebefore="no">&number_token;[&ordm;&sup_o;]</token>
+                        <token regexp="yes" spacebefore="no">&number_token;&any_masc_ord;</token>
                     </marker>
                 </pattern>
                 <message>&degree_ordinal_msg;</message>
@@ -41230,7 +41262,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
             <rule id="DEGREE_SYMBOL_NEGATIVE">
                 <pattern>
-                    <token regexp="yes">&minus_sign;\d+[\d,.]*[&ordm;&sup_o;]</token>
+                    <token regexp="yes">&minus_sign;\d+[\d,.]*&any_masc_ord;</token>
                 </pattern>
                 <message>&degree_ordinal_msg;</message>
                 <suggestion><match no="1" regexp_match="^(&minus_sign;\d+[\d.,]*).+" regexp_replace="$1&deg;"/></suggestion>
@@ -41238,7 +41270,45 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <!-- SIMBOLO_DE_GRAU_ESPACAMENTO -->
+        <rulegroup id="SIMBOLO_DE_GRAU_ESPACAMENTO" name="Dar espaçamento antes do símbolo de grau em escalas com nomes.">
+            <!--Our strategy was to suggest a narrow non-breaking space even when
+            users manually input a regular whitespace. Now we will only
+            trigger when users skip the space altogether. Trust their word
+            processing software to know what to do; LT can't do that reliably.-->
+            <rule id="SIMBOLO_DE_GRAU_ESPACAMENTO_NENHUM" default="on">
+                <pattern>
+                    <token regexp="yes" case_sensitive="yes">&degree_token;&degree_abbrevs;</token>
+                </pattern>
+                <message>Neste caso, põe-se um espaço estreito entre o número e o símbolo de grau.</message>
+                <suggestion><match no="1" regexp_match="^(.+)(&deg;&degree_abbrevs;)$" regexp_replace="$1&nnbsp;$2"/></suggestion>
+                <example correction="22&nnbsp;&deg;C">Faz <marker>22&deg;C</marker> à sombra.</example>
+                <!-- here the space will need to be between the degree sign and the letter, different sub-rule -->
+                <example>As coordenadas são 50&deg;N e 66&deg;W.</example>
+            </rule>
+            <rule id="SIMBOLO_DE_GRAU_ESPACAMENTO_GRAU_E_UNIDADE" default="temp_off">
+                <pattern>
+                    <token regexp="yes">&degree_token;</token>
+                    <token regexp="yes" spacebefore="yes" case_sensitive="yes">&degree_abbrevs;</token>
+                </pattern>
+                <message>Não se põe espaço entre o símbolo de grau e a abreviatura da escala.</message>
+                <suggestion><match no="1" regexp_match="^(.+)&deg;$" regexp_replace="$1&nnbsp;&deg;"/>\2</suggestion>
+                <example correction="22&nnbsp;&deg;C">Faz <marker>22&deg; C</marker> à sombra.</example>
+                <example correction="77&nnbsp;&deg;Rø">O valor parece ser de <marker>77&deg; Rø</marker>.</example>
+                <example>Fica a uns 99&deg; N.</example>
+            </rule>
+        </rulegroup>
+
+        <rulegroup id="GRAU_EM_COORDENADAS_ESPACAMENTO" name="Dar espaçamento entre o símbolo de grau e pontos cardeais em coordenadas geográficas" tags="picky">
+            <rule>
+                <regexp case_sensitive="yes" type="exact">\b(&number_token;)\s?&deg;\s?(&cardinal_points;)\b</regexp>
+                <filter class="org.languagetool.rules.patterns.RegexAntiPatternFilter" args="antipatterns:\d&deg;\s&cardinal_points;"/>
+                <message>Em coordenadas geográficas, prefira a formato <suggestion>\1&deg;&nnbsp;\2</suggestion>.</message>
+                <example correction="60&deg;&nnbsp;N">Fica a <marker>60 &deg;N</marker>.</example>
+                <example correction="70&deg;&nnbsp;N">Fica a <marker>70 &deg; N</marker>.</example>
+                <example correction="80&deg;&nnbsp;N">Fica a <marker>80&deg;N</marker>.</example>
+                <example>Fica a 90&deg; S.</example>
+            </rule>
+        </rulegroup>
 
         <rulegroup id="SIMBOLO_DE_GRAU_ORDINAL" name="Símbolo de grau usado no lugar de um indicator ordinal." default="on" tags="picky">
             <rule> <!-- singular, dot-separated -->

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
@@ -368,6 +368,9 @@ public class MorfologikPortugueseSpellerRuleTest {
     assertNoErrors("3°C", ltBR, ruleBR);
     assertNoErrors("4,0ºc", ltBR, ruleBR);
     assertNoErrors("5.0ºc", ltBR, ruleBR);
+    assertNoErrors("6,0ºRø", ltBR, ruleBR); // degrees Rømer
+    assertNoErrors("7,5ºN", ltBR, ruleBR); // North
+    assertNoErrors("−8,0°", ltBR, ruleBR); // negative
   }
 
   @Test

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
@@ -167,6 +167,9 @@ public class PortugueseWordTokenizerTest {
     testTokenise("29.0°C", new String[]{"29.0°C"});
     testTokenise("30,0°c", new String[]{"30,0°c"});
     testTokenise("31.0°c", new String[]{"31.0°c"});
+    testTokenise("32°Ra", new String[]{"32°Ra"});
+    testTokenise("33,1°Rø", new String[]{"33,1°Rø"});
+    testTokenise("34°N", new String[]{"34°N"});
   }
 
   @Test


### PR DESCRIPTION
Prob. still not perfect, but first let's get rid of the low-hanging fruit FPs:
- make a systematic distinction between temperature scales (which require a space *before* the degree sign) and cardinal points (which require the space between the degree and the abbreviation):
    - `90 °F` but `90° N`, 'noventa graus Fahrenheit' but 'noventa graus ao norte'.

- improve, somewhat, the recognition for coordinates like `90° 45′ 22″`, using the prime/double prime characters for angular minutes/seconds, but this may require some more tinkering (and potentially also different tokenisation, which I'm not keen on...);

- crucially, I've added `o` to the ordinal/degree detection rule – the nightly corpus reveals many instances of `100o` clearly indicating degrees; once this is working, the `ORDINAL_ABBREVIATION` rules should be easier to work with, as we will have eliminated many FPs (and these rules are, crucially, the last ones of this group to run!).

---

<sup>As a small aside, users' habit of replacing the degree sign with lowercase `o` may come from some kind of automatic MS Word rule to convert that to the ordinal indicator after `\d`, since they, uh, _look similar_. It would be lovely to eliminate this habit somehow, and the first results on the live degree/ordinal rules show very high acceptance rates.</sup>