### PR TITLE
[fr] Removal Académie Française

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/resource/spelling_global.txt
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/spelling_global.txt
@@ -22212,7 +22212,6 @@ Smithsonian Institution
 Accademia della Crusca
 The British Library
 Real Academia Española
-Académie Française
 Académie française
 Alliance Française
 Alliance française


### PR DESCRIPTION
The Académie themselves defined howwe should spell their name, and considering their pickyness, we should not accept or suggest the version with Française capitalized. 
See the corresponding point in https://www.academie-francaise.fr/questions-de-langue#48_strong-em-majuscules-em-strong

> 3. Majuscules dans les noms d’organismes et d’institutions,
> 
> Les noms des organismes (organismes d’État, organismes culturels et éducatifs, etc.), lorsqu’il en existe plusieurs de leur espèce, ne prennent pas de majuscule ; c’est le nom propre ou le nom de spécialisation qui les accompagne éventuellement qui la prend : le conseil général d’Île-de-France, la cour d’appel de Versailles, la mairie de Paris, l’académie de Toulouse, le ministère de la Culture, le lycée Fénelon, la bibliothèque Mazarine. Le musée Rodin, le musée des Arts décoratifs (mais, seulement suivi d’un adjectif non dérivé d’un nom propre : le Musée océanographique, le Musée postal).
> 
> En revanche, s’ils sont seuls de leur espèce (à l’échelle nationale ou internationale), le premier mot nécessaire à l’identification porte la majuscule, ainsi que les adjectifs le précédant éventuellement : l’Académie française, l’Institut de France, la Bibliothèque nationale, la Cour de cassation, la Haute Cour de justice, le Conseil de l’Europe, les Nations unies, la Croix-Rouge, l’École polytechnique, l’École normale supérieure…