### PR TITLE
[en] change the encoding of NZ spelling dictionary

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/en_NZ.info
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/en_NZ.info
@@ -5,7 +5,7 @@
 #
 
 fsa.dict.separator=+
-fsa.dict.encoding=utf-8
+fsa.dict.encoding=iso-8859-1
 
 fsa.dict.encoder=SUFFIX
 

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/MorfologikNewZealandSpellerRuleTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/MorfologikNewZealandSpellerRuleTest.java
@@ -80,6 +80,11 @@ public class MorfologikNewZealandSpellerRuleTest extends AbstractEnglishSpellerR
     assertEquals(3, matches2[0].getFromPos());
     assertEquals(10, matches2[0].getToPos());
     assertEquals("taught", matches2[0].getSuggestedReplacements().get(0));
+
+    // test words with diacritics in the spelling dictionary
+    assertEquals(0, rule.match(lt.getAnalyzedSentence("émigré or émigrés")).length);
+    assertEquals(0, rule.match(lt.getAnalyzedSentence("tête-à-tête")).length);
+
   }
 
 }


### PR DESCRIPTION
The encoding was wrong. It was not much relevant because there are few words with diacritics in English (only foreign terms). 

I don't know if there will be some undesired effects after this change. Do we need more testing?

The encoding was changed here: https://github.com/languagetool-org/languagetool/commit/8bb96ad05b0060158a93504337eb2dcfcecaa15f, but it was probably wrong. 