### PR TITLE
[es,ca] ignore English words

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/AbstractDisambiguator.java
+++ b/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/AbstractDisambiguator.java
@@ -72,7 +72,9 @@ public abstract class AbstractDisambiguator implements Disambiguator {
     }
     if (lang != null) {
       spellingRule = lang.getDefaultSpellingRule();
-      tagsToIgnore = tagsToBeIgnored;
+      if (tagsToBeIgnored != null) {
+        tagsToIgnore = tagsToBeIgnored;
+      }
       if (languageCode.startsWith("en")) {
         commonWords = commonEnglishWords;
       }

--- a/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/AbstractDisambiguator.java
+++ b/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/AbstractDisambiguator.java
@@ -1,6 +1,6 @@
-/* LanguageTool, a natural language style checker 
+/* LanguageTool, a natural language style checker
  * Copyright (C) 2017 Daniel Naber (http://www.danielnaber.de)
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -18,11 +18,21 @@
  */
 package org.languagetool.tagging.disambiguation;
 
-import org.languagetool.AnalyzedSentence;
+import org.languagetool.*;
+import org.languagetool.rules.spelling.SpellingCheckRule;
+
+import org.jetbrains.annotations.Nullable;
+import org.languagetool.tools.StringTools;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Abstract Disambiguator class to provide default (empty) implementation
  * for {@link Disambiguator#preDisambiguate(AnalyzedSentence)}.
+ *
  * @since 3.7
  */
 public abstract class AbstractDisambiguator implements Disambiguator {
@@ -30,6 +40,84 @@ public abstract class AbstractDisambiguator implements Disambiguator {
   @Override
   public AnalyzedSentence preDisambiguate(AnalyzedSentence input) {
     return input;
+  }
+
+  private SpellingCheckRule spellingRule = null;
+  private List<String> commonWords = new ArrayList<>();
+  private final List<String> commonEnglishWords = Arrays.asList("the", "to", "of", "and", "in", "a", "was", "is",
+    "this", "i", "as", "for", "on", "with", "by", "that", "from", "at", "his", "an", "he", "are", "were", "don't",
+    "which", "it", "or", "had", "has", "one", "but", "first", "very", "we", "not", "their", "any", "have", "who",
+    "been", "her", "two", "get", "other", "after", "into", "they", "time", "all", "be", "me", "more", "must", "only",
+    "when", "years", "most", "over", "used", "would", "you", "can", "during", "going", "good", "him", "new", "out",
+    "she", "such", "where", "between", "made", "many", "some", "then", "there", "year", "about", "back", "became",
+    "later", "part", "under", "well", "being", "including", "them", "through", "area", "both", "make", "name",
+    "before", "called", "could", "fine", "people", "second", "until", "while", "will", "i'll", "against", "age",
+    "city", "go", "may", "number", "population", "season", "several", "team", "these", "work", "born", "early",
+    "family", "film", "now", "same", "series", "so", "use", "what", "album", "based", "four", "it's", "life",
+    "released", "since", "state", "began", "century", "each", "end", "following", "found", "game", "high", "located",
+    "town", "i've", "around", "because", "can't", "come", "day", "did", "didn't", "government", "group", "here",
+    "home", "large", "like", "love", "music", "my", "named", "no", "often", "system", "that's", "three", "too", "up",
+    "us", "won", "yes", "you're", "along", "built", "career", "former", "if", "include", "left", "line", "local",
+    "long", "off", "own", "place", "small", "still", "those", "took", "band", "due", "form", "held", "its", "last",
+    "major", "member", "members", "much", "don", "didn", "doesn", "wasn", "weren", "'s", "'t", "'ll");
+
+  private String[] tagsToIgnore = new String[0];
+
+  protected void initExtraSpellingRule(String languageCode, String[] tagsToBeIgnored) {
+    Language lang = null;
+    try {
+      lang = Languages.getLanguageForShortCode(languageCode);
+    } catch (IllegalArgumentException e) {
+      // The language is not available; ignoring words will not be available
+    }
+    if (lang != null) {
+      spellingRule = lang.getDefaultSpellingRule();
+      tagsToIgnore = tagsToBeIgnored;
+      if (languageCode.startsWith("en")) {
+        commonWords = commonEnglishWords;
+      }
+    }
+  }
+
+  /*
+   * Ignore the spelling of words from a different language, e.g. English, at least two consecutive words
+   * The speller is initiated by initExtraSpellingRule().
+   *
+   * @Since 6.4
+   */
+  protected AnalyzedSentence ignoreSpellingWithExtraSpellingRule(AnalyzedSentence input,
+                                                                 @Nullable JLanguageTool.CheckCancelledCallback checkCanceled) throws IOException {
+    if (spellingRule == null) {
+      return input;
+    }
+    AnalyzedTokenReadings[] anTokens = input.getTokens();
+    AnalyzedTokenReadings[] output = anTokens;
+    boolean prevIsEnglish = false;
+    boolean isEnglish;
+    Integer skippedTokens = 1;
+    for (int i = 1; i < anTokens.length - 1; i++) {
+      String word = output[i].getToken();
+      if (word.length() < 1 || StringTools.isWhitespace(word) || StringTools.isNotWordString(word)) {
+        skippedTokens++;
+        continue;
+      }
+      String lcword = word.toLowerCase().replaceAll("’", "'");
+      // avoid checking with the speller as many words as possible
+      boolean currentIsEnglish = output[i].hasAnyPartialPosTag(tagsToIgnore) || commonWords.contains(lcword);
+      if (!prevIsEnglish && (output[i].isIgnoredBySpeller() || output[i].isTagged() || currentIsEnglish)) {
+        prevIsEnglish = currentIsEnglish;
+        skippedTokens = 1;
+        continue;
+      }
+      isEnglish = currentIsEnglish || !spellingRule.isMisspelled(word);
+      if (isEnglish && prevIsEnglish && i - skippedTokens > 0) {
+        output[i].ignoreSpelling();
+        output[i - skippedTokens].ignoreSpelling();
+      }
+      skippedTokens = 1;
+      prevIsEnglish = isEnglish;
+    }
+    return new AnalyzedSentence(output);
   }
 
 }

--- a/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/AbstractDisambiguator.java
+++ b/languagetool-core/src/main/java/org/languagetool/tagging/disambiguation/AbstractDisambiguator.java
@@ -97,7 +97,7 @@ public abstract class AbstractDisambiguator implements Disambiguator {
     boolean prevIsEnglish = false;
     boolean isEnglish;
     Integer skippedTokens = 1;
-    for (int i = 1; i < anTokens.length - 1; i++) {
+    for (int i = 1; i < anTokens.length; i++) {
       String word = output[i].getToken();
       if (word.length() < 1 || StringTools.isWhitespace(word) || StringTools.isNotWordString(word)) {
         skippedTokens++;

--- a/languagetool-language-modules/ca/src/main/java/org/languagetool/rules/ca/OblidarseSugestionsFilter.java
+++ b/languagetool-language-modules/ca/src/main/java/org/languagetool/rules/ca/OblidarseSugestionsFilter.java
@@ -91,10 +91,6 @@ public class OblidarseSugestionsFilter extends RuleFilter {
   public RuleMatch acceptRuleMatch(RuleMatch match, Map<String, String> arguments, int patternTokenPos,
                                    AnalyzedTokenReadings[] patternTokens, List<Integer> tokenPositions) throws IOException {
     int posWord = 0;
-    if (match.getSentence().getText().contains("A massa gent")) {
-      int ii = 0;
-      ii++;
-    }
     AnalyzedTokenReadings[] tokens = match.getSentence().getTokensWithoutWhitespace();
     while (posWord < tokens.length
         && (tokens[posWord].getStartPos() < match.getFromPos() || tokens[posWord].isSentenceStart())) {

--- a/languagetool-language-modules/ca/src/main/java/org/languagetool/tagging/disambiguation/ca/CatalanHybridDisambiguator.java
+++ b/languagetool-language-modules/ca/src/main/java/org/languagetool/tagging/disambiguation/ca/CatalanHybridDisambiguator.java
@@ -20,9 +20,6 @@
 package org.languagetool.tagging.disambiguation.ca;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 import org.jetbrains.annotations.Nullable;
 import org.languagetool.*;
@@ -56,13 +53,14 @@ public class CatalanHybridDisambiguator extends AbstractDisambiguator {
   public CatalanHybridDisambiguator(Language lang) {
     disambiguator = new XmlRuleDisambiguator(lang, true);
     chunker.setRemovePreviousTags(true);
+    initExtraSpellingRule("en-US", new String[]{"_english_ignore_"});
   }
-  
+
   @Override
-  public final AnalyzedSentence disambiguate(AnalyzedSentence input, @Nullable JLanguageTool.CheckCancelledCallback checkCanceled) throws IOException {
-    return disambiguator.disambiguate(chunker.disambiguate(chunkerGlobal.disambiguate(input, checkCanceled), checkCanceled), checkCanceled);
+  public final AnalyzedSentence disambiguate(AnalyzedSentence input,
+                                             @Nullable JLanguageTool.CheckCancelledCallback checkCanceled) throws IOException {
+    return ignoreSpellingWithExtraSpellingRule(disambiguator.disambiguate(chunker.disambiguate(
+      chunkerGlobal.disambiguate(input, checkCanceled), checkCanceled), checkCanceled), checkCanceled);
   }
-
-
 
 }

--- a/languagetool-language-modules/ca/src/main/resources/org/languagetool/rules/ca/replace_multiwords.txt
+++ b/languagetool-language-modules/ca/src/main/resources/org/languagetool/rules/ca/replace_multiwords.txt
@@ -443,3 +443,4 @@ femme fatal=femme fatale
 Segurtat Social|Segurat Social=Seguretat Social	¿Volíeu dir "Seguretat Social"?
 sentiments trobats=sentiments oposats	Possible error de traducció automàtica.
 Duns Scot=Duns Escot	Grafia habitual d'aquest nom.
+Rocky Mountains National Park=Rocky Mountain National Park

--- a/languagetool-language-modules/es/src/main/java/org/languagetool/tagging/disambiguation/es/SpanishHybridDisambiguator.java
+++ b/languagetool-language-modules/es/src/main/java/org/languagetool/tagging/disambiguation/es/SpanishHybridDisambiguator.java
@@ -49,6 +49,7 @@ public class SpanishHybridDisambiguator extends AbstractDisambiguator {
   public SpanishHybridDisambiguator(Language lang) {
     disambiguator = new XmlRuleDisambiguator(lang, true);
     chunker.setRemovePreviousTags(true);
+    initExtraSpellingRule("en-US", new String[]{"_english_ignore_"});
   }
 
   @Override
@@ -62,7 +63,8 @@ public class SpanishHybridDisambiguator extends AbstractDisambiguator {
    */
   @Override
   public AnalyzedSentence disambiguate(AnalyzedSentence input, @Nullable JLanguageTool.CheckCancelledCallback checkCanceled) throws IOException {
-    return disambiguator.disambiguate(chunker.disambiguate(chunkerGlobal.disambiguate(input, checkCanceled), checkCanceled), checkCanceled);
+    return ignoreSpellingWithExtraSpellingRule(disambiguator.disambiguate(chunker.disambiguate(
+      chunkerGlobal.disambiguate(input, checkCanceled), checkCanceled), checkCanceled), checkCanceled);
   }
 
 }

--- a/languagetool-standalone/src/test/java/org/languagetool/JLanguageToolTest.java
+++ b/languagetool-standalone/src/test/java/org/languagetool/JLanguageToolTest.java
@@ -487,6 +487,10 @@ public class JLanguageToolTest {
     assertEquals(1, matches.size());
     matches = lt.check("This is, it seems, a good gasdfghadsfha.");
     assertEquals(1, matches.size());
+    matches = lt.check("Rocky Mountains National Park");
+    assertEquals(1, matches.size());
+    matches = lt.check("Rocky Mountain National Park");
+    assertEquals(0, matches.size());
   }
 
 }

--- a/languagetool-standalone/src/test/java/org/languagetool/JLanguageToolTest.java
+++ b/languagetool-standalone/src/test/java/org/languagetool/JLanguageToolTest.java
@@ -21,10 +21,7 @@ package org.languagetool;
 import org.hamcrest.CoreMatchers;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.languagetool.language.AmericanEnglish;
-import org.languagetool.language.Demo;
-import org.languagetool.language.English;
-import org.languagetool.language.GermanyGerman;
+import org.languagetool.language.*;
 import org.languagetool.markup.AnnotatedText;
 import org.languagetool.markup.AnnotatedTextBuilder;
 import org.languagetool.rules.*;
@@ -471,6 +468,25 @@ public class JLanguageToolTest {
     }
     System.out.println("Total matches:" + matchesCounter);
     assertThat(matchesCounter, is(0));
+  }
+
+
+  @Test
+  public void testIgnoringEnglishWordsInCatalan() throws IOException {
+    Language lang = new Catalan();
+    JLanguageTool lt = new JLanguageTool(lang);
+    List<RuleMatch> matches = lt.check("This asdfasdfasd m'agrada molt.");
+    assertEquals(2, matches.size());
+    matches = lt.check("This is a good thing.");
+    assertEquals(0, matches.size());
+    matches = lt.check("This is a good gasdfghadsfha.");
+    assertEquals(1, matches.size());
+    matches = lt.check("I didn't know gasdfghadsfha.");
+    assertEquals(1, matches.size());
+    matches = lt.check("Didn't know gasdfghadsfha.");
+    assertEquals(1, matches.size());
+    matches = lt.check("This is, it seems, a good gasdfghadsfha.");
+    assertEquals(1, matches.size());
   }
 
 }


### PR DESCRIPTION
New version of https://github.com/languagetool-org/languagetool/pull/10320
This code can be easily shared by other languages, even to ignore Spanish words in English. 