### PR TITLE
[pt] Add hotfix for titlecasing of hyphenated compounds

### DIFF
--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRule.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRule.java
@@ -18,7 +18,6 @@
  */
 package org.languagetool.rules.pt;
 
-import org.apache.commons.lang3.StringUtils;
 import org.languagetool.*;
 import org.languagetool.rules.RuleMatch;
 import org.languagetool.rules.SuggestedReplacement;

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/tagging/pt/PortugueseTagger.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/tagging/pt/PortugueseTagger.java
@@ -145,7 +145,22 @@ public class PortugueseTagger extends BaseTagger {
       List<AnalyzedToken> l = new ArrayList<>();
       String lowerWord = word.toLowerCase(locale);
       boolean isLowercase = word.equals(lowerWord);
-      boolean isMixedCase = StringTools.isMixedCase(word);
+      boolean isMixedCase;
+      // if the word contains a hyphen, it is only mixed case if at least one element is mixed case
+      if (word.contains("-")) {
+        isMixedCase = false;
+        String[] parts = word.split("-");
+        for (String part : parts) {
+          if (StringTools.isMixedCase(part)) {
+            isMixedCase = true;
+            break;
+          }
+        }
+      // No hyphens found, just do a regular isMixedCase check
+      } else {
+        isMixedCase = StringTools.isMixedCase(word);
+      }
+
       List<AnalyzedToken> taggerTokens = asAnalyzedTokenListForTaggedWords(word, getWordTagger().tag(word));
       
       // normal case:

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -15882,13 +15882,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <token>:</token>
                 <example>Andrey Koreshkov (Russo: nome em russo aqui)</example>
             </antipattern>
-            <antipattern>
-                <token regexp="yes">[nd]o</token>
-                <token case_sensitive="yes">Sul</token>
-                <token spacebefore='no'>-</token>
-                <token regexp="yes" spacebefore='no' inflected="yes">&languages;</token>
-                <example>Participou do Sul-Americano.</example>
-            </antipattern>
+            <!-- p-goulart@2024-02-20 - DESC: comment out due to changes in tokenisation of Sul-Americano (this is tricky) -->
+            <!-- <antipattern> -->
+                <!-- <token regexp="yes">[nd]o</token> -->
+                <!-- <token case_sensitive="yes">Sul</token> -->
+                <!-- <token spacebefore='no'>-</token> -->
+                <!-- <token regexp="yes" spacebefore='no' inflected="yes">&languages;</token> -->
+                <!-- <example>Participou do Sul-Americano.</example> -->
+            <!-- </antipattern> -->
             <antipattern>
                 <token regexp="yes" inflected="yes">&languages;</token>
                 <token>de</token>

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
@@ -634,4 +634,11 @@ public class MorfologikPortugueseSpellerRuleTest {
     assertNoErrors("sub-taça", ltBR, ruleBR);
     assertNoErrors("sub-pratos", ltBR, ruleBR);
   }
+
+  @Test public void testPortugueseSpellerAcceptsCapitalisationOfAllCompoundElements() throws Exception {
+    assertNoErrors("jiu-jitsu.", ltBR, ruleBR);
+    assertNoErrors("Jiu-jitsu.", ltBR, ruleBR);
+    assertNoErrors("Jiu-Jitsu.", ltBR, ruleBR);
+    assertErrorLength("jIu-JItsU", 2, ltBR, ruleBR, new String[]{});
+  }
 }

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/tagging/pt/PortugueseTaggerTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/tagging/pt/PortugueseTaggerTest.java
@@ -87,4 +87,12 @@ public class PortugueseTaggerTest {
     TestTools.myAssert("to", "to/[tu:ele]PP2CSO00:PP3MSA00", tokenizer, tagger);
     TestTools.myAssert("ao", "ao/[a:o]SPS00:DA0MS0", tokenizer, tagger);
   }
+
+  @Test
+  public void testTaggerTagsCompoundsRegardlessOfLetterCase() throws IOException {
+    TestTools.myAssert("jiu-jitsu", "jiu-jitsu/[jiu-jitsu]NCMS000", tokenizer, tagger);
+    TestTools.myAssert("Jiu-jitsu", "Jiu-jitsu/[jiu-jitsu]NCMS000", tokenizer, tagger);
+    TestTools.myAssert("JIU-JITSU", "JIU-JITSU/[jiu-jitsu]NCMS000", tokenizer, tagger);
+    TestTools.myAssert("Jiu-Jitsu", "Jiu-Jitsu/[jiu-jitsu]NCMS000", tokenizer, tagger);
+  }
 }

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertEquals;
 public class PortugueseWordTokenizerTest {
   final PortugueseWordTokenizer wordTokenizer = new PortugueseWordTokenizer();
 
-  private void testTokenise(String sentence, String[] tokens) {
+  private void testTokenise(String sentence, String ...tokens) {
     assertArrayEquals(tokens, wordTokenizer.tokenize(sentence).toArray());
   }
 
@@ -69,6 +69,14 @@ public class PortugueseWordTokenizerTest {
     testTokenise("Montemor-o-Novo", new String[]{"Montemor-o-Novo"});
     testTokenise("Andorra-a-Velha", new String[]{"Andorra-a-Velha"});
     testTokenise("Tsé-Tung", new String[]{"Tsé-Tung"});
+  }
+
+  @Test
+  public void testTokeniseHyphenatedSplitRegardlessOfLetterCase() {
+    testTokenise("jiu-jitsu", "jiu-jitsu");
+    testTokenise("Jiu-jitsu", "Jiu-jitsu");
+    testTokenise("JIU-JITSU", "JIU-JITSU");
+    testTokenise("Jiu-Jitsu", "Jiu-Jitsu");
   }
 
   @Test


### PR DESCRIPTION
- cases like 'Jiu-Jitsu' were not being accepted (e.g. [here](https://regression.languagetoolplus.com/via-http/2024-02-17/pt-BR/result_java_MORFOLOGIK_RULE_PT_BR.html));

- this became clear due to changes made to the multitoken rule [here](https://github.com/languagetool-org/languagetool/commit/14d79a0cd0f92f3b74ae0ba5a332b73a54595554);

- the tagger and tokeniser have been changed to account for valid titlecasing of hyphenated compounds, by making sure we only mark a token as mixedCase when *at least one* of its components is mixedCase; since both 'Jiu' and 'Jitsu' start with an uppercase letter, they are not mixed and, therefore, valid;

- the speller also had to be changed to accept such words, since we cannot impact the titlecasing rules of tokens that contain only hyphens (the titlecasing logic is tied to multiword entries in the chunker, which generally only refers to entries that contain **spaces**).


