### PR TITLE
new rule GenericUnpairedQuotesRule - applied to English and German - …

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/GenericUnpairedQuotesRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/GenericUnpairedQuotesRule.java
@@ -158,6 +158,10 @@ public class GenericUnpairedQuotesRule extends TextLevelRule {
   private boolean isOpeningQuote(AnalyzedTokenReadings[] tokens, int i) {
     for (int j = 0; j < startSymbols.size(); j++) {
       if (startSymbols.get(j).equals(tokens[i].getToken())) {
+        if ((tokens[i - 1].isSentenceStart() || tokens[i].isWhitespaceBefore())
+            && (i >= tokens.length -1 || tokens[i + 1].isWhitespaceBefore())) {
+          return false;
+        }
         if (endSymbols.contains(startSymbols.get(j))) {
           return (tokens[i - 1].isSentenceStart()
               || tokens[i].isWhitespaceBefore()
@@ -175,6 +179,10 @@ public class GenericUnpairedQuotesRule extends TextLevelRule {
   private boolean isClosingQuote(AnalyzedTokenReadings[] tokens, int i) {
     for (int j = 0; j < endSymbols.size(); j++) {
       if (endSymbols.get(j).equals(tokens[i].getToken())) {
+        if ((tokens[i - 1].isSentenceStart() || tokens[i].isWhitespaceBefore())
+            && (i >= tokens.length -1 || tokens[i + 1].isWhitespaceBefore())) {
+          return false;
+        }
         return true;
       }
     }

--- a/languagetool-core/src/main/java/org/languagetool/rules/GenericUnpairedQuotesRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/GenericUnpairedQuotesRule.java
@@ -27,7 +27,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 /**
- * Rule that finds unpaired quotes, brackets etc.
+ * Rule that finds unpaired quotes
  * 
  * @author Fred Kruse
  * @since 6.4

--- a/languagetool-core/src/main/java/org/languagetool/rules/GenericUnpairedQuotesRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/GenericUnpairedQuotesRule.java
@@ -1,0 +1,261 @@
+/* LanguageTool, a natural language style checker 
+ * Copyright (C) 2009 Daniel Naber (http://www.danielnaber.de)
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package org.languagetool.rules;
+
+import org.languagetool.AnalyzedSentence;
+import org.languagetool.AnalyzedTokenReadings;
+
+import java.text.MessageFormat;
+import java.util.*;
+import java.util.regex.Pattern;
+
+/**
+ * Rule that finds unpaired quotes, brackets etc.
+ * 
+ * @author Fred Kruse
+ * @since 6.4
+ */
+public class GenericUnpairedQuotesRule extends TextLevelRule {
+
+  private static final Pattern OPENING_BRACKETS = Pattern.compile("[(\\[{]");
+  private static final Pattern POSSIBLE_APOSTROPHE = Pattern.compile("[‘’']");
+  private static final Pattern INCH_PATTERN = Pattern.compile(".*\\d\".*", Pattern.DOTALL);
+
+  private final List<String> startSymbols;
+  private final List<String> endSymbols;
+  private final String ruleId;
+//  private final Pattern numerals;
+
+  public GenericUnpairedQuotesRule(String ruleId, ResourceBundle messages, List<String> startSymbols, List<String> endSymbols) {
+    super(messages);
+    this.ruleId = ruleId != null ? ruleId : "UNPAIRED_QUOTES";
+    super.setCategory(Categories.PUNCTUATION.getCategory(messages));
+    if (startSymbols.size() != endSymbols.size()) {
+      throw new IllegalArgumentException("Different number of start and end symbols: " + startSymbols + " vs. " + endSymbols);
+    }
+    this.startSymbols = startSymbols;
+    this.endSymbols = endSymbols;
+    setLocQualityIssueType(ITSIssueType.Typographical);
+  }
+
+  /**
+   * @param startSymbols start symbols like "(" - note that the array must be of equal length as the next parameter
+   *                     and the sequence of starting symbols must match exactly the sequence of ending symbols.
+   * @param endSymbols end symbols like ")"
+   */
+  public GenericUnpairedQuotesRule(ResourceBundle messages, List<String> startSymbols, List<String> endSymbols) {
+    this(null, messages, startSymbols, endSymbols);
+  }
+
+  /**
+   * Construct rule with a set of default start and end symbols: <code>“” "" ‘’ ''</code>
+   */
+  public GenericUnpairedQuotesRule(ResourceBundle messages) {
+    this(null, messages, Arrays.asList("“", "\"", "‘", "'"), Arrays.asList("”", "\"", "’", "'"));
+  }
+
+  @Override
+  public String getId() {
+    return ruleId;
+  }
+
+  @Override
+  public String getDescription() {
+    return messages.getString("desc_unpaired_quotes");
+  }
+
+  @Override
+  public final RuleMatch[] match(List<AnalyzedSentence> sentences) {
+    List<SymbolLocator> openingQuotes = new ArrayList<>();
+    List<RuleMatch> ruleMatches = new ArrayList<>();
+    String lastApostropheSymbol = null;
+    boolean wasInch = false;
+    int startPosBase = 0;
+    for (AnalyzedSentence sentence : sentences) {
+      AnalyzedTokenReadings[] tokens = sentence.getTokensWithoutWhitespace();
+      for (int i = 1; i < tokens.length; i++) {
+        if (isOpeningQuote(tokens, i)) {
+          String symbol = tokens[i].getToken();
+          if (!isNotBeginningApostrophe(tokens, i)) {
+            lastApostropheSymbol = symbol;
+            continue;
+          }
+          if ("\"".equals(symbol)) {
+            wasInch = false;
+          }
+          if (lastApostropheSymbol != null && lastApostropheSymbol.equals(symbol)) {
+            lastApostropheSymbol = null;;
+          }
+          int index = indexOfOpeningQuote(openingQuotes, symbol);
+          if (index >= 0) {
+            removeAllOpenInnerQuotes(index - 1, openingQuotes, ruleMatches, "(s1)");
+          }
+          openingQuotes.add(new SymbolLocator(symbol, tokens[i].getStartPos() + startPosBase, sentence));
+        } else if (isClosingQuote(tokens, i)) {
+          String symbol = tokens[i].getToken();
+          boolean isInchSymb = "\"".equals(symbol);
+          boolean isInch = isInchSymb ? isInchQuote(sentence.getText()) : false;
+          String startSymbol = findCorrespondingSymbol(symbol);
+          int index = indexOfOpeningQuote(openingQuotes, startSymbol);
+          if (index >= 0) {
+            removeAllOpenInnerQuotes(index, openingQuotes, ruleMatches, "(e1)");
+            openingQuotes.remove(index);
+            if (lastApostropheSymbol != null && lastApostropheSymbol.equals(startSymbol)) {
+              lastApostropheSymbol = null;;
+            }
+            if (isInch) {
+              wasInch = true;
+            }
+          } else if (isNotEndingApostrophe(tokens, i)){
+            if (!isInch && (!isInchSymb || !wasInch)) {
+              if (lastApostropheSymbol == null || !lastApostropheSymbol.equals(symbol)) {
+                addMatch(new SymbolLocator(symbol, tokens[i].getStartPos() + startPosBase, sentence), ruleMatches, "(e2)");
+              } else {
+                lastApostropheSymbol = null;
+              }
+            } else {
+              wasInch = false;
+            }
+          }
+        }
+      }
+      startPosBase += sentence.getCorrectedTextLength();
+    }
+    removeAllOpenInnerQuotes(-1, openingQuotes, ruleMatches, "(s2)");
+    return toRuleMatchArray(ruleMatches);
+  }
+  
+  private boolean isStartSymbolbefore(AnalyzedTokenReadings[] tokens, int i) {
+    for (int j = i - 1; j > 0; j--) {
+      if (startSymbols.contains(tokens[j].getToken())) {
+        if (tokens[j - 1].isSentenceStart() || tokens[j].isWhitespaceBefore()) {
+          return true;
+        }
+      } else {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean isOpeningQuote(AnalyzedTokenReadings[] tokens, int i) {
+    for (int j = 0; j < startSymbols.size(); j++) {
+      if (startSymbols.get(j).equals(tokens[i].getToken())) {
+        if (endSymbols.contains(startSymbols.get(j))) {
+          return (tokens[i - 1].isSentenceStart()
+              || tokens[i].isWhitespaceBefore()
+              || OPENING_BRACKETS.matcher(tokens[i - 1].getToken()).matches()
+              || isStartSymbolbefore(tokens, i)
+              || tokens[i - 1].getToken().endsWith("-"));
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isClosingQuote(AnalyzedTokenReadings[] tokens, int i) {
+    for (int j = 0; j < endSymbols.size(); j++) {
+      if (endSymbols.get(j).equals(tokens[i].getToken())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isInchQuote(String text) {
+    return INCH_PATTERN.matcher(text).matches();
+  }
+  
+  protected boolean isNotBeginningApostrophe(AnalyzedTokenReadings[] tokens, int i) {
+    return !POSSIBLE_APOSTROPHE.matcher(tokens[i].getToken()).matches()
+        || (i < tokens.length - 1  && tokens[i + 1].isNonWord());
+            
+  }
+
+  protected boolean isNotEndingApostrophe(AnalyzedTokenReadings[] tokens, int i) {
+    return !POSSIBLE_APOSTROPHE.matcher(tokens[i].getToken()).matches()
+            || tokens[i - 1].isNonWord();
+  }
+  
+  private int indexOfOpeningQuote(List<SymbolLocator> openingQuotes, String symbol) {
+    for(int i = 0; i < openingQuotes.size(); i++) {
+      if (symbol.equals(openingQuotes.get(i).getSymbol())) {
+        return i;
+      }
+    }
+    return -1;
+  }
+  
+  private void addMatch(SymbolLocator openingQuote, List<RuleMatch> ruleMatches, String add) {
+    String message = MessageFormat.format(messages.getString("unpaired_brackets"), findCorrespondingSymbol(openingQuote.getSymbol()) + add);
+    RuleMatch match = new RuleMatch(this, openingQuote.getSentence(), openingQuote.getStartPos(), 
+        openingQuote.getStartPos() + openingQuote.getSymbol().length(), message);
+    ruleMatches.add(match);
+  }
+  
+  private void removeAllOpenInnerQuotes(int index, List<SymbolLocator> openingQuotes, List<RuleMatch> ruleMatches, String add) {
+    for (int i = openingQuotes.size() - 1; i > index; i--) {
+      addMatch(openingQuotes.get(i), ruleMatches, add);
+      openingQuotes.remove(i);
+    }
+  }
+
+  protected String findCorrespondingSymbol(String symbol) {
+    int idx1 = startSymbols.indexOf(symbol);
+    if (idx1 >= 0) {
+      return endSymbols.get(idx1);
+    } else {
+      int idx2 = endSymbols.indexOf(symbol);
+      return startSymbols.get(idx2);
+    }
+  }
+
+  @Override
+  public int minToCheckParagraph() {
+    return -1;
+  }
+
+  protected class SymbolLocator {
+
+    private final String symbol;
+    private final int startPos;
+    private final AnalyzedSentence sentence;
+
+    SymbolLocator(String symbol, int startPos, AnalyzedSentence sentence) {
+      this.symbol = symbol;
+      this.startPos = startPos;
+      this.sentence = sentence;
+    }
+
+    public String getSymbol() {
+      return symbol;
+    }
+
+    int getStartPos() {
+      return startPos;
+    }
+
+    AnalyzedSentence getSentence() {
+      return sentence;
+    }
+
+  }
+}

--- a/languagetool-core/src/main/java/org/languagetool/rules/GenericUnpairedQuotesRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/GenericUnpairedQuotesRule.java
@@ -105,7 +105,7 @@ public class GenericUnpairedQuotesRule extends TextLevelRule {
           }
           int index = indexOfOpeningQuote(openingQuotes, symbol);
           if (index >= 0) {
-            removeAllOpenInnerQuotes(index - 1, openingQuotes, ruleMatches, "(s1)");
+            removeAllOpenInnerQuotes(index - 1, openingQuotes, ruleMatches);
           }
           openingQuotes.add(new SymbolLocator(symbol, tokens[i].getStartPos() + startPosBase, sentence));
         } else if (isClosingQuote(tokens, i)) {
@@ -115,7 +115,7 @@ public class GenericUnpairedQuotesRule extends TextLevelRule {
           String startSymbol = findCorrespondingSymbol(symbol);
           int index = indexOfOpeningQuote(openingQuotes, startSymbol);
           if (index >= 0) {
-            removeAllOpenInnerQuotes(index, openingQuotes, ruleMatches, "(e1)");
+            removeAllOpenInnerQuotes(index, openingQuotes, ruleMatches);
             openingQuotes.remove(index);
             if (lastApostropheSymbol != null && lastApostropheSymbol.equals(startSymbol)) {
               lastApostropheSymbol = null;;
@@ -126,7 +126,7 @@ public class GenericUnpairedQuotesRule extends TextLevelRule {
           } else if (isNotEndingApostrophe(tokens, i)){
             if (!isInch && (!isInchSymb || !wasInch)) {
               if (lastApostropheSymbol == null || !lastApostropheSymbol.equals(symbol)) {
-                addMatch(new SymbolLocator(symbol, tokens[i].getStartPos() + startPosBase, sentence), ruleMatches, "(e2)");
+                addMatch(new SymbolLocator(symbol, tokens[i].getStartPos() + startPosBase, sentence), ruleMatches);
               } else {
                 lastApostropheSymbol = null;
               }
@@ -138,7 +138,7 @@ public class GenericUnpairedQuotesRule extends TextLevelRule {
       }
       startPosBase += sentence.getCorrectedTextLength();
     }
-    removeAllOpenInnerQuotes(-1, openingQuotes, ruleMatches, "(s2)");
+    removeAllOpenInnerQuotes(-1, openingQuotes, ruleMatches);
     return toRuleMatchArray(ruleMatches);
   }
   
@@ -163,7 +163,8 @@ public class GenericUnpairedQuotesRule extends TextLevelRule {
               || tokens[i].isWhitespaceBefore()
               || OPENING_BRACKETS.matcher(tokens[i - 1].getToken()).matches()
               || isStartSymbolbefore(tokens, i)
-              || tokens[i - 1].getToken().endsWith("-"));
+              || (tokens[i - 1].getToken().endsWith("-") 
+                  && i < tokens.length - 1 && !tokens[i + 1].isWhitespaceBefore()));
         }
         return true;
       }
@@ -204,16 +205,16 @@ public class GenericUnpairedQuotesRule extends TextLevelRule {
     return -1;
   }
   
-  private void addMatch(SymbolLocator openingQuote, List<RuleMatch> ruleMatches, String add) {
-    String message = MessageFormat.format(messages.getString("unpaired_brackets"), findCorrespondingSymbol(openingQuote.getSymbol()) + add);
+  private void addMatch(SymbolLocator openingQuote, List<RuleMatch> ruleMatches) {
+    String message = MessageFormat.format(messages.getString("unpaired_brackets"), findCorrespondingSymbol(openingQuote.getSymbol()));
     RuleMatch match = new RuleMatch(this, openingQuote.getSentence(), openingQuote.getStartPos(), 
         openingQuote.getStartPos() + openingQuote.getSymbol().length(), message);
     ruleMatches.add(match);
   }
   
-  private void removeAllOpenInnerQuotes(int index, List<SymbolLocator> openingQuotes, List<RuleMatch> ruleMatches, String add) {
+  private void removeAllOpenInnerQuotes(int index, List<SymbolLocator> openingQuotes, List<RuleMatch> ruleMatches) {
     for (int i = openingQuotes.size() - 1; i > index; i--) {
-      addMatch(openingQuotes.get(i), ruleMatches, add);
+      addMatch(openingQuotes.get(i), ruleMatches);
       openingQuotes.remove(i);
     }
   }

--- a/languagetool-core/src/main/resources/org/languagetool/MessagesBundle.properties
+++ b/languagetool-core/src/main/resources/org/languagetool/MessagesBundle.properties
@@ -53,6 +53,7 @@ desc_repetition_beginning_word = Three successive sentences begin with the same 
 desc_repetition_beginning_adv = Two successive sentences begin with the same adverb.
 desc_repetition_beginning_thesaurus = Consider rewording the sentence or use a thesaurus to find a synonym.
 desc_unpaired_brackets = Unpaired braces, brackets, quotation marks and similar symbols
+desc_unpaired_quotes = Unpaired quotation marks
 desc_uppercase_sentence = Checks that a sentence starts with an uppercase letter
 desc_whitespacerepetition = Whitespace repetition (bad formatting)
 desc_spelling = Possible spelling mistake

--- a/languagetool-core/src/main/resources/org/languagetool/MessagesBundle_en.properties
+++ b/languagetool-core/src/main/resources/org/languagetool/MessagesBundle_en.properties
@@ -53,6 +53,7 @@ desc_repetition_beginning_word = Three successive sentences begin with the same 
 desc_repetition_beginning_adv = Two successive sentences begin with the same adverb.
 desc_repetition_beginning_thesaurus = Consider rewording the sentence or use a thesaurus to find a synonym.
 desc_unpaired_brackets = Unpaired braces, brackets, quotation marks and similar symbols
+desc_unpaired_quotes = Unpaired quotation marks
 desc_uppercase_sentence = Checks that a sentence starts with an uppercase letter
 desc_whitespacerepetition = Whitespace repetition (bad formatting)
 desc_spelling = Possible spelling mistake

--- a/languagetool-core/src/test/java/org/languagetool/rules/GenericUnpairedQuotesRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/GenericUnpairedQuotesRuleTest.java
@@ -1,0 +1,138 @@
+/* LanguageTool, a natural language style checker 
+ * Copyright (C) 2014 Daniel Naber (http://www.danielnaber.de)
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules;
+
+import org.junit.Test;
+import org.languagetool.FakeLanguage;
+import org.languagetool.JLanguageTool;
+import org.languagetool.Language;
+import org.languagetool.TestTools;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class GenericUnpairedQuotesRuleTest {
+
+  private JLanguageTool lt;
+
+  @Test
+  public void testRule() throws IOException {
+    setUpRule(new FakeLanguage());
+
+    assertMatches(0, "This is »correct«.");
+    assertMatches(0, "This is «correct».");
+    assertMatches(0, "»Correct«\n»And ›here‹ it ends.«");
+    assertMatches(0, "«Correct»\n«And ‹here› it ends.»");
+    assertMatches(0, "»Correct. This is more than one sentence.«");
+    assertMatches(0, "»Correct. This is more than one sentence.«\n»And ›here‹ it ends.«");
+    assertMatches(0, "»Correct«\n\n»And here it ends.«\n\nMore text.");
+    assertMatches(0, "»Correct, he said. This is the next sentence.« Here's another sentence.");
+    assertMatches(0, "»Correct«, he said.\n\n»This is the next sentence.« »Here's another sentence.«");
+    assertMatches(0, "»Correct«, he said. »This is the next sentence.«\n»Here's another sentence.«");
+    assertMatches(0, "This »is also ›correct‹«.");
+    assertMatches(0, "Good.\n\nThis »is also ›correct‹«.");
+    assertMatches(0, "Good.\n\n\nThis »is also ›correct‹«.");
+    assertMatches(0, "Good.\n\n\n\nThis »is also ›correct‹«.");
+
+    assertMatches(0, "This is \"correct\".");
+    assertMatches(0, "This is 'correct'.");
+    assertMatches(0, "\"Correct\"\n\"And 'here' it ends.\"");
+    assertMatches(0, "'Correct'\n'And \"here\" it ends.'");
+    assertMatches(0, "This \"is also 'correct'\".");
+    assertMatches(0, "This isn't \"incorrect\".");
+    assertMatches(0, "\"This isn't incorrect.\"");
+    assertMatches(0, "The screen is 20\" wide.");
+    assertMatches(0, "\"The screen is 20\" wide.\"");
+
+    assertMatches(1, "This is not correct«");
+    assertMatches(1, "This is »not correct.");
+    assertMatches(1, "This is »not correct");
+    assertMatches(1, "This is »not an error yet\n\nBut now it has become one");
+    assertMatches(1, "This is correct.\n\n»But this is not.");
+    assertMatches(1, "This is correct.\n\nBut this is not«");
+    assertMatches(1, "»This is correct«\n\nBut this is not«");
+    assertMatches(1, "»This is correct«\n\nBut this »is« not«");
+    assertMatches(1, "This is not correct. No matter if it's more than one sentence«");
+    assertMatches(1, "»This is not correct. No matter if it's more than one sentence");
+    assertMatches(1, "Correct, he said. This is the next sentence.« Here's another sentence.");
+    assertMatches(1, "»Correct, he said. This is the next sentence. Here's another sentence.");
+    assertMatches(1, "»Correct, he said. This is the next sentence.\n\nHere's another sentence.");
+    assertMatches(1, "»Correct, he said. This is the next sentence.\n\n\n\nHere's another sentence.");
+
+    assertMatches(2, "»Correct«\n»And »here« it ends with two matches.«");
+    assertMatches(2, "»Correct. This is more than one sentence.«\n»And »here« it ends.«");
+    assertMatches(2, "Good.\n\nThis »is also »correct««.");
+    assertMatches(2, "Good.\n\n\nThis »is also »correct««.");
+    assertMatches(2, "Good.\n\n\n\nThis »is also »correct««.");
+  }
+
+  @Test
+  public void testRuleMatchPositions() throws IOException {
+    setUpRule(new FakeLanguage());
+    RuleMatch match1 = lt.check("This »is a test.").get(0);
+    assertThat(match1.getFromPos(), is(5));
+    assertThat(match1.getToPos(), is(6));
+    assertThat(match1.getLine(), is(0));
+    assertThat(match1.getEndLine(), is(0));
+    assertThat(match1.getColumn(), is(5));
+    assertThat(match1.getEndColumn(), is(6));
+
+    RuleMatch match2 = lt.check("This.\nSome stuff.\nIt »is a test.").get(0);
+    assertThat(match2.getFromPos(), is(21));
+    assertThat(match2.getToPos(), is(22));
+    assertThat(match2.getLine(), is(2));  // first line is 0
+    assertThat(match2.getEndLine(), is(2));
+    assertThat(match2.getColumn(), is(4));
+    assertThat(match2.getEndColumn(), is(5));
+
+    RuleMatch match3 = lt.check("Th\u00ADis »is a test.").get(0);
+    assertThat(match3.getFromPos(), is(6));
+    assertThat(match3.getToPos(), is(7));
+  }
+
+  private void setUpRule(Language language) {
+    lt = new JLanguageTool(language);
+    for (Rule rule : lt.getAllRules()) {
+      lt.disableRule(rule.getId());
+    }
+    GenericUnpairedQuotesRule rule = new GenericUnpairedQuotesRule(TestTools.getEnglishMessages(),
+        Arrays.asList("»", "«", "\"", "'", "›", "‹"), Arrays.asList("«", "»", "\"", "'", "‹", "›"));
+    lt.addRule(rule);
+  }
+
+  private void assertMatches(int expectedMatches, String input) throws IOException {
+    List<RuleMatch> ruleMatches = lt.check(input);
+    assertEquals("Expected " + expectedMatches + " matches, got: " + ruleMatches, expectedMatches, ruleMatches.size());
+  }
+
+  public static GenericUnpairedQuotesRule getQuotesRule(JLanguageTool lt) {
+    for (Rule rule : lt.getAllActiveRules()) {
+      if (rule instanceof GenericUnpairedQuotesRule) {
+        return (GenericUnpairedQuotesRule)rule;
+      }
+    }
+    throw new RuntimeException("Rule not found: " + GenericUnpairedQuotesRule.class);
+  }
+
+}

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
@@ -143,6 +143,7 @@ public class German extends Language implements AutoCloseable {
                     Example.fixed("Die Partei<marker>,</marker> die die letzte Wahl gewann."),
                     Tools.getUrl("https://languagetool.org/insights/de/beitrag/grammatik-leerzeichen/#fehler-1-leerzeichen-vor-und-nach-satzzeichen")),
             new GermanUnpairedBracketsRule(messages, this),
+            new GermanUnpairedQuotesRule(messages, this),
             new UppercaseSentenceStartRule(messages, this,
                     Example.wrong("Das Haus ist alt. <marker>es</marker> wurde 1950 gebaut."),
                     Example.fixed("Das Haus ist alt. <marker>Es</marker> wurde 1950 gebaut."),

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanUnpairedBracketsRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanUnpairedBracketsRule.java
@@ -30,8 +30,11 @@ import java.util.function.Supplier;
 
 public class GermanUnpairedBracketsRule extends GenericUnpairedBracketsRule {
 
-  private static final List<String> DE_START_SYMBOLS = Arrays.asList("[", "(", "{", "„", "»", "«", "\"");
-  private static final List<String> DE_END_SYMBOLS   = Arrays.asList("]", ")", "}", "“", "«", "»", "\"");
+  //  private static final List<String> DE_START_SYMBOLS = Arrays.asList("[", "(", "{", "„", "»", "«", "\"");
+  //  private static final List<String> DE_END_SYMBOLS   = Arrays.asList("]", ")", "}", "“", "«", "»", "\"");
+
+  private static final List<String> DE_START_SYMBOLS = Arrays.asList("[", "(", "{");
+  private static final List<String> DE_END_SYMBOLS   = Arrays.asList("]", ")", "}");
 
   public GermanUnpairedBracketsRule(ResourceBundle messages, Language language) {
     super(messages, DE_START_SYMBOLS, DE_END_SYMBOLS);
@@ -44,7 +47,7 @@ public class GermanUnpairedBracketsRule extends GenericUnpairedBracketsRule {
   public String getId() {
     return "UNPAIRED_BRACKETS";  // no "DE_" to be compatible with old versions
   }
-
+/*  TODO: Remove after tests
   @Override
   protected List<String> getSuggestions(Supplier<String> text, int startPos, int endPos, Symbol symbol, String otherSymbol) {
     if (startPos > 0 && endPos <= text.get().length()) {
@@ -65,5 +68,5 @@ public class GermanUnpairedBracketsRule extends GenericUnpairedBracketsRule {
     }
     return null;
   }
-
+*/
 }

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanUnpairedQuotesRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanUnpairedQuotesRule.java
@@ -1,0 +1,48 @@
+/* LanguageTool, a natural language style checker 
+ * Copyright (C) 2021 Daniel Naber (http://danielnaber.de)
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.de;
+
+import org.languagetool.Language;
+import org.languagetool.rules.Example;
+import org.languagetool.rules.GenericUnpairedQuotesRule;
+import org.languagetool.tools.Tools;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.ResourceBundle;
+
+public class GermanUnpairedQuotesRule extends GenericUnpairedQuotesRule {
+
+  private static final List<String> DE_START_SYMBOLS = Arrays.asList("„", "»", "«", "\"", "'", "‚", "›", "‹");
+  private static final List<String> DE_END_SYMBOLS   = Arrays.asList("“", "«", "»", "\"", "'", "‘", "‹", "›");
+
+  public GermanUnpairedQuotesRule(ResourceBundle messages, Language language) {
+    super(messages, DE_START_SYMBOLS, DE_END_SYMBOLS);
+    setUrl(Tools.getUrl("https://languagetool.org/insights/de/beitrag/klammern/"));
+    addExamplePair(Example.wrong("»Hallo Hans ist das dein <marker>›</marker>neues Auto?«, fragte er."),
+                   Example.fixed("»Hallo Hans ist das dein <marker>›</marker>neues‹ Auto?«, fragte er."));
+  }
+
+  @Override
+  public String getId() {
+    return "DE_UNPAIRED_QUOTES";
+  }
+
+
+}

--- a/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/GenericUnpairedBracketsRuleTest.java
+++ b/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/GenericUnpairedBracketsRuleTest.java
@@ -40,8 +40,8 @@ public class GenericUnpairedBracketsRuleTest {
     rule = org.languagetool.rules.GenericUnpairedBracketsRuleTest.getBracketsRule(lt);
     // correct sentences:
     assertMatches("(Das sind die Sätze, die sie testen sollen).", 0);
-    assertMatches("(Das sind die «Sätze», die sie testen sollen).", 0);
-    assertMatches("(Das sind die »Sätze«, die sie testen sollen).", 0);
+    assertMatches("(Das sind die {Sätze}, die sie testen sollen).", 0);
+    assertMatches("(Das sind die [Sätze], die sie testen sollen).", 0);
     assertMatches("(Das sind die Sätze (noch mehr Klammern [schon wieder!]), die sie testen sollen).", 0);
     assertMatches("Das ist ein Satz mit Smiley :-)", 0);
     assertMatches("Das ist auch ein Satz mit Smiley ;-)", 0);
@@ -53,12 +53,6 @@ public class GenericUnpairedBracketsRuleTest {
     assertMatches("(Die URL lautet https://de.wikipedia.org/wiki/Schlammersdorf)", 0);
     assertMatches("(Die URL lautet https://de.wikipedia.org/wiki/Schlammersdorf oder so)", 0);
     assertMatches("(Die URL lautet: http://www.pariscinema.org/).", 0);
-    assertMatches("Drücken Sie auf den \"Jetzt Starten\"-Knopf.", 0);
-    assertMatches("Welches ist dein Lieblings-\"Star Wars\"-Charakter?", 0);
-    // incorrect sentences:
-    assertMatches("Die „Sätze zum Testen.", 1);
-    assertMatches("Die «Sätze zum Testen.", 1);
-    assertMatches("Die »Sätze zum Testen.", 1);
     // these used to have wrong positions, causing "Could not map ... to original position":
     lt.check("Im Kran\u00ADken\u00ADhaus. Auch)");
     lt.check("Ein Kran\u00ADken\u00ADhaus. Auch)");

--- a/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/GermanUnpairedQuotesRuleTest.java
+++ b/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/GermanUnpairedQuotesRuleTest.java
@@ -58,6 +58,7 @@ public class GermanUnpairedQuotesRuleTest {
     assertMatches("'Das ist Hans'.'", 0);
     assertMatches("Das Fahrrad hat 26\" Räder.", 0);
     assertMatches("\"Das Fahrrad hat 26\" Räder.\"", 0);
+    assertMatches("und steigern » Datenbankperformance steigern » Tipps zur Performance-Verbesserung", 0);
     // incorrect sentences:
     assertMatches("\"Das Fahrrad hat 26\" Räder.\" \"Und hier fehlt das abschließende doppelte Anführungszeichen.", 1);
     assertMatches("Die „Sätze zum Testen.", 1);

--- a/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/GermanUnpairedQuotesRuleTest.java
+++ b/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/GermanUnpairedQuotesRuleTest.java
@@ -1,0 +1,79 @@
+/* LanguageTool, a natural language style checker 
+ * Copyright (C) 2008 Daniel Naber (http://www.danielnaber.de)
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.de;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.junit.Test;
+import org.languagetool.JLanguageTool;
+import org.languagetool.Languages;
+import org.languagetool.rules.GenericUnpairedQuotesRule;
+import org.languagetool.rules.GenericUnpairedQuotesRuleTest;
+import org.languagetool.rules.RuleMatch;
+
+public class GermanUnpairedQuotesRuleTest {
+
+  private GenericUnpairedQuotesRule rule;
+  private JLanguageTool lt;
+
+  @Test
+  public void testGermanRule() throws IOException {
+    lt = new JLanguageTool(Languages.getLanguageForShortCode("de-DE"));
+    rule = GenericUnpairedQuotesRuleTest.getQuotesRule(lt);
+    // correct sentences:
+    assertMatches("»Das sind die Sätze, die sie testen sollen«.", 0);
+    assertMatches("«Das sind die ‹Sätze›, die sie testen sollen».", 0);
+    assertMatches("»Das sind die ›Sätze‹, die sie testen sollen«.", 0);
+    assertMatches("»Das sind die Sätze ›noch mehr Anführungszeichen‹ ›schon wieder!‹, die sie testen sollen«.", 0);
+    assertMatches("»Das sind die Sätze ›noch mehr Anführungszeichen ›hier ein Fehler!‹‹, die sie testen sollen«.", 2);
+    assertMatches("„Das sind die Sätze ‚noch mehr Anführungszeichen‘ ‚schon wieder!‘, die sie testen sollen“.", 0);
+    assertMatches("„Das sind die Sätze ‚noch mehr Anführungszeichen ‚hier ein Fehler!‘‘, die sie testen sollen“.", 2);
+    assertMatches("„Das sind die Sätze, die sie testen sollen.“ „Hier steht ein zweiter Satz.“", 0);
+    assertMatches("Drücken Sie auf den \"Jetzt Starten\"-Knopf.", 0);
+    assertMatches("Welches ist dein Lieblings-\"Star Wars\"-Charakter?", 0);
+    assertMatches("‚So 'n Blödsinn!‘", 0);
+    assertMatches("‚’n Blödsinn!‘", 0);
+    assertMatches("'So 'n Blödsinn!'", 0);
+    assertMatches("''n Blödsinn!'", 0);
+    assertMatches("‚Das ist Hans’.‘", 0);
+    assertMatches("'Das ist Hans'.'", 0);
+    assertMatches("Das Fahrrad hat 26\" Räder.", 0);
+    assertMatches("\"Das Fahrrad hat 26\" Räder.\"", 0);
+    // incorrect sentences:
+    assertMatches("\"Das Fahrrad hat 26\" Räder.\" \"Und hier fehlt das abschließende doppelte Anführungszeichen.", 1);
+    assertMatches("Die „Sätze zum Testen.", 1);
+    assertMatches("Die «Sätze zum Testen.", 1);
+    assertMatches("Die »Sätze zum Testen.", 1);
+    // these used to have wrong positions, causing "Could not map ... to original position":
+    lt.check("Im Kran\u00ADken\u00ADhaus. Auch)");
+    lt.check("Ein Kran\u00ADken\u00ADhaus. Auch)");
+    lt.check("Das Kran\u00ADken\u00ADhaus. Auch)");
+    lt.check("Kran\u00ADken\u00ADhaus. Auch)");
+    lt.check("Kran\u00ADken\u00ADhaus. (Auch");
+  }
+
+  private void assertMatches(String input, int expectedMatches) throws IOException {
+    RuleMatch[] matches = rule.match(Collections.singletonList(lt.getAnalyzedSentence(input)));
+    assertEquals(expectedMatches, matches.length);
+  }
+  
+}

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/language/English.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/language/English.java
@@ -192,6 +192,7 @@ public class English extends Language implements AutoCloseable {
         new ConsistentApostrophesRule(messages),
         new EnglishSpecificCaseRule(messages),
         new EnglishUnpairedBracketsRule(messages, this),
+        new EnglishUnpairedQuotesRule(messages, this),
         new EnglishWordRepeatRule(messages, this),
         new AvsAnRule(messages),
         new EnglishWordRepeatBeginningRule(messages, this),

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishUnpairedBracketsRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishUnpairedBracketsRule.java
@@ -36,19 +36,24 @@ import org.languagetool.tools.Tools;
 
 public class EnglishUnpairedBracketsRule extends GenericUnpairedBracketsRule {
 
-  //private static final List<String> EN_START_SYMBOLS = Arrays.asList("[", "(", "{");
-  //private static final List<String> EN_END_SYMBOLS   = Arrays.asList("]", ")", "}");
-  private static final Pattern INCH_PATTERN = Pattern.compile(".*\\d\".*", Pattern.DOTALL);
+  private static final List<String> EN_START_SYMBOLS = Arrays.asList("[", "(", "{");
+  private static final List<String> EN_END_SYMBOLS   = Arrays.asList("]", ")", "}");
+  // private static final Pattern INCH_PATTERN = Pattern.compile(".*\\d\".*", Pattern.DOTALL);
   // This is more strict, but also leads to confusing messages for users who mix up the many
   // characters that are be used as a quote character (https://github.com/languagetool-org/languagetool/issues/2356): 
-  private static final List<String> EN_START_SYMBOLS = Arrays.asList("[", "(", "{", "“", "\"", "'", "‘");
-  private static final List<String> EN_END_SYMBOLS   = Arrays.asList("]", ")", "}", "”", "\"", "'", "’");
+  // private static final List<String> EN_START_SYMBOLS = Arrays.asList("[", "(", "{", "“", "\"", "'", "‘");
+  // private static final List<String> EN_END_SYMBOLS   = Arrays.asList("]", ")", "}", "”", "\"", "'", "’");
+  // ^^^ Quotes are handled by EnglishUnpairedQuotesRule since 6.4 ^^^
 
   public EnglishUnpairedBracketsRule(ResourceBundle messages, Language language) {
     super(messages, EN_START_SYMBOLS, EN_END_SYMBOLS);
     setUrl(Tools.getUrl("https://languagetool.org/insights/post/punctuation-guide/#what-are-parentheses"));
-      addExamplePair(Example.wrong("\"I'm over here,<marker></marker> she said."),
-                     Example.fixed("\"I'm over here,<marker>\"</marker> she said."));
+/*
+    addExamplePair(Example.wrong("\"I'm over here,<marker></marker> she said."),
+        Example.fixed("\"I'm over here,<marker>\"</marker> she said."));
+*/
+    addExamplePair(Example.wrong("He lived in a <marker>(</marker>large house."),
+        Example.fixed("He lived in a <marker>(</marker>large) house."));
   }
 
   @Override
@@ -56,6 +61,7 @@ public class EnglishUnpairedBracketsRule extends GenericUnpairedBracketsRule {
     return "EN_UNPAIRED_BRACKETS";
   }
 
+/*  TODO:  Remove after Tests
   @Override
   protected boolean preventMatch(AnalyzedSentence sentence) {
     String text = sentence.getText();
@@ -96,6 +102,6 @@ public class EnglishUnpairedBracketsRule extends GenericUnpairedBracketsRule {
     }
     return true;
   }
- 
+*/ 
 
 }

--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishUnpairedQuotesRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/EnglishUnpairedQuotesRule.java
@@ -1,0 +1,66 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2010 Daniel Naber (http://www.languagetool.org)
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package org.languagetool.rules.en;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.ResourceBundle;
+
+import org.languagetool.AnalyzedTokenReadings;
+import org.languagetool.Language;
+import org.languagetool.rules.Example;
+import org.languagetool.rules.GenericUnpairedQuotesRule;
+import org.languagetool.tools.Tools;
+
+public class EnglishUnpairedQuotesRule extends GenericUnpairedQuotesRule {
+
+  private static final List<String> EN_START_SYMBOLS = Arrays.asList("“", "\"", "'", "‘");
+  private static final List<String> EN_END_SYMBOLS   = Arrays.asList("”", "\"", "'", "’");
+
+  public EnglishUnpairedQuotesRule(ResourceBundle messages, Language language) {
+    super(messages, EN_START_SYMBOLS, EN_END_SYMBOLS);
+    setUrl(Tools.getUrl("https://languagetool.org/insights/post/punctuation-guide/#what-are-parentheses"));
+      addExamplePair(Example.wrong("\"I'm over here,<marker></marker> she said."),
+                     Example.fixed("\"I'm over here,<marker>\"</marker> she said."));
+  }
+
+  @Override
+  public String getId() {
+    return "EN_UNPAIRED_QUOTES";
+  }
+
+  @Override
+  protected boolean isNotBeginningApostrophe(AnalyzedTokenReadings[] tokens, int i) {
+    if (tokens[i].hasPosTag("_apostrophe_contraction_") || tokens[i].hasPosTag("POS")) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  protected boolean isNotEndingApostrophe(AnalyzedTokenReadings[] tokens, int i) {
+    if (tokens[i].hasPosTag("_apostrophe_contraction_") || tokens[i].hasPosTag("POS")) {
+      return false;
+    }
+    return true;
+  }
+ 
+
+}

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishUnpairedBracketsRuleTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishUnpairedBracketsRuleTest.java
@@ -56,54 +56,9 @@ public class EnglishUnpairedBracketsRuleTest {
     assertCorrect("This is a sentence with a smiley :(");
     assertCorrect("This is a sentence with a smiley :-)");
     assertCorrect("This is a sentence with a smiley ;-) and so on...");
-    assertCorrect("I don't know.");
-    assertCorrect("This is the joint presidents' declaration.");
-    assertCorrect("The screen is 20\"");
-    assertCorrect("The screen is 20\" wide.");
-    assertIncorrect("The screen is very\" wide.");
     assertCorrect("This is a [test] sentence...");
     assertCorrect("The plight of Tamil refugees caused a surge of support from most of the Tamil political parties.[90]");
-    assertCorrect("This is what he said: \"We believe in freedom. This is what we do.\"");
     assertCorrect("(([20] [20] [20]))");
-    
-    assertCorrect("He was an ol' man.");
-    assertCorrect("'till the end.");
-    assertCorrect("jack-o'-lantern");
-    assertCorrect("jack o'lantern");
-    assertCorrect("sittin' there");
-    assertCorrect("Nothin'");
-    assertCorrect("ya'");
-    assertCorrect("I'm not goin'");
-    assertCorrect("y'know");
-    assertCorrect("Please find attached Fritz' revisions");
-    assertCorrect("You're only foolin' round.");
-    assertCorrect("I stayed awake 'till the morning.");
-    assertCorrect("under the 'Global Markets' heading");
-    assertCorrect("He's an 'admin'.");
-    assertCorrect("However, he's still expected to start in the 49ers' next game on Oct.");
-    assertCorrect("all of his great-grandfathers' names");
-    assertCorrect("Though EES' past profits now are in question");
-    assertCorrect("Networks' Communicator and FocusFocus' Conference.");
-    assertCorrect("Additional funding came from MegaMags' founders and existing individual investors.");
-    assertCorrect("al-Jazā’er");
-    assertCorrect("second Mu’taq and third");
-    assertCorrect("second Mu'taq and third");
-    assertCorrect("The phrase ‘\\1 \\2’ is British English.");
-    assertCorrect("The phrase ‘1 2’ is British English.");
-    
-    assertCorrect("22' N., long. ");
-    assertCorrect("11º 22'");
-    assertCorrect("11° 22'");
-    assertCorrect("11° 22.5'");
-    assertCorrect("In case I garbled mine, here 'tis.");
-    assertCorrect("It's about three o’clock.");
-    assertCorrect("It's about three o'clock.");
-    assertCorrect("Rory O’More");
-    assertCorrect("Rory O'More");
-    assertCorrect("Côte d’Ivoire");
-    assertCorrect("Côte d'Ivoire");
-    assertCorrect("Colonel d’Aubigni");
-    
     
     // test for a case that created a false alarm after disambiguation
     assertCorrect("This is a \"special test\", right?");
@@ -112,31 +67,10 @@ public class EnglishUnpairedBracketsRuleTest {
     assertCorrect("The jury recommended that: (1) Four additional deputies be employed.");
     assertCorrect("We discussed this in section 1a).");
     assertCorrect("We discussed this in section iv).");
-    //inches exception shouldn't match " here:
-    assertCorrect("In addition, the government would pay a $1,000 \"cost of education\" grant to the schools.");
-    assertCorrect("Paradise lost to the alleged water needs of Texas' big cities Thursday.");
-    assertCorrect("Kill 'em all!");
-    assertCorrect("Puttin' on the Ritz");
-    assertCorrect("Dunkin' Donuts");
-    assertCorrect("Hold 'em!");
     //some more cases
     assertCorrect("(Ketab fi Isti'mal al-'Adad al-Hindi)");
     assertCorrect("(al-'Adad al-Hindi)");
-    assertCorrect("On their 'host' societies.");
-    assertCorrect("On their 'host society'.");
-    assertCorrect("Burke-rostagno the Richard S. Burkes' home in Wayne may be the setting for the wedding reception for their daughter.");
-    assertCorrect("The '49 team was off to a so-so 5-5 beginning");
-    assertCorrect("The best reason that can be advanced for the state adopting the practice was the advent of expanded highway construction during the 1920s and '30s.");
-    assertCorrect("A Republican survey says Kennedy won the '60 election on the religious issue.");
-    assertCorrect("Economy class seats have a seat pitch of 31-33\", with newer aircraft having thinner seats that have a 31\" pitch.");
-    assertCorrect("\"02\" will sort before \"10\" as expected so it will have size of 10\".");
-    assertCorrect("\"02\" will sort before \"10\" as expected so it will have size of 10\""); // inch symbol is at the sentence end
-    assertCorrect("\"02\" will sort before \"10\""); // quotation mark is at the sentence end
-    assertCorrect("On their 'host societies'.");
-    assertCorrect("On their host 'societies'.");
-    assertIncorrect("On their 'host societies.");
     //TODO: ambiguous
-    assertCorrect("On their host societies'.");
     assertCorrect("a) item one\nb) item two\nc) item three");
     assertCorrectText("\n\n" +
                       "a) New York\n" +
@@ -151,37 +85,20 @@ public class EnglishUnpairedBracketsRuleTest {
                       "A) New York\n" +
                       "B) Boston\n" +
                       "C) Foo\n");
-    assertCorrect("This is not so (neither a nor b)");
-    assertCorrect("I think that Liszt's \"Forgotten Waltz No.3\" is a hidden masterpiece.");
-    assertCorrect("I think that Liszt's \"Forgotten Waltz No. 3\" is a hidden masterpiece.");
-    assertCorrect("Turkish distinguishes between dotted and dotless \"I\"s.");
-    assertCorrect("It has recognized no \"bora\"-like pattern in his behaviour."); //It's fixed with the new tokenizer
 
     // incorrect sentences:
     assertIncorrect("(This is a test sentence.");
-    assertIncorrect("This is a test with an apostrophe &'.");  
-    //FIXME? assertIncorrect("&'");
-    //FIXME? assertIncorrect("!'");
-    //FIXME: assertIncorrect("What?'");
     assertCorrect("This is not so (neither a nor b");
     assertIncorrect("This is not so (neither a nor b.");
     assertIncorrect("This is not so neither a nor b)");
     assertIncorrect("This is not so neither foo nor bar)");
-    assertIncorrect("He is making them feel comfortable all along.\"");
-    assertIncorrect("\"He is making them feel comfortable all along.");
 
     // this is currently considered incorrect... although people often use smileys this way:
     assertCorrect("Some text (and some funny remark :-) with more text to follow");  //TODO: Why is this correct and the next one incorrect?
     assertIncorrect("Some text (and some funny remark :-) with more text to follow!");
-    assertCorrect("Some text. This is \"12345\", a number.");
-    assertCorrect("Some text.\n\nThis is \"12345\", a number.");
-    assertCorrect("Some text. This is 12345\", a number.");  // could be "inch", so no error
-    assertCorrect("Some text. This is 12345\", a number.");  // could be "inch", so no error
-    assertCorrect("\"When you bring someone,\" he said.\n" +
-      "Gibson introduced the short-scale (30.5\") bass in 1961.");  // could be "inch", so no error
 
     RuleMatch[] matches;
-    matches = rule.match(Collections.singletonList(lt.getAnalyzedSentence("(This is a test” sentence.")));
+    matches = rule.match(Collections.singletonList(lt.getAnalyzedSentence("(This is a test] sentence.")));
     assertEquals(2, matches.length);
     matches = rule.match(Collections.singletonList(lt.getAnalyzedSentence("This [is (a test} sentence.")));
     assertEquals(3, matches.length);

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishUnpairedQuotesRuleTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/EnglishUnpairedQuotesRuleTest.java
@@ -1,0 +1,188 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2010 Daniel Naber (http://www.languagetool.org)
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package org.languagetool.rules.en;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.languagetool.JLanguageTool;
+import org.languagetool.Languages;
+import org.languagetool.TestTools;
+import org.languagetool.markup.AnnotatedText;
+import org.languagetool.markup.AnnotatedTextBuilder;
+import org.languagetool.rules.RuleMatch;
+import org.languagetool.rules.TextLevelRule;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class EnglishUnpairedQuotesRuleTest {
+
+  private TextLevelRule rule;
+  private JLanguageTool lt;
+
+  @Before
+  public void setUp() {
+    rule = new EnglishUnpairedQuotesRule(TestTools.getEnglishMessages(), Languages.getLanguageForShortCode("en"));
+    lt = new JLanguageTool(Languages.getLanguageForShortCode("en"));
+  }
+
+  @Test
+  public void testRule() throws IOException {
+
+    // correct sentences:
+    assertCorrect("This is a word 'test'.");
+    assertCorrect("I don't know.");
+    assertCorrect("This is the joint presidents' declaration.");
+    assertCorrect("The screen is 20\"");
+    assertCorrect("The screen is 20\" wide.");
+    assertIncorrect("The screen is very\" wide.");
+    assertCorrect("This is what he said: \"We believe in freedom. This is what we do.\"");
+    
+    assertCorrect("He was an ol' man.");
+    assertCorrect("'till the end.");
+    assertCorrect("jack-o'-lantern");
+    assertCorrect("jack o'lantern");
+    assertCorrect("sittin' there");
+    assertCorrect("Nothin'");
+    assertCorrect("ya'");
+    assertCorrect("I'm not goin'");
+    assertCorrect("y'know");
+    assertCorrect("Please find attached Fritz' revisions");
+    assertCorrect("You're only foolin' round.");
+    assertCorrect("I stayed awake 'till the morning.");
+    assertCorrect("under the 'Global Markets' heading");
+    assertCorrect("He's an 'admin'.");
+    assertCorrect("However, he's still expected to start in the 49ers' next game on Oct.");
+    assertCorrect("all of his great-grandfathers' names");
+    assertCorrect("Though EES' past profits now are in question");
+    assertCorrect("Networks' Communicator and FocusFocus' Conference.");
+    assertCorrect("Additional funding came from MegaMags' founders and existing individual investors.");
+    assertCorrect("al-Jazā’er");
+    assertCorrect("second Mu’taq and third");
+    assertCorrect("second Mu'taq and third");
+    assertCorrect("The phrase ‘\\1 \\2’ is British English.");
+    assertCorrect("The phrase ‘1 2’ is British English.");
+    
+    assertCorrect("22' N., long. ");
+    assertCorrect("11º 22'");
+    assertCorrect("11° 22'");
+    assertCorrect("11° 22.5'");
+    assertCorrect("In case I garbled mine, here 'tis.");
+    assertCorrect("It's about three o’clock.");
+    assertCorrect("It's about three o'clock.");
+    assertCorrect("Rory O’More");
+    assertCorrect("Rory O'More");
+    assertCorrect("Côte d’Ivoire");
+    assertCorrect("Côte d'Ivoire");
+    assertCorrect("Colonel d’Aubigni");
+    
+    
+    // test for a case that created a false alarm after disambiguation
+    assertCorrect("This is a \"special test\", right?");
+    //inches exception shouldn't match " here:
+    assertCorrect("In addition, the government would pay a $1,000 \"cost of education\" grant to the schools.");
+    assertCorrect("Paradise lost to the alleged water needs of Texas' big cities Thursday.");
+    assertCorrect("Kill 'em all!");
+    assertCorrect("Puttin' on the Ritz");
+    assertCorrect("Dunkin' Donuts");
+    assertCorrect("Hold 'em!");
+    //some more cases
+    assertCorrect("(Ketab fi Isti'mal al-'Adad al-Hindi)");
+    assertCorrect("(al-'Adad al-Hindi)");
+    assertCorrect("On their 'host' societies.");
+    assertCorrect("On their 'host society'.");
+    assertCorrect("Burke-rostagno the Richard S. Burkes' home in Wayne may be the setting for the wedding reception for their daughter.");
+    assertCorrect("The '49 team was off to a so-so 5-5 beginning");
+    assertCorrect("The best reason that can be advanced for the state adopting the practice was the advent of expanded highway construction during the 1920s and '30s.");
+    assertCorrect("A Republican survey says Kennedy won the '60 election on the religious issue.");
+    assertCorrect("Economy class seats have a seat pitch of 31-33\", with newer aircraft having thinner seats that have a 31\" pitch.");
+    assertCorrect("\"02\" will sort before \"10\" as expected so it will have size of 10\".");
+    assertCorrect("\"02\" will sort before \"10\" as expected so it will have size of 10\""); // inch symbol is at the sentence end
+    assertCorrect("\"02\" will sort before \"10\""); // quotation mark is at the sentence end
+    assertCorrect("On their 'host societies'.");
+    assertCorrect("On their host 'societies'.");
+    assertIncorrect("On their 'host societies.");
+    //TODO: ambiguous
+    assertCorrect("On their host societies'.");
+    assertCorrect("I think that Liszt's \"Forgotten Waltz No.3\" is a hidden masterpiece.");
+    assertCorrect("I think that Liszt's \"Forgotten Waltz No. 3\" is a hidden masterpiece.");
+    assertCorrect("Turkish distinguishes between dotted and dotless \"I\"s.");
+    assertCorrect("It has recognized no \"bora\"-like pattern in his behaviour."); //It's fixed with the new tokenizer
+
+    // incorrect sentences:
+    assertIncorrect("This is a test with an apostrophe &'.");  
+    //FIXME? assertIncorrect("&'");
+    //FIXME? assertIncorrect("!'");
+    //FIXME: assertIncorrect("What?'");
+    assertIncorrect("He is making them feel comfortable all along.\"");
+    assertIncorrect("\"He is making them feel comfortable all along.");
+
+    // this is currently considered incorrect... although people often use smileys this way:
+    assertCorrect("Some text. This is \"12345\", a number.");
+    assertCorrect("Some text.\n\nThis is \"12345\", a number.");
+    assertCorrect("Some text. This is 12345\", a number.");  // could be "inch", so no error
+    assertCorrect("Some text. This is 12345\", a number.");  // could be "inch", so no error
+    assertCorrect("\"When you bring someone,\" he said.\n" +
+      "Gibson introduced the short-scale (30.5\") bass in 1961.");  // could be "inch", so no error
+
+    RuleMatch[] matches;
+    matches = rule.match(Collections.singletonList(lt.getAnalyzedSentence("\"This is a test” sentence.")));
+    assertEquals(2, matches.length);
+    matches = rule.match(Collections.singletonList(lt.getAnalyzedSentence("This \"is 'a test” sentence.")));
+    assertEquals(3, matches.length);
+  }
+
+  private void assertCorrect(String sentence) throws IOException {
+    RuleMatch[] matches = rule.match(Collections.singletonList(lt.getAnalyzedSentence(sentence)));
+    assertEquals(0, matches.length);
+  }
+
+  private void assertCorrectText(String sentences) throws IOException {
+    AnnotatedText aText = new AnnotatedTextBuilder().addText(sentences).build();
+    RuleMatch[] matches = rule.match(lt.analyzeText(sentences), aText);
+    assertEquals(0, matches.length);
+  }
+
+  private void assertIncorrect(String sentence) throws IOException {
+    RuleMatch[] matches = rule.match(Collections.singletonList(lt.getAnalyzedSentence(sentence)));
+    assertEquals(1, matches.length);
+  }
+
+  @Test
+  public void testMultipleSentences() throws IOException {
+    JLanguageTool lt = new JLanguageTool(Languages.getLanguageForShortCode("en"));
+
+    assertEquals(0, getMatches("This is multiple sentence text that contains Quotes: "
+                             + "\"This is a bracket. With some text.\" and this continues.\n", lt));
+
+    assertEquals(0, getMatches("This is multiple sentence text that contains Quotes. "
+                             + "“This is a bracket. \n\n With some text.” and this continues.", lt));
+
+    assertEquals(1, getMatches("This is multiple sentence text that contains a Quote: "
+                             + "“This is a bracket. With some text. And this continues.\n\n", lt));
+  }
+
+  private int getMatches(String input, JLanguageTool lt) throws IOException {
+    return lt.check(input).size();
+  }
+
+}

--- a/languagetool-office-extension/src/test/java/org/languagetool/openoffice/MainTest.java
+++ b/languagetool-office-extension/src/test/java/org/languagetool/openoffice/MainTest.java
@@ -139,7 +139,7 @@ public class MainTest {
     ProofreadingResult paRes = prog.doProofreading("1", paragraphs.get(0), locale, 0, paragraphs.get(0).length(), propertyValues);
     assertEquals("1", paRes.aDocumentIdentifier);
     assertEquals(2, paRes.aErrors.length);  // This may be critical if rules changed
-    assertTrue(paRes.aErrors[0].aRuleIdentifier.equals("UNPAIRED_BRACKETS"));
+    assertTrue(paRes.aErrors[0].aRuleIdentifier.equals("DE_UNPAIRED_QUOTES"));
     assertTrue(paRes.aErrors[1].aRuleIdentifier.equals("DE_AGREEMENT"));
     MultiDocumentsHandler documents = prog.getMultiDocumentsHandler();
     SingleDocument document = documents.getDocuments().get(0);
@@ -148,24 +148,25 @@ public class MainTest {
     // test rules are:
     // DE_AGREEMENT - test of rule on sentence level
     // WHITESPACE_RULE - test of rule on level of single paragraph
-    // ENGLISH_WORD_REPEAT_BEGINNING_RULE - test of rule on level of three paragraphs
-    // EN_UNPAIRED_BRACKETS - test of rule on level of chapter / full text
-    // EN_QUOTES - negative test of rule on level of chapter / full text
+    // GERMAN_WORD_REPEAT_BEGINNING_RULE - test of rule on level of three paragraphs
+    // UNPAIRED_BRACKETS - test of rule on level of chapter / full text
+    // DE_UNPAIRED_QUOTES - test of rule on level of chapter / full text
     Set<String> enabledRules = new HashSet<>();
     for (Rule rule : lt.getAllActiveOfficeRules()) {
       if (!rule.getId().equals("DE_AGREEMENT") && !rule.getId().equals("WHITESPACE_RULE")
-          && !rule.getId().equals("UNPAIRED_BRACKETS") && !rule.getId().equals("GERMAN_WORD_REPEAT_BEGINNING_RULE")) {
+          && !rule.getId().equals("UNPAIRED_BRACKETS") && !rule.getId().equals("DE_UNPAIRED_QUOTES") 
+          && !rule.getId().equals("GERMAN_WORD_REPEAT_BEGINNING_RULE")) {
         lt.disableRule(rule.getId());
       } else {
         enabledRules.add(rule.getId());
       }
     }
-    assertEquals(4, enabledRules.size()); // test if all needed 4 rules are enabled 
+    assertEquals(5, enabledRules.size()); // test if all needed 5 rules are enabled 
     enabledRules.clear();
     for (Rule rule : lt.getAllActiveOfficeRules()) {
       enabledRules.add(rule.getId());
     }
-    assertEquals(4, enabledRules.size()); // test if not more than needed rules are enabled
+    assertEquals(5, enabledRules.size()); // test if not more than needed rules are enabled
     // set document cache of virtual document
     // NOTE: this step has to be done, when all other preparations are done
     document.setDocumentCacheForTests(paragraphs, textParagraphs, footnotes, chapterBegins, locale);
@@ -295,7 +296,7 @@ public class MainTest {
     ProofreadingResult paRes = prog.doProofreading("1", paragraphs.get(0), locale, 0, paragraphs.get(0).length(), propertyValues);
     assertEquals("1", paRes.aDocumentIdentifier);
     assertEquals(2, paRes.aErrors.length);  // This may be critical if rules changed
-    assertTrue(paRes.aErrors[0].aRuleIdentifier.equals("UNPAIRED_BRACKETS"));
+    assertTrue(paRes.aErrors[0].aRuleIdentifier.equals("DE_UNPAIRED_QUOTES"));
     assertTrue(paRes.aErrors[1].aRuleIdentifier.equals("DE_AGREEMENT"));
     MultiDocumentsHandler documents = prog.getMultiDocumentsHandler();
     SingleDocument document = documents.getDocuments().get(0);
@@ -304,24 +305,25 @@ public class MainTest {
     // test rules are:
     // DE_AGREEMENT - test of rule on sentence level
     // WHITESPACE_RULE - test of rule on level of single paragraph
-    // ENGLISH_WORD_REPEAT_BEGINNING_RULE - test of rule on level of three paragraphs
-    // EN_UNPAIRED_BRACKETS - test of rule on level of chapter / full text
-    // EN_QUOTES - negative test of rule on level of chapter / full text
+    // GERMAN_WORD_REPEAT_BEGINNING_RULE - test of rule on level of three paragraphs
+    // DE_UNPAIRED_QUOTES - test of rule on level of chapter / full text
+    // UNPAIRED_BRACKETS - test of rule on level of chapter / full text
     Set<String> enabledRules = new HashSet<>();
     for (Rule rule : lt.getAllActiveOfficeRules()) {
       if (!rule.getId().equals("DE_AGREEMENT") && !rule.getId().equals("WHITESPACE_RULE")
-          && !rule.getId().equals("UNPAIRED_BRACKETS") && !rule.getId().equals("GERMAN_WORD_REPEAT_BEGINNING_RULE")) {
+          && !rule.getId().equals("DE_UNPAIRED_QUOTES") && !rule.getId().equals("UNPAIRED_BRACKETS") 
+          && !rule.getId().equals("GERMAN_WORD_REPEAT_BEGINNING_RULE")) {
         lt.disableRule(rule.getId());
       } else {
         enabledRules.add(rule.getId());
       }
     }
-    assertEquals(4, enabledRules.size()); // test if all needed 4 rules are enabled 
+    assertEquals(5, enabledRules.size()); // test if all needed 5 rules are enabled 
     enabledRules.clear();
     for (Rule rule : lt.getAllActiveOfficeRules()) {
       enabledRules.add(rule.getId());
     }
-    assertEquals(4, enabledRules.size()); // test if not more than needed rules are enabled
+    assertEquals(5, enabledRules.size()); // test if not more than needed rules are enabled
     int textParagraphsSize = 0;
     for (int i = 0; i < DocumentCache.NUMBER_CURSOR_TYPES; i++) {
       textParagraphsSize += textParagraphs.get(i).size();


### PR DESCRIPTION
The changes solve issue #10113.
A new rule "GenericUnpairedQuotesRule" was created to resolve issue #10113. The "GenericUnpairedBracketsRule" has not been changed, but the English and German rules have been modified to separate the bracket rules from the quotation mark rules.
The same was done with the test cases.
All tests involving quotation marks that had to satisfy "UnpairedBracketsRules" are now also satisfied by the "UnpairedQuotesRules" (especially the special cases for apostrophe and inch symbol). Additionally, the cases described in issue #10113 were included in the testing.