### PR TITLE
[fr] A_ACCENT_A and A_ACCENT AP added

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/remote-rule-filters.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/remote-rule-filters.xml
@@ -665,7 +665,7 @@ To ignore a remote rule match, set the <marker> so that it exactly covers the te
                 <pattern>
                     <token postag="K"/>
                     <marker>
-                        <token spacebefore="no" regexp="yes">-|-|—</token>
+                        <token spacebefore="no">-</token>
                     </marker>
                     <token postag="K" spacebefore="no"/>
                 </pattern>


### PR DESCRIPTION
To address and close: https://github.com/languagetooler-gmbh/languagetool-premium/issues/7050

2 APs added, 1 pattern and 1 example modified.