### PR TITLE
[pt] Add spelling hotfixes

### DIFF
--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
@@ -251,8 +251,9 @@ public class Portuguese extends Language implements AutoCloseable {
     id2prio.put("PT_DIACRITICS_REPLACE", -45);  // prefer over spell checker
     id2prio.put("DIACRITICS", -45);
     id2prio.put("PT_COMPOUNDS_POST_REFORM", -45);
-    id2prio.put("AUX_VERBO", -45);  // HIGHER THAN SPELLER
+    id2prio.put("AUX_VERBO", -45);
     id2prio.put("ENSINO_A_DISTANCIA", -45);
+    id2prio.put("EMAIL_SEM_HIFEN_ORTHOGRAPHY", -45); // HIGHER THAN SPELLER
     // MORFOLOGIK SPELLER FITS HERE AT -50 ---------------------  // SPELLER (-50)
     id2prio.put("PRETERITO_PERFEITO", -51);  // LOWER THAN SPELLER
     id2prio.put("PT_BR_SIMPLE_REPLACE", -51);

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
@@ -252,6 +252,7 @@ public class Portuguese extends Language implements AutoCloseable {
     id2prio.put("DIACRITICS", -45);
     id2prio.put("PT_COMPOUNDS_POST_REFORM", -45);
     id2prio.put("AUX_VERBO", -45);  // HIGHER THAN SPELLER
+    id2prio.put("ENSINO_A_DISTANCIA", -45);
     // MORFOLOGIK SPELLER FITS HERE AT -50 ---------------------  // SPELLER (-50)
     id2prio.put("PRETERITO_PERFEITO", -51);  // LOWER THAN SPELLER
     id2prio.put("PT_BR_SIMPLE_REPLACE", -51);

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
@@ -212,3 +212,5 @@ EF	EF	NCCS000
 BT	BT	AQ0CN0
 Linux	Linux	AQ0CN0
 
+story	story	NCFS000
+stories	story	NCFP000

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
@@ -308,3 +308,5 @@ paul
 Aix-en-Provence
 Agualva-Cacém
 Bósnia-Herzegovina
+story
+stories

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -36888,6 +36888,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
     <category id='MISSPELLING' name="Erros Ortográficos" type="misspelling">
+        <rule id="ENSINO_A_DISTANCIA" name="Sugerir EaD para ensino a distância">
+            <!-- p-goulart@2024-02-27 - DESC: must have higher priority than the speller rule! -->
+            <pattern>
+                <token case_sensitive="yes">EAD</token>
+            </pattern>
+            <message>Se estiver se referindo a &quot;ensino a distância&quot;, prefira <suggestion>EaD</suggestion>.</message>
+            <example correction="EaD">Professores de <marker>EAD</marker> têm várias dificuldades.</example>
+        </rule>
+
         <rulegroup id="DIACRITICS" name="Confusão com diacríticos">
             <!--      Created by Jaume Ortolà, Portuguese rule 2021-01-08      -->
             <!--

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -36897,6 +36897,17 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="EaD">Professores de <marker>EAD</marker> têm várias dificuldades.</example>
         </rule>
 
+        <rule id="EMAIL_SEM_HIFEN_ORTHOGRAPHY" name="Corrigir email para e-mail">
+            <!-- p-goulart@2024-02-27 - DESC: the _ORTHOGRAPHY suffix is to get a red underline -->
+            <pattern>
+                <token regexp="yes">emails?</token>
+            </pattern>
+            <message>A palavra <suggestion><match no="1" regexp_match="(?i)email(s)?" regexp_replace="e-mail$1"/></suggestion> se escreve com hífen.</message>
+            <example correction="e-mail">Ele me enviou outro <marker>email</marker>.</example>
+            <example correction="e-mails">Não vejo <marker>emails</marker> novos.</example>
+            <example correction="E-mail"><marker>Email</marker>: foo@bar.com</example>
+        </rule>
+
         <rulegroup id="DIACRITICS" name="Confusão com diacríticos">
             <!--      Created by Jaume Ortolà, Portuguese rule 2021-01-08      -->
             <!--


### PR DESCRIPTION
For `email`, I'm just adding a very specific grammar rule specifically telling people to add a hyphen there, since our suggestions were maybe getting in the way:

<img width="431" alt="Screenshot 2024-02-27 at 5 58 05 PM" src="https://github.com/languagetool-org/languagetool/assets/50704700/863774e8-7f5f-4484-a932-317b717fefe7">

Since this is the most frequent addition, maybe it's worth being very explicit..?

---

For `stories`, I assume that's the Instagram thing... I think we should just support it. Adding it here as a hotfix since it's in our top 10 for the past month.

---

For `EAD`, I'm not adding speller support, since it is wrong, but I am adding a super simple grammar rule to suggest `EaD` when specifically referring to 'ensino a distância`, which has higher priority than the speller.

---

<img width="937" alt="Screenshot 2024-02-27 at 5 36 29 PM" src="https://github.com/languagetool-org/languagetool/assets/50704700/ba607272-0631-4852-971d-d4443056662f">
