### PR TITLE
External file for rule confidence

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/tools/RuleMatchesAsJsonSerializer.java
+++ b/languagetool-core/src/main/java/org/languagetool/tools/RuleMatchesAsJsonSerializer.java
@@ -297,11 +297,6 @@ public class RuleMatchesAsJsonSerializer {
       }
       if (replacement.getConfidence() != null) {
         g.writeNumberField("confidence", replacement.getConfidence());
-      } else if (ruleIdToConfidence != null) {
-        Float confidence = ruleIdToConfidence.get(match.getRule().getId());
-        if (confidence != null) {
-          g.writeNumberField("confidence", confidence);
-        }
       }
       g.writeEndObject();
     }
@@ -360,6 +355,12 @@ public class RuleMatchesAsJsonSerializer {
         g.writeString(tag.name());
       }
       g.writeEndArray();
+    }
+    if (ruleIdToConfidence != null) {
+      Float confidence = ruleIdToConfidence.get(rule.getId());
+      if (confidence != null) {
+        g.writeNumberField("confidence", confidence);
+      }
     }
     g.writeEndObject();
   }

--- a/languagetool-core/src/main/java/org/languagetool/tools/RuleMatchesAsJsonSerializer.java
+++ b/languagetool-core/src/main/java/org/languagetool/tools/RuleMatchesAsJsonSerializer.java
@@ -51,6 +51,7 @@ public class RuleMatchesAsJsonSerializer {
 
   private final int compactMode;
   private final Language lang;
+  private Map<String, Float> ruleIdToConfidence;
 
   public RuleMatchesAsJsonSerializer() {
     this(0, null);
@@ -296,6 +297,11 @@ public class RuleMatchesAsJsonSerializer {
       }
       if (replacement.getConfidence() != null) {
         g.writeNumberField("confidence", replacement.getConfidence());
+      } else if (ruleIdToConfidence != null) {
+        Float confidence = ruleIdToConfidence.get(match.getRule().getId());
+        if (confidence != null) {
+          g.writeNumberField("confidence", confidence);
+        }
       }
       g.writeEndObject();
     }
@@ -366,4 +372,7 @@ public class RuleMatchesAsJsonSerializer {
     g.writeEndObject();
   }
 
+  public void setRuleIdToConfidenceMap(Map<String, Float> ruleIdToConfidence) {
+    this.ruleIdToConfidence = ruleIdToConfidence;
+  }
 }

--- a/languagetool-language-modules/nl/src/main/java/org/languagetool/rules/nl/CompoundAcceptor.java
+++ b/languagetool-language-modules/nl/src/main/java/org/languagetool/rules/nl/CompoundAcceptor.java
@@ -1099,7 +1099,7 @@ public class CompoundAcceptor {
     }
   }
 
-  private DutchTagger dutchTagger = DutchTagger.INSTANCE;
+  private final DutchTagger dutchTagger = DutchTagger.INSTANCE;
 
   public CompoundAcceptor() {
   }

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
@@ -73,6 +73,7 @@ public class HTTPServerConfig {
   protected int textCheckerQueueSize = 8;
   protected Mode mode;
   protected File languageModelDir = null;
+  protected File ruleIdToConfidenceFile = null;
   protected boolean pipelineCaching = false;
   protected boolean pipelinePrewarming = false;
 
@@ -205,7 +206,8 @@ public class HTTPServerConfig {
     "redisUseSentinel", "sentinelHost", "sentinelPort", "sentinelPassword", "sentinelMasterId",
     "dbLogging", "premiumOnly", "nerUrl", "minPort", "maxPort", "localApiMode", "motherTongue", "preferredLanguages",
     "dictLimitUser", "dictLimitTeam", "styleGuideLimitUser", "styleGuideLimitTeam",
-    "passwortLoginAccessListPath", "redisDictTTLSeconds", "requestLimitAccessToken");
+    "passwortLoginAccessListPath", "redisDictTTLSeconds", "requestLimitAccessToken",
+    "ruleIdToConfidenceFile");
 
   /**
    * Create a server configuration for the default port ({@link #DEFAULT_PORT}).
@@ -338,6 +340,13 @@ public class HTTPServerConfig {
         maxPort = Integer.parseInt(getOptionalProperty(props, "maxPort", "0"));
         String url = getOptionalProperty(props, "serverURL", null);
         setServerURL(url);
+        String ruleIdToConfidence = getOptionalProperty(props, "ruleIdToConfidenceFile", null);
+        if (ruleIdToConfidence != null) {
+          ruleIdToConfidenceFile = new File(ruleIdToConfidence);
+          if (!ruleIdToConfidenceFile.exists() || !ruleIdToConfidenceFile.isFile()) {
+            throw new RuntimeException("ruleIdToConfidenceFile cannot be found: " + ruleIdToConfidenceFile);
+          }
+        }
         String langModel = getOptionalProperty(props, "languageModel", null);
         if (langModel != null && loadLangModel) {
           setLanguageModelDirectory(langModel);
@@ -1503,4 +1512,10 @@ public class HTTPServerConfig {
     this.dbMaxConnections = dbMaxConnections;
   }
 
+  /**
+   * @since 6.4
+   */
+  public File getRuleIdToConfidenceFile() {
+    return ruleIdToConfidenceFile;
+  }
 }

--- a/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/HTTPServerConfig.java
@@ -1515,6 +1515,7 @@ public class HTTPServerConfig {
   /**
    * @since 6.4
    */
+  @Nullable
   public File getRuleIdToConfidenceFile() {
     return ruleIdToConfidenceFile;
   }

--- a/languagetool-server/src/main/java/org/languagetool/server/V2TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/V2TextChecker.java
@@ -66,16 +66,16 @@ class V2TextChecker extends TextChecker {
         if (line.startsWith("#")) {
           continue;
         }
-        String[] parts = line.split(";");
-        if (parts.length == 2) {
+        String[] parts = line.split(",");
+        if (parts.length >= 2) {
           try {
             float confidence = Float.parseFloat(parts[1]);
             ruleIdToConfidence.put(parts[0], confidence);
           } catch (NumberFormatException e) {
-            throw new RuntimeException("Invalid confidence float value in " + config.getRuleIdToConfidenceFile() + ", expected 'RULE_ID;float_value': " + line);
+            throw new RuntimeException("Invalid confidence float value in " + config.getRuleIdToConfidenceFile() + ", expected 'RULE_ID,float_value[,...]': " + line);
           }
         } else {
-          throw new RuntimeException("Invalid line in " + config.getRuleIdToConfidenceFile() + ", expected 'RULE_ID;float_value': " + line);
+          throw new RuntimeException("Invalid line in " + config.getRuleIdToConfidenceFile() + ", expected 'RULE_ID,float_value[,...]': " + line);
         }
       }
     }

--- a/languagetool-server/src/main/java/org/languagetool/server/V2TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/V2TextChecker.java
@@ -25,10 +25,16 @@ import org.languagetool.markup.AnnotatedText;
 import org.languagetool.rules.RuleMatch;
 import org.languagetool.tools.StringTools;
 import org.languagetool.tools.RuleMatchesAsJsonSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.languagetool.server.ServerTools.setCommonHeaders;
 
 /**
@@ -39,9 +45,40 @@ class V2TextChecker extends TextChecker {
 
   private static final String JSON_CONTENT_TYPE = "application/json";
   private static final Pattern COMMA_WHITESPACE_PATTERN = Pattern.compile(",\\s*");
+  private static final Logger logger = LoggerFactory.getLogger(V2TextChecker.class);
+
+  private static final Map<String,Float> ruleIdToConfidence = new HashMap<>();
 
   V2TextChecker(HTTPServerConfig config, boolean internalServer, Queue<Runnable> workQueue, RequestCounter reqCounter) {
     super(config, internalServer, workQueue, reqCounter);
+    try {
+      loadConfidenceMap();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void loadConfidenceMap() throws IOException {
+    if (config.getRuleIdToConfidenceFile() != null) {
+      logger.info("Loading confidence map for rules from " + ruleIdToConfidence);
+      List<String> lines = Files.readAllLines(Paths.get(config.getRuleIdToConfidenceFile().getAbsolutePath()), UTF_8);
+      for (String line : lines) {
+        if (line.startsWith("#")) {
+          continue;
+        }
+        String[] parts = line.split(";");
+        if (parts.length == 2) {
+          try {
+            float confidence = Float.parseFloat(parts[1]);
+            ruleIdToConfidence.put(parts[0], confidence);
+          } catch (NumberFormatException e) {
+            throw new RuntimeException("Invalid confidence float value in " + config.getRuleIdToConfidenceFile() + ", expected 'RULE_ID;float_value': " + line);
+          }
+        } else {
+          throw new RuntimeException("Invalid line in " + config.getRuleIdToConfidenceFile() + ", expected 'RULE_ID;float_value': " + line);
+        }
+      }
+    }
   }
 
   @Override
@@ -53,6 +90,7 @@ class V2TextChecker extends TextChecker {
   protected String getResponse(AnnotatedText text, Language usedLang, DetectedLanguage lang, Language motherTongue, List<CheckResults> matches,
                                List<RuleMatch> hiddenMatches, String incompleteResultsReason, int compactMode, boolean showPremiumHint, JLanguageTool.Mode mode) {
     RuleMatchesAsJsonSerializer serializer = new RuleMatchesAsJsonSerializer(compactMode, usedLang);
+    serializer.setRuleIdToConfidenceMap(ruleIdToConfidence);
     return serializer.ruleMatchesToJson2(matches, hiddenMatches, text, CONTEXT_SIZE, lang, incompleteResultsReason,
       showPremiumHint, mode);
   }

--- a/languagetool-server/src/main/java/org/languagetool/server/V2TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/V2TextChecker.java
@@ -67,7 +67,7 @@ class V2TextChecker extends TextChecker {
           continue;
         }
         String[] parts = line.split(",");
-        if (parts.length >= 2) {
+        if (parts.length >= 2) {   // there might be more columns for better debugging, but we don't use them here
           try {
             float confidence = Float.parseFloat(parts[1]);
             ruleIdToConfidence.put(parts[0], confidence);


### PR DESCRIPTION
Load rule confidence from am external file. This is limited to one confidence per match/rule, even though the match might have more than one suggestion. They will all end up with the same confidence and the client needs to interpret that...