### PR TITLE
Remove misspelled ai suggestions

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
@@ -266,7 +266,7 @@ public abstract class RemoteRule extends Rule {
         || id.matches("AI_.._GGEC_.*")) {
         if (!m.getSuggestedReplacementObjects().stream().allMatch(checkSpelling)) {
           SimpleDateFormat sdf = new SimpleDateFormat("HH");
-          System.out.println(sdf.format(new Date()) + " - ignored AI suggestion: " + m.getSuggestedReplacements().toString()
+          System.out.println(sdf.format(new Date()) + " - ignored AI suggestion " + id +": " + m.getSuggestedReplacements().toString()
             + "; original: " + m.getOriginalErrorStr());
           continue;
         }
@@ -277,7 +277,7 @@ public abstract class RemoteRule extends Rule {
           .filter(checkSpelling).collect(Collectors.toList());
         if (suggestedReplacements.isEmpty()) {
           SimpleDateFormat sdf = new SimpleDateFormat("HH");
-          System.out.println(sdf.format(new Date()) + " - ignored AI suggestion: " + m.getSuggestedReplacements().toString()
+          System.out.println(sdf.format(new Date()) + " - ignored AI suggestion " + id +": " + m.getSuggestedReplacements().toString()
             + "; original: " + m.getOriginalErrorStr());
           continue;
         }

--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
@@ -260,15 +261,24 @@ public abstract class RemoteRule extends Rule {
 
     for (RuleMatch m : sentenceMatches) {
       String id = m.getRule().getId();
-      if (suppressMisspelledMatch != null && suppressMisspelledMatch.matcher(id).matches()) {
+      m.setOriginalErrorStr();
+      if ((suppressMisspelledMatch != null && suppressMisspelledMatch.matcher(id).matches())
+        || id.matches("AI_.._GGEC_.*")) {
         if (!m.getSuggestedReplacementObjects().stream().allMatch(checkSpelling)) {
+          SimpleDateFormat sdf = new SimpleDateFormat("HH");
+          System.out.println(sdf.format(new Date()) + " - ignored AI suggestion: " + m.getSuggestedReplacements().toString()
+            + "; original: " + m.getOriginalErrorStr());
           continue;
         }
       }
-      if (suppressMisspelledSuggestions != null && suppressMisspelledSuggestions.matcher(id).matches()) {
+      if ((suppressMisspelledSuggestions != null && suppressMisspelledSuggestions.matcher(id).matches())
+        || id.matches("AI_.._GGEC_.*")) {
         List<SuggestedReplacement> suggestedReplacements = m.getSuggestedReplacementObjects().stream()
           .filter(checkSpelling).collect(Collectors.toList());
         if (suggestedReplacements.isEmpty()) {
+          SimpleDateFormat sdf = new SimpleDateFormat("HH");
+          System.out.println(sdf.format(new Date()) + " - ignored AI suggestion: " + m.getSuggestedReplacements().toString()
+            + "; original: " + m.getOriginalErrorStr());
           continue;
         }
         m.setSuggestedReplacementObjects(suggestedReplacements);
@@ -276,7 +286,6 @@ public abstract class RemoteRule extends Rule {
       // TODO: make configurable
       if (ruleLanguage.getShortCodeWithCountryAndVariant().matches("de-(AT|CH)") && id.matches("AI_DE_GGEC_.*ORTHOGRAPHY.*")) {
         try {
-          m.setOriginalErrorStr();
           AnalyzedSentence sentence = lt.getAnalyzedSentence(m.getOriginalErrorStr());
           RuleMatch[] matches = speller.match(sentence);
           if (matches.length == 0) {


### PR DESCRIPTION
This can be quite drastic, but it seems to be the desired outcome: remove all matches with misspelled suggestions. 