### PR TITLE
[pt] Disable AONDE_BR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -33839,8 +33839,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <antipattern><!-- futuro perifrástico -->
                     <token inflected='yes'>ir</token>
                     <token postag='VMN0000'><!-- TODO add exceptions. e.g. "Onde vamos comer?" "Nós não decidimos onde vamos descansar."-->
-                        <exception>levar</exception> <!-- MARCOAGPINTO AND RICARDO JOSEH LIMA, MOTION VERBS - 2022-04-17 - "Onde você vai levar seu filho?" -->
+                        <exception regexp="yes">levar|ir</exception> <!-- MARCOAGPINTO AND RICARDO JOSEH LIMA, MOTION VERBS - 2022-04-17 - "Onde você vai levar seu filho?" -->
                     </token>
+                    <example>Não conte para o Tom aonde estamos indo.</example>
                 </antipattern>
                 <pattern>
                     <marker>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
@@ -1068,7 +1068,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
     <!-- ********************************************************** -->
     <!-- CONFUNDIR ONDE POR AONDE -->
 
-    <rule id="AONDE_BR" name="Onde">
+    <rule id="AONDE_BR" name="Onde" default="off">
+    <!-- p-goulart@2024-02-13 - DESC: disable completely, this causes more FPs than fixes actual issues -->
       <pattern>
         <token>aonde</token>
         <token>você</token>


### PR DESCRIPTION
From the gGEC loop task. We already have `CONFUSÃO_AONDE_ONDE`, and gGEC seems to handle these cases well enough.