### PR TITLE
[en] improve EN_A_VS_AN

### DIFF
--- a/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/AvsAnRule.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/rules/en/AvsAnRule.java
@@ -95,6 +95,11 @@ public class AvsAnRule extends Rule {
       }
       if (equalsA || equalsAn) {
         Determiner determiner = getCorrectDeterminerFor(token);
+        if (token.getToken().equals("EUR") && i < tokens.length - 1) {
+          determiner = getCorrectDeterminerFor(tokens[i + 1]);
+        } else if (token.getToken().equals("EUR") && i == tokens.length - 1) {
+          determiner = Determiner.A;
+        }
         String msg = null;
         if (equalsA && determiner == Determiner.AN) {
           String replacement = StringTools.startsWithUppercase(prevTokenStr) ? "An" : "an";

--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_a.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/det_a.txt
@@ -3,6 +3,7 @@
 # line starts with '*').
 # Add words that allow both 'a' and 'an' to det_a.txt and det_an.txt.
 # Also see: http://www.learnenglish.org.uk/grammar/archive/articles_pronunciation.html
+100
 Eucharistic
 eukaryote
 eukaryotic

--- a/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/AvsAnRuleTest.java
+++ b/languagetool-language-modules/en/src/test/java/org/languagetool/rules/en/AvsAnRuleTest.java
@@ -44,6 +44,8 @@ public class AvsAnRuleTest {
   public void testRule() throws IOException {
 
     // correct sentences:
+    assertCorrect("The company has also entered into a EUR 100 million ($88 million) debt");
+    assertCorrect("The company has also entered into an EUR 80 million debt");
     assertCorrect("Import an Xcode project.");
     assertCorrect("This is a oncer.");
     assertCorrect("She was a Oaxacan chef.");
@@ -73,6 +75,8 @@ public class AvsAnRuleTest {
     assertCorrect("He also wrote the comic strips Abbie an' Slats.");
 
     // errors:
+    assertIncorrect("The company has also entered into an EUR 100 million ($88 million) debt");
+    assertIncorrect("The company has also entered into a EUR 80 million debt");
     assertIncorrect("It was a hour ago.");
     assertIncorrect("It was an sentence that's long.");
     assertIncorrect("It was a uninteresting talk.");


### PR DESCRIPTION
If "a" or "an" is followed by "EUR", look to the _next token_ to determine the correct determiner.
I needed to add "100" to `det_a.txt` to make the 3rd example work:
`assertIncorrect("The company has also entered into an EUR 100 million ($88 million) debt");`

Not sure why I had to do this, but I do notice that:
>The company has also entered into an 100 million USD debt

is not caught by this particular rule either.
Maybe there's a blind spot with certain digits.