### PR TITLE
[en] add rule for comma postag

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/disambiguation.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/disambiguation.xml
@@ -62,6 +62,13 @@
         </pattern>
         <disambig action="add"><wd pos="PCT"/></disambig>
     </rule>
+
+    <rule id="COMMA_POSTAG" name="separate postag for commas">
+        <pattern>
+            <token>,</token>
+        </pattern>
+        <disambig action="add"><wd pos=","/></disambig>
+    </rule>
     
     <rulegroup id="CONTRACTIONS" name="contractions: special cases">
         <!--TODO: should be done before the chunker to get better results? -->


### PR DESCRIPTION
For [english-pos-dict #3](https://github.com/languagetool-org/english-pos-dict/issues/3).
Specifically, in response to [this comment](https://github.com/languagetool-org/english-pos-dict/issues/3#issuecomment-1911041883).

The comma postag has been removed, however `postag=","` appears over 100 times in OS grammar.xml alone.
PR'ing because I'm not entirely sure if I've done this correctly...