### PR TITLE
[pt] Remove entender/intender pair from wrongWordInContext

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/wrongWordInContext.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/wrongWordInContext.txt
@@ -35,8 +35,6 @@
 (?i)enform.+	(?i)inform.+	enf	inf	(?i)chapéus|fôrmas?|moldes?|sapatos?	(?i)avisos?|cartas?|correios?|direc?tivas?|telefon.+|contac?at.+	meter em fôrma	avisar
 # enfestar/infestar
 (?i)enfest.+	(?i)infest.+	enf	inf	(?i)(calça|camisa|toalha|camisola|roupa|tabuleiro|guardanapo|lenço)s?|lenç(ol|ois)	(?i)(barata|fungo|parasita|daninha|larva|rato|insec?to)s?	dobrar ao meio	assolar
-# entender/intender
-(?i)entend.+	(?i)intend.+	ent	int	(?i)(argumentaç|liç|raz)(ão|ões)|(anúncio|argumento|cartaz|conhecimento|discurso|filosofia|ideia|ideologia|lição|matéria|memorando|notícia|disciplina)s?	(?i)responsáv(el|eis)|chef(ia|)es?|(polícia|patrulha|guarda|segurança)s?	compreender	exercer vigilância
 # estrato/extrato
 (?i)estratos?	(?i)extratos?	strat	xtrat	(?i)nuve(m|ns)|geologia|meteorologia|(céu|cirr[ou]|geológico|solo)s?	(?i)(bancário|chá.+|multibanco|contabilidade|[Ff]inanças|saldo|dívida|hipoteca|renda|rendimento|guaco|xarope)s?|amortizaç(ão|ões)	camada	resumo ou extração
 # infligir/infringir - converted from Catalan file


### PR DESCRIPTION
As per [Slack thread](https://languagetooler.slack.com/archives/C058BK14VND/p1707983331009219).