### PR TITLE
[pt-PT] Rewrote and moved to confused words, rule ID:AUTO-FALANTE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -41016,6 +41016,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <token>auto</token>
                     <token min='0' spacebefore='no'>-</token>
                     <token regexp='yes'>\p{Ll}+
+                        <exception regexp='yes'>falantes?</exception>
                         <exception regexp='yes'>[srhoó]\p{L}+</exception>
                         <exception postag='SPS.+|C.+|R.+|D.+|P.+' postag_regexp='yes'/>
                     </token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -3509,7 +3509,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <rule>
           <antipattern>
               <token regexp='yes'>auto|quilo</token>
-              <token regexp='yes'>d[aeo]s?|policial</token>
+              <token regexp='yes'>d[aeo]s?|policial|falantes?</token>
           </antipattern>
           <pattern>
               <token regexp='yes'>&prefixos_o;|&prefixos_o_2;|arqui

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -2793,27 +2793,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <example>Assim, com a divisão de valores mais próximos do zero, o resultado será o zero absoluto.</example>
         <example>Teoricamente, ao cessar a agitação térmica das moléculas a pressão é nula, e atinge-se o zero absoluto.</example>
     </rule>
-    <rulegroup id='AUTO-FALANTE' name="[pt-PT] Altifalante">
-        <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
-        <rule>
-            <pattern>
-                <token>auto</token>
-                <token regexp='yes' min='0'>&tracos_de_separacao;</token>
-                <token>falante</token>
-            </pattern>
-            <message>Substitua por <suggestion>altifalante</suggestion>.</message>
-            <example correction="altifalante">O <marker>auto-falante</marker> está avariado.</example>
-        </rule>
-        <rule>
-            <pattern>
-                <token>auto</token>
-                <token regexp='yes' min='0'>&tracos_de_separacao;</token>
-                <token>falantes</token>
-            </pattern>
-            <message>Substitua por <suggestion>altifalantes</suggestion>.</message>
-            <example correction="altifalantes">Os <marker>auto-falantes</marker> estão avariados.</example>
-        </rule>
-    </rulegroup>
     <rule id='DAÍ' name="[pt-PT] Contração: de aí">
         <!-- Created by Marco A.G. Pinto, Portuguese rule -->
         <pattern>
@@ -4156,6 +4135,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <url>https://pt.wiktionary.org/wiki/prémio</url>
         <example correction='prémio'>E tem <marker>premio</marker> para todos.</example>
         <example correction='prémios'>E tem <marker>premios</marker> para todos.</example>
+    </rule>
+
+
+    <rule id='AUTO-FALANTE' name="[pt-PT] Confusão: Auto-falante/Altifalante" default="temp_off">
+        <pattern>
+            <token>auto</token>
+            <token regexp='yes' min='0'>&tracos_de_separacao;</token>
+            <token regexp='yes'>falantes?</token>
+        </pattern>
+        <message>Possível confusão de termos.</message>
+        <suggestion><match no='3' postag='AQ0C(.)0' postag_replace='AQ0C$10'>altifalante</match></suggestion>
+        <suggestion>alto-\3</suggestion>
+        <example correction="altifalante|alto-falante">O <marker>auto-falante</marker> está avariado.</example>
+        <example correction="altifalantes|alto-falantes">Os <marker>auto-falantes</marker> estão avariados.</example>
     </rule>
 
 


### PR DESCRIPTION
Heya again,

This one should be straightforward.

https://www.soportugues.com.br/secoes/FAQresposta.php?id=390

https://dicionario.priberam.org/altifalante

```
Title: <plaintext>
1.) Line 1, column 33, Rule ID: AUTO-FALANTE[1] [temp_off]
Message: Possível confusão de termos.
Suggestion: altifalantes; alto-falantes
Rule source: /org/languagetool/rules/pt/pt-PT/grammar.xml
ou só ficava o fio (que liga os auto falantes nas portas) exposto ?
                                ^^^^^^^^^^^^^                      

Title: <plaintext>
1.) Line 1, column 1, Rule ID: AUTO-FALANTE[1] [temp_off]
Message: Possível confusão de termos.
Suggestion: Altifalantes; Alto-falantes
Rule source: /org/languagetool/rules/pt/pt-PT/grammar.xml
Auto-falantes e televisores "jumbotron" foram postos ao longo de ambos os lados norte e sul para fazer com que a ...
^^^^^^^^^^^^^                                                                                                    

Title: <plaintext>
1.) Line 1, column 52, Rule ID: AUTO-FALANTE[1] [temp_off]
Message: Possível confusão de termos.
Suggestion: altifalante; alto-falante
Rule source: /org/languagetool/rules/pt/pt-PT/grammar.xml
O mesmo jovem que mal falava... e agora anuncia no auto-falante.
                                                   ^^^^^^^^^^^^ 
Portuguese (Portugal): 3 total matches
Portuguese (Portugal): 811129 total sentences considered
Portuguese (Portugal): ø0.00 rule matches per sentence
Portuguese (Portugal): 54420 input lines ignored (e.g. not between 10 and 300 chars or at least 4 tokens)
```



