### PR TITLE
[fr] Dictionary additions

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
@@ -35939,3 +35939,8 @@ Pétrone;Pétrone;Z m s
 Satyricon;Satyricon;Z m s
 O'Sullivan;O'Sullivan;Z e sp
 Goldberg;Goldberg;Z e sp
+ostarine;ostarine;N f s
+homoérotique;homoérotique;J e s
+homoérotiques;homoérotique;J e p
+homoérotisme;homoérotisme;N m s
+homoérotismes;homoérotisme;N m p

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/multiwords.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/multiwords.txt
@@ -3812,4 +3812,5 @@ beach tennis;N m sp
 Judith Godrèche;Z f s
 Club Med;Z m s
 Club Meds;Z m p
+Ysaora Thibus;Z f s
 Laurent Jouvet;Z m s


### PR DESCRIPTION
Adding proper names, nouns and adj to the FR dict files.
I decided to add "_homoérotique_" and "_homoérotisme_" without dash or space, to align the form with "_homosexualité_".
These words are not (yet) in the Larousse, Robert or TLF. CNRTL provides this list of words with homo- as a prefix, most of them not having a dash: https://www.cnrtl.fr/definition/homo-