### PR TITLE
[pt] Enable ORDINAL_ABBREVIATION

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -41394,7 +41394,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example>2.a. Sistemas</example>
         </rule>
 
-        <rulegroup id="ORDINAL_ABBREVIATION" name="Abreviatura de ordinais: 1o -> 1º" default="temp_off">
+        <rulegroup id="ORDINAL_ABBREVIATION" name="Abreviatura de ordinais: 1o -> 1º">
             <antipattern> <!-- enumeration as 2a. -->
                 <token postag="SENT_START"/>
                 <token regexp="yes">\d+a</token>


### PR DESCRIPTION
The number tokenisation works, the [changes](https://internal1.languagetool.org/regression-tests/via-http/2024-01-17/pt-BR/result_grammar_ORDINAL_ABBREVIATION%5B1%5D.html) look good. I think we can finally enable.