### PR TITLE
[en] amended hyphenated compound rule cream-colored

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/compounds.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/compounds.txt
@@ -7612,8 +7612,8 @@ pseudo-codes?
 privacy-sensitive*
 #rainbow-coloured*
 #rainbow-colored*
-cream-colored*
-cream-coloured*
+#cream-colored*
+#cream-coloured*
 work-mindedness*
 wide-mouthed*
 simple-hearted*


### PR DESCRIPTION
Requesting your review on this, as I changed `<token regexp="yes" chunk_re="I-NP-.*">colou?red</token>` to `<token regexp="yes" postag="JJ">colou?red</token>`. 

For some reason, our chunker chunks `coloured` as `B-VP` in the sentence _The cream coloured jumper looked particularly smart._

Not sure if `JJ` instead of `I-NP-.*` is going to have any unintended consequences...