### PR TITLE
[pt] Use new POS tagging schema

### DIFF
--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseEnclisisFilter.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseEnclisisFilter.java
@@ -1,0 +1,56 @@
+package org.languagetool.rules.pt;
+
+import org.languagetool.AnalyzedToken;
+import org.languagetool.AnalyzedTokenReadings;
+import org.languagetool.rules.RuleMatch;
+import org.languagetool.rules.patterns.RuleFilter;
+import org.languagetool.synthesis.pt.PortugueseSynthesizer;
+import org.languagetool.tools.StringTools;
+
+import java.io.IOException;
+import java.util.*;
+
+public class PortugueseEnclisisFilter extends RuleFilter {
+  protected PortugueseSynthesizer getSynthesizer() {
+    return PortugueseSynthesizer.INSTANCE;
+  }
+
+  @Override
+  public RuleMatch acceptRuleMatch(RuleMatch match, Map<String, String> arguments, int patternTokenPos,
+                                   AnalyzedTokenReadings[] patternTokens, List<Integer> tokenPositions) throws IOException {
+    AnalyzedTokenReadings verbStemTokenReadings = patternTokens[0];
+    AnalyzedTokenReadings pronounTokenReadings = patternTokens[2];
+    String pronounTag = null;
+    for (AnalyzedToken at : pronounTokenReadings.getReadings()) {
+      String posTag = at.getPOSTag();
+      if (posTag != null && posTag.startsWith("PP")) {
+        pronounTag = posTag;
+        break;
+      }
+    }
+    if (pronounTag == null) {
+      return null;
+    }
+    List<String> suggestions = new ArrayList<>(Collections.emptyList());
+    boolean isTitleCase = StringTools.startsWithUppercase(verbStemTokenReadings.getToken());
+    boolean isAllCaps = StringTools.isAllUppercase(verbStemTokenReadings.getToken());
+    for (AnalyzedToken at : verbStemTokenReadings.getReadings()) {
+      String posTag = at.getPOSTag();
+      if (posTag != null && posTag.startsWith("V")) {
+        String enclisisTag = posTag + ":" + pronounTag;
+        String[] forms = getSynthesizer().synthesize(at, enclisisTag);
+        for (String form : forms) {
+          if (isTitleCase) {
+            form = StringTools.uppercaseFirstChar(form);
+          } else if (isAllCaps) {
+            form = form.toUpperCase();
+          }
+          suggestions.add(form);
+        }
+        break;
+      }
+    }
+    match.setSuggestedReplacements(suggestions);
+    return match;
+  }
+}

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseProclisisFilter.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseProclisisFilter.java
@@ -1,0 +1,69 @@
+package org.languagetool.rules.pt;
+
+import org.languagetool.AnalyzedToken;
+import org.languagetool.AnalyzedTokenReadings;
+import org.languagetool.rules.RuleMatch;
+import org.languagetool.rules.patterns.RuleFilter;
+import org.languagetool.synthesis.pt.PortugueseSynthesizer;
+import org.languagetool.tools.StringTools;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.function.Predicate;
+
+public class PortugueseProclisisFilter extends RuleFilter {
+  protected PortugueseSynthesizer getSynthesizer() {
+    return PortugueseSynthesizer.INSTANCE;
+  }
+
+  @Override
+  public RuleMatch acceptRuleMatch(RuleMatch match, Map<String, String> arguments, int patternTokenPos,
+                                   AnalyzedTokenReadings[] patternTokens, List<Integer> tokenPositions) throws IOException {
+    AnalyzedTokenReadings encliticVerbTokenReadings = patternTokens[patternTokens.length - 1];
+    HashSet<String> suggestions = new HashSet<>(Collections.emptyList());
+    for (AnalyzedToken at : encliticVerbTokenReadings.getReadings()) {
+      String posTag = at.getPOSTag();
+      String oldToken = at.getToken();
+      assert posTag != null;
+      String[] tagParts = posTag.split(":");
+      String verbTag = tagParts[0];
+      String newVerb = getSynthesizer().synthesize(at, verbTag)[0];
+      String[] oldTokenParts = oldToken.split("-");
+      // Includes only the relevant part of the verb; i.e. for mesoclitics, we ignore the ending
+      String oldVerb = oldTokenParts[0];
+      String oldPronoun = oldTokenParts[1];
+      List<String> newPronounForms = new ArrayList<>(Collections.emptyList());
+      switch (oldPronoun) {
+        case "lo":
+        case "no":
+          newPronounForms.add("o");
+          break;
+        case "la":
+        case "na":
+          newPronounForms.add("a");
+          break;
+        case "los":
+          newPronounForms.add("os");
+          break;
+        case "las":
+        case "nas":
+          newPronounForms.add("as");
+          break;
+        case "nos":
+          newPronounForms.add("nos");
+          if (oldVerb.endsWith("m") || oldVerb.endsWith("ão") || oldVerb.endsWith("õe")) {
+            newPronounForms.add("os");
+          }
+          break;
+        default:
+          newPronounForms.add(oldPronoun);
+      }
+      for (String newPronoun : newPronounForms) {
+        String suggestion = newPronoun + " " + newVerb;
+        suggestions.add(suggestion);
+      }
+    }
+    match.setSuggestedReplacements(new ArrayList<>(suggestions));
+    return match;
+  }
+}

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizer.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizer.java
@@ -86,7 +86,7 @@ public class PortugueseWordTokenizer extends WordTokenizer {
   // - ©®™
   // - # (hashtags)
   // This leads to some inconsistencies, e.g. '@user' is tokenised as '@user', but '#hashtag' as '#' + 'hashtag'.
-  private final String wordCharsLeftEdge = "§@€£\\$¢¥¤";
+  private final String wordCharsLeftEdge = "@€£\\$¢¥¤";
   private final String wordCharsRightEdge = "€£\\$%‰‱ºªᵃᵒˢ";
   private final Pattern wordPattern = compile(
     "[" + wordCharsLeftEdge + "]?[" + wordChars + "]+[" + wordCharsRightEdge + "]?|" +

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizer.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizer.java
@@ -86,7 +86,7 @@ public class PortugueseWordTokenizer extends WordTokenizer {
   // - ©®™
   // - # (hashtags)
   // This leads to some inconsistencies, e.g. '@user' is tokenised as '@user', but '#hashtag' as '#' + 'hashtag'.
-  private final String wordCharsLeftEdge = "@€£\\$¢¥¤";
+  private final String wordCharsLeftEdge = "−@€£\\$¢¥¤";
   private final String wordCharsRightEdge = "€£\\$%‰‱ºªᵃᵒˢ";
   private final Pattern wordPattern = compile(
     "[" + wordCharsLeftEdge + "]?[" + wordChars + "]+[" + wordCharsRightEdge + "]?|" +

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizer.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizer.java
@@ -80,7 +80,7 @@ public class PortugueseWordTokenizer extends WordTokenizer {
   // \u2070-\u209F is the range of superscript characters
   // The degree sign is included in the word characters, as it is used in temperatures and angles, and can appear
   // in the middle of a token, e.g. "30°C".
-  private final String wordChars = "°\\-\\p{L}\\d\\u0300-\\u036F\\u00A8\\u2070-\\u209F" + DECIMAL_COMMA_SUBST +
+  private final String wordChars = "°\\^\\-\\p{L}\\d\\u0300-\\u036F\\u00A8\\u2070-\\u209F" + DECIMAL_COMMA_SUBST +
     NON_BREAKING_DOT_SUBST + NON_BREAKING_COLON_SUBST + NON_BREAKING_SPACE_SUBST + HYPHEN_SUBST;
   // The following characters might be included at some point, but, to preserve the current behaviour, they aren't:
   // - ©®™

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3687,4 +3687,15 @@
           <disambig action="ignore_spelling"/>
       </rule>
   </rulegroup>
+
+  <rulegroup id="VERBS_WITH_CLITICS" name="Ignore spelling issues in verbs tagged with clitics">
+      <rule>
+          <!-- p-goulart@2024-03-07 - DESC: all tags that contain verbs *and* pronouns come from our tagger and need to be accepted...
+          the only exception being -ámos verbs in pt-BR, but I feel like this is a super edge case...-->
+          <pattern>
+              <token postag_regexp="yes" postag="V.+:P.+"/>
+          </pattern>
+          <disambig action="ignore_spelling"/>
+      </rule>
+  </rulegroup>
 </rules>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3688,14 +3688,14 @@
       </rule>
   </rulegroup>
 
-  <rulegroup id="VERBS_WITH_CLITICS" name="Ignore spelling issues in verbs tagged with clitics">
-      <rule>
           <!-- p-goulart@2024-03-07 - DESC: all tags that contain verbs *and* pronouns come from our tagger and need to be accepted...
           the only exception being -ámos verbs in pt-BR, but I feel like this is a super edge case...-->
-          <pattern>
-              <token postag_regexp="yes" postag="V.+:P.+"/>
-          </pattern>
-          <disambig action="ignore_spelling"/>
-      </rule>
-  </rulegroup>
+  <!-- <rulegroup id="VERBS_WITH_CLITICS" name="Ignore spelling issues in verbs tagged with clitics"> -->
+      <!-- <rule> -->
+      <!--     <pattern> -->
+      <!--         <token postag_regexp="yes" postag="V.+:P.+"/> -->
+      <!--     </pattern> -->
+      <!--     <disambig action="ignore_spelling"/> -->
+      <!-- </rule> -->
+  <!-- </rulegroup> -->
 </rules>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3677,6 +3677,17 @@
       </rule>
   </rulegroup>
 
+  <rulegroup id="COMPRAZER_VERB" name="Remove comprazer lemma from 'comprá-la'">
+      <rule>
+          <pattern>
+              <marker>
+                  <token regexp="yes">comprá-l[oa]s?</token>
+              </marker>
+          </pattern>
+          <disambig action="remove"><wd lemma="comprazer"/></disambig>
+      </rule>
+  </rulegroup>
+
   <rulegroup id="NATIONAL_PREFIXES" name="Ignore spelling in tagged words with national prefixes">
       <rule>
           <pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -340,18 +340,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <rule id="ELISAO_VERBAL_SEM_ENCLITICO">
                 <antipattern>
                     <token postag="_QUOT"/>
-                    <token regexp="yes">.+mo$.+[áê]$</token>
+                    <token postag_regexp="yes" postag="V.+X"/>
                     <token postag="_QUOT"/>
                     <example>Outra tradição culinária é a “ligada” ou "ligá”</example>
                 </antipattern>
                 <antipattern>
                     <token>-</token>
-                    <token spacebefore="no" regexp="yes">.+mo$.+[áê]$</token>
+                    <token spacebefore="no" postag_regexp="yes" postag="V.+X"/>
                     <example>castenheira-do-pará.</example>
                 </antipattern>
                 <pattern>
                     <marker>
-                        <token regexp="yes">.+mo$.+[áê]$
+                        <token postag_regexp="yes" postag="V.+X">
+                            <exception negate_pos="yes" postag_regexp="yes" postag="V.+X"/>
                             <exception regexp="yes">\p{Lu}*|arraiá|avi|mangá|zumbi|abadá|atê|di|bumbá</exception>
                             <!--TODO: create confusion pair rule for atê vs. até-->
                         </token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -340,19 +340,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <rule id="ELISAO_VERBAL_SEM_ENCLITICO">
                 <antipattern>
                     <token postag="_QUOT"/>
-                    <token postag_regexp="yes" postag="V.+X"/>
+                    <token regexp="yes">.+mo$.+[áê]$</token>
                     <token postag="_QUOT"/>
                     <example>Outra tradição culinária é a “ligada” ou "ligá”</example>
                 </antipattern>
                 <antipattern>
                     <token>-</token>
-                    <token spacebefore="no" postag_regexp="yes" postag="V.+X"/>
+                    <token spacebefore="no" regexp="yes">.+mo$.+[áê]$</token>
                     <example>castenheira-do-pará.</example>
                 </antipattern>
                 <pattern>
                     <marker>
-                        <token postag_regexp="yes" postag="V.+X">
-                            <exception negate_pos="yes" postag_regexp="yes" postag="V.+X"/>
+                        <token regexp="yes">.+mo$.+[áê]$
                             <exception regexp="yes">\p{Lu}*|arraiá|avi|mangá|zumbi|abadá|atê|di|bumbá</exception>
                             <!--TODO: create confusion pair rule for atê vs. até-->
                         </token>
@@ -374,9 +373,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <rule id="ELISAO_VERBAL_COM_ENCLITICO_INCORRETO_1PL">
                 <pattern>
                     <marker>
-                        <token postag_regexp="yes" postag="V...1P.X" regexp="yes">.+mo$
-                            <exception negate_pos="yes" postag_regexp="yes" postag="V.+X"/>
-                        </token>
+                        <token regexp="yes">.+mo$</token>
                     </marker>
                     <token spacebefore="no">-</token>
                     <token regexp="yes" spacebefore="no">(te|vos|lhes?)</token>
@@ -389,9 +386,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <!-- Specifically skip 'parti-lo' because of valid 'parti-o', Portuguese is DIFFICULT -->
                 <pattern>
                     <marker>
-                        <token postag="VMN0000X" regexp="yes">.+[áê]$
-                            <exception negate_pos="yes" postag_regexp="yes" postag="V.+X"/>
-                        </token>
+                        <token regexp="yes">.+[áê]$</token>
                     </marker>
                     <token spacebefore="no">-</token>
                     <token regexp="yes" spacebefore="no">([smt]e|[nv]os|lhes?)</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -336,67 +336,68 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <rulegroup id="ELISAO_VERBAL_DESNECESSARIA" type="grammar" name="Formas verbais com elisão usadas no contexto incorreto.">
-            <rule id="ELISAO_VERBAL_SEM_ENCLITICO">
-                <antipattern>
-                    <token postag="_QUOT"/>
-                    <token postag_regexp="yes" postag="V.+X"/>
-                    <token postag="_QUOT"/>
-                    <example>Outra tradição culinária é a “ligada” ou "ligá”</example>
-                </antipattern>
-                <antipattern>
-                    <token>-</token>
-                    <token spacebefore="no" postag_regexp="yes" postag="V.+X"/>
-                    <example>castenheira-do-pará.</example>
-                </antipattern>
-                <pattern>
-                    <marker>
-                        <token postag_regexp="yes" postag="V.+X">
-                            <exception negate_pos="yes" postag_regexp="yes" postag="V.+X"/>
-                            <exception regexp="yes">\p{Lu}*|arraiá|avi|mangá|zumbi|abadá|atê|di|bumbá</exception>
-                            <!--TODO: create confusion pair rule for atê vs. até-->
-                        </token>
-                    </marker>
-                    <token negate="yes" regexp="yes">-|–|[ln][oa]s?</token>
-                    <!--TODO: create rule to fix wrong use of en dash for verbs-->
-                    <!--TODO: fix missing hyphen before pronouns-->
-                </pattern>
-                <message>Só se faz elisão da consoante final de verbos antes de alguns pronomes enclíticos.</message>
-                <suggestion><match no="1" postag_regexp="yes" postag="(V.+)X" postag_replace="$1"/></suggestion>
-                <example correction="compramos">Ontem <marker>compramo</marker> três ingressos.</example>
-                <example correction="Vamos"><marker>Vamo</marker> embora.</example>
-                <example correction="fazer">O que você quer <marker>fazê</marker>?</example>
-                <example>O bebê acordou.</example>
-                <example>Com bolsa de bebê, guardanapo, e bolinho caso ela chore?</example>
-                <example>terá de cumprir a promessa e beijá –lo.</example>
-            </rule>
-
-            <rule id="ELISAO_VERBAL_COM_ENCLITICO_INCORRETO_1PL">
-                <pattern>
-                    <marker>
-                        <token regexp="yes">.+mo$</token>
-                    </marker>
-                    <token spacebefore="no">-</token>
-                    <token regexp="yes" spacebefore="no">(te|vos|lhes?)</token>
-                </pattern>
-                <message>Antes do pronome átono &quot;\3&quot; não se faz elisão da forma verbal <suggestion><match no="1" postag_regexp="yes" postag="(V.+)X" postag_replace="$1"/></suggestion></message>
-                <example correction="Amamos"><marker>Amamo</marker>-te muito.</example>
-            </rule>
-
-            <rule id="ELISAO_VERBAL_COM_ENCLITICO_INCORRETO_INF">
-                <!-- Specifically skip 'parti-lo' because of valid 'parti-o', Portuguese is DIFFICULT -->
-                <pattern>
-                    <marker>
-                        <token regexp="yes">.+[áê]$</token>
-                    </marker>
-                    <token spacebefore="no">-</token>
-                    <token regexp="yes" spacebefore="no">([smt]e|[nv]os|lhes?)</token>
-                </pattern>
-                <message>Antes do pronome átono &quot;\3&quot; não se faz elisão da forma verbal <suggestion><match no="1" postag_regexp="yes" postag="(V.+)X" postag_replace="$1"/></suggestion></message>
-                <example correction="Amar"><marker>Amá</marker>-te é difícil.</example>
-                <example correction="conhecer">Quero <marker>conhecê</marker>-nos há tempo.</example>
-            </rule>
-        </rulegroup>
+            <!-- p-goulart@2024-03-27 - DESC: disable as of dict v0.13 -->
+       <!--  <rulegroup id="ELISAO_VERBAL_DESNECESSARIA" type="grammar" name="Formas verbais com elisão usadas no contexto incorreto." default="off"> -->
+            <!-- <rule id="ELISAO_VERBAL_SEM_ENCLITICO"> -->
+            <!--     <antipattern> -->
+            <!--         <token postag="_QUOT"/> -->
+            <!--         <token postag_regexp="yes" postag="V.+X"/> -->
+            <!--         <token postag="_QUOT"/> -->
+            <!--         <example>Outra tradição culinária é a “ligada” ou "ligá”</example> -->
+            <!--     </antipattern> -->
+            <!--     <antipattern> -->
+            <!--         <token>-</token> -->
+            <!--         <token spacebefore="no" postag_regexp="yes" postag="V.+X"/> -->
+            <!--         <example>castenheira-do-pará.</example> -->
+            <!--     </antipattern> -->
+            <!--     <pattern> -->
+            <!--         <marker> -->
+            <!--             <token postag_regexp="yes" postag="V.+X"> -->
+            <!--                 <exception negate_pos="yes" postag_regexp="yes" postag="V.+X"/> -->
+            <!--                 <exception regexp="yes">\p{Lu}*|arraiá|avi|mangá|zumbi|abadá|atê|di|bumbá</exception> -->
+            <!--                 [>TODO: create confusion pair rule for atê vs. até<] -->
+            <!--             </token> -->
+            <!--         </marker> -->
+            <!--         <token negate="yes" regexp="yes">-|–|[ln][oa]s?</token> -->
+            <!--         [>TODO: create rule to fix wrong use of en dash for verbs<] -->
+            <!--         [>TODO: fix missing hyphen before pronouns<] -->
+            <!--     </pattern> -->
+            <!--     <message>Só se faz elisão da consoante final de verbos antes de alguns pronomes enclíticos.</message> -->
+            <!--     <suggestion><match no="1" postag_regexp="yes" postag="(V.+)X" postag_replace="$1"/></suggestion> -->
+            <!--     <example correction="compramos">Ontem <marker>compramo</marker> três ingressos.</example> -->
+            <!--     <example correction="Vamos"><marker>Vamo</marker> embora.</example> -->
+            <!--     <example correction="fazer">O que você quer <marker>fazê</marker>?</example> -->
+            <!--     <example>O bebê acordou.</example> -->
+            <!--     <example>Com bolsa de bebê, guardanapo, e bolinho caso ela chore?</example> -->
+            <!--     <example>terá de cumprir a promessa e beijá –lo.</example> -->
+            <!-- </rule> -->
+            <!--  -->
+            <!-- <rule id="ELISAO_VERBAL_COM_ENCLITICO_INCORRETO_1PL"> -->
+            <!--     <pattern> -->
+            <!--         <marker> -->
+            <!--             <token regexp="yes">.+mo$</token> -->
+            <!--         </marker> -->
+            <!--         <token spacebefore="no">-</token> -->
+            <!--         <token regexp="yes" spacebefore="no">(te|vos|lhes?)</token> -->
+            <!--     </pattern> -->
+            <!--     <message>Antes do pronome átono &quot;\3&quot; não se faz elisão da forma verbal <suggestion><match no="1" regexp_match="(.+)" regexp_replace="$1s"/></suggestion></message> -->
+            <!--     <example correction="Amamos"><marker>Amamo</marker>-te muito.</example> -->
+            <!-- </rule> -->
+            <!--  -->
+            <!-- <rule id="ELISAO_VERBAL_COM_ENCLITICO_INCORRETO_INF"> -->
+            <!--     [> Specifically skip 'parti-lo' because of valid 'parti-o', Portuguese is DIFFICULT <] -->
+            <!--     <pattern> -->
+            <!--         <marker> -->
+            <!--             <token regexp="yes">.+[áê]$</token> -->
+            <!--         </marker> -->
+            <!--         <token spacebefore="no">-</token> -->
+            <!--         <token regexp="yes" spacebefore="no">([smt]e|[nv]os|lhes?)</token> -->
+            <!--     </pattern> -->
+            <!--     <message>Antes do pronome átono &quot;\3&quot; não se faz elisão da forma verbal <suggestion><match no="1" postag_regexp="yes" postag="(V.+)X" postag_replace="$1"/></suggestion></message> -->
+            <!--     <example correction="Amar"><marker>Amá</marker>-te é difícil.</example> -->
+            <!--     <example correction="conhecer">Quero <marker>conhecê</marker>-nos há tempo.</example> -->
+            <!-- </rule> -->
+        <!-- </rulegroup> -->
 
         <rulegroup id="MELHOR_EDUCADO" name="Melhor educado -> mais bem-educado">
             <rule>
@@ -823,34 +824,30 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="desde essa">Isso acontece <marker>des dessa</marker> época.</example>
         </rule>
 
-        <!-- ESCREVE-LO escrevê-lo -->
         <rule id='ACENTUAÇÃO_VOGAL_ÊNCLISE' name="Acentuação vogal ênclise">
-            <!--      Created by Marco A.G.Pinto and Jaume Ortolà with Ricardo Joseh Lima suggestions, Portuguese rule 2022-04-05 (1-JAN-2022+)      -->
-            <!--
-      Quero escreve-lo amanhã. → Quero escrevê-lo amanhã.
-      -->
+            <antipattern>
+                <token>tu</token>
+                <token postag_regexp="yes" postag="R." min="0" max="2"/>
+                <token postag='VMIP2S0:PP3..A00' postag_regexp='yes' regexp="yes">.+-l[oa]s?</token>
+                <example>Tu canta-la bem.</example>
+            </antipattern>
+            <!-- p-goulart@2024-03-27 - DESC: this rule technically matches correct forms such as "canta-la", but they're rare enough in pt-BR that we can be certain "cantá-la" is meant -->
             <pattern>
                 <marker>
-                    <token postag='VMIP3S0|VMM02S0' postag_regexp='yes'>
-                        <exception regexp='yes'>.*[àáãâèéêìíîòóõôùúû]</exception>
-                    </token>
+                    <token postag='VMIP2S0:PP3..A00' postag_regexp='yes' regexp="yes">.+-l[oa]s?</token>
                 </marker>
-                <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                <token regexp='yes' spacebefore='no'>l[ao]s?</token>
             </pattern>
-            <message>Quando a ênclise é formada por 'la', 'las', 'lo' ou 'los', a vogal que a precede, antes do hífen, é acentuada</message>
-            <suggestion><match no="1" postag="(VMIP3S0|VMM02S0)" postag_regexp="yes" postag_replace="V.N....X"/></suggestion>
-            <example correction="escrevê">Ele vai <marker>escreve</marker>-lo amanhã.</example>
-            <example correction="puxá">O ímpeto de <marker>puxa</marker>-las.</example>
+            <message>Possível erro de acentuação.</message>
+            <suggestion><match no="1" postag="VMIP2S0:(PP.+)" postag_regexp="yes" postag_replace="VMN0000:$1"/></suggestion>
+            <example correction="escrevê-lo">Ele vai <marker>escreve-lo</marker> amanhã.</example>
+            <example correction="puxá-las">O ímpeto de <marker>puxa-las</marker>.</example>
         </rule>
 
 
         <rulegroup id='AUXILIARY_VERB_INFINITIVE' name="Erro de concordância: Verbo auxiliar + verbo no infinitivo">
             <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/o-conceito-de-verbo-auxiliar/24055</url>
             <antipattern>
-                <token regexp="yes">.+mo$.+[áê]$</token>
-                <token spacebefore='no' regexp='yes'>&hifen;</token>
-                <token spacebefore='no' regexp='yes'>&pronomes_nao_ambiguos;|&pronomes_ambiguos;</token>
+                <token postag_regexp="yes" postag="V(MN0000|MN0[13]S0|...1P0|.SF[13]S0):PP.+"/>
             </antipattern>
             <antipattern>
                 <token>há</token>
@@ -923,10 +920,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <example>Os que já vieram estão no salão.</example>
                 </antipattern>
                 <antipattern>
-                    <token postag='VMIP[13]S0|VMM02S0|VMII.S.+' postag_regexp='yes'/>
-                    <token min="0" max="1" regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                    <token min="0" max="1" regexp='yes'>l[ao]s?|lh[aeo]s?|n[ao]s?|me|se|te|vos</token>
-                    <example>Quando poderei revê-lo?</example>
+                    <token postag='VMIP2S0:PP3..A00' postag_regexp='yes' regexp="yes">.+-l[oa]s?</token>
                 </antipattern>
                 <antipattern>
                     <token postag='VMG0000'/>
@@ -1011,9 +1005,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
             <rule>
                 <antipattern>
-                    <token postag='VMIP[13]S0|VMM02S0|VMII.S.+' postag_regexp='yes'/>
-                    <token min="0" max="1" regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                    <token min="0" max="1" regexp='yes'>l[ao]s?|lh[aeo]s?|n[ao]s?|me|se|te|vos</token>
+                    <token postag='VMIP2S0:PP3..A00' postag_regexp='yes' regexp="yes">.+-l[oa]s?</token>
                 </antipattern>
                 <antipattern>
                     <token postag='VMG0000'/>
@@ -1023,11 +1015,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <token inflected="yes" regexp='yes'>&verbos_auxiliares_aspectuais;|&verbos_auxiliares_modais;
                         <exception inflected='yes'>ser</exception>
                         <exception negate_pos='yes' postag_regexp="yes" postag="V.+"/>
-                        <!--exception regexp='yes'>quer|fora</exception--></token>
+                        <!--exception regexp='yes'>quer|fora</exception-->
+                    </token>
                     <token regexp='yes'>de|a</token>
                     <token postag="V.+" postag_regexp='yes'>
                         <exception postag="VMN0000"/>
-                        <exception negate_pos='yes' postag_regexp="yes" postag="V.+"/></token>
+                        <exception negate_pos='yes' postag_regexp="yes" postag="V.+"/>
+                    </token>
                 </pattern>
                 <message>Verbos auxiliares devem ser seguidos de formas verbais no infinitivo ou no gerúndio. Se esse não é o caso, verifique se está faltando uma vírgula entre os dois verbos.</message>
                 <suggestion>\1 \2 <match no='3' postag='VMN0000'/></suggestion>
@@ -10914,16 +10908,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <rule> <!-- #18: precisam-se -->
                 <pattern>
                     <marker>
-                        <and>
-                            <token inflected='yes' regexp="yes">precisar|tratar</token>
-                            <token postag='VMIP3P0:PP3CNO00'/>
-                        </and>
+                        <token inflected='yes' regexp="yes" postag_regexp="yes" postag="V...3P0:PP3CNO00">precisar|tratar</token>
                     </marker>
                     <token>de</token>
                     <token postag='AQ..P.+|NC.P.+|[AD]...P.+|Z..P.+' postag_regexp='yes'/>
                 </pattern>
                 <message>Os verbos 'precisar'/'tratar' seguidos de '-se' não podem estar no plural devido à preposição 'de':</message>
-                <suggestion><match no='1' postag='VMIP3P0:PP3CNO00' postag_replace='VMIP3S0:PP3CNO00'/></suggestion>
+                <suggestion><match no='1' postag='(V...)3P0:PP3CNO00' postag_regexp="yes" postag_replace='$13S0:PP3CNO00'/></suggestion>
                 <example correction="Precisa-se"><marker>Precisam-se</marker> de trabalhadores.</example>
                 <example correction="Trata-se"><marker>Tratam-se</marker> de pessoas estudiosas.</example>
             </rule>
@@ -11196,7 +11187,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <token negate_pos="yes" postag='AQ0.P.+|NC.P.+|V....P.+|V...2S.+' postag_regexp='yes'/>
                 </pattern>
                 <message>De acordo com a gramática tradicional, o verbo permanece no singular, visto que o 'sujeito' está preposicionado.</message>
-                <suggestion><match no='6' postag='V.(..)3P(.+)' postag_regexp="yes" postag_replace='VM$13S$2'/>-se</suggestion>
+                <suggestion><match no='6' postag='V.(..)3P(.+)' postag_regexp="yes" postag_replace='VM$13S$2'/></suggestion>
                 <example correction="mostra-se">A realidade das pessoas <marker>mostram-se</marker>.</example>
                 <example>Uma variedade de pessoas juntou-se na reunião.</example>
                 <example>Grande parte destas crateras localiza-se no hemisfério sul.</example>
@@ -11430,7 +11421,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <token postag='[DP][ADIPR]..P.+|SPS00:[DP][ADIPR]..P.+' postag_regexp='yes'/>
                 <token min="1" max="2" postag='AQ..P.+|NC.P.+|NP.P.+' postag_regexp='yes'/>
                 <token min="0" max="1" postag='_PUNCT' postag_regexp='no'/>
-                <token postag='VMI.3S0:PP3CNO00' postag_regexp='yes'/>
+                <token postag='VMI.3P0:PP3CNO00' postag_regexp='yes'/>
                 <token postag='AQ..S.+|NC.S.+|NP.S.+' postag_regexp='yes'/>
                 <example>Suas predições tornaram-se realidade.</example>
                 <example>Seus sonhos tornaram-se realidade.</example>
@@ -11442,7 +11433,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <token postag='CC' postag_regexp='no'/>
                 <token min="1" max="2" postag='AQ.+|NC.+|NP.+' postag_regexp='yes'/>
                 <token min="0" max="1" postag='_PUNCT' postag_regexp='no'/>
-                <token postag='VMI.3S0:PP3CNO00' postag_regexp='yes'/>
+                <token postag='VMI.3P0:PP3CNO00' postag_regexp='yes'/>
                 <token min="1" max="2" postag='[DP][ADIPR]..S.+|SPS00:[DP][ADIPR]..S.+' postag_regexp='yes'/>
                 <token postag='AQ..S.+|NC.S.+|NP.S.+|_PUNCT' postag_regexp='yes'/>
                 <example>Pão, café e tabaco tornaram-se sua dieta padrão.</example>
@@ -11450,7 +11441,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </antipattern>
             <antipattern>
                 <token postag='_PUNCT' postag_regexp='no'/>
-                <token postag='VMI.3S0:PP3CNO00' postag_regexp='yes'>entender|ler</token>
+                <token postag='VM[MS]P3S0:PP3CNO00' postag_regexp='yes' inflected='yes' regexp="yes">entender|ler</token>
                 <token postag='AQ.+|NC.+|NP.+' postag_regexp='yes'/>
                 <token postag='CC' postag_regexp='no'/>
                 <token postag='AQ.+|NC.+|NP.+' postag_regexp='yes'/>
@@ -11463,7 +11454,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <token postag_regexp='yes' postag='(?:N..|A...)P.+'/>
                 </antipattern>
                 <antipattern>
-                    <token postag='VMI.VMIP3S0:PP3CNO00|VMM02S0:PP3CNO00' postag_regexp='yes'/>
+                    <token postag='VMIP3S0:PP3CNO00|VMM02S0:PP3CNO00' postag_regexp='yes'/>
                     <token postag='CS|RG' postag_regexp='yes'/>
                 </antipattern>
                 <pattern>
@@ -11477,7 +11468,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                         <exception negate_pos='yes' postag_regexp='yes' postag='(?:N..|A...)P.+'/></token>
                 </pattern>
                 <message>Possível erro de concordância.</message>
-                <suggestion><match no='1' postag='(V....)S(.+)' include_skipped='all' postag_replace='$1P$2' postag_regexp='yes'/>\2\3 <match no='4' include_skipped='all'/> <match no='5' include_skipped='all'/> <match no='6' include_skipped='all'/></suggestion>
+                <suggestion><match no='1' postag='(V....)S(.+)' include_skipped='all' postag_replace='$1P$2' postag_regexp='yes'/> <match no='2' include_skipped='all'/> <match no='3' include_skipped='all'/> <match no='4' include_skipped='all'/></suggestion>
                 <example correction='juntaram-se os amigos'>A ele <marker>juntou-se os amigos</marker> e família.</example>
                 <example correction='juntaram-se muitos bons amigos'>A ele <marker>juntou-se muitos bons amigos</marker> e família.</example>
                 <example>…leia-se superstições…</example>
@@ -11491,22 +11482,24 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <rule>
                 <pattern>
                     <marker>
-                        <token postag_regexp='yes' postag='V....P.+'>
+                        <token postag_regexp='yes' postag='V....P0:PP3CNO00'>
                             <exception inflected='yes'>concentrar</exception>
-                            <exception negate_pos='yes' postag_regexp='yes' postag='V....P.+'/></token>
-                        <token regexp='yes' spacebefore='no'>&hifen;</token>
-                        <token>se</token>
+                            <exception negate_pos='yes' postag_regexp='yes' postag='V....P.+'/>
+                        </token>
                         <token min="0" max="3" postag_regexp='yes' postag='R.'/>
                         <token postag_regexp='yes' postag='D...S.+' min='0'>
-                            <exception negate_pos='yes' postag_regexp='yes' postag='D...S.+'/></token>
+                            <exception negate_pos='yes' postag_regexp='yes' postag='D...S.+'/>
+                        </token>
                         <token max="3" postag_regexp='yes' postag='(?:N..|A...)S.+'>
-                            <exception negate_pos='yes' postag_regexp='yes' postag='(?:N..|A...)S.+'/></token>
+                            <exception negate_pos='yes' postag_regexp='yes' postag='(?:N..|A...)S.+'/>
+                        </token>
                     </marker>
                     <token>
-                        <exception regexp='yes'>e|,</exception></token>
+                        <exception regexp='yes'>e|,</exception>
+                    </token>
                 </pattern>
                 <message>Possível erro de concordância.</message>
-                <suggestion><match no='1' postag='(V....)P(.+)' include_skipped='all' postag_replace='$1S$2' postag_regexp='yes'/>\2\3 <match no='4' include_skipped='all'/> <match no='5' include_skipped='all'/> <match no='6' include_skipped='all'/></suggestion>
+                <suggestion><match no='1' postag='(V....)P(.+)' include_skipped='all' postag_replace='$1S$2' postag_regexp='yes'/> <match no='2' include_skipped='all'/> <match no='3' include_skipped='all'/> <match no='4' include_skipped='all'/></suggestion>
                 <example correction='juntara-se a família|juntou-se a família'>A ele <marker>juntaram-se a família</marker>.</example>
                 <!--example correction='juntara-se à família|juntou-se à família'>Ele <marker>juntaram-se à família</marker>.</example-->
                 <example>A ele <marker>juntaram-se uma amiga</marker> e a família.</example>
@@ -12465,14 +12458,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <pattern>
                 <token postag_regexp='yes' postag='V.+' regexp='yes'>.+(?:m|ão|õe)$</token>
                 <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                <marker>
-                    <token regexp='yes' spacebefore='no'>[oa]s?</token>
-                </marker>
+                <token regexp='yes' spacebefore='no'>[oa]s?</token>
             </pattern>
-            <message>O pronome &quot;\3&quot; se transforma em <suggestion>n\3</suggestion> quando em ênclise após uma vogal nasal.</message>
+            <filter class="org.languagetool.rules.pt.PortugueseEnclisisFilter" args="foo:bar"/>
+            <message>O pronome &quot;\3&quot; se transforma em &quot;n\3&quot; quando em ênclise após uma vogal nasal.</message>
+            <suggestion>{suggestion}</suggestion>
             <url>https://pt.wikipedia.org/wiki/Coloca%C3%A7%C3%A3o_pronominal#.C3.8Anclise</url>
-            <example correction='no'>Muitos tinham-<marker>o</marker> como um bom amigo.</example>
-            <example correction="nas">Põe-<marker>as</marker> na primeira gaveta.</example>
+            <example correction='tinham-no'>Muitos <marker>tinham-o</marker> como um bom amigo.</example>
+            <example correction="Põe-nas"><marker>Põe-as</marker> na primeira gaveta.</example>
             <example>Eu tinha-o como um bom amigo.</example>
         </rule>
 
@@ -12482,8 +12475,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
                 <token regexp='yes' spacebefore='no'>[oa]s?</token>
             </pattern>
+            <filter class="org.languagetool.rules.pt.PortugueseEnclisisFilter" args="foo:bar"/>
             <message>Em ênclises após formas verbais terminadas por &quot;r&quot;, &quot;s&quot; ou &quot;z&quot;, o pronome &quot;\3&quot; e a forma verbal se modificam.</message>
-            <suggestion><match no='1' postag_regexp="yes" postag="(V.+)" postag_replace="$1X"/>-l\3</suggestion>
+            <!-- <suggestion><match no='1' postag_regexp="yes" postag="(V.+)" postag_replace="$1X"/>-l\3</suggestion> -->
+            <suggestion>{suggestion}</suggestion>
             <url>https://pt.wikipedia.org/wiki/Coloca%C3%A7%C3%A3o_pronominal#.C3.8Anclise</url>
             <example correction='Comê-las'>Estas entradas são deliciosas. Vá! <marker>Comer-as</marker>.</example>
             <example correction="parti-lo">Você precisa <marker>partir-o</marker> em dois pedaços.</example>
@@ -12543,7 +12538,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <rulegroup id="COLOCACAO_PRONOMINAL_COM_ATRATOR" name="Preferir próclise em vez de ênclise e mesóclise com atratores" default="on">
+
+        <rulegroup id="COLOCACAO_PRONOMINAL_COM_ATRATOR" name="Preferir próclise em vez de ênclise e mesóclise com atratores">
             <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/a-colocacao-dos-pronomes-atonos/11366</url>
             <antipattern>
                 <token postag_regexp="yes" postag="D.+"/>
@@ -12551,492 +12547,136 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>O caso tornou-se um escândalo de saúde após a morte de várias crianças imunizadas…</example>
             </antipattern>
             <!-- Must be placed AFTER the rules that correct improper enclitic/mesoclitic pronoun forms. -->
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_ENCLISE_SIMPLES">
-                <pattern>
-                    <token regexp="yes">&introduz_proclise;|&negacoes;
-                        <exception scope="previous" spacebefore="no">-</exception>
-                    </token>
-                    <token min="0" regexp="yes">&pronomes_retos;</token>
-                    <marker>
-                        <token postag_regexp="yes" postag="V.+[^X]$"/>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">[mst]e|lhes?|(lh|[mt])?[oa]s?|vos</token>
-                    </marker>
-                    <token negate="yes">-</token> <!-- not followed by hyphen, i.e. not a mesoclitic -->
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion>\5 \3</suggestion>
-                <example correction="o beba">Não <marker>beba-o</marker>.</example>
-                <example correction="lhe diga">Nunca <marker>diga-lhe</marker> a verdade.</example>
-                <example correction="te conhecia">Já eu <marker>conhecia-te</marker> naquela época.</example>
-                <example correction="lhe dar">Ainda <marker>dar-lhe</marker> um presente é boa idea.</example>
-                <example correction="vos deram">Todos eles <marker>deram-vos</marker> um bom exemplo.</example>
-                <example correction="te recebemos">Sabes que <marker>recebemos-te</marker> de braços abertos.</example>
-                <example correction="me couber">Se <marker>couber-me</marker> fazê-lo, tentarei.</example>
-                <!-- From old rule -->
-                <example correction="me diga">Não <marker>diga-me</marker> isso.</example>
-                <example correction="te farei">Nunca <marker>farei-te</marker> essa promessa.</example>
-                <example correction="se propôs">Ninguém <marker>propôs-se</marker> a fazer o relatório de contas.</example>
-                <example>Ao juntar-se mostrou-se pronto.</example>
-                <example correction='se admiram'>Todos eles <marker>admiram-se</marker> da sua perseverança.</example>
-                <example correction='se admiram'>Todos <marker>admiram-se</marker> da sua perseverança.</example>
-                <example correction='me persuadiu'>Foi então que algo <marker>persuadiu-me</marker> a continuar.</example>
-                <example correction='lhe contou'>Quem <marker>contou-lhe</marker> essa notícia?</example>
-                <example correction='lhe tenha'>É natural que ela <marker>tenha-lhe</marker> dado notícia.</example>
-                <example>…l durante seu governo) e um dos pontos utilizados para atraí-los era, evidentemente, o apoio à construção de rodov…</example>
-                <example>…ao juntar-se mostrou-se…</example>
-                <example correction='te tirei'>Só <marker>tirei-te</marker> o brinquedo, porque te portaste mal</example>
-                <!-- removed 'para' from attractor list, I can't find it in any recent grammar -->
-                <example>Para entendê-los melhor, faça mais perguntas!</example>
-            </rule>
 
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_ENCLISE_MOS">
-                <pattern>
-                    <token regexp="yes">&introduz_proclise;|&negacoes;
-                        <exception scope="previous" spacebefore="no">-</exception>
-                    </token>
-                    <token min="0" regexp="yes">&pronomes_retos;</token>
-                    <marker>
-                        <token regexp="yes">.+[eair]mo$</token>
-                        <!-- <token postag_regexp="yes" postag="V.+X" regexp="yes">.+mo$</token> <] [> requires changes to POS tagger -->
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">nos|l[oa]s?</token>
-                    </marker>
-                    <token negate="yes">-</token> <!-- not followed by hyphen, i.e. not a mesoclitic -->
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <!-- <suggestion><match no="4" regexp_match="l([oa]s?)" regexp_replace="$1"/> <match no="2" postag_regexp="yes" postag="(V.+)X" postag_replace="$1"/></suggestion> -->
-                <suggestion><match no="5" regexp_match="l([oa]s?)" regexp_replace="$1"/> <match no="3" regexp_match="(.+)" regexp_replace="$1s"/></suggestion>
-                <example correction="o bebemos">Não <marker>bebemo-lo</marker>.</example>
-                <example correction="nos atrasamos">Ora <marker>atrasamo-nos</marker>, ora chegamos cedo.</example>
-                <example correction="as conhecíamos">Já <marker>conhecíamo-las</marker> naquela época.</example> <!-- this is a null tag -->
-            </rule>
-
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_ENCLISE_NASAL_NAO_AMBIGUO">
-                <pattern>
-                    <token regexp="yes">&introduz_proclise;|&negacoes;
-                        <exception scope="previous" spacebefore="no">-</exception>
-                    </token>
-                    <token min="0" regexp="yes">&pronomes_retos;</token>
-                    <marker>
-                        <token postag_regexp="yes" postag="V.+" regexp="yes">.+(ão|õe|m)$</token>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">nas?|no</token>
-                    </marker>
-                    <token negate="yes">-</token> <!-- not followed by hyphen, i.e. not a mesoclitic -->
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion><match no="5" regexp_match="n([oa]s?)" regexp_replace="$1"/> \3</suggestion>
-                <example correction="o dão">Não <marker>dão-no</marker> a ninguém.</example>
-                <example correction="as têm">Todos <marker>têm-nas</marker> na mão.</example> <!-- this is a null tag -->
-            </rule>
-
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_ENCLISE_NASAL_AMBIGUO_NOS">
-                <pattern>
-                    <token regexp="yes">&introduz_proclise;|&negacoes;
-                        <exception scope="previous" spacebefore="no">-</exception>
-                    </token>
-                    <token min="0" regexp="yes">&pronomes_retos;</token>
-                    <marker>
-                        <token postag_regexp="yes" postag="V.+" regexp="yes">.+(ão|õe|m)$</token>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no">nos</token>
-                    </marker>
-                    <token negate="yes">-</token> <!-- not followed by hyphen, i.e. not a mesoclitic -->
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion>nos \3</suggestion> <!-- 'nos' after a nasal can be 1PL or 3PL.MASC -->
-                <suggestion>os \3</suggestion>
-                <example correction="nos puseram|os puseram">Nunca <marker>puseram-nos</marker> em primeiro lugar.</example>
-            </rule>
-
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_ENCLISE_ELISAO">
-                <!-- Apparently, for so-called 'loose infinitives' (their phrasing), pronoun placement is free, so we exclude infinitives. -->
-                <pattern>
-                    <token regexp="yes">&introduz_proclise;|&negacoes;
-                        <exception scope="previous" spacebefore="no">-</exception>
-                    </token>
-                    <token min="0" regexp="yes">&pronomes_retos;</token>
-                    <marker>
-                        <token postag_regexp="yes" postag="V.[^N].+X"/>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">[l][oa]s?</token>
-                    </marker>
-                    <token negate="yes">-</token> <!-- not followed by hyphen, i.e. not a mesoclitic -->
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion><match no="5" regexp_match="l([oa]s?)" regexp_replace="$1"/> <match no="3" postag_regexp="yes" postag="(V.+)X" postag_replace="$1"/></suggestion>
-                <example>Nunca fazê-lo não é boa ideia.</example>
-                <example>Para conhecê-las melhor, faça perguntas.</example>
-                <example correction="o quis">Fi-lo porque <marker>qui-lo</marker>.</example>
-                <example>Nunca fá-lo-ia desta maneira!</example>  <!-- mesoclitic sub-rule below ;) -->
-            </rule>
-
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_ENCLISE_ELISAO_FUT_SUBJ_REG">
+            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_SIMPLES" default="on">
                 <antipattern>
                     <token regexp="yes">por|do</token>
                     <token>que</token>
                     <token postag_regexp="yes" postag="R." min="0" max="2"/>
-                    <token postag_regexp="yes" postag="V.+X$"/>
+                    <token postag_regexp="yes" postag="(VMN.+|V.SF3S0):PP.+"/>
                     <example>Por que não ensiná-los?</example>
                     <example>É melhor confiá-la a ti do que entregá-la a um estranho.</example>
-                </antipattern>
-                <antipattern>
-                    <token>-</token>
-                    <token>se</token>
-                    <token postag_regexp="yes" postag="R." min="0" max="2"/>
-                    <token postag_regexp="yes" postag="V.+X$"/>
-                    <example>Se não se pode ter filhos, pode-se adotá-los.</example>
-                    <example>Pode-se encontrá-la em quase todos os processos químicos.</example>
                 </antipattern>
                 <antipattern>
                     <token inflected="yes">saber</token>
                     <token regexp="yes">quando|onde</token>
                     <token postag_regexp="yes" postag="R." min="0" max="2"/>
-                    <token postag_regexp="yes" postag="V.+X$"/>
+                    <token postag_regexp="yes" postag="(VMN.+|V.SF3S0):PP.+"/>
                     <example>Não sei onde achá-lo.</example>
                 </antipattern>
                 <antipattern>
                     <token inflected="yes">ter</token>
                     <token>que</token>
-                    <token postag_regexp="yes" postag="V.+X$"/>
+                    <token postag_regexp="yes" postag="(VMN.+|V.SF3S0):PP.+"/>
                     <example>Temos que achá-lo.</example>
                     <example>Você terá que adicioná-los um a um.</example>
                 </antipattern>
-                <pattern>
-                    <token regexp="yes">se|que|quando|onde</token>
-                    <token min="0" postag_regexp="yes" postag="R."/>
-                    <marker>
-                        <token postag_regexp="yes" postag="V.+X$"/>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">[l][oa]s?</token>
-                    </marker>
-                    <token negate="yes">-</token> <!-- not followed by hyphen, i.e. not a mesoclitic -->
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion><match no="5" regexp_match="l([oa]s?)" regexp_replace="$1"/> <match no="3" postag_regexp="yes" postag="(V.+)X" postag_replace="$1"/></suggestion>
-                <example correction="o entender">Quando <marker>entendê-lo</marker>, dir-te-ei.</example>
-                <example correction="as comprar">Se <marker>comprá-las</marker>, gastará muito dinheiro.</example>
-            </rule>
 
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_ENCLISE_ELISAO_FUT_SUBJ_IRREG">
-                <pattern>
-                    <token regexp="yes">se|que|quando|onde</token>
-                    <token min="0" postag_regexp="yes" postag="R."/>
-                    <marker>
-                        <token regexp="yes">.+(é)$</token>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">[l][oa]s?</token>
-                    </marker>
-                    <token negate="yes">-</token> <!-- not followed by hyphen, i.e. not a mesoclitic -->
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion><match no="5" regexp_match="l([oa]s?)" regexp_replace="$1"/> <match no="3" regexp_match="(.+)é" regexp_replace="$1er"/></suggestion>
-                <example correction="as fizer">Quando <marker>fizé-las</marker>, dir-te-ei.</example>
-                <example correction="o souber">Se <marker>soubé-lo</marker>, mando uma mensagem.</example>
-            </rule>
-
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_MESOCLISE_SIMPLES_REG">
                 <pattern>
                     <token regexp="yes">&introduz_proclise;|&negacoes;
-                        <exception scope="previous" spacebefore="no">-</exception>
-                    </token>
-                    <token min="0" regexp="yes">&pronomes_retos;</token>
-                    <marker>
-                        <!-- doesn't take into account irregular future stems like 'trar-lhe-ia', 'far-nos-á', etc., because those aren't tagged as INF -->
-                        <token postag_regexp="yes" postag="V.N.+[^X]$"/>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">[nv]os|lh[oae]s?|[mts]e|[mt][oa]s?</token>
-                        <token spacebefore="no">-</token>
-                        <token regexp="yes">eis?|ás?|emos|ão|ia[ms]?|íeis|íamos</token>
-                    </marker>
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion>\5 \3\7</suggestion>
-                <example correction="lhe contarei">Só <marker>contar-lhe-ei</marker> o que der.</example>
-                <example correction="te chamaria">Não <marker>chamar-te-ia</marker> a essa hora!</example>
-                <example>Não dir-lhe-ei nada.</example>
-            </rule>
+                    <exception scope="previous" spacebefore="no">-</exception>
+                </token>
+                <token min="0" regexp="yes">&pronomes_retos;</token>
+                <marker>
+                    <token postag_regexp="yes" postag="V.+:PP.+"/>
+                </marker>
+            </pattern>
+            <filter class="org.languagetool.rules.pt.PortugueseProclisisFilter" args="foo:bar"/>
+            <message>&proclitic_required_msg;</message>
+            <suggestion>{suggestion}</suggestion>
+            <example correction="o bebemos">Não <marker>bebemo-lo</marker>.</example>
+            <example correction="nos atrasamos">Ora <marker>atrasamo-nos</marker>, ora chegamos cedo.</example>
+            <example correction="as conhecíamos">Já <marker>conhecíamo-las</marker> naquela época.</example> <!-- this is a null tag -->
+            <example correction="o dão">Não <marker>dão-no</marker> a ninguém.</example>
+            <example correction="as têm">Todos <marker>têm-nas</marker> na mão.</example> <!-- this is a null tag -->
+            <example correction="os puseram|nos puseram">Nunca <marker>puseram-nos</marker> em primeiro lugar.</example>
+            <example correction="o quis">Fi-lo porque <marker>qui-lo</marker>.</example>
+            <example correction="o entender">Quando <marker>entendê-lo</marker>, dir-te-ei.</example>
+            <example correction="as comprar">Se <marker>comprá-las</marker>, gastará muito dinheiro.</example>
+            <example correction="as fizer">Quando <marker>fizé-las</marker>, dir-te-ei.</example>
+            <example correction="o souber">Se <marker>soubé-lo</marker>, mando uma mensagem.</example>
+            <example correction="o beba">Não <marker>beba-o</marker>.</example>
+            <example correction="lhe diga">Nunca <marker>diga-lhe</marker> a verdade.</example>
+            <example correction="te conhecia">Já eu <marker>conhecia-te</marker> naquela época.</example>
+            <example correction="lhe dar">Ainda <marker>dar-lhe</marker> um presente é boa idea.</example>
+            <example correction="vos deram">Todos eles <marker>deram-vos</marker> um bom exemplo.</example>
+            <example correction="te recebemos">Sabes que <marker>recebemos-te</marker> de braços abertos.</example>
+            <example correction="me couber">Se <marker>couber-me</marker> fazê-lo, tentarei.</example>
+            <!-- From old rule -->
+            <example correction="me diga">Não <marker>diga-me</marker> isso.</example>
+            <example correction="te farei">Nunca <marker>farei-te</marker> essa promessa.</example>
+            <example correction="se propôs">Ninguém <marker>propôs-se</marker> a fazer o relatório de contas.</example>
+            <example>Ao juntar-se mostrou-se pronto.</example>
+            <example correction='se admiram'>Todos eles <marker>admiram-se</marker> da sua perseverança.</example>
+            <example correction='se admiram'>Todos <marker>admiram-se</marker> da sua perseverança.</example>
+            <example correction='me persuadiu'>Foi então que algo <marker>persuadiu-me</marker> a continuar.</example>
+            <example correction='lhe contou'>Quem <marker>contou-lhe</marker> essa notícia?</example>
+            <example correction='lhe tenha'>É natural que ela <marker>tenha-lhe</marker> dado notícia.</example>
+            <example>…l durante seu governo) e um dos pontos utilizados para atraí-los era, evidentemente, o apoio à construção de rodov…</example>
+            <example>…ao juntar-se mostrou-se…</example>
+            <example correction='te tirei'>Só <marker>tirei-te</marker> o brinquedo, porque te portaste mal</example>
+            <!-- removed 'para' from attractor list, I can't find it in any recent grammar -->
+            <example>Para entendê-los melhor, faça mais perguntas!</example>
+            <!-- MESOCLITICS -->
+            <example correction="lhe contarei">Só <marker>contar-lhe-ei</marker> o que der.</example>
+            <example correction="te chamaria">Não <marker>chamar-te-ia</marker> a essa hora!</example>
+            <example correction="lhe direi">Não <marker>dir-lhe-ei</marker> nada.</example>
+            <example correction="nos fariam">Já <marker>far-nos-iam</marker> um enorme favor...</example>
+            <example correction="me trarão">Sonhei que <marker>trar-me-ão</marker> muita alegria.</example>
+            <example correction="a amarei">Não <marker>amá-la-ei</marker> enquanto usar aquele chapéu.</example>
+            <example correction="os entenderia">Acho que <marker>entendê-los-ia</marker> melhor se os tentasse conhecer.</example>
+            <example correction="o faríamos">Já <marker>fá-lo-íamos</marker> se pudéssemos...</example>
+            <example correction="as traremos">Disse que <marker>trá-las-emos</marker> no sábado.</example>
+            <example correction='me diga'>Não <marker>diga-me</marker> isso.</example>
+            <example correction='te farei'>Nunca <marker>farei-te</marker> essa promessa.</example>
+            <example correction='se propôs'>Ninguém <marker>propôs-se</marker> a fazer o relatório de contas.</example>
+        </rule>
 
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_MESOCLISE_SIMPLES_IRREG">
-                <pattern>
-                    <token regexp="yes">&introduz_proclise;|&negacoes;
-                        <exception scope="previous" spacebefore="no">-</exception>
-                    </token>
-                    <token min="0" regexp="yes">&pronomes_retos;</token>
-                    <marker>
-                        <token regexp="yes" postag_regexp="yes" postag="V.+" negate_pos="yes">.*(dir|far|trar)$</token>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">[nv]os|lh[oae]s?|[mts]e|[mt][oa]s?</token>
-                        <token spacebefore="no">-</token>
-                        <token regexp="yes">eis?|ás?|emos|ão|ia[ms]?|íeis|íamos</token>
-                    </marker>
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion>\5 \3\7</suggestion>
-                <example correction="lhe direi">Não <marker>dir-lhe-ei</marker> nada.</example>
-                <example correction="nos fariam">Já <marker>far-nos-iam</marker> um enorme favor...</example>
-                <example correction="me trarão">Sonhei que <marker>trar-me-ão</marker> muita alegria.</example>
-            </rule>
+        <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO" default="temp_off">
+            <pattern>
+                <token>de</token>
+                <token regexp='yes'>forma|maneira|jeito|modo</token>
+                <token regexp='yes'>(?:algum|nenhum)a?</token>
+                <marker>
+                    <token postag_regexp="yes" postag="V.+:PP.+"/>
+                </marker>
+            </pattern>
+            <filter class="org.languagetool.rules.pt.PortugueseProclisisFilter" args="foo:bar"/>
+            <message>&proclitic_required_msg;</message>
+            <suggestion>{suggestion}</suggestion>
+            <example correction="o bebi">De maneira nenhuma <marker>bebi-o</marker>.</example>
+            <example correction="o bebemos">De jeito algum <marker>bebemo-lo</marker>.</example>
+            <example correction="o dão">De modo algum <marker>dão-no</marker> a mim.</example>
+            <example correction="os puseram|nos puseram">De forma alguma <marker>puseram-nos</marker> em primeiro lugar.</example>
+            <example correction="o quis">De jeito nenhum <marker>qui-lo</marker>.</example>
+            <example correction="lhe contarei">De maneira alguma <marker>contar-lhe-ei</marker> nada.</example>
+            <example correction="te chamaria">De jeito nenhum <marker>chamar-te-ia</marker> a essa hora!</example>
+            <example correction="a amarei">De forma alguma <marker>amá-la-ei</marker> enquanto usar aquele chapéu.</example>
+            <example correction="os entenderia">De maneira nenhuma <marker>entendê-los-ia</marker> melhor se os tentasse conhecer.</example>
+            <example correction="lhe direi">De jeito algum <marker>dir-lhe-ei</marker> nada.</example>
+            <example correction="nos fariam">De maneira nenhuma <marker>far-nos-iam</marker> um enorme favor...</example>
+            <example correction="me trarão">De modo algum <marker>trar-me-ão</marker> muita alegria.</example>
+            <example correction="o faríamos">De modo algum <marker>fá-lo-íamos</marker> se pudéssemos...</example>
+            <example correction="as traremos">De maneira nenhuma <marker>trá-las-emos</marker> no sábado.</example>
+            <example correction='me diga'>De forma alguma <marker>diga-me</marker> isso.</example>
+        </rule>
+    </rulegroup>
 
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_MESOCLISE_ELISAO_REG">
-                <pattern>
-                    <token regexp="yes">&introduz_proclise;|&negacoes;
-                        <exception scope="previous" spacebefore="no">-</exception>
-                    </token>
-                    <token min="0" regexp="yes">&pronomes_retos;</token>
-                    <marker>
-                        <!-- doesn't take into account irregular future stems like 'trar-lhe-ia', 'far-nos-á', etc., because those aren't tagged as INF -->
-                        <token postag_regexp="yes" postag="V.N.+X$"/>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">l[oa]s?</token>
-                        <token spacebefore="no">-</token>
-                        <token regexp="yes">eis?|ás?|emos|ão|ia[ms]?|íeis|íamos</token>
-                    </marker>
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion><match no="5" regexp_match="l([oa]s?)" regexp_replace="$1"/> <match no="3" postag_regexp="yes" postag="(V.+)X$" postag_replace="$1"/>\7</suggestion>
-                <example correction="a amarei">Não <marker>amá-la-ei</marker> enquanto usar aquele chapéu.</example>
-                <example correction="os entenderia">Acho que <marker>entendê-los-ia</marker> melhor se os tentasse conhecer.</example>
-            </rule>
-
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_MESOCLISE_ELISAO_IRREG_A">
-                <pattern>
-                    <token regexp="yes">&introduz_proclise;|&negacoes;
-                        <exception scope="previous" spacebefore="no">-</exception>
-                    </token>
-                    <token min="0" regexp="yes">&pronomes_retos;</token>
-                    <marker>
-                        <token regexp="yes" postag_regexp="yes" postag="V.+">.*(fá|trá)$</token>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">l[oa]s?</token>
-                        <token spacebefore="no">-</token>
-                        <token regexp="yes">eis?|ás?|emos|ão|ia[ms]?|íeis|íamos</token>
-                    </marker>
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion><match no="5" regexp_match="l([oa]s?)" regexp_replace="$1"/> <match no="3" regexp_match="(.+)á" regexp_replace="$1ar"/>\7</suggestion>
-                <example correction="o faríamos">Já <marker>fá-lo-íamos</marker> se pudéssemos...</example>
-                <example correction="as traremos">Disse que <marker>trá-las-emos</marker> no sábado.</example>
-            </rule>
-        </rulegroup>
-
-        <rulegroup id="COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO" name="Preferir próclise em vez de ênclise e mesóclise com atratores complexos" default="temp_off">
-            <!-- Must be placed AFTER the rules that correct improper enclitic/mesoclitic pronoun forms. -->
-            <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/a-colocacao-dos-pronomes-atonos/11366</url>
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO_ENCLISE_SIMPLES">
-                <pattern>
-                    <token>de</token>
-                    <token regexp='yes'>forma|maneira|jeito|modo</token>
-                    <token regexp='yes'>(?:algum|nenhum)a?</token>
-                    <marker>
-                        <token postag_regexp="yes" postag="V.+[^X]$"/>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">[mst]e|lhes?|(lh|[mt])?[oa]s?|vos</token>
-                    </marker>
-                    <token negate="yes">-</token> <!-- not followed by hyphen, i.e. not a mesoclitic -->
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion>\6 \4</suggestion>
-                <example correction="o bebi">De maneira nenhuma <marker>bebi-o</marker>.</example>
-            </rule>
-
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO_ENCLISE_MOS">
-                <pattern>
-                    <token>de</token>
-                    <token regexp='yes'>forma|maneira|jeito|modo</token>
-                    <token regexp='yes'>(?:algum|nenhum)a?</token>
-                    <marker>
-                        <token regexp="yes">.+[eair]mo$</token>
-                        <!-- <token postag_regexp="yes" postag="V.+X" regexp="yes">.+mo$</token> <] [> requires changes to POS tagger -->
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">nos|l[oa]s?</token>
-                    </marker>
-                    <token negate="yes">-</token> <!-- not followed by hyphen, i.e. not a mesoclitic -->
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <!-- <suggestion><match no="4" regexp_match="l([oa]s?)" regexp_replace="$1"/> <match no="2" postag_regexp="yes" postag="(V.+)X" postag_replace="$1"/></suggestion> -->
-                <suggestion><match no="6" regexp_match="l([oa]s?)" regexp_replace="$1"/> <match no="4" regexp_match="(.+)" regexp_replace="$1s"/></suggestion>
-                <example correction="o bebemos">De jeito algum <marker>bebemo-lo</marker>.</example>
-            </rule>
-
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO_ENCLISE_NASAL_NAO_AMBIGUO">
-                <pattern>
-                    <token>de</token>
-                    <token regexp='yes'>forma|maneira|jeito|modo</token>
-                    <token regexp='yes'>(?:algum|nenhum)a?</token>
-                    <marker>
-                        <token postag_regexp="yes" postag="V.+" regexp="yes">.+(ão|õe|m)$</token>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">nas?|no</token>
-                    </marker>
-                    <token negate="yes">-</token> <!-- not followed by hyphen, i.e. not a mesoclitic -->
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion><match no="6" regexp_match="n([oa]s?)" regexp_replace="$1"/> \4</suggestion>
-                <example correction="o dão">De modo algum <marker>dão-no</marker> a mim.</example>
-            </rule>
-
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO_ENCLISE_NASAL_AMBIGUO_NOS">
-                <pattern>
-                    <token>de</token>
-                    <token regexp='yes'>forma|maneira|jeito|modo</token>
-                    <token regexp='yes'>(?:algum|nenhum)a?</token>
-                    <marker>
-                        <token postag_regexp="yes" postag="V.+" regexp="yes">.+(ão|õe|m)$</token>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no">nos</token>
-                    </marker>
-                    <token negate="yes">-</token> <!-- not followed by hyphen, i.e. not a mesoclitic -->
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion>nos \4</suggestion> <!-- 'nos' after a nasal can be 1PL or 3PL.MASC -->
-                <suggestion>os \4</suggestion>
-                <example correction="nos puseram|os puseram">De forma alguma <marker>puseram-nos</marker> em primeiro lugar.</example>
-            </rule>
-
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO_ENCLISE_ELISAO">
-                <!-- Apparently, for so-called 'loose infinitives' (their phrasing), pronoun placement is free, so we exclude infinitives. -->
-                <pattern>
-                    <token>de</token>
-                    <token regexp='yes'>forma|maneira|jeito|modo</token>
-                    <token regexp='yes'>(?:algum|nenhum)a?</token>
-                    <marker>
-                        <token postag_regexp="yes" postag="V.[^N].+X"/>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">[l][oa]s?</token>
-                    </marker>
-                    <token negate="yes">-</token> <!-- not followed by hyphen, i.e. not a mesoclitic -->
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion><match no="6" regexp_match="l([oa]s?)" regexp_replace="$1"/> <match no="4" postag_regexp="yes" postag="(V.+)X" postag_replace="$1"/></suggestion>
-                <example correction="o quis">De jeito nenhum <marker>qui-lo</marker>.</example>
-            </rule>
-
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO_MESOCLISE_SIMPLES_REG">
-                <pattern>
-                    <token>de</token>
-                    <token regexp='yes'>forma|maneira|jeito|modo</token>
-                    <token regexp='yes'>(?:algum|nenhum)a?</token>
-                    <marker>
-                        <!-- doesn't take into account irregular future stems like 'trar-lhe-ia', 'far-nos-á', etc., because those aren't tagged as INF -->
-                        <token postag_regexp="yes" postag="V.N.+[^X]$"/>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">[nv]os|lh[oae]s?|[mts]e|[mt][oa]s?</token>
-                        <token spacebefore="no">-</token>
-                        <token regexp="yes">eis?|ás?|emos|ão|ia[ms]?|íeis|íamos</token>
-                    </marker>
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion>\6 \4\8</suggestion>
-                <example correction="lhe contarei">De maneira alguma <marker>contar-lhe-ei</marker> nada.</example>
-                <example correction="te chamaria">De jeito nenhum <marker>chamar-te-ia</marker> a essa hora!</example>
-            </rule>
-
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO_MESOCLISE_SIMPLES_IRREG">
-                <pattern>
-                    <token>de</token>
-                    <token regexp='yes'>forma|maneira|jeito|modo</token>
-                    <token regexp='yes'>(?:algum|nenhum)a?</token>
-                    <marker>
-                        <token regexp="yes" postag_regexp="yes" postag="V.+" negate_pos="yes">.*(dir|far|trar)$</token>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">[nv]os|lh[oae]s?|[mts]e|[mt][oa]s?</token>
-                        <token spacebefore="no">-</token>
-                        <token regexp="yes">eis?|ás?|emos|ão|ia[ms]?|íeis|íamos</token>
-                    </marker>
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion>\6 \4\8</suggestion>
-                <example correction="lhe direi">De jeito algum <marker>dir-lhe-ei</marker> nada.</example>
-                <example correction="nos fariam">De maneira nenhuma <marker>far-nos-iam</marker> um enorme favor...</example>
-                <example correction="me trarão">De modo algum <marker>trar-me-ão</marker> muita alegria.</example>
-            </rule>
-
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO_MESOCLISE_ELISAO_REG">
-                <pattern>
-                    <token>de</token>
-                    <token regexp='yes'>forma|maneira|jeito|modo</token>
-                    <token regexp='yes'>(?:algum|nenhum)a?</token>
-                    <marker>
-                        <!-- doesn't take into account irregular future stems like 'trar-lhe-ia', 'far-nos-á', etc., because those aren't tagged as INF -->
-                        <token postag_regexp="yes" postag="V.N.+X$"/>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">l[oa]s?</token>
-                        <token spacebefore="no">-</token>
-                        <token regexp="yes">eis?|ás?|emos|ão|ia[ms]?|íeis|íamos</token>
-                    </marker>
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion><match no="6" regexp_match="l([oa]s?)" regexp_replace="$1"/> <match no="4" postag_regexp="yes" postag="(V.+)X$" postag_replace="$1"/>\8</suggestion>
-                <example correction="a amarei">De forma alguma <marker>amá-la-ei</marker> enquanto usar aquele chapéu.</example>
-                <example correction="os entenderia">De maneira nenhuma <marker>entendê-los-ia</marker> melhor se os tentasse conhecer.</example>
-            </rule>
-
-            <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO_MESOCLISE_ELISAO_IRREG_A">
-                <pattern>
-                    <token>de</token>
-                    <token regexp='yes'>forma|maneira|jeito|modo</token>
-                    <token regexp='yes'>(?:algum|nenhum)a?</token>
-                    <marker>
-                        <token regexp="yes" postag_regexp="yes" postag="V.+">.*(fá|trá)$</token>
-                        <token spacebefore="no">-</token>
-                        <token spacebefore="no" regexp="yes">l[oa]s?</token>
-                        <token spacebefore="no">-</token>
-                        <token regexp="yes">eis?|ás?|emos|ão|ia[ms]?|íeis|íamos</token>
-                    </marker>
-                </pattern>
-                <message>&proclitic_required_msg;</message>
-                <suggestion><match no="6" regexp_match="l([oa]s?)" regexp_replace="$1"/> <match no="4" regexp_match="(.+)á" regexp_replace="$1ar"/>\8</suggestion>
-                <example correction="o faríamos">De modo algum <marker>fá-lo-íamos</marker> se pudéssemos...</example>
-                <example correction="as traremos">De maneira nenhuma <marker>trá-las-emos</marker> no sábado.</example>
-            </rule>
-        </rulegroup>
 
         <rulegroup id="COLOCACAO_PRONOMINAL_EM_O_SENDO" name="Preferir a próclise em construções do tipo 'em o sendo'" default="temp_off">
             <rule>
                 <pattern>
                     <token>em</token>
                     <token min="0" postag_regexp="yes" postag="R."/>
-                    <token postag_regexp="yes" postag="V.G.+"/>
-                    <token spacebefore="no">-</token>
-                    <token regexp="yes" spacebefore="no">&pronomes_obliquos;</token>
+                    <marker>
+                        <token postag_regexp="yes" postag="V.G.+:PP.+"/>
+                    </marker>
                 </pattern>
+                <filter class="org.languagetool.rules.pt.PortugueseProclisisFilter" args="foo:bar"/>
                 <message>Com gerúndios regidos por &quot;em&quot;, recomenda-se o uso da próclise.</message>
-                <suggestion>em \5 \2 \3</suggestion>
-                <example correction="Em o trazendo"><marker>Em trazendo-o</marker>, fez mais mal que bem.</example>
-                <example correction="Em a não enxergando"><marker>Em não enxergando-a</marker>, atropelou-a.</example>
-            </rule>
-        </rulegroup>
-
-        <rulegroup id='PRONOMIAL_COLOCATIONS_NEGATIONS' name='Colocações pronomiais: próclises por negações' default="off">
-            <!-- Superseded by COLOCACAO_PRONOMINAL_COM_ATRATOR and COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO -->
-            <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/a-colocacao-dos-pronomes-atonos/11366</url>
-            <rule>
-                <pattern>
-                    <token regexp='yes'>&negacoes;</token>
-                    <token postag_regexp='yes' postag='V.+'/>
-                    <token regexp='yes'>&tracos_de_separacao;</token>
-                    <token regexp='yes'>me|te|se|lhe|nos|vos|lhes</token>
-                </pattern>
-                <message>As negações colocam o pronome antes do verbo.</message>
-                <suggestion>\1 \4 \2</suggestion>
-                <example correction='Não me diga'><marker>Não diga-me</marker> isso.</example>
-                <example correction='Nunca te farei'><marker>Nunca farei-te</marker> essa promessa.</example>
-                <example correction='Ninguém se propôs'><marker>Ninguém propôs-se</marker> a fazer o relatório de contas.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token>de</token>
-                    <token regexp='yes'>forma|jeito|modo</token>
-                    <token regexp='yes'>(?:algum|nenhum)a?</token>
-                    <token postag_regexp='yes' postag='V.+'/>
-                    <token regexp='yes'>&tracos_de_separacao;</token>
-                    <token regexp='yes'>me|te|se|lhe|nos|vos|lhes</token>
-                </pattern>
-                <message>As negações colocam o pronome antes do verbo.</message>
-                <suggestion>\1 \2 \3 \6 \4</suggestion>
-                <example correction='De forma alguma me diga'><marker>De forma alguma diga-me</marker> isso.</example>
+                <suggestion>{suggestion}</suggestion>
+                <example correction="o trazendo">Em <marker>trazendo-o</marker>, fez mais mal que bem.</example>
+                <example correction="a enxergando">Em não <marker>enxergando-a</marker>, atropelou-a.</example>
             </rule>
         </rulegroup>
 
@@ -13495,99 +13135,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <rulegroup id='GENERAL_PRONOMIAL_COLOCATIONS' name='Colocações pronomiais: próclises obrigatórias' default="off">
-            <!-- Superseded by COLOCACAO_PRONOMINAL_COM_ATRATOR -->
-            <url>https://pt.wikipedia.org/wiki/Coloca%C3%A7%C3%A3o_pronominal</url>
-            <short>Erro de colocação pronominal</short>
-            <rule>
-                <pattern>
-                    <token regexp='yes'>tod[ao]s?|tudo|nada|pouc[ao]s?|muit[ao]s?|algo</token><!-- TODO Review algu[mn]a?s? -->
-                    <token regexp='yes' min='0'>&pronomes_retos;</token>
-                    <token postag_regexp='yes' postag='V.+'>
-                        <exception postag_regexp='yes' postag='V.[NX].+'/></token>
-                    <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                    <token regexp='yes' spacebefore='no'>&pronomes_ambiguos;|lhe|lhes|me|te|vos</token>
-                </pattern>
-                <message>Com alguns pronomes indefinidos devem utilizar a próclise.</message>
-                <suggestion><match no='1' include_skipped='all'/> <match no='2' include_skipped='all'/> \5 \3</suggestion>
-                <example correction='Todos eles se admiram'><marker>Todos eles admiram-se</marker> da sua perseverança.</example>
-                <example correction='Todos se admiram'><marker>Todos admiram-se</marker> da sua perseverança.</example>
-                <example correction='algo me persuadiu'>Foi então que <marker>algo persuadiu-me</marker> a continuar.</example>
-            </rule>
-            <rule>
-                <antipattern>
-                    <token regexp='yes'>cidadãos?</token>
-                    <token>de</token>
-                    <token>bem</token>
-                </antipattern>
-                <antipattern>
-                    <token postag_regexp='yes' postag='D.+'/>
-                    <token regexp='yes'>&introduz_proclise;</token>
-                </antipattern>
-                <pattern>
-                    <marker>
-                        <token regexp='yes'>&introduz_proclise;
-                            <exception scope='previous' regexp='yes' spacebefore='no'>&hifen;</exception></token>
-                        <token regexp='yes' min='0'>&pronomes_retos;</token>
-                        <token postag_regexp='yes' postag='V.+'>
-                            <exception postag_regexp='yes' postag='V.[NX].+'/></token>
-                        <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                        <token regexp='yes' spacebefore='no'>&pronomes_ambiguos;|lhe|lhes|me|te|vos</token>
-                    </marker>
-                    <token negate_pos='yes' postag_regexp='yes' postag='V.[^P].+'/>
-                </pattern>
-                <message>Certos pronomes relativos, conjunções subordinativas e advérbios devem ser seguidos de próclise.</message>
-                <suggestion><match no='1' include_skipped='all'/> <match no='2' include_skipped='all'/> \5 \3</suggestion>
-                <example correction='Quem lhe contou'><marker>Quem contou-lhe</marker> essa notícia?</example>
-                <example correction='que ela lhe tenha'>É natural <marker>que ela tenha-lhe</marker> dado notícia.</example>
-                <example>…l durante seu governo) e um dos pontos utilizados para atraí-los era, evidentemente, o apoio à construção de rodov…</example>
-                <example>…ao juntar-se mostrou-se…</example>
-                <example>O caso tornou-se um escândalo de saúde após a morte de várias crianças imunizadas…</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp='yes'>só|ora|quer</token><!-- TODO Review ou -->
-                    <token postag_regexp='yes' postag='V.+'>
-                        <exception postag_regexp='yes' postag='V.[NX].+'/></token>
-                    <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                    <token regexp='yes' spacebefore='no'>&pronomes_ambiguos;|lhe|lhes|me|te|vos</token>
-                </pattern>
-                <message>"só", "ora" e "quer" devem ser seguidos de próclise.</message><!-- TODO Review "ou",  -->
-                <suggestion>\1 \4 \2</suggestion>
-                <example correction='Só te tirei'><marker>Só tirei-te</marker> o brinquedo, porque te portaste mal</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token regexp='yes'>&negacoes;</token>
-                    <token postag_regexp='yes' postag='N.+' min='0'>
-                        <exception negate_pos='yes' postag_regexp='yes' postag='N.+'/></token>
-                    <token postag_regexp='yes' postag='V.+'>
-                        <exception postag_regexp='yes' postag='V.[NX].+'/></token>
-                    <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                    <token regexp='yes' spacebefore='no'>&pronomes_ambiguos;|lhe|lhes|me|te|vos</token>
-                </pattern>
-                <message>As palavras de sentido negativo devem ser seguidas de próclise.</message>
-                <suggestion>\1 \2 \5 \3</suggestion>
-                <example correction='Nenhum lugar te recorda'><marker>Nenhum lugar recorda-te</marker> daquelas férias?</example>
-            </rule>
-        </rulegroup>
-
         <rulegroup id='DEQUEISMO_QUEISMO' name="Queísmos e dequeismos" type="grammar">
-            <!-- DEQUEISMO_QUEISMO rules from Spanish grammar.xml  - START-->
-            <!--    Localized by Tiago F. Santos, Portuguese rule, 2016-11-25     -->
             <rule id='INF_PP_QUE' name="Infinitivo do tipo convencer + pron.pess. + que">
                 <pattern>
-                    <token regexp="yes">(?:alegrar<!--|saber-->|informar|duvidar|convencer|fartar|queixar|protestar)</token>
-                    <token regexp='yes'>&tracos_de_separacao;</token>
-                    <token regexp="yes">(?:me|te|lh[ea][s]?|se|nos|os)</token>
-                    <token>que</token>
+                    <token regexp="yes" postag="VMN0000:PP3CNO00" inflected="yes">(?:alegrar<!--|saber-->|informar|duvidar|convencer|fartar|queixar|protestar)</token>
+                    <marker>
+                        <token>que</token>
+                    </marker>
                 </pattern>
-                <message>Neste contexto, o verbo é seguido normalmente da preposição 'de': <suggestion>\1\2\3 de \4</suggestion></message>
+                <message>Neste contexto, o verbo é seguido normalmente da preposição 'de': <suggestion>de que</suggestion></message>
                 <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/uso-de-de-que-de-novo-queismo-e-dequeismo/19156</url>
                 <short>Possível queísmo</short>
-                <example correction="alegrar-se de que">Está bem <marker>alegrar-se que</marker> haja dinheiro para todos.</example>
-                <example correction="Informar-se de que"><marker>Informar-se que</marker> ocorreu alterações ao código.</example>
-                <example>Não pareces <marker>alegrar-te de que</marker> tudo está resolvido.</example>
+                <example correction="de que">Está bem alegrar-se <marker>que</marker> haja dinheiro para todos.</example>
+                <example correction="de que">Informar-se <marker>que</marker> ocorreu alterações ao código.</example>
+                <example>Não pareces alegrar-te de que tudo está resolvido.</example>
             </rule>
             <!--    Localized by Tiago F. Santos, Portuguese rule, 2016-10-28      -->
             <rule id='ESTAR_SEGURO_QUE' name="Estar + seguro + que">
@@ -13666,17 +13227,17 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <!--    Localized by Tiago F. Santos, Portuguese rule, 2016-11-25      -->
             <rule id='V3_DE_QUE' name="Verbo na 3.ª pessoa + de que">
                 <pattern>
-                    <token regexp="yes">alegra|entristece|importa|resvala|farta|emociona|altera|aburrece|falta|preocupa</token>
-                    <token regexp='yes'>&tracos_de_separacao;</token>
-                    <token postag="PP[123]C.[0OD]00" postag_regexp="yes"/>
-                    <token regexp="yes">d[aeo]s?</token>
-                    <token>que</token>
+                    <token regexp="yes" inflected="yes" postag_regexp="yes" postag="VMIP3S0:PP.+">alegrar|entristecer|importar|resvalar|fartar|emocionar|alterar|aburrecer|faltar|preocupar</token>
+                    <marker>
+                        <token regexp="yes">d[aeo]s?</token>
+                        <token>que</token>
+                    </marker>
                 </pattern>
-                <message>Possível dequeísmo: <suggestion>\1\2\3 \5</suggestion>.</message>
+                <message>Possível dequeísmo: <suggestion>que</suggestion>.</message>
                 <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/uso-de-de-que-de-novo-queismo-e-dequeismo/19156</url>
                 <short>Possível 'dequeísmo'</short>
-                <example correction="Alegra-me que"><marker>Alegra-me de que</marker> voltemos a encontrar-nos</example>
-                <example><marker>Entristece-me que</marker> tenham mudado de marca.</example>
+                <example correction="que">Alegra-me <marker>de que</marker> voltemos a encontrar-nos</example>
+                <example>Entristece-me que tenham mudado de marca.</example>
             </rule>
             <!--    Localized by Tiago F. Santos, Portuguese rule, 2016-10-28      -->
             <rule id='INSISTIR_DE_QUE' name="Verbo do tipo insistir + de que">
@@ -14183,17 +13744,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
             <rule> <!-- #20 -->
                 <pattern>
+                    <token postag_regexp="yes" postag="V.+:PP.+" inflected='yes'>candidatar</token>
                     <marker>
-                        <token inflected='yes'>candidatar</token>
-                        <token regexp='yes' spacebefore='no'>&hifen;</token>
-                        <token regexp='yes'>[mts]e|[nv]os</token>
                         <token regexp='yes'>as?</token>
                     </marker>
                     <token postag_regexp='yes' postag='(?:N.|A..)F.+'/>
                 </pattern>
                 <message>Neste contexto utiliza-se a crase.</message>
-                <suggestion>\1-se <match no='4' regexp_match='(a)(s?)' regexp_replace='à$2'/></suggestion>
-                <example correction='candidatou-se à'>Ele <marker>candidatou-se a</marker> posição de gestor.</example>
+                <suggestion><match no='2' regexp_match='(a)(s?)' regexp_replace='à$2'/></suggestion>
+                <example correction='à'>Ele candidatou-se <marker>a</marker> posição de gestor.</example>
             </rule>
             <rule> <!-- #21 -->
                 <pattern>
@@ -14774,22 +14333,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="A gente vai|A gente vá"><marker>A gente vamos</marker> à praia.</example>
         </rule>
 
-        <!-- TODO Use inflections to improve rule. Suggestion inflect='yes'>procurar<	-->
-        <!-- Concordance error plural - PROCURA-SE > PROCURAM-SE -->
+
         <rule id='PROCURA_SE-PROCURAM_SE' name="Erro de concordância do plural PROCURA-SE > PROCURAM-SE">
             <pattern>
                 <marker>
-                    <token>procura</token>
-                    <token regexp='yes'>&tracos_de_separacao;</token>
-                    <token>se</token>
+                    <token postag_regexp="yes" postag="V...3S.+:PP3CNO00" inflected="yes">procurar</token>
                 </marker>
                 <token postag_regexp="yes"  postag="(?:N..|A...)P.+"/>
             </pattern>
             <message>&MSG_ECN;</message>
-            <suggestion>procuram-se</suggestion>
+            <suggestion><match no="1" postag_regexp="yes" postag="(V...)3S(.+)" postag_replace="$13P$2"/></suggestion>
             <example correction="procuram-se">Aqui <marker>procura-se</marker> pessoas sérias.</example>
         </rule>
-
 
         <rule id='IR_CONTRACTION_NOUN' name="Ir + 'na/no' + nome → à/ao">
             <!-- To do: remove verb "mercar" ("mercado") POS? It removes all valid entries using "mercado" -->
@@ -17303,15 +16858,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <rule id='ESQUECEU-SE_QUE' name="Esqueceu-se de que">
-            <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
-                <token inflected="yes">esquecer</token>
-                <token regexp='yes'>&tracos_de_separacao;</token>
-                <token>se</token>
-                <token>que</token>
+                <token inflected="yes" postag_regexp="yes" postag="V.+:PP.+">esquecer</token>
+                <marker>
+                    <token>que</token>
+                </marker>
             </pattern>
-            <message>Substitua por <suggestion>\1\2\3 de que</suggestion>.</message>
-            <example correction="esqueceu-se de que">O Rui <marker>esqueceu-se que</marker> tinha um exame.</example>
+            <message>Substitua por <suggestion>de que</suggestion>.</message>
+            <example correction="de que">O Rui esqueceu-se <marker>que</marker> tinha um exame.</example>
         </rule>
 
 
@@ -17356,17 +16910,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
         <rule id='FALARAM-SE_DE' name="Falou-se de">
-            <!-- Created by Marco A.G.Pinto, 2016-XX-XX -->
             <pattern>
-                <token>falaram</token>
-                <token regexp='yes'>&tracos_de_separacao;</token>
-                <token>se</token>
+                <marker>
+                    <token postag_regexp="yes" postag="V...3P.:PP3CNO00" inflected="yes">falar</token>
+                </marker>
                 <token>de</token>
             </pattern>
-            <message>Substitua por <suggestion>falou-se de</suggestion>.</message>
-            <example correction="falou-se de">Hoje <marker>falaram-se de</marker> de vários problemas.</example>
+            <message>Substitua por <suggestion><match no="1" postag_regexp="yes" postag="(V...)3P(.+)" postag_replace="$13S$2"/></suggestion>.</message>
+            <example correction="falara-se|falou-se">Hoje <marker>falaram-se</marker> de vários problemas.</example>
         </rule>
-
 
         <rule id='FOI_ATRAVÉS_DAS_QUAIS' name="Foi pelas quais">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
@@ -19248,9 +18800,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <!-- VÍRGULA A MAIS -->
-        <!--      Created by Marco A.G.Pinto, Portuguese rule 2020-12-08 (21-OCT-2020+)  *START*   -->
-        <rule id='VERB_COMMA_NOT_NEEDED' name="Vírgula não necessária">
+        <rule id='VERB_COMMA_NOT_NEEDED' name="Vírgula desnecessária">
             <pattern>
                 <marker>
                     <token postag='VMM03S0|VMSP[13]S0' postag_regexp='yes'>
@@ -19258,13 +18808,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <token min="0" max="1" postag='SPS.+|DA.+' postag_regexp='yes'/>
                     <token postag='PI.+' postag_regexp='yes'/>
                     <token regexp='yes' spacebefore='no'>[,]</token>
-                    <token postag='V.+' postag_regexp='yes'/>
-                    <token spacebefore='no'>-</token>
-                    <token regexp='yes' spacebefore='no'>la|lo|lhes?|te|vos</token>
+                    <token postag='VMN0000:PP.+' postag_regexp='yes'/>
                 </marker>
             </pattern>
-            <message>Vírgula não necessária.</message>
-            <suggestion>\1 \2 \3 \5\6\7</suggestion>
+            <message>Vírgula desnecessária.</message>
+            <suggestion>\1 \2 \3 \5</suggestion>
             <example correction="deixe ninguém usá-la">Não <marker>deixe ninguém, usá-la</marker> com você e ganhar o jogo.</example>
         </rule>
 
@@ -31324,14 +30872,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <pattern>
                     <token>
                         <exception regexp='yes'>&art_detecao_paronimos;|\-</exception>
-                        <exception postag='(?:A|C|D|SP|V).+|_PUNCT|SENT_START' postag_regexp='yes'/></token>
-                    <token regexp='yes'>serras?
-                        <exception case_sensitive='yes'>Serra</exception></token>
+                        <exception postag='(?:A|C|D|SP|V).+|_PUNCT|SENT_START' postag_regexp='yes'/>
+                    </token>
+                    <token regexp='yes' inflected="yes">serrar
+                        <exception case_sensitive='yes'>Serra</exception>
+                    </token>
                 </pattern>
                 <message>Esta palavra refere-se a uma montanha ou instrumento de corte. Se pretende referir-se à ação de cortar, deve utilizar a forma com 'c'.</message>
-                <suggestion>\1 <match no='2' regexp_match='se' regexp_replace='ce'/></suggestion>
+                <suggestion>\1 <match no='2' regexp_match='^se' regexp_replace='ce'/></suggestion>
                 <url>https://pt.wiktionary.org/wiki/cerrar</url>
-                <example correction='carpinteiro cerra'>O <marker>carpinteiro serra</marker>-te isso à medida.</example>
+                <example correction='carpinteiro cerra-te'>O <marker>carpinteiro serra-te</marker> isso à medida.</example>
                 <example>Formigueiro-da-serra</example>
             </rule>
             <rule id='HOMONYM_CUMPRIMENTOS_COMPRIMENTOS' name='Homófona: cumprimentos - comprimentos'>
@@ -33151,7 +32701,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     </marker>
                     <token postag='NC.+|AQ.+' postag_regexp='yes'>
                         <exception postag_regexp='yes' postag='AO.+'/>
-                        <exception scope='next' postag_regexp='yes' postag='VMP00.+|VMN0000'/>
+                        <exception scope='next' postag_regexp='yes' postag='VMP00.+|VMN0000|VMIF.+'/>
                     </token>
                 </pattern>
                 <message>Substitua por <suggestion>está</suggestion>.</message>
@@ -33789,7 +33339,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <rulegroup id="PECO_PECSO" name="[Confusão] peco/peço">
-            <!-- Created by Tiago F. Santos, 2019-09-19 -->
             <rule>
                 <pattern>
                     <token regexp='yes'>&pronomes_nao_ambiguos;</token>
@@ -33802,12 +33351,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
             <rule>
                 <pattern>
-                    <token regexp='yes'>pec(?:o|a(?:s?|mos|is|m))</token>
-                    <token regexp='yes' spacebefore='no'>&hifen;</token>
-                    <token regexp='yes' spacebefore='no'>&pronomes_nao_ambiguos;</token>
+                    <and>
+                        <token postag_regexp="yes" postag="VM.+:PP.+" inflected="yes">pecar</token>
+                        <token regexp='yes'>pec(?:o|a(?:s?|mos|is|m))(-.+)?</token>
+                    </and>
                 </pattern>
                 <message>'\1' refere-se ao verbo pecar com significado religioso. A forma do verbo pedir escreve-se com 'ç'.</message>
-                <suggestion><match no='1' regexp_match='ec' regexp_replace='eç'/>\2\3</suggestion>
+                <suggestion><match no='1' regexp_match='ec' regexp_replace='eç'/></suggestion>
                 <short>Possível confusão de termos</short>
                 <example correction="peço-te">Não, não te pergunto nada, só <marker>peco-te</marker> para me dizeres.</example>
             </rule>
@@ -34776,28 +34326,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <!-- RIU-ME rio-me -->
         <rule id='RIU-ME' name="[Confusão] riu-me/rio-me">
             <pattern>
-                <token>riu</token>
-                <token regexp='yes'>&tracos_de_separacao;</token>
-                <token>me</token>
+                <token>riu-me</token>
             </pattern>
             <message>Substitua por <suggestion>rio-me</suggestion>.</message>
             <example correction="rio-me">Eu <marker>riu-me</marker> das tuas piadas.</example>
         </rule>
 
 
-        <!-- SE si -->
         <rulegroup id='SE_SI' name='[Confusão] Se/Si'>
-            <!--      Created by Marco A.G.Pinto, Portuguese rule 2021-12-07 (25-JUN-2021+)      -->
-            <!--
-      No fim não conseguiu salvar a se mesmo. → No fim não conseguiu salvar a si mesmo.
-      No fim não conseguiu salvar a se próprio. → No fim não conseguiu salvar a si próprio.
-      No fim não conseguiu salvar-se a se mesmo. → No fim não conseguiu salvar-se a si mesmo.
-      No fim não conseguiu salvar-se a se próprio. → No fim não conseguiu salvar-se a si próprio.
-      -->
-
             <rule>
                 <pattern>
                     <token postag='V.+' postag_regexp='yes'/>
@@ -34820,9 +34358,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
             <rule>
                 <pattern>
-                    <token postag='V.+' postag_regexp='yes'/>
-                    <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                    <token regexp='yes' spacebefore='no'>[ao]s?|l[ao]s?|lh[ae]s?|n[ao]s?|me|se|te|vos</token>
+                    <token postag='V.+:PP.+' postag_regexp='yes'/>
                     <token>a</token>
                     <marker>
                         <token>se</token>
@@ -40439,7 +39975,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                         <exception regexp='yes'>concertos?</exception></token>
                 </pattern>
                 <message>'\1' refere-se a estar em acordo ou sintonia com algo. O sinónimo de reparar escreve-se <suggestion><match no='1' regexp_match='once' regexp_replace='onse'/></suggestion>.</message>
-                <example correction="consertá">Para <marker>concertá</marker>-lo terá de gastar 100€.</example>
+                <example correction="consertá-lo">Para <marker>concertá-lo</marker> terá de gastar 100€.</example>
                 <example>…concertado na especialidade entre socialistas, bloquistas e comunistas,…</example>
             </rule>
         </rulegroup>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -11458,9 +11458,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <token postag='CS|RG' postag_regexp='yes'/>
                 </antipattern>
                 <pattern>
-                    <token postag_regexp='yes' postag='V....S.:PP3CNO00' regexp='yes'>
+                    <token postag_regexp='yes' postag='V....S.:PP3CNO00' regexp='no'>
                         <exception inflected='yes'>concentrar</exception>
-                        <exception negate_pos='yes' postag_regexp='yes' postag='V....S.:PP3CNO00'/></token>
+                        <exception negate_pos='yes' postag_regexp='yes' postag='V....S.:PP3CNO00'/>
+                    </token>
                     <token min="0" max="3" postag_regexp='yes' postag='R.'/>
                     <token postag_regexp='yes' postag='D...P.+' min='0'>
                         <exception negate_pos='yes' postag_regexp='yes' postag='D...P.+'/></token>
@@ -30874,7 +30875,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                         <exception regexp='yes'>&art_detecao_paronimos;|\-</exception>
                         <exception postag='(?:A|C|D|SP|V).+|_PUNCT|SENT_START' postag_regexp='yes'/>
                     </token>
-                    <token regexp='yes' inflected="yes">serrar
+                    <token inflected="yes">serrar
                         <exception case_sensitive='yes'>Serra</exception>
                     </token>
                 </pattern>
@@ -41412,31 +41413,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
         <rulegroup id='SI_UNITS_EXPONENT' name="Unidades: Sistema Internacional: km2/km²">
-            <!-- Created by Tiago F. Santos, 2017-05-12 -->
             <url>https://pt.wikipedia.org/wiki/Exponencia%C3%A7%C3%A3o</url>
             <short>Erro tipográfico</short>
 
-            <!-- MARCOAGPINTO 2022-05-30 + 2022-10-02 (Checked/Enhanced) (24-MAY-2022+) *START* -->
-            <!--
-            THIS ANTIPATTERN ALSO APPEARS IN TWO OTHER PLACES ALSO ^2 RELATED.
-            As forças estão organizadas numa hierarquia C2.
-            -->
             <antipattern>
                 <token regexp='yes'>ciclos?|estruturas?|hierarquias?|hierárquicas?</token>
                 <token min="0" max="1">de</token>
                 <token case_sensitive='yes'>C2</token>
             </antipattern>
-            <!-- 2022-10-02 -->
-            <!--
-            O grupo detém pouca análise de alvos, C2 ou capacidade de aprendizagem.
-            -->
             <antipattern>
                 <token postag='NC.+|AQ.+' postag_regexp='yes'/>
                 <token min="0" max="1" postag='_PUNCT' postag_regexp='no'/>
                 <token case_sensitive='yes'>C2</token>
                 <token postag='CC' postag_regexp='no'/>
             </antipattern>
-            <!-- MARCOAGPINTO 2022-05-30 + 2022-10-02 (Checked/Enhanced) (24-MAY-2022+) *END* -->
 
             <rule>
                 <pattern case_sensitive="yes">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -846,11 +846,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <rulegroup id='AUXILIARY_VERB_INFINITIVE' name="Erro de concordância: Verbo auxiliar + verbo no infinitivo">
-            <!--      Created by Tiago F. Santos, 2019-03-16      -->
-            <!--      Improved by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2022-03-29/30/31 + 2022-05-30 (1-JAN-2022+)      -->
             <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/o-conceito-de-verbo-auxiliar/24055</url>
             <antipattern>
-                <token postag="VMN0000X"/>
+                <token regexp="yes">.+mo$.+[áê]$</token>
                 <token spacebefore='no' regexp='yes'>&hifen;</token>
                 <token spacebefore='no' regexp='yes'>&pronomes_nao_ambiguos;|&pronomes_ambiguos;</token>
             </antipattern>
@@ -867,57 +865,41 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <token case_sensitive='yes'>Podemos</token>
             </antipattern>
             <rule>
-
-                <!-- MARCOAGPINTO 2020-07-14 (2-JUL-2020+) *START* -->
-                <!-- "Na semana que vem vou ao cinema." -->
                 <antipattern>
                     <token postag='CS|PE0CN000|PR0CN000|PT0CN000' postag_regexp='yes'/>
                     <token postag='VMIP3S0|VMM02S0' postag_regexp='yes'/>
                     <token postag='V.+' postag_regexp='yes'/>
+                    <example>Na semana que vem vou ao cinema.</example>
                 </antipattern>
-                <!-- MARCOAGPINTO 2020-07-14 (2-JUL-2020+) *END* -->
-                <!-- MARCOAGPINTO 2020-07-14 (2-JUL-2020+) *START* -->
-                <!-- "O que há de vir virá." -->
-                <!-- "Se você puder venha conosco." -->
-                <!-- "O primeiro a chegar foi Émile Levassor." -->
-                <!-- "As entrelinhas do que estava por vir estavam se amarrando entre si." -->
                 <antipattern>
                     <token postag='CS|PE0CN000|PR0CN000|PT0CN000|SPS00|PP3CS000|PD0FS000|PP3FSA00|CC|PD0CN000' postag_regexp='yes'/>
                     <token postag='VMN0000|VMN0[13]S0|VMSF[13]S0' postag_regexp='yes'/>
                     <token postag='V.+' postag_regexp='yes'/>
+                    <example>As entrelinhas do que estava por vir estavam se amarrando entre si.</example>
                 </antipattern>
-                <!-- MARCOAGPINTO 2020-07-14 (2-JUL-2020+) *END* -->
-                <!-- MARCOAGPINTO 2020-07-15 (2-JUL-2020+) *START* -->
-                <!-- "Cristo não chegou aqui com Colombo, quem chegou foi o Anticristo." -->
-                <!-- "Quando ele chegou viu que as Terras Natais tinham sido saqueadas." -->
                 <antipattern>
                     <token postag='P[RTDE]0CN000|PP3[FM]S000' postag_regexp='yes'/>
                     <token postag='VMIS3S0'/>
                     <token postag='VMIS3S0'/>
                     <token postag='DA0[FM]S0|CS|P[RTE]0CN000' postag_regexp='yes'/>
+                    <example>Cristo não chegou aqui com Colombo, quem chegou foi o Anticristo.</example>
                 </antipattern>
-                <!-- "A primeira mulher que eu vi foi numa revista." -->
                 <antipattern>
                     <token postag='CS|P[RTE]0CN000' postag_regexp='yes'/>
                     <token min="0" max="1" postag='PP1CSN00'/>
-                    <token postag='VMN0000X|VMIS1S0' postag_regexp='yes'/>
+                    <token postag='VMIS1S0'/>
                     <token postag='VMIS3S0'/>
                     <token regexp='yes'>a|o|como|na|no|numa|num</token>
+                    <example>A primeira mulher que eu vi foi numa revista.</example>
                 </antipattern>
-                <!-- "A última vez que nos vimos foi no aniversário da Ana." -->
                 <antipattern>
                     <token postag='CS|P[RTE]0CN000' postag_regexp='yes'/>
                     <token min="0" max="1">nos</token>
                     <token postag='VMI[SP]1P0' postag_regexp='yes'/>
                     <token postag='VMIS3S0'/>
                     <token regexp='yes'>a|o|como|na|no|numa|num</token>
+                    <example>A última vez que nos vimos foi no aniversário da Ana.</example>
                 </antipattern>
-                <!-- MARCOAGPINTO 2020-07-15 (2-JUL-2020+) *END* -->
-                <!-- MARCOAGPINTO 2021-01-24 (1-JAN-2021+) *START* -->
-                <!--
-        Já cá ando há mais de meio século.
-        Foi nesse pequeno país que a civilização ocidental começou há mais de dois mil e oitocentos anos.
-        -->
                 <antipattern>
                     <token postag='V.+' postag_regexp='yes'/>
                     <and>
@@ -925,17 +907,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                         <token postag='VMIP3S0|VMM02S0' postag_regexp='yes'/>
                     </and>
                     <token postag='RG'/>
+                    <example>Foi nesse pequeno país que a civilização ocidental começou há mais de dois mil e oitocentos anos.</example>
                 </antipattern>
-                <!-- MARCOAGPINTO 2021-01-24 (1-JAN-2021+) *END* -->
-                <!-- MARCOAGPINTO 2021-01-26 (1-JAN-2021+) *START* -->
-                <!--
-        Tudo o que consegui foi um punhado de contratempos.
-        Tudo o que conseguimos foi um punhado de contratempos.
-        Nós conseguimos hoje o que não se conseguia há séculos.
-        Você poderia refazer esse exercício?
-        Acredita-se os que primeiros habitantes da Coreia chegaram há aproximadamente 500 mil anos.
-        Os que já vieram estão no salão.
-        -->
                 <antipattern>
                     <token postag='V.+' postag_regexp='yes'>
                         <exception postag_regexp='yes' postag='NP.+|SPS.+|VMIF3S0|VMN03P0'/>
@@ -947,48 +920,26 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <token postag='DA.+|DD.+|DI.+|SPS.+|RG|VMN0000' postag_regexp='yes'>
                         <exception postag_regexp='yes' postag='CC|AQ.+'/>
                     </token>
+                    <example>Os que já vieram estão no salão.</example>
                 </antipattern>
-                <!-- MARCOAGPINTO 2021-01-26 (1-JAN-2021+) *END* -->
-
-                <!-- MARCOAGPINTO 2022-03-29/30 (1-JAN-2022+) *START* -->
-                <!--
-        IT APPEAR IN TWO PLACES! 1/2
-        Eu realmente quero ler esse livro, pois parece ter uma história que podemos aprecia-la.
-        Caso o mesmo volte a ficar disponível, poderemos notifica-lo, bastando para tal que nos indique o seu endereço de email.
-        Desculpe, mas não posso considera-los como irmãos em Cristo Jesus.
-        Quando poderei revê-lo?
-        Tente envia-lo novamente, por favor.
-        Agora imagine que esse é um anencéfalo: como devemos trata-lo?
-        Quero revê-la.
-        Se Jesus voltar fico-me pelas modalidades até ele sair.
-        Apenas por curiosidade comecei a coloca-las em um mapa através do Google Maps.
-        -->
                 <antipattern>
                     <token postag='VMIP[13]S0|VMM02S0|VMII.S.+' postag_regexp='yes'/>
                     <token min="0" max="1" regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
                     <token min="0" max="1" regexp='yes'>l[ao]s?|lh[aeo]s?|n[ao]s?|me|se|te|vos</token>
+                    <example>Quando poderei revê-lo?</example>
                 </antipattern>
                 <antipattern>
                     <token postag='VMG0000'/>
                     <token postag='_PUNCT'/>
                 </antipattern>
-                <!-- MARCOAGPINTO 2022-03-29/30 (1-JAN-2022+) *END* -->
-
-                <!-- MARCOAGPINTO 2022-05-30 (24-MAY-2022+) *START* -->
-                <!--
-        THE RESULTS ARE JUST 1 HIT AND A VERY SMALL .TXT FILE WHICH MAKES IT IMPOSSIBLE TO IMPROVE THE RULE.
-        Qualquer um que queira vir será bem-vindo.
-        Até essa altura chegar decorrerão inúmeros conflitos.
-        -->
                 <antipattern>
                     <token postag='VMN0000'/>
                     <token postag='VMI[FP].+' postag_regexp='yes'/>
                     <token postag='AQ.+|NC.+|CC' postag_regexp='yes'/>
+                    <example>Até essa altura chegar decorrerão inúmeros conflitos.</example>
                 </antipattern>
-                <!-- MARCOAGPINTO 2022-05-30 (24-MAY-2022+) *END* -->
-
                 <antipattern>
-                    <token postag="VMN0000X"/>
+                    <token regexp="yes">.+mo$.+[áê]$</token>
                     <token spacebefore="no">-</token>
                     <token spacebefore="no"/>
                 </antipattern>
@@ -1021,7 +972,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>Podemos acompanhá-lo em sua caminhada?</example>
                 <example>É claro que isso foi há muito tempo atrás.</example>
                 <example>Seu poder prorrogou a partir de Mashhad, no oeste da Caxemira, para o…</example>
-                <example>Ela tentou persuadi-lo a ir com ela.</example>
                 <example>Ele começou há seis anos.</example>
                 <example>Não podem é impor que alguém seja forçado a trabalhar.</example>
 
@@ -1060,20 +1010,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
 
             <rule>
-
-                <!-- MARCOAGPINTO 2022-03-29/30 (1-JAN-2022+) *START* -->
-                <!--
-        IT APPEAR IN TWO PLACES! 2/2
-        Eu realmente quero ler esse livro, pois parece ter uma história que podemos aprecia-la.
-        Caso o mesmo volte a ficar disponível, poderemos notifica-lo, bastando para tal que nos indique o seu endereço de email.
-        Desculpe, mas não posso considera-los como irmãos em Cristo Jesus.
-        Quando poderei revê-lo?
-        Tente envia-lo novamente, por favor.
-        Agora imagine que esse é um anencéfalo: como devemos trata-lo?
-        Quero revê-la.
-        Se Jesus voltar fico-me pelas modalidades até ele sair.
-        Apenas por curiosidade comecei a coloca-las em um mapa através do Google Maps.
-        -->
                 <antipattern>
                     <token postag='VMIP[13]S0|VMM02S0|VMII.S.+' postag_regexp='yes'/>
                     <token min="0" max="1" regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
@@ -1083,8 +1019,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <token postag='VMG0000'/>
                     <token postag='_PUNCT'/>
                 </antipattern>
-                <!-- MARCOAGPINTO 2022-03-29/30 (1-JAN-2022+) *END* -->
-
                 <pattern>
                     <token inflected="yes" regexp='yes'>&verbos_auxiliares_aspectuais;|&verbos_auxiliares_modais;
                         <exception inflected='yes'>ser</exception>
@@ -10982,18 +10916,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <marker>
                         <and>
                             <token inflected='yes' regexp="yes">precisar|tratar</token>
-                            <token postag='VMIP3P0'/>
+                            <token postag='VMIP3P0:PP3CNO00'/>
                         </and>
                     </marker>
-                    <token regexp="yes" spacebefore='no'>[-]</token>
-                    <token spacebefore='no'>se</token>
                     <token>de</token>
                     <token postag='AQ..P.+|NC.P.+|[AD]...P.+|Z..P.+' postag_regexp='yes'/>
                 </pattern>
                 <message>Os verbos 'precisar'/'tratar' seguidos de '-se' não podem estar no plural devido à preposição 'de':</message>
-                <suggestion><match no='1' postag='VMIP3S0' postag_replace='VMIP3P0'/></suggestion>
-                <example correction="Precisa"><marker>Precisam</marker>-se de trabalhadores.</example>
-                <example correction="Trata"><marker>Tratam</marker>-se de pessoas estudiosas.</example>
+                <suggestion><match no='1' postag='VMIP3P0:PP3CNO00' postag_replace='VMIP3S0:PP3CNO00'/></suggestion>
+                <example correction="Precisa-se"><marker>Precisam-se</marker> de trabalhadores.</example>
+                <example correction="Trata-se"><marker>Tratam-se</marker> de pessoas estudiosas.</example>
             </rule>
 
             <rule> <!-- #19: como foram suas férias -->
@@ -11171,24 +11103,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
         <!-- MOSTRAM mostra -->
         <rulegroup id='CONCORDANCIA_COM_NUCLEO_DO_SUJEITO_V2' name='Concordância com núcleo do sujeito'>
-            <!--      Created by Ricardo Joseh Lima and improved by Marco A.G.Pinto, Portuguese rule 2021-10-13/14/15/19/20 (25-JUN-2021+)      -->
-            <!--
-      A realidade das pessoas mostram. → A realidade das pessoas mostra.
-      -->
-            <!--
-      Uma série de obras foram bem sucedidas apenas no seio da comunidade mórmon.
-      No extremo das interações estão as junções de galáxias.
-      Na constituição dos átomos predominam os espaços vazios.
-      Ao longo dos tempos foram vários os sistemas para classificar a artilharia segundo o calibre utilizado.
-      Ao longo dos séculos foram sendo registrados muitos problemas curiosos, cujas resoluções têm como base este famoso teorema.
-      Do lado dos cangaceiros morreram cinco bandidos.
-      No rescaldo dos confrontos morrem quatro pessoas.
-      A habilidade destes radares diferenciarem dois objetos próximos depende da largura do sinal emitido.
-      No Concelho das Velas existem 6 bandas filarmónicas.
-      No Porto de Pipas naufragaram 7 navios.
-      Neste tipo de erupções predominaram as de estilo pliniano, conduzindo ao abatimento da caldeira do vulcão mencionado.
-      Na aldeia de Pedras existiam também umas pedras lavradas antigas, que terão dado nome ao lugar.
-      -->
             <antipattern>
                 <token postag='SENT_START'/>
                 <token/>
@@ -11206,13 +11120,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <token postag='AQ0.P.+|NC.P.+|V....P.+|V...2S.+|D[AI]0.P.+|SPS00' postag_regexp='yes'/>
                 <token negate_pos="yes" postag_regexp='yes' postag='UNKNOWN|DA0.S.+'/>
             </antipattern>
-            <!--
-      Ao longo dos tempos desenvolveram-se vários simuladores.
-      Na Praia dos Cavaleiros realizam-se as competições esportivas do FestVerão.
-      Na freguesia das Lameiras encontram-se as Lameiras, o Barregão e a Vendada.
-      Na época das Descobertas instalam-se novas actividades industriais e comerciais.
-      Na prestação de Serviços destacam-se cabeleireiros, oficinas mecânicas, eletrônicas.
-      -->
             <antipattern>
                 <token postag='SENT_START'/>
                 <token/>
@@ -11222,15 +11129,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 </token>
                 <token postag='SPS.+' postag_regexp='yes'/>
                 <token postag='AQ0.P.+|NC.P.+' postag_regexp='yes'/>
-                <token postag='V...3P.+' postag_regexp='yes'/>
-                <token regexp='yes' spacebefore='no'>&hifen;</token>
-                <token spacebefore='no'>se</token>
+                <token postag='V...3P.:PP3CNO00' postag_regexp="yes"/>
                 <token postag='RG|VMG0000|D[AI]0.P.+|RM|Z0.P.+|AQ0.P.+|NC.P.+|Z0CN0' postag_regexp='yes'>
                     <exception regexp='yes'>[1]</exception>
                 </token>
                 <token min="0" max="1" regexp='yes'>[,]</token>
                 <token postag='AQ0.P.+|NC.P.+|V....P.+|V...2S.+|D[AI]0.P.+|SPS00' postag_regexp='yes'/>
                 <token negate_pos="yes" postag_regexp='yes' postag='UNKNOWN|DA0.S.+'/>
+                <example>Ao longo dos tempos desenvolveram-se vários simuladores.</example>
             </antipattern>
             <rule>
                 <pattern>
@@ -11285,14 +11191,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <token postag='SPS.+' postag_regexp='yes'/>
                     <token postag='AQ0.P.+|NC.P.+' postag_regexp='yes'/>
                     <marker>
-                        <token postag='V...3P.+' postag_regexp='yes'/>
-                        <token regexp='yes' spacebefore='no'>&hifen;</token>
-                        <token spacebefore='no'>se</token>
+                        <token postag='V...3P.:PP3CNO00' postag_regexp='yes'/>
                     </marker>
                     <token negate_pos="yes" postag='AQ0.P.+|NC.P.+|V....P.+|V...2S.+' postag_regexp='yes'/>
                 </pattern>
                 <message>De acordo com a gramática tradicional, o verbo permanece no singular, visto que o 'sujeito' está preposicionado.</message>
-                <suggestion><match no='6' postag='V.(..)3P.+' postag_regexp="yes" postag_replace='VM$13S0'/>-se</suggestion>
+                <suggestion><match no='6' postag='V.(..)3P(.+)' postag_regexp="yes" postag_replace='VM$13S$2'/>-se</suggestion>
                 <example correction="mostra-se">A realidade das pessoas <marker>mostram-se</marker>.</example>
                 <example>Uma variedade de pessoas juntou-se na reunião.</example>
                 <example>Grande parte destas crateras localiza-se no hemisfério sul.</example>
@@ -11510,98 +11414,62 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <rulegroup id='REFLEXIVE_VERB_SE_AGREEMENT' name='Concordância verbal: Verbo -se + Plural'>
-            <!--      Created by Tiago F. Santos, Portuguese rule, 2017-07-19      -->
-            <!--
-           MARCOAGPINTO inserted global antipatterns for all subrules on top using the logic (25-JUL-2022+)
-      -->
             <url>http://www.infoescola.com/portugues/concordancia-verbal/</url>
             <short>&MSG_ECV;</short>
-
-            <!-- MARCOAGPINTO 2022-11-13 (Checked/Enhanced) (25-JUL-2022+) *START* -->
-            <!-- Zero hits in 600 000 sentence, only affects my thesis. -->
             <antipattern>
                 <token postag='SENT_START|_PUNCT' postag_regexp='yes'/>
                 <token min="1" max="2" postag='AQ..S.+|NC.S.+|NP.S.+' postag_regexp='yes'/>
                 <token min="0" max="1" postag='_PUNCT' postag_regexp='no'/>
-                <token postag='VMI[PS].S.+' postag_regexp='yes'/>
-                <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                <token spacebefore='no' postag='PP3CNO00' postag_regexp='no'/> <!-- "se" -->
+                <token postag='VMI.3S0:PP3CNO00' postag_regexp='yes'/>
                 <token postag='RG' postag_regexp='no'/>
                 <token postag='AQ..P.+|NC.P.+|NP.P.+' postag_regexp='yes'/>
                 <example>O jovem vendedor, Rui Santos, imolou-se quando polícias tentaram prendê-lo.</example>
                 <example>O jovem vendedor, Rui Santos, imola-se quando polícias tentaram prendê-lo.</example>
             </antipattern>
-            <!-- MARCOAGPINTO 2022-11-13 (Checked/Enhanced) (25-JUL-2022+) *END* -->
-
-            <!-- MARCOAGPINTO 2022-11-13 (Checked/Enhanced) (25-JUL-2022+) *START* -->
             <antipattern>
                 <token postag='[DP][ADIPR]..P.+|SPS00:[DP][ADIPR]..P.+' postag_regexp='yes'/>
                 <token min="1" max="2" postag='AQ..P.+|NC.P.+|NP.P.+' postag_regexp='yes'/>
                 <token min="0" max="1" postag='_PUNCT' postag_regexp='no'/>
-                <token postag='VMI[MPS].P.+' postag_regexp='yes'/>
-                <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                <token spacebefore='no' postag='PP3CNO00' postag_regexp='no'/> <!-- "se" -->
+                <token postag='VMI.3S0:PP3CNO00' postag_regexp='yes'/>
                 <token postag='AQ..S.+|NC.S.+|NP.S.+' postag_regexp='yes'/>
                 <example>Suas predições tornaram-se realidade.</example>
                 <example>Seus sonhos tornaram-se realidade.</example>
                 <example>Com a beleza prática de Brinox, os ambientes tornam-se cenário de experiências memoráveis, pois permitem que você possa ter mais tempo para aproveitar a vida junt...</example>
                 <example>...e colaboram para a apropriação de um ambiente de comunicação, o computador e seus inúmeros recursos destacam-se como ferramenta de acesso apoiado por diferentes programas sociais do governo federal.</example>
             </antipattern>
-            <!-- MARCOAGPINTO 2022-11-13 (Checked/Enhanced) (25-JUL-2022+) *END* -->
-
-            <!-- MARCOAGPINTO 2022-11-13 (Checked/Enhanced) (25-JUL-2022+) *START* -->
             <antipattern>
                 <token min="1" max="2" postag='AQ.+|NC.+|NP.+' postag_regexp='yes'/>
                 <token postag='CC' postag_regexp='no'/>
                 <token min="1" max="2" postag='AQ.+|NC.+|NP.+' postag_regexp='yes'/>
                 <token min="0" max="1" postag='_PUNCT' postag_regexp='no'/>
-                <token postag='VMI[MPS].P.+' postag_regexp='yes'/>
-                <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                <token spacebefore='no' postag='PP3CNO00' postag_regexp='no'/> <!-- "se" -->
+                <token postag='VMI.3S0:PP3CNO00' postag_regexp='yes'/>
                 <token min="1" max="2" postag='[DP][ADIPR]..S.+|SPS00:[DP][ADIPR]..S.+' postag_regexp='yes'/>
                 <token postag='AQ..S.+|NC.S.+|NP.S.+|_PUNCT' postag_regexp='yes'/>
                 <example>Pão, café e tabaco tornaram-se sua dieta padrão.</example>
                 <example>Pão, café e tabaco tornaram-se a sua dieta padrão.</example>
             </antipattern>
-            <!-- MARCOAGPINTO 2022-11-13 (Checked/Enhanced) (25-JUL-2022+) *END* -->
-
-            <!-- MARCOAGPINTO 2022-11-13 (Checked/Enhanced) (25-JUL-2022+) *START* -->
             <antipattern>
                 <token postag='_PUNCT' postag_regexp='no'/>
-                <token regexp="yes">entenda|leia</token>
-                <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                <token>se</token>
+                <token postag='VMI.3S0:PP3CNO00' postag_regexp='yes'>entender|ler</token>
                 <token postag='AQ.+|NC.+|NP.+' postag_regexp='yes'/>
                 <token postag='CC' postag_regexp='no'/>
                 <token postag='AQ.+|NC.+|NP.+' postag_regexp='yes'/>
                 <example>...mã, minha digníssima esposa Magnólia, sempre tão solidária em relação aos problemas de sua família (entenda-se pais e irmãs) resolveu convidá-la a ficar uns tempos morando em casa, ou seja, na edícula, com a Freira,...</example>
             </antipattern>
-            <!-- MARCOAGPINTO 2022-11-13 (Checked/Enhanced) (25-JUL-2022+) *END* -->
 
             <rule>
                 <antipattern>
-                    <token postag_regexp='yes' postag='V....S.+' inflected='yes' regexp='yes'>dizer|ler</token>
-                    <token regexp='yes' spacebefore='no'>&hifen;</token>
-                    <token>se</token>
+                    <token postag_regexp='yes' postag='V....S.:PP3CNO00' inflected='yes' regexp='yes'>dizer|ler</token>
                     <token postag_regexp='yes' postag='(?:N..|A...)P.+'/>
                 </antipattern>
-                <!-- MARCOAGPINTO 2021-10-04 (25-JUN-2021+) *START* -->
-                <!--
-        Isto observa-se quando as forças avaliam mal o cenário.
-        -->
                 <antipattern>
-                    <token postag='VMIP3S0|VMM02S0' postag_regexp='yes'/>
-                    <token regexp='yes' spacebefore='no'>[-]</token>
-                    <token spacebefore='no'>se</token>
+                    <token postag='VMI.VMIP3S0:PP3CNO00|VMM02S0:PP3CNO00' postag_regexp='yes'/>
                     <token postag='CS|RG' postag_regexp='yes'/>
                 </antipattern>
-                <!-- MARCOAGPINTO 2021-10-04 (25-JUN-2021+) *END* -->
                 <pattern>
-                    <token postag_regexp='yes' postag='V....S.+'>
+                    <token postag_regexp='yes' postag='V....S.:PP3CNO00' regexp='yes'>
                         <exception inflected='yes'>concentrar</exception>
-                        <exception negate_pos='yes' postag_regexp='yes' postag='V....S.+'/></token>
-                    <token regexp='yes' spacebefore='no'>&hifen;</token>
-                    <token>se</token>
+                        <exception negate_pos='yes' postag_regexp='yes' postag='V....S.:PP3CNO00'/></token>
                     <token min="0" max="3" postag_regexp='yes' postag='R.'/>
                     <token postag_regexp='yes' postag='D...P.+' min='0'>
                         <exception negate_pos='yes' postag_regexp='yes' postag='D...P.+'/></token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -12461,13 +12461,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
                 <token regexp='yes' spacebefore='no'>[oa]s?</token>
             </pattern>
-            <filter class="org.languagetool.rules.pt.PortugueseEnclisisFilter" args="foo:bar"/>
+            <filter class="org.languagetool.rules.pt.PortugueseEnclisisFilter" args="verbPos:0 pronounPos:2 convertToAccusative:False"/>
             <message>O pronome &quot;\3&quot; se transforma em &quot;n\3&quot; quando em ênclise após uma vogal nasal.</message>
             <suggestion>{suggestion}</suggestion>
             <url>https://pt.wikipedia.org/wiki/Coloca%C3%A7%C3%A3o_pronominal#.C3.8Anclise</url>
             <example correction='tinham-no'>Muitos <marker>tinham-o</marker> como um bom amigo.</example>
             <example correction="Põe-nas"><marker>Põe-as</marker> na primeira gaveta.</example>
-            <example>Eu tinha-o como um bom amigo.</example>
+            <example correction="TEM-NO">ELE <marker>TEM-O</marker> NA MÃO.</example>
         </rule>
 
         <rule id='PRONOMIAL_COLOCATIONS_ADJUSTMENT_LOS' name='Colocações pronomiais: ênclise com o infinitivo (lo, la, los, las)'>
@@ -12476,7 +12476,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
                 <token regexp='yes' spacebefore='no'>[oa]s?</token>
             </pattern>
-            <filter class="org.languagetool.rules.pt.PortugueseEnclisisFilter" args="foo:bar"/>
+            <filter class="org.languagetool.rules.pt.PortugueseEnclisisFilter" args="verbPos:0 pronounPos:2 convertToAccusative:False"/>
             <message>Em ênclises após formas verbais terminadas por &quot;r&quot;, &quot;s&quot; ou &quot;z&quot;, o pronome &quot;\3&quot; e a forma verbal se modificam.</message>
             <!-- <suggestion><match no='1' postag_regexp="yes" postag="(V.+)" postag_replace="$1X"/>-l\3</suggestion> -->
             <suggestion>{suggestion}</suggestion>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
@@ -1729,13 +1729,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <exception scope='next' regexp='yes'>&separadores_de_oracoes;</exception>
                 </token>
                 <marker>
-                    <token postag_regexp='yes' postag='V.+'/>
-                    <token spacebefore='no' regexp='yes'>&hifen;</token>
-                    <token spacebefore='no'>se</token>
+                    <token postag_regexp='no' postag='VMIP3S0:PP3CNO00'/>
                 </marker>
             </pattern>
             <message>O subjuntivo é utilizado em condicionais (&quot;se...&quot;). Talvez você queira utilizar um pronome reflexivo?</message>
-            <suggestion>\2sse</suggestion>
+            <suggestion><match no="2" postag_regexp="yes" postag="V.+" postag_replace="VMSI3S0"/></suggestion>
             <example correction='lavasse'>Se <marker>lava-se</marker> os pratos, seria bom.</example>
             <example correction='trabalhasse'>Embora Chekhov <marker>trabalha-se</marker> como médico, enriqueceu a sua escrita com…</example>
         </rule>
@@ -1746,15 +1744,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         <rule>
             <pattern>
                 <marker>
-                    <token postag='VMIP2S0'/>
-                    <token regexp='yes' spacebefore='no'>&hifen;</token>
-                    <token spacebefore='no'>te</token>
+                    <token postag='VMIP2S0:PP2CSO00'/>
                 </marker>
                 <token postag='SPS.+|PD0FS.+|PP3FSA.+' postag_regexp='yes'/>
                 <token postag='AQ0.+|NC.+|V.+|DD.+' postag_regexp='yes'/>
             </pattern>
             <message>Caso se trate de uma forma do pretérito perfeito da segunda pessoa do singular, escreve-se sem hífen.</message>
-            <suggestion>\1\3</suggestion>
+            <suggestion><match no="1" postag_regexp="yes" postag="V.+" postag_replace="VMIS2S0"/></suggestion>
             <example correction="trocaste">Hoje tu <marker>trocas-te</marker> de computador?</example>
             <example>Tu andaste cantando?</example>
             <example>Tu cantaste a canção?</example>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -482,7 +482,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
               </marker>
           </pattern>
           <message>Em escrita formal não se começa uma frase com pronome átono. Coloque o pronome após o verbo.</message>
-          <suggestion><match no='3' case_conversion='startupper' postag="VMIP1P0" postag_regexp="yes" postag_replace="VMIP1P0X"/>-<match no='2' case_conversion='startlower'/></suggestion>
+          <suggestion><match no='3' case_conversion='startupper' postag="VMIP1P0" postag_regexp="yes" postag_replace="VMIP1P0:PP1CPO00"/></suggestion>
           <suggestion><match no='2' regexp_match="o" regexp_replace="ó"/> \3</suggestion>
           <example correction="Acostumamo-nos|Nós acostumamos"><marker>Nos acostumamos</marker> com tudo.</example>
       </rule>
@@ -966,7 +966,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
       <!-- Whole antipatterns must be rewritten: 2024+ -->
       <antipattern>
-          <token regexp='yes'>&pronomes_nao_ambiguos;</token>
+          <token postag_regexp="yes" postag="V.+:PP.+"/>
           <token regexp='yes'>comigo|con[st]igo|con[nv]osco</token>
           <token min='0' max='1' postag='_PUNCT' postag_regexp='no'/>
           <token postag='DP1..S' postag_regexp='yes'/>
@@ -2818,15 +2818,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             -->
             <pattern>
                 <marker>
-                    <token postag='VMIP2S0'/>
-                    <token regexp='yes' spacebefore='no'>&hifen;</token>
-                    <token spacebefore='no'>te</token>
+                    <token postag='VMIP2S0:PP2CSO00'/>
                 </marker>
                 <token postag='SPS.+|PD0FS.+|PP3FSA.+' postag_regexp='yes'/>
                 <token postag='AQ0.+|NC.+|V.+|DD.+' postag_regexp='yes'/>
             </pattern>
             <message>Caso se trate de uma forma do pretérito perfeito, escreve-se sem hífen.</message>
-            <suggestion>\1\3</suggestion>
+            <suggestion><match no="1" postag_regexp="yes" postag="V.+" postag_replace="VMIS2S0"/></suggestion>
             <example correction="trocaste">Hoje <marker>trocas-te</marker> de computador?</example>
             <example>Hoje andaste a cantar?</example>
             <example>Hoje andaste à procura da chave?</example>
@@ -2862,39 +2860,41 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 </token>
                 <marker>
                     <token postag_regexp='yes' postag='VMSI.+' regexp='yes'>.+sse
-                    <exception negate_pos='yes' postag_regexp='yes' postag='VMSI.+'/></token>
-            </marker>
-        </pattern>
-        <message>O conjuntivo é utilizado em condicionais ('se...'). Será que pretende utilizar a forma reflexiva?</message>
-        <suggestion><match no='2' regexp_match='(.+)sse' regexp_replace='$1-se'/></suggestion>
-        <example correction='chega-se'>Ela <marker>chegasse</marker> mais perto, a cada palavra.</example>
-    </rule>
-    <rule>
-        <pattern>
-            <token regexp='yes' skip='-1'>&separadores_de_oracoes;
-            <exception scope='next' regexp='yes'>&separadores_de_oracoes;</exception>
-            <exception scope='next' regexp='yes'>&introduz_conjuntivo;</exception></token>
-        <marker>
-            <token postag_regexp='yes' postag='VMSI.+' regexp='yes'>.+sse
-            <exception negate_pos='yes' postag_regexp='yes' postag='VMSI.+'/></token>
-    </marker>
-</pattern>
-<message>O conjuntivo é utilizado em condicionais ('se...'). Será que pretende utilizar a forma reflexiva?</message>
-<suggestion><match no='2' regexp_match='(.+)sse' regexp_replace='$1-se'/></suggestion>
-<example correction='chega-se'>A cada palavra, ela <marker>chegasse</marker> mais perto.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <token skip='-1' postag_regexp='yes' postag='C.+' regexp='yes'>se|embora
-                    <exception scope='next' regexp='yes'>&separadores_de_oracoes;</exception></token>
+                        <exception negate_pos='yes' postag_regexp='yes' postag='VMSI.+'/>
+                    </token>
+                </marker>
+            </pattern>
+            <message>O conjuntivo é utilizado em condicionais ('se...'). Será que pretende utilizar a forma reflexiva?</message>
+            <suggestion><match no='2' regexp_match='(.+)sse' regexp_replace='$1-se'/></suggestion>
+            <example correction='chega-se'>Ela <marker>chegasse</marker> mais perto, a cada palavra.</example>
+        </rule>
+        <rule>
+            <pattern>
+                <token regexp='yes' skip='-1'>&separadores_de_oracoes;
+                    <exception scope='next' regexp='yes'>&separadores_de_oracoes;</exception>
+                    <exception scope='next' regexp='yes'>&introduz_conjuntivo;</exception>
+                </token>
                 <marker>
-                    <token postag_regexp='yes' postag='V.+'/>
-                    <token spacebefore='no' regexp='yes'>&hifen;</token>
-                    <token spacebefore='no'>se</token>
+                    <token postag_regexp='yes' postag='VMSI.+' regexp='yes'>.+sse
+                        <exception negate_pos='yes' postag_regexp='yes' postag='VMSI.+'/>
+                    </token>
+                </marker>
+            </pattern>
+            <message>O conjuntivo é utilizado em condicionais ('se...'). Será que pretende utilizar a forma reflexiva?</message>
+            <suggestion><match no='2' regexp_match='(.+)sse' regexp_replace='$1-se'/></suggestion>
+            <example correction='chega-se'>A cada palavra, ela <marker>chegasse</marker> mais perto.</example>
+        </rule>
+        <rule>
+            <pattern>
+                <token skip='-1' postag_regexp='yes' postag='C.+' regexp='yes'>se|embora
+                    <exception scope='next' regexp='yes'>&separadores_de_oracoes;</exception>
+                </token>
+                <marker>
+                    <token postag_regexp='yes' postag='V.+:PP3CNO00'/>
                 </marker>
             </pattern>
             <message>O conjuntivo no pretérito imperfeito é utilizado em orações condicionais. Considere se esta não é uma dessas situações.</message>
-            <suggestion>\2sse</suggestion>
+            <suggestion><match no="2" postag_regexp="yes" postag="V.+" postag_replace="VMSI3S0"/></suggestion>
             <example correction='lavasse'>Se <marker>lava-se</marker> os pratos, é que era bom.</example>
             <example correction='trabalhasse'>Embora Tchecov  <marker>trabalha-se</marker> como médico, enriqueceu a sua escrita com…</example>
         </rule>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -255,14 +255,13 @@ USA
 
         <rule>
             <pattern>
-                <token inflected='yes' regexp='yes'>estar|andar|ir|vir</token><!-- TODO Review all cases and confirm it can be safely expanded to more cases-->
-                <token regexp='yes' spacebefore='no'>&hifen;</token>
-                <token postag='PP.*' postag_regexp='yes'/>
+                <token inflected='yes' regexp='yes' postag_regexp="yes" postag="V.+:PP.+">estar|andar|ir|vir</token><!-- TODO Review all cases and confirm it can be safely expanded to more cases-->
                 <token postag='V.G0+' postag_regexp='yes'>
-                    <exception postag='V.G0+' postag_regexp='yes' negate_pos='yes'/></token>
+                    <exception postag='V.G0+' postag_regexp='yes' negate_pos='yes'/>
+                </token>
             </pattern>
             <message>Se possível, evite o gerúndio.</message>
-            <suggestion>\1\2\3 a <match no='4' postag='VMN0000' case_conversion="alllower"/></suggestion>
+            <suggestion>\1 a <match no='2' postag='VMN0000' case_conversion="alllower"/></suggestion>
             <example correction='iam-se a acender'>As luzes <marker>iam-se acendendo</marker> à medida que ela passava.</example>
 
             <example type='correct'>Ao fazê-lo <marker>vão saindo</marker> resultados cada vez mais inesperados.</example>
@@ -1165,8 +1164,6 @@ USA
         <rule>
             <pattern>
                 <token inflected='yes'>bobear</token>
-                <token min='0' regexp='yes' spacebefore='no'>&hifen;</token>
-                <token min='0'>se</token>
             </pattern>
             <message>Linguagem informal. Considere as alternativas.</message>
             <suggestion/>
@@ -1494,9 +1491,7 @@ USA
     </rule>
     <rule>
         <pattern>
-            <token inflected='yes'>dizer</token>
-            <token>-</token>
-            <token>me</token>
+            <token inflected='yes' postag_regexp="yes" postag="V.+:PP1CSO00">dizer</token>
             <token>com</token>
             <token>quem</token>
             <token>andas</token>
@@ -2025,8 +2020,6 @@ USA
     <rule>
         <pattern>
             <token inflected='yes'>ver</token>
-            <token>-</token>
-            <token spacebefore='no' regexp='yes'>&pronomes_nao_ambiguos;|&pronomes_ambiguos;</token>
             <token>à</token>
             <token>brocha</token>
         </pattern>
@@ -2396,7 +2389,7 @@ USA
         -->
 
         <antipattern>
-            <token regexp='yes' inflected='yes'>alterar|banir|bloquear|efetuar|enviar|fazer|modificar|pedir|querer|realizar|receber|requerer|ser|solicitar</token>
+            <token regexp='yes' inflected='yes' postag_regexp="yes" postag="V......">alterar|banir|bloquear|efetuar|enviar|fazer|modificar|pedir|querer|realizar|receber|requerer|ser|solicitar</token>
             <token min="0" max="1" postag='[DP][ADIPR].+|SPS00:[DP][ADIPR].+|SPS00|CC|CS|RG|I|RM|RN' postag_regexp='yes'/>
             <token regexp='yes'>chamad[ao]s?|chamares</token>
             <token>de</token>
@@ -2419,8 +2412,6 @@ USA
 
         <antipattern>
             <token regexp='yes' inflected='yes'>alterar|banir|bloquear|chamar|efetuar|enviar|fazer|modificar|pedir|querer|realizar|receber|requerer|ser|solicitar</token>
-            <token min="0" max="1" regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-            <token min="0" max="1" regexp='yes'>&pronomes_obliquos;</token>
             <token>de</token>
             <token regexp='yes'>áudio|regresso|retorno|telefone|vídeo|volta</token>
             <example>Ele foi chamado de volta, em meio à sua viagem.</example>
@@ -2431,9 +2422,9 @@ USA
         </antipattern>
 
         <rule>
-            <pattern>
+            <pattern> <!-- most cases -->
                 <marker>
-                    <token regexp='yes' inflected='yes'>&verbos_pronominais;</token>
+                    <token regexp='yes' inflected='yes' postag_regexp="yes" postag="V.+">&verbos_pronominais;</token>
                     <token>de</token>
                 </marker>
                 <token min="0" max="1" postag='_QUOT' postag_regexp='no'/>
@@ -2444,12 +2435,12 @@ USA
             <example correction="denominada">Temos uma teoria <marker>denominada de</marker> matemática.</example>
         </rule>
 
-        <rule>
+        <rule> <!-- weird pt-PT contractions -->
             <pattern>
                 <marker>
                     <token regexp='yes' inflected='yes'>&verbos_pronominais;</token>
                     <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                    <token regexp='yes' spacebefore='no'>&pronomes_obliquos;</token>
+                    <token regexp='yes' spacebefore='no'>lh[oa]s?|[tm][oa]</token>
                     <token>de</token>
                 </marker>
                 <token min="0" max="1" postag='_QUOT' postag_regexp='no'/>
@@ -3897,9 +3888,7 @@ USA
 
         <!-- MARCOAGPINTO 2023-01-21 (Checked/Enhanced) (25-JUL-2022+) *START* -->
         <antipattern>
-            <token postag='VMIP3.+' postag_regexp='yes'/>
-            <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-            <token regexp='yes' spacebefore='no'>me|lhes?|nos</token>
+            <token postag='VMIP3.+:(PP1C.O00|PP3C.D00)' postag_regexp='yes'/>
             <token postag='DA.+|SPS00:DA.+|DI.+|SPS00:DI.+' postag_regexp='yes'/>
             <token postag='NC.+|AQ.+' postag_regexp='yes'/>
             <token postag='DA.+|DI.+' postag_regexp='yes'/>
@@ -3916,15 +3905,13 @@ USA
         <antipattern>
             <token postag='DA.+|DI.+' postag_regexp='yes'/>
             <token postag='NC.+|AQ.+|NP.+' postag_regexp='yes' skip='-1'/>
-            <token postag='VMIP3.+' postag_regexp='yes'/>
-            <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-            <token regexp='yes' spacebefore='no'>me|lhes?|nos</token>
+            <token postag='VMIP3..:(PP1C.O00|PP3C.D00)' postag_regexp='yes'/>
             <token min="0" max="1" postag='DA.+|SPS00:DA.+|DI.+|SPS00:DI.+' postag_regexp='yes'/>
             <token postag='NC.+|AQ.+' postag_regexp='yes'/>
             <example>O livro [9] dá-nos informação sobre as várias técnicas de combate.</example>
             <example>O ASPIRANTE AMÉRICO VICTOR SALVATO rende-me como Comandante da Prontidão.</example>
             <example>A Ana [11] dá-nos a quantidade de informação necessária.</example>
-            <example>Esta fórmula que se afirma “elitista” e nesse sentido rejeita todas as tendências actuais, concede-lhes a contra-gosto apenas os mínimos possíveis.</example>
+            <example>Esta fórmula que se afirma “elitista” e nesse sentido rejeita todas as tendências recentes, concede-lhes a contra-gosto apenas os mínimos possíveis.</example>
         </antipattern>
         <!-- MARCOAGPINTO 2023-01-26 + 2023-01-27 (Checked/Enhanced) (25-JUL-2022+) *END* -->
 
@@ -4208,13 +4195,13 @@ USA
     </rule>
     <rule>
         <pattern>
-            <token>te</token>
+            <token postag_regexp="yes" postag="V.+:PP2CSO00"/>
         </pattern>
-        <message>O uso explícito do pronome "\1" pode ser interpretado como desrespeitoso. Considere substituí-lo pelo pronome de tratamento adequado.</message>
-        <suggestion>lhe</suggestion>
+        <message>O uso explícito do pronome "te" pode ser interpretado como desrespeitoso. Considere substituí-lo pelo pronome de tratamento adequado.</message>
+        <suggestion><match no="1" regexp_match="(.+)-te" regexp_replace="$1-lhe"/></suggestion>
         <short>Tratamento inapropriado</short>
-        <example correction="lhe">O Dr. Mário faz-<marker>te</marker> essa análise sem problemas.</example>
-        <example>—O Dr. Mário faz-<marker>te</marker> essa análise sem problemas.</example>
+        <example correction="faz-lhe">O Dr. Mário <marker>faz-te</marker> essa análise sem problemas.</example>
+        <example>—O Dr. Mário <marker>faz-te</marker> essa análise sem problemas.</example>
     </rule>
     <rule>
         <pattern>
@@ -4304,12 +4291,10 @@ USA
     <!-- JAUME + MARCOAGPINTO 2020-07-27 (2-JUL-2020+) Improved *END* -->
     <rule>
         <pattern>
-            <token postag="V.+" postag_regexp='yes'/>
-            <token regexp='yes' spacebefore='no'>&hifen;</token>
-            <token>te</token>
+            <token postag="V.+:PP2CSO00" postag_regexp='yes'/>
         </pattern>
         <message>Confirme se esta forma de tratamento informal é apropriada.</message>
-        <suggestion>\1-lhe</suggestion>
+        <suggestion><match no="1" postag_regexp="yes" postag="(V.+):PP2CSO00" postag_replace="$1:PP3CSD00"/></suggestion>
         <short>Possível tratamento informal</short>
         <example correction="Garanto-lhe"><marker>Garanto-te</marker> que foi mesmo assim.</example>
         <example>—<marker>Garanto-te</marker> que foi mesmo assim.</example>
@@ -4328,9 +4313,7 @@ USA
         <antipattern>
             <token negate="yes" regexp='yes'>muito|pouco|por</token>
             <token postag="PD0NN000|NC[CFM]S000" postag_regexp='yes'/>
-            <token postag="V...2.+" postag_regexp='yes'/>
-            <token regexp='yes' spacebefore='no'>&hifen;</token>
-            <token regexp='yes'>me|nos</token>
+            <token postag="V...2.+:PP1C.O00" postag_regexp='yes'/>
         </antipattern>
         <!-- MARCOAGPINTO 2020-06-07 *END* -->
         <!-- MARCOAGPINTO 2020-10-23 (21-OCT-2020+) *START* -->
@@ -4338,9 +4321,7 @@ USA
         <!-- "E assim abri-lhe a porta." -->
         <!-- "E assim abri-lhes a porta." -->
         <antipattern>
-            <token postag='VMX0000|VMIP2P0|VMIS1S0|VMM02P0' postag_regexp='yes'/>
-            <token regexp='yes' spacebefore='no'>&hifen;</token>
-            <token regexp='yes' spacebefore='no'>me|lhes?</token>
+            <token postag='(VMX0000|VMIP2P0|VMIS1S0|VMM02P0):(PP1CSO00|PP3C.D00)' postag_regexp='yes'/>
         </antipattern>
         <!-- MARCOAGPINTO 2020-10-23 (21-OCT-2020+) *END* -->
         <!-- MARCOAGPINTO 2021-01-11 + 2021-01-12 (1-JAN-2021+) *START* -->
@@ -4352,11 +4333,9 @@ USA
             Entristece-me ao ouvir isso.
         -->
         <antipattern>
-            <token postag='VMIP3S0|VMM02S0' postag_regexp='yes'>
+            <token postag='(VMIP3S0|VMM02S0):(PP1C.O00|PP3C.D00)' postag_regexp='yes'>
                 <exception postag='NCFS000' postag_regexp='no'/> <!-- NOUN MALE SEEMS TO WORK WELL WITH THIS RULE "Dói-me dizer" WHILE FEMALE GIVES FALSE POSITIVES  "Deixa-me dizer"-->
             </token>
-            <token regexp='yes' spacebefore='no'>&hifen;</token>
-            <token regexp='yes' spacebefore='no'>me|lhes?|nos</token>
             <token min="0" max="1" postag='SPS.+' postag_regexp='yes'/>
             <token postag='VMN0000' postag_regexp='no'/>
         </antipattern>
@@ -4371,9 +4350,7 @@ USA
             <token min="1" max="3" postag='NC.+|NP.+|AQ.+' postag_regexp='yes'>
                 <exception postag_regexp='yes' postag='V.+'/>
             </token>
-            <token postag='V.+' postag_regexp='yes'/>
-            <token regexp='yes' spacebefore='no'>&hifen;</token>
-            <token regexp='yes' spacebefore='no'>me|lhes?|nos</token>
+            <token postag='V.+:(PP1C.O00|PP3C.D00)' postag_regexp='yes'/>
         </antipattern>
         <!-- MARCOAGPINTO 2021-03-07 (1-JAN-2021+) *END* -->
         <!-- MARCOAGPINTO 2021-04-29 + 2021-07-16 (Enhanced) (17-MAR-2021+) *START* -->
@@ -4390,9 +4367,7 @@ USA
                 <exception postag_regexp='yes' postag='NP.+'/>
             </token>
             <token min="0" max="1" postag='_PUNCT' postag_regexp='no'/>
-            <token postag='VMIP3S0|VMM0[23]S0|VMSP[13]S0' postag_regexp='yes'/>
-            <token regexp='yes' spacebefore='no'>&hifen;</token>
-            <token regexp='yes' spacebefore='no'>me|lhes?|nos</token>
+            <token postag='(VMIP3S0|VMM0[23]S0|VMSP[13]S0):(PP1C.O00|PP3C.D00)' postag_regexp='yes'/>
         </antipattern>
         <!-- MARCOAGPINTO 2021-04-29 + 2021-07-16 (Enhanced) (17-MAR-2021+) *END* -->
 
@@ -4404,9 +4379,7 @@ USA
             Dói-me aqui.
         -->
         <antipattern>
-            <token postag='VMIP3P0' postag_regexp='no'/>
-            <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-            <token regexp='yes' spacebefore='no'>me|lhes?|nos</token>
+            <token postag='VMIP3P0:(PP1C.O00|PP3C.D00)' postag_regexp='yes'/>
         </antipattern>
         <!-- MARCOAGPINTO 2022-01-26 (1-JAN-2022+) *END* -->
 
@@ -4421,17 +4394,15 @@ USA
         -->
         <antipattern>
             <token postag='P[ADIP][3N][FMN].+|D[ADIP].+' postag_regexp='yes'/>
-            <token postag='VMIP3S0' postag_regexp='no'/>
+            <token postag="VMIP3S0:(PP1C.O00|PP3C.D00)" postag_regexp="yes"/>
         </antipattern>
         <!-- MARCOAGPINTO 2022-05-29 (Checked/Enhanced) (24-MAY-2022+) *END* -->
 
         <!-- MARCOAGPINTO 2022-06-06 (Checked/Enhanced) (5-JUN-2022+) *START* -->
         <antipattern>
-            <token postag='VMIP3S0|VMM0[23]S0|VMSP[13]S0' postag_regexp='yes'>
+            <token postag='(VMIP3S0|VMM0[23]S0|VMSP[13]S0):(PP1CPO00|PP3C.D00)' postag_regexp='yes'>
                 <exception scope="previous" postag="SENT_START|_PUNCT" postag_regexp='yes'/>
             </token>
-            <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-            <token regexp='yes' spacebefore='no'>lhes?|nos</token>
             <token postag='SPS.+|CC|CS|[DP][ADIP].+|RG' postag_regexp='yes'/>
             <token postag='NC.+|AQ.+|NP.+|[DP][ADI].+|CS|RG' postag_regexp='yes'/>
             <example>Ambrósio responde-lhe por um tratado "Sobre a fé para Graciano Augusto", em cinco livros.</example>
@@ -4448,9 +4419,7 @@ USA
         <!-- MARCOAGPINTO 2022-06-06 (Checked/Enhanced) (5-JUN-2022+) *START* -->
         <antipattern>
             <!--<token postag="AQ..S.+|NC.S.+" postag_regexp='yes'/>-->
-            <token postag="V...3S.+" postag_regexp='yes'/>
-            <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-            <token regexp='yes'>lhes?</token>
+            <token postag="V...3S.+:PP3C.D00" postag_regexp='yes'/>
             <token><exception postag='PP2CSN00|DA.+|_PUNCT|SPS00' postag_regexp='yes'/></token>
             <example>Falta-lhe talento para ser ator.</example>
             <example>À Mary, falta-lhe delicadeza.</example>
@@ -4463,14 +4432,12 @@ USA
 
         <pattern>
             <token min='0' regexp='yes'>tu|vós</token>
-            <token postag="V...2.+" postag_regexp='yes'>
+            <token postag="V...2..:(PP[12]C.O00|PP3C.D00)" postag_regexp='yes'>
                 <exception>parece</exception>
-                <!--<exception postag="V..[^P]3.+" postag_regexp='yes'/>--></token>
-            <token regexp='yes' spacebefore='no'>&hifen;</token>
-            <token regexp='yes'>me|te|lhe|nos|vos|lhes</token>
+            </token>
         </pattern>
         <message>Confirme se esta forma de tratamento informal é apropriada.</message>
-        <suggestion><match no="2" postag="(V...)2(.+)" postag_replace='$13$2' postag_regexp="yes"/>-\4</suggestion>
+        <suggestion><match no="2" postag="(V...)2(.+)" postag_replace='$13$2' postag_regexp="yes"/></suggestion>
         <short>Possível tratamento informal</short>
         <example correction="Diga-me"><marker>Diz-me</marker> que foi mesmo assim?</example>
         <example correction="Diga-me"><marker>Tu diz-me</marker> que foi mesmo assim?</example>
@@ -4586,9 +4553,7 @@ USA
 
     <!-- MARCOAGPINTO 2022-10-21 (Checked/Enhanced) (25-JUL-2022+) *START* -->
     <antipattern>
-        <token postag='VMIP3S0' postag_regexp="no"/>
-        <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-        <token regexp='no' spacebefore='no'>se</token>
+        <token postag='VMIP3S0:PP3CNO00' postag_regexp="no"/>
         <example>Em amarelo representa-se o conhecimento como um conjunto de crenças verdadeiras, que foram provadas e justificadas.</example>
         <example>Estende-se por uma área de 45,89 km².</example>
         <example>Pode-se chegar lá depressa?</example>
@@ -4631,10 +4596,10 @@ USA
     <rule>
         <pattern>
             <token min='0' regexp='yes'>tu|vós</token>
-            <token postag="V...2.+" postag_regexp='yes'/>
+            <token postag="V...2.." postag_regexp='yes'/>
         </pattern>
         <message>Confirme se esta forma de tratamento informal é apropriada.</message>
-        <suggestion><match no="2" postag="(V...)2(.+)" postag_replace='$13$2' postag_regexp="yes"/></suggestion>
+        <suggestion><match no="2" postag="(V...)2(..)" postag_replace='$13$2' postag_regexp="yes"/></suggestion>
         <url>https://pt.wikipedia.org/wiki/Distin%C3%A7%C3%A3o_t-v</url>
         <short>Tratamento informal</short>
         <example correction="Cole"><marker>Cola</marker> aqui o texto.</example>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3546,21 +3546,17 @@ USA
             </rule>
         </rulegroup>
         <rulegroup id='AVOID_ALL_PASSIVE_VOICE' name='Escrita Criativa: Evitar a Passiva (todas a formas)' type='style' default='off'>
-            <!-- Created by Tiago F. Santos , Portuguese rule, 2016-11-24 	-->
-            <!-- 			Synthetic Passive Voice			-->
             <rule>
                 <pattern>
-                    <token postag='V...3.+' postag_regexp='yes'>
-                        <exception inflected='yes' regexp='yes'>vestir|calçar|magoar|ferir</exception></token>
-                    <token spacebefore='no' regexp='yes'>&hifen;</token>
-                    <token spacebefore='no'>se</token>
+                    <token postag='V...3.+:PP3CNO00' postag_regexp='yes'>
+                        <exception inflected='yes' regexp='yes'>vestir|calçar|magoar|ferir</exception>
+                    </token>
                 </pattern>
                 <message>Evite a voz passiva.</message>
                 <url>https://pt.wikipedia.org/wiki/Voz_verbal#Voz_passiva</url>
                 <example type='incorrect'>O trabalho <marker>fez-se</marker>.</example>
                 <example>Alguém <marker>fez</marker> o trabalho.</example>
             </rule>
-            <!-- 		Analitic Passive Voice Complement	        -->
             <rule>
                 <pattern>
                     <token postag='V.P.+' postag_regexp='yes'/>
@@ -5195,16 +5191,14 @@ USA
             <rule id='CLICHE_18_LEVANTAR' name='Clichê: Levantar com o pé esquerdo'>
                 <pattern>
                     <token inflected='yes'>levantar</token>
-                    <token min='0' regexp='yes' spacebefore='no'>&hifen;</token>
-                    <token min='0'>se</token>
                     <token>com</token>
                     <token>o</token>
                     <token>pé</token>
                     <token>esquerdo</token>
                 </pattern>
                 <message>&cliche_msg;</message>
-                <suggestion><match no='1' postag='V.+' postag_regexp='yes'>ter</match> um dia mau</suggestion>
-                <example correction='teve um dia mau'><marker>levantou-se com o pé esquerdo</marker>.</example>
+                <suggestion><match no='1' postag='(V......):PP.+' postag_regexp='yes' postag_replace="$1">ter</match> um dia ruim</suggestion>
+                <example correction='teve um dia ruim'><marker>levantou-se com o pé esquerdo</marker>.</example>
             </rule>
             <rule id='CLICHE_19_METER' name='Clichê: Meter o dedo na ferida'>
                 <pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -5819,17 +5819,15 @@ USA
             <rule id='CLICHE_240_ARMAR-SE' name='Clichê: Armar-se até aos dentes|armado até aos dentes|armado até os dentes'>
                 <pattern>
                     <token inflected='yes' regexp='yes'>armar|armado</token>
-                    <token min='0' regexp='yes' spacebefore='no'>&hifen;</token>
-                    <token min='0'>se</token>
                     <token>até</token>
                     <token regexp='yes'>a?os</token>
                     <token>dentes</token>
                 </pattern>
                 <message>&cliche_msg;</message>
-                <suggestion>exageradamente <match no='1' postag='V.+' postag_regexp='yes'>armar</match></suggestion>
+                <suggestion><match no='1' postag='V.+' postag_regexp='yes'>armar</match> exageradamente</suggestion>
                 <suggestion><match no='1' postag='V.+' postag_regexp='yes'>preparar</match> para uma situação</suggestion>
-                <example correction='exageradamente armar|preparar para uma situação'><marker>armar-se até aos dentes</marker>.</example>
-                <example correction='exageradamente armado|preparado para uma situação'><marker>armado até aos dentes</marker>.</example>
+                <example correction='armar-se exageradamente|preparar-se para uma situação'><marker>armar-se até aos dentes</marker>.</example>
+                <example correction='armado exageradamente|preparado para uma situação'><marker>armado até aos dentes</marker>.</example>
             </rule>
             <rule id='CLICHE_242_ARREBENTAR' name='Clichê: Arrebentar a boca do balão'>
                 <pattern>
@@ -7770,9 +7768,7 @@ USA
             </rule>
             <rule id='CLICHE_449_TRAIR-SE' name='Clichê: Trair-se pela emoção'>
                 <pattern>
-                    <token inflected='yes'>trair</token>
-                    <token regexp='yes' spacebefore='no'>&hifen;</token>
-                    <token>se</token>
+                    <token inflected='yes' postag_regexp="yes" postag="V.+:PP.+">trair</token>
                     <token>pela</token>
                     <token>emoção</token>
                 </pattern>
@@ -8110,12 +8106,10 @@ USA
         <rule id='BASEIA-SE_EM' name="Tem por base" default='off'>
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
-                <token inflected='yes'>basear</token>
-                <token regexp='yes' min='0'>&tracos_de_separacao;</token>
-                <token>se</token>
+                <token inflected='yes' postag_regexp="yes" postag="V.+:PP3CNO00">basear</token>
                 <token>em</token>
             </pattern>
-            <message>Substitua por <suggestion><match no='1' postag_regexp='yes' postag='V.+'>ter</match> por base</suggestion>.</message>
+            <message>Substitua por <suggestion><match no='1' postag_regexp='yes' postag='(V.+):PP3CNO00' postag_replace="$1">ter</match> por base</suggestion>.</message>
             <example correction="tem por base">O estudo <marker>baseia-se em</marker> dados estatísticos.</example>
         </rule>
 
@@ -9054,29 +9048,12 @@ USA
                 <suggestion>deliberadamente</suggestion>
                 <example correction="deliberadamente">Eles fizeram <marker>de propósito</marker>.</example>
                 <example correction="deliberadamente">Eles fizeram aquilo <marker>de propósito</marker>.</example>
-            </rule>
-
-            <rule>
-                <pattern>
-                    <token inflected='yes'>fazer</token>
-                    <token regexp='yes' spacebefore='no'>&tracos_de_separacao;</token>
-                    <token regexp='yes' spacebefore='no'>&pronomes_obliquos;</token>
-                    <marker>
-                        <token>de</token>
-                        <token>propósito</token>
-                    </marker>
-                </pattern>
-                <message>Num contexto formal/científico, é preferível escrever &quot;deliberadamente&quot;.</message>
-                <suggestion>deliberadamente</suggestion>
                 <example correction="deliberadamente">Eles fizeram-no <marker>de propósito</marker>.</example>
             </rule>
-
         </rulegroup>
 
 
-        <!-- USAR empregar -->
         <rulegroup id='CIENTÍFICO_EMPREGAR_TERMO' name="[Científico] usar → empregar" type="style" tags="picky" tone_tags="formal" is_goal_specific="true">
-            <!--      Created by Marco A.G.Pinto, Portuguese rule 2021-03-31 (Enhanced) (17-MAR-2021+) *START* -->
             <rule>
                 <pattern>
                     <marker>
@@ -9089,19 +9066,6 @@ USA
                 <suggestion><match no='1' postag='V.+' postag_regexp='yes'>empregar</match></suggestion>
                 <example correction="empregamos">Na nossa investigação <marker>usamos</marker> o termo “terrorismo”.</example>
                 <example correction="empregamos">Na nossa investigação <marker>usamos</marker> termos caros.</example>
-            </rule>
-            <rule>
-                <pattern>
-                    <marker>
-                        <token inflected='yes'>usar</token>
-                        <token regexp='yes' spacebefore='no'>&hifen;</token>
-                        <token spacebefore='no'>se</token>
-                    </marker>
-                    <token min="0" max="1" negate="yes" regexp="yes">termos?</token>
-                    <token regexp="yes">termos?</token>
-                </pattern>
-                <message>Num contexto formal, é preferível escrever &quot;empregar um termo&quot;.</message>
-                <suggestion><match no='1' postag='V.+' postag_regexp='yes'>empregar</match>-se</suggestion>
                 <example correction="emprega-se">Na nossa investigação <marker>usa-se</marker> o termo “terrorismo”.</example>
                 <example correction="emprega-se">Na nossa investigação <marker>usa-se</marker> termos caros.</example>
             </rule>
@@ -10251,12 +10215,7 @@ USA
         </rule>
 
 
-        <!-- PARA AJUDAR A MELHORAR para melhorar -->
         <rule id='PHD_TESE_PARA_AJUDAR_A_VINFINITIVO_PARA_VINFINITIVO' name="[Universitário] Para Ajudar a + V.Inf. → Para V.Inf." type='style' tone_tags="academic">
-            <!-- Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2023-01-24 (25-JUL-2022+) -->
-            <!--
-            Estas regras servem para ajudar a melhorar a gramática. → Estas regras servem para melhorar a gramática.
-            -->
             <pattern>
                 <marker>
                     <token>para</token>
@@ -10268,8 +10227,8 @@ USA
             <message>&thesis_msg;</message>
             <suggestion>\1 \4</suggestion>
             <example correction="para melhorar">Estas regras servem <marker>para ajudar a melhorar</marker> a gramática.</example>
-            <example correction="Para planejar"><marker>Para ajudá a planejar</marker> o orçamento.</example>
-            <example correction="para alcançar"><marker>para ajudá a alcançar</marker> seus objetivos</example>
+            <example correction="Para planejar"><marker>Para ajudá-la a planejar</marker> o orçamento.</example>
+            <example correction="para alcançar"><marker>para ajudar-nos a alcançar</marker> seus objetivos</example>
         </rule>
 
 
@@ -12256,16 +12215,14 @@ USA
 
 
         <rule id='SER_NECESSARIO_NECESSARIO_V2' name="Simplificar: Ser necessário → necessário">
-            <!-- IDEA shorten_it -->
-
             <antipattern>
-                <token postag='VMIP.+|VMSF.+|NC.+|AQ.+' postag_regexp='yes'/>
+                <token postag="V.+|NC.+" postag_regexp='yes'/>
                 <token>que</token>
                 <token regexp='yes'>é|são</token>
                 <token regexp='yes'>necessários?</token>
-                <token postag='VMN03.+|RG|CS' postag_regexp='yes'/>
+                <token postag='VMN.+|RG|CS' postag_regexp='yes'/>
                 <token min='0' max='1' postag='SPS00'/>
-                <token postag='(SPS00:)?D[AI].+|VMN03.+' postag_regexp='yes'/>
+                <token postag='(SPS00:)?D[AI].+|VMN.+' postag_regexp='yes'/>
                 <example>Sinceramente, não recomendo esse tipo de pratica pois entendo que é necessário sempre um ambiente profissional para garantir a qualidade e a produtividade.</example>
                 <example>Todos nós sabemos que é necessário acelerar o Programa de Aceleração do Crescimento", emendou ele, usando um trocadilho para se referi...</example>
                 <example>Com a incorporação da Adequação Sociotécnica à Teoria, passa-se a entender que é necessário que um processo seja concebido nas condições em que ele acontecerá.</example>
@@ -14397,14 +14354,7 @@ USA
         </rule>
 
 
-        <!-- QUANDO TEMOS DE LIDAR ao lidarmos -->
         <rule id='QUANDO_TER_DE_QUE_VINF_AO_VINF' name="[Simplificar] 'Quando V.Ter de/que V.Inf.' com → 'Ao V.Inf.'" type="style" tags="picky">
-            <!--IDEA shorten_it-->
-            <!-- Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2023-04-10 (2-MAR-2023+) -->
-            <!--
-      Quando tenho de lidar com muitos elementos. → Ao lidar com muitos elementos.
-      Quando temos de lidar com muitos elementos. → Ao lidarmos com muitos elementos.
-      -->
             <pattern>
                 <marker>
                     <token>quando</token>
@@ -14417,7 +14367,7 @@ USA
                 </marker>
                 <token>com</token>
             </pattern>
-            <filter class="org.languagetool.rules.pt.AdvancedSynthesizerFilter" args="lemmaFrom:4 lemmaSelect:V.* postagFrom:2 postagSelect:VMIP(.)(.).* postagReplace:VMN0[\b1][\b2].*"/>
+            <filter class="org.languagetool.rules.pt.AdvancedSynthesizerFilter" args="lemmaFrom:4 lemmaSelect:V.* postagFrom:2 postagSelect:VMIP(.)(.). postagReplace:VMN0[\b1][\b2]."/>
             <message>&simplify_msg;</message>
             <suggestion>ao {suggestion}</suggestion>
             <example correction="Ao lidar"><marker>Quando tenho de lidar</marker> com muitos elementos.</example>
@@ -14519,7 +14469,7 @@ USA
             <antipattern>
                 <token postag='V.+' postag_regexp='yes'/>
                 <token postag='V.+' postag_regexp='yes'/>
-                <token postag='SPS00_?' postag_regexp='no'/>
+                <token postag='SPS00_?' postag_regexp='yes'/>
                 <token postag='NC.+|AQ.+' postag_regexp='yes'/>
                 <token min="0" max="1" postag='_PUNCT' postag_regexp='no'/>
                 <example>Eu acho que ela estava planejando ir visitar a mãe, que está no hospital.</example>
@@ -15889,15 +15839,7 @@ USA
         </rule>
 
 
-        <!-- VERBO_ESTAR + A + VERBO_INF verbo -->
         <rulegroup id='VERBO_ESTAR_A_VERBO_INF' name="[Simplificar] Verbo estar + a + V.Inf. → Verbo" type="style" tags="picky">
-            <!--IDEA shorten_it-->
-            <!--      Created by Marco A.G.Pinto, Portuguese rule 2020-11-11 (21-OCT-2020+)     -->
-            <!--
-           MARCOAGPINTO inserted global antipatterns for all subrules on top using the logic (25-JUL-2022+)
-      -->
-
-            <!-- MARCOAGPINTO 2023-02-08 (Checked/Enhanced) (25-JUL-2022+) *START* -->
             <antipattern>
                 <token inflected='yes'>estar</token>
                 <token>a</token>
@@ -15910,11 +15852,8 @@ USA
                 <example>Um projecto de 3 anos (começou com AVB) que nos deu 3 campeonatos e uma liga europa está a ser trucidado.</example>
                 <example>O aparecimento “espontâneo” de vida, por outro lado, está a ser estudado.</example>
             </antipattern>
-            <!-- MARCOAGPINTO 2023-02-08 (Checked/Enhanced) (25-JUL-2022+) *END* -->
-
-            <!-- Fixes false positives - Rule needs to be rewritten: 2024-01-13 -->
             <antipattern>
-                <token regexp='yes'>lhes?</token>
+                <token postag_regexp="yes" postag="V.+:PP3C.D00"/>
                 <token postag='CS'/>
                 <token inflected='yes'>estar</token>
                 <token>a</token>
@@ -15938,8 +15877,6 @@ USA
                 <example>O telemóvel está a carregar.</example>
                 <example>A dívida nacional está a aumentar.</example>
             </antipattern>
-
-            <!-- estou -->
             <rule>
                 <pattern>
                     <token negate_pos="yes" postag='SENT_START'/>
@@ -15953,8 +15890,6 @@ USA
                 <suggestion><match no='4' postag='VMN0000' postag_regexp="yes" postag_replace='VMIP1S0'/></suggestion>
                 <example correction="oriento">Temos diferentes perspetivas mediante a lógica pela qual me <marker>estou a orientar</marker>.</example>
             </rule>
-
-            <!-- estás -->
             <rule>
                 <pattern>
                     <token negate_pos="yes" postag='SENT_START'/>
@@ -15969,8 +15904,6 @@ USA
                 <suggestion>\2 <match no='4' postag='VMN0000' postag_regexp="yes" postag_replace='VMG0000'/></suggestion>
                 <example correction="orientas|estás orientando">Temos diferentes perspetivas mediante a lógica pela qual me <marker>estás a orientar</marker>.</example>
             </rule>
-
-            <!-- está -->
             <rule>
                 <pattern>
                     <token negate_pos="yes" postag='SENT_START'/>
@@ -15985,8 +15918,6 @@ USA
                 <suggestion>\2 <match no='4' postag='VMN0000' postag_regexp="yes" postag_replace='VMG0000'/></suggestion>
                 <example correction="orienta|está orientando">Temos diferentes perspetivas mediante a lógica pela qual me <marker>está a orientar</marker>.</example>
             </rule>
-
-            <!-- estamos -->
             <rule>
                 <pattern>
                     <token negate_pos="yes" postag='SENT_START'/>
@@ -16001,8 +15932,6 @@ USA
                 <suggestion>\2 <match no='4' postag='VMN0000' postag_regexp="yes" postag_replace='VMG0000'/></suggestion>
                 <example correction="orientamos|estamos orientando">Temos diferentes perspetivas mediante a lógica pela qual nos <marker>estamos a orientar</marker>.</example>
             </rule>
-
-            <!-- estais -->
             <rule>
                 <pattern>
                     <token negate_pos="yes" postag='SENT_START'/>
@@ -16017,8 +15946,6 @@ USA
                 <suggestion>\2 <match no='4' postag='VMN0000' postag_regexp="yes" postag_replace='VMG0000'/></suggestion>
                 <example correction="orientais|estais orientando">Temos diferentes perspetivas mediante a lógica pela qual nos <marker>estais a orientar</marker>.</example>
             </rule>
-
-            <!-- estão -->
             <rule>
                 <pattern>
                     <token negate_pos="yes" postag='SENT_START'/>
@@ -18526,6 +18453,11 @@ USA
                     <token regexp='yes'>&pronomes_obliquos;</token>
                     <token inflected='yes'>ver</token>
                     <example>Te vi chegar em casa ontem.</example>
+                </antipattern>
+                <antipattern>
+                    <token postag_regexp="yes" postag="V.+:PP.+"/>
+                    <token inflected='yes'>ver</token>
+                    <example>Deixa-me ver isso aqui.</example>
                 </antipattern>
                 <antipattern>
                     <token inflected='yes'>ver</token>

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
@@ -18,6 +18,8 @@
  */
 package org.languagetool.rules.pt;
 
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.languagetool.JLanguageTool;
 import org.languagetool.Languages;
@@ -35,24 +37,34 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 public class MorfologikPortugueseSpellerRuleTest {
-  private final MorfologikPortugueseSpellerRule ruleBR = getSpellerRule("BR");
-  private final JLanguageTool ltBR = getLT("BR");
-  private final MorfologikPortugueseSpellerRule rulePT = getSpellerRule("PT");
-  private final JLanguageTool ltPT = getLT("PT");
+  private static MorfologikPortugueseSpellerRule ruleBR;
+  private static JLanguageTool ltBR;
+  private static MorfologikPortugueseSpellerRule rulePT;
+  private static JLanguageTool ltPT;
   // This one is used to test the pre-90 agreement spellings
-  private final MorfologikPortugueseSpellerRule ruleMZ = getSpellerRule("MZ");
-  private final JLanguageTool ltMZ = getLT("MZ");
+  private static MorfologikPortugueseSpellerRule ruleMZ;
+  private static JLanguageTool ltMZ;
 
   public MorfologikPortugueseSpellerRuleTest() throws IOException {
   }
 
-  private MorfologikPortugueseSpellerRule getSpellerRule(String countryCode) throws IOException {
+  private static MorfologikPortugueseSpellerRule getSpellerRule(String countryCode) throws IOException {
     return new MorfologikPortugueseSpellerRule(TestTools.getMessages("pt"),
       Languages.getLanguageForShortCode("pt-" + countryCode), null, null);
   }
 
-  private JLanguageTool getLT(String countryCode) {
+  private static JLanguageTool getLT(String countryCode) {
     return new JLanguageTool(Languages.getLanguageForShortCode("pt-" + countryCode));
+  }
+
+  @BeforeClass
+  public static void setUp() throws IOException {
+    ltBR = getLT("BR");
+    ltPT = getLT("PT");
+    ltMZ = getLT("MZ");
+    ruleBR = getSpellerRule("BR");
+    rulePT = getSpellerRule("PT");
+    ruleMZ = getSpellerRule("MZ");
   }
 
   private List<String> getFirstSuggestions(RuleMatch match, int max) {

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
@@ -204,6 +204,7 @@ public class MorfologikPortugueseSpellerRuleTest {
     assertNoErrors("pu-las", lt, rule);
     assertNoErrors("pusé-lo", lt, rule);
     assertNoErrors("soubé-lo", lt, rule);
+    assertNoErrors("partam-no", lt, rule);
     // here we are mostly testing the suggestions
     assertSingleError("amarte", lt, rule, "amar-te");
     assertSingleError("amamonos", lt, rule, "amamo-nos");
@@ -213,11 +214,17 @@ public class MorfologikPortugueseSpellerRuleTest {
   @Test
   public void testEuropeanPortugueseHyphenatedClitics() throws Exception {
     testPortugueseHyphenatedClitics(ltPT, rulePT);
+    // These are dialect-specific; pt-PT doesn't have 'detetava-se' in the speller
+    assertNoErrors("detetava-se", ltPT, rulePT);
+    assertSingleError("detectava-se", ltPT, rulePT, "detetava-se");
   }
 
   @Test
   public void testBrazilianPortugueseHyphenatedClitics() throws Exception {
     testPortugueseHyphenatedClitics(ltBR, ruleBR);
+    // These are dialect-specific; pt-PT doesn't have 'detetava-se' in the speller
+    assertNoErrors("detectava-se", ltBR, ruleBR);
+    assertSingleError("detetava-se", ltBR, ruleBR, "detectava-se");
   }
 
   @Test

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
@@ -204,32 +204,15 @@ public class MorfologikPortugueseSpellerRuleTest {
     assertNoErrors("pu-las", lt, rule);
     assertNoErrors("pusé-lo", lt, rule);
     assertNoErrors("soubé-lo", lt, rule);
+    // here we are mostly testing the suggestions
+    assertSingleError("amarte", lt, rule, "amar-te");
+    assertSingleError("amamonos", lt, rule, "amamo-nos");
+    assertSingleError("amarlhe", lt, rule, "amar-lhe");
   }
 
   @Test
   public void testEuropeanPortugueseHyphenatedClitics() throws Exception {
-//    testPortugueseHyphenatedClitics(ltPT, rulePT);
-    JLanguageTool lt = ltPT;
-    MorfologikPortugueseSpellerRule rule = rulePT;
-
-//    assertNoErrors("diz-se", lt, rule);
-    assertNoErrors("fá-lo-á", lt, rule);
-    assertNoErrors("dir-lhe-ia", lt, rule);
-    assertNoErrors("amar-nos-emos", lt, rule);
-    assertNoErrors("dê-mo", lt, rule);  // not a single token!
-    assertNoErrors("fizemo-lo", lt, rule);
-//    assertNoErrors("compramo-lo", lt, rule);
-    assertNoErrors("apercebemo-nos", lt, rule);
-    assertNoErrors("referirmo-nos", lt, rule);
-//    assertNoErrors("amamo-las", lt, rule);
-    assertNoErrors("mantínhamo-nos", lt, rule);
-    assertNoErrors("qui-lo", lt, rule);
-    assertNoErrors("fi-lo", lt, rule);
-    assertNoErrors("fê-lo", lt, rule);
-    assertNoErrors("trá-las", lt, rule);
-    assertNoErrors("pu-las", lt, rule);
-//    assertNoErrors("pusé-lo", lt, rule);
-//    assertNoErrors("soubé-lo", lt, rule);
+    testPortugueseHyphenatedClitics(ltPT, rulePT);
   }
 
   @Test
@@ -443,7 +426,8 @@ public class MorfologikPortugueseSpellerRuleTest {
 
   @Test
   public void testBrazilPortugueseSpellingSplitsEmoji() throws Exception {
-    assertSingleError("☺☺☺Só", ltBR, ruleBR, new String[]{"☺☺☺ Só"});
+    // Due to new tokenisation, this is no longer a spelling mistake <3
+    assertNoErrors("☺☺☺Só", ltBR, ruleBR);
   }
 
   @Test

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
@@ -689,4 +689,11 @@ public class MorfologikPortugueseSpellerRuleTest {
     // not a prefix per se, true compounding (the first element exists as an independent lexeme)
     assertNoErrors("húngaro-romeno", ltBR, ruleBR);
   }
+
+  @Test public void testPortugueseSpellerAcceptsParagraphAndOrdinal() throws Exception {
+    assertNoErrors("§1º", ltBR, ruleBR);
+    assertNoErrors("§ 1º", ltBR, ruleBR);
+    assertNoErrors("§1º-A", ltBR, ruleBR);
+    assertNoErrors("§ 1º-A", ltBR, ruleBR);
+  }
 }

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
@@ -190,7 +190,7 @@ public class MorfologikPortugueseSpellerRuleTest {
     assertNoErrors("fá-lo-á", lt, rule);
     assertNoErrors("dir-lhe-ia", lt, rule);
     assertNoErrors("amar-nos-emos", lt, rule);
-    assertNoErrors("dê-mo", lt, rule);
+    assertNoErrors("dê-mo", lt, rule);  // not a single token!
     assertNoErrors("fizemo-lo", lt, rule);
     assertNoErrors("compramo-lo", lt, rule);
     assertNoErrors("apercebemo-nos", lt, rule);
@@ -202,11 +202,34 @@ public class MorfologikPortugueseSpellerRuleTest {
     assertNoErrors("fê-lo", lt, rule);
     assertNoErrors("trá-las", lt, rule);
     assertNoErrors("pu-las", lt, rule);
+    assertNoErrors("pusé-lo", lt, rule);
+    assertNoErrors("soubé-lo", lt, rule);
   }
 
   @Test
   public void testEuropeanPortugueseHyphenatedClitics() throws Exception {
-    testPortugueseHyphenatedClitics(ltPT, rulePT);
+//    testPortugueseHyphenatedClitics(ltPT, rulePT);
+    JLanguageTool lt = ltPT;
+    MorfologikPortugueseSpellerRule rule = rulePT;
+
+//    assertNoErrors("diz-se", lt, rule);
+    assertNoErrors("fá-lo-á", lt, rule);
+    assertNoErrors("dir-lhe-ia", lt, rule);
+    assertNoErrors("amar-nos-emos", lt, rule);
+    assertNoErrors("dê-mo", lt, rule);  // not a single token!
+    assertNoErrors("fizemo-lo", lt, rule);
+//    assertNoErrors("compramo-lo", lt, rule);
+    assertNoErrors("apercebemo-nos", lt, rule);
+    assertNoErrors("referirmo-nos", lt, rule);
+//    assertNoErrors("amamo-las", lt, rule);
+    assertNoErrors("mantínhamo-nos", lt, rule);
+    assertNoErrors("qui-lo", lt, rule);
+    assertNoErrors("fi-lo", lt, rule);
+    assertNoErrors("fê-lo", lt, rule);
+    assertNoErrors("trá-las", lt, rule);
+    assertNoErrors("pu-las", lt, rule);
+//    assertNoErrors("pusé-lo", lt, rule);
+//    assertNoErrors("soubé-lo", lt, rule);
   }
 
   @Test
@@ -219,12 +242,18 @@ public class MorfologikPortugueseSpellerRuleTest {
     // These will need to be accepted until the tokenisation is made to work with pt-BR better.
     // We will, for now, have an XML rule to correct these (id: ELISAO_VERBAL_DESNECESSARIA).
     // Once we rework the tokenisation logic, these will need to be single error assertions!
-    assertNoErrors("amávamo", ltBR, ruleBR);
-    assertNoErrors("fizemo", ltBR, ruleBR);
-    assertNoErrors("compramo", ltBR, ruleBR);
-    assertNoErrors("pusemo", ltBR, ruleBR);
-    assertNoErrors("fazê", ltBR, ruleBR);
-    assertNoErrors("fi", ltBR, ruleBR);  // 'fi-lo'
+    assertSingleError("amávamo", ltBR, ruleBR, new String[]{"amávamos"});
+    assertSingleError("fizemo", ltBR, ruleBR, new String[]{"fizemos"});
+    assertSingleError("compramo", ltBR, ruleBR, new String[]{"compramos"});
+    assertSingleError("pusemo", ltBR, ruleBR, new String[]{"pusemos"});
+    assertSingleError("fazê", ltBR, ruleBR, new String[]{"fazer"});
+    assertSingleError("fê", ltBR, ruleBR, new String[]{"fé"});  // 'fê-lo', not sure about suggesting "fez"
+  }
+
+  @Test
+  public void testPortugueseSpellerAcceptsVerbsWithProductivePrefixes() throws Exception {
+    assertNoErrors("soto-pôr", ltBR, ruleBR);     // exists in speller, ignoreSpelling() from tagger
+    assertNoErrors("soto-trepar", ltBR, ruleBR);  // NOT in speller, ignoreSpelling() from tagger
   }
 
   @Test
@@ -265,8 +294,8 @@ public class MorfologikPortugueseSpellerRuleTest {
     // new words from portal da língua portuguesa
     assertTwoWayDialectError("napoleônia", "napoleónia");
     assertTwoWayDialectError("hiperêmese", "hiperémese");
-    // will not work due to tokenisation quirk, bebê-lo, must be fixed
-    // assertTwoWayDialectError("bebê", "bebé");
+    // as of dict v0.13! party emoji!
+    assertTwoWayDialectError("bebê", "bebé");
   }
 
   @Test
@@ -351,7 +380,7 @@ public class MorfologikPortugueseSpellerRuleTest {
     // each given incorrectly spelt word
     assertSingleErrorWithNegativeSuggestion("pwta", ltBR, ruleBR, "puta");
     assertSingleErrorWithNegativeSuggestion("bâbaca", ltBR, ruleBR, "babaca");
-    assertSingleErrorWithNegativeSuggestion("redardado", ltBR, ruleBR, "retardado");
+    assertSingleErrorWithNegativeSuggestion("rexardado", ltBR, ruleBR, "retardado");
     assertSingleErrorWithNegativeSuggestion("cagguei", ltBR, ruleBR, "caguei");
     assertSingleErrorWithNegativeSuggestion("bucetas", ltBR, ruleBR, "bocetas");
     assertSingleErrorWithNegativeSuggestion("mongolóide", ltBR, ruleBR, "mongoloide");

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
@@ -25,6 +25,7 @@ import org.languagetool.JLanguageTool;
 import org.languagetool.Languages;
 import org.languagetool.TestTools;
 import org.languagetool.rules.RuleMatch;
+import org.languagetool.rules.patterns.PatternRuleXmlCreatorTest;
 
 
 import java.io.IOException;
@@ -698,5 +699,15 @@ public class MorfologikPortugueseSpellerRuleTest {
     assertNoErrors("§ 1º", ltBR, ruleBR);
     assertNoErrors("§1º-A", ltBR, ruleBR);
     assertNoErrors("§ 1º-A", ltBR, ruleBR);
+  }
+
+  @Test public void testPortugueseSpellerReplacesOldGrammarRules() throws Exception {
+    // ELISAO_VERBAL_COM_ENCLITICO_INCORRETO_1PL
+    assertSingleError("Amamo-te", ltBR, ruleBR, "Amamos");
+    // ELISAO_VERBAL_COM_ENCLITICO_INCORRETO_INF
+    assertSingleError("Amá-te", ltBR, ruleBR, "Amar");
+    // ELISAO_VERBAL_SEM_ENCLITICO
+    assertSingleError("Fazê o quê?", ltBR, ruleBR, "Fazer");
+    assertSingleError("Vamo embora", ltBR, ruleBR, "Vamos");
   }
 }

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/PortugueseWordRepeatRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/PortugueseWordRepeatRuleTest.java
@@ -37,7 +37,8 @@ public class PortugueseWordRepeatRuleTest {
     assertTrue(ignore("blá blá", lt, rule, 2));
     assertTrue(ignore("Aaptos aaptos", lt, rule, 2));
     assertTrue(ignore("Logo logo vamos ao mercado", lt, rule, 2));
-    assertTrue(ignore("Coloquem-na na sala.", lt, rule, 4)); // the hyphen is a token
+    // as of the v0.13 dict, the following is not a repetition, since 'coloquem-na' is a single token <3
+    assertFalse(ignore("Coloquem-na na sala.", lt, rule, 2));
   }
 
   private boolean ignore(String input, JLanguageTool lt, PortugueseWordRepeatRule rule, int position) throws IOException {

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/tagging/pt/PortugueseTaggerTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/tagging/pt/PortugueseTaggerTest.java
@@ -55,8 +55,9 @@ public class PortugueseTaggerTest {
     TestTools.myAssert("tentou resolver",
         "tentou/[tentar]VMIS3S0 -- resolver/[resolver]VMN0000|resolver/[resolver]VMN01S0|resolver/[resolver]VMN03S0|resolver/[resolver]VMSF1S0|resolver/[resolver]VMSF3S0"
         , tokenizer, tagger);
+    // as of dict v0.13, verbs with enclitics are considered as a single word and tagged as such
     TestTools.myAssert("Deixe-me",
-      "Deixe/[deixar]VMM03S0|Deixe/[deixar]VMSP1S0|Deixe/[deixar]VMSP3S0 -- me/[eu]PP1CSO00",
+      "Deixe-me/[deixar]VMM03S0:PP1CSO00|Deixe-me/[deixar]VMSP1S0:PP1CSO00|Deixe-me/[deixar]VMSP3S0:PP1CSO00",
       tokenizer, tagger);
   }
 
@@ -94,5 +95,16 @@ public class PortugueseTaggerTest {
     TestTools.myAssert("Jiu-jitsu", "Jiu-jitsu/[jiu-jitsu]NCMS000", tokenizer, tagger);
     TestTools.myAssert("JIU-JITSU", "JIU-JITSU/[jiu-jitsu]NCMS000", tokenizer, tagger);
     TestTools.myAssert("Jiu-Jitsu", "Jiu-Jitsu/[jiu-jitsu]NCMS000", tokenizer, tagger);
+  }
+  @Test
+  public void testTagProductivePrefixesNotPresentInSpeller() throws IOException {
+    // not a real prefix, must be null
+    TestTools.myAssert("xoxotrepei", "xoxotrepei/[null]null", tokenizer, tagger);
+    // auto- and re- are Tiago's original prefixes
+    TestTools.myAssert("autotrepei", "autotrepei/[autotrepar]VMIS1S0", tokenizer, tagger);
+    TestTools.myAssert("retrepei", "retrepei/[retrepar]VMIS1S0", tokenizer, tagger);
+    // new prefixes, to work with dict v0.13
+    // include prefixes that always require a hyphen, like 'soto-'
+    TestTools.myAssert("soto-trepei", "soto-trepei/[soto-trepar]VMIS1S0", tokenizer, tagger);
   }
 }

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
@@ -267,4 +267,9 @@ public class PortugueseWordTokenizerTest {
     testTokenise("⌈Herói⌋", new String[]{"⌈", "Herói", "⌋"});
     testTokenise("″Santo Antônio do Manga″", new String[]{"″", "Santo", " ", "Antônio", " ", "do", " ", "Manga", "″"});
   }
+
+  @Test
+  public void testTokeniseParagraphSymbol() {
+    testTokenise("§1º", "§", "1º");
+  }
 }

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
@@ -139,7 +139,7 @@ public class PortugueseWordTokenizerTest {
   @Test
   public void testDoNotTokeniseUserMentions() {
     // Twitter and whatnot; same as English
-    testTokenise("@user", new String[]{"@user"});
+    testTokenise("@user", "@user");
   }
 
   @Test
@@ -152,14 +152,16 @@ public class PortugueseWordTokenizerTest {
 
   @Test
   public void testTokeniseSplitsPercent() {
-    testTokenise("50%OFF", new String[]{"50%", "OFF"});
-    testTokenise("%50", new String[]{"%", "50"});
-    testTokenise("%", new String[]{"%"});
+    testTokenise("50%", "50%");
+    testTokenise("50%%", "50%", "%"); // "%" is a right-edge character that can repeat ONCE
+    testTokenise("50%OFF", "50%", "OFF");
+    testTokenise("%50", "%", "50");
+    testTokenise("%", "%");
   }
 
   @Test
   public void testTokeniseNumberAbbreviation() {
-    testTokenise("Nº666", new String[]{"Nº666"});  // superscript 'o'
+    testTokenise("Nº666", new String[]{"Nº666"});  // ordinal indicator 'o'
     testTokenise("N°666", new String[]{"N°666"});  // degree symbol
     testTokenise("Nº 420", new String[]{"Nº", " ", "420"});
     testTokenise("N.º69", new String[]{"N", ".", "º69"});  // the '.' char splits it
@@ -236,14 +238,28 @@ public class PortugueseWordTokenizerTest {
   }
 
   @Test
-  public void testDoNotTokeniseEmoji() {
-    testTokenise("☺☺☺Só", new String[]{"☺☺☺Só"});
+  public void testTokeniseEmoji() {
+    testTokenise("☺☺☺Só", "☺", "☺", "☺", "Só");
   }
 
   @Test
   public void testDoNotTokeniseModifierDiacritics() {
     // the tilde here is a unicode modifier char; normally, the unicode a-tilde (ã) is used
-    testTokenise("Não", new String[]{"Não"});
+    testTokenise("Não", "Não");
+  }
+
+  @Test
+  public void testTokeniseExtraWordEdgeChars() {
+    // left-edge
+    testTokenise("§50", "§50");  // single char
+    testTokenise("§§50", "§", "§50");  // two chars
+    testTokenise("50§", "50", "§");  // wrong edge
+    testTokenise("666§50", "666", "§50");  // middle of the word
+    // right-edge
+    testTokenise("50‰", "50‰");  // single char
+    testTokenise("50‰‰", "50‰", "‰");  // two chars
+    testTokenise("‰50", "‰", "50");  // wrong edge
+    testTokenise("50‰666", "50‰", "666");  // middle of the word
   }
 
   @Test

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
@@ -251,10 +251,10 @@ public class PortugueseWordTokenizerTest {
   @Test
   public void testTokeniseExtraWordEdgeChars() {
     // left-edge
-    testTokenise("§50", "§50");  // single char
-    testTokenise("§§50", "§", "§50");  // two chars
-    testTokenise("50§", "50", "§");  // wrong edge
-    testTokenise("666§50", "666", "§50");  // middle of the word
+    testTokenise("@50", "@50");  // single char
+    testTokenise("@@50", "@", "@50");  // two chars
+    testTokenise("50@", "50", "@");  // wrong edge
+    testTokenise("666@50", "666", "@50");  // middle of the word
     // right-edge
     testTokenise("50‰", "50‰");  // single char
     testTokenise("50‰‰", "50‰", "‰");  // two chars

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
@@ -92,14 +92,32 @@ public class PortugueseWordTokenizerTest {
 
   @Test
   public void testTokeniseHyphenatedClitics() {
-    testTokenise("diz-se", new String[]{"diz", "-", "se"});
+    // As of dict v0.13!
+    testTokenise("diz-se", new String[]{"diz-se"});
+    testTokenise("amamo-lo", new String[]{"amamo-lo"});
+    testTokenise("fi-lo", new String[]{"fi-lo"});
+    testTokenise("pusé-lo", new String[]{"pusé-lo"});
+    testTokenise("canta-lo", new String[]{"canta-lo"}); // cantas + o, may not be in speller!
+    // pretty rare, but we need to generate these because the 'nos' in 'no-lo' triggers elision in -mos forms >:(
+    testTokenise("dar-no-lo", new String[]{"dar-no-lo"});
+    // rare contractions like these are NOT generated
+    testTokenise("dê-mo", new String[]{"dê", "-", "mo"});
   }
 
   @Test
   public void testTokeniseMesoclisis() {
-    testTokenise("fá-lo-á", new String[]{"fá", "-", "lo", "-", "á"});
-    testTokenise("dir-lhe-ia", new String[]{"dir", "-", "lhe", "-", "ia"});
-    testTokenise("banhar-nos-emos", new String[]{"banhar", "-", "nos", "-", "emos"});
+    // As of dict v0.13!
+    testTokenise("fá-lo-á", new String[]{"fá-lo-á"});
+    testTokenise("dir-lhe-ia", new String[]{"dir-lhe-ia"});
+    testTokenise("banhar-nos-emos", new String[]{"banhar-nos-emos"});
+  }
+
+  @Test
+  public void testTokeniseProductivePrefixes() {
+    // These are specifically forms that are NOT in the tagger dict (though they might be in the speller).
+    // The idea is that our word tagger should be able to tag them by identifying the prefix.
+    testTokenise("soto-pôr", new String[]{"soto-pôr"});  // speller, but not tagger
+    testTokenise("soto-trepar", new String[]{"soto-trepar"});  // neither speller nor tagger
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <optimaize.languagedetector.language-detector.version>0.6</optimaize.languagedetector.language-detector.version>
         <!-- see https://github.com/languagetool-org/languagetool/issues/4088 before you upgrade this -->
         <spanish-pos-dict.version>2.2</spanish-pos-dict.version>
-        <portuguese-pos-dict.version>0.12</portuguese-pos-dict.version>
+        <portuguese-pos-dict.version>0.13</portuguese-pos-dict.version>
         <dutch-pos-dict.version>0.1</dutch-pos-dict.version>
         <english-pos-dict.version>0.3</english-pos-dict.version>
         <belarusian-pos-dict.version>1.0.2</belarusian-pos-dict.version>


### PR DESCRIPTION
⚠️ This change **requires** the [portuguese-pos-dict](https://github.com/languagetool-org/portuguese-pos-dict) dependency to be `v0.13` or later!

## tl;dr

This PR adds POS tags to the `pt` tagset for enclitic pronouns.

## What changes

Let's use `diz-me` ('tell me') to illustrate the changes.

|was|will be|
|---|---|
|three tokens (`diz`, `-`, `me`)|a single token (`diz-me`)|
|each token tagged separately|tagged as `dizer[VMM02S0:PP1CSO00]`|

### Consequences
- dictionary suggestions consider whole word forms (e.g. `ama-se` <=> `amasse`);
- forms that only appear in derived environments are no longer accepted by the dictionary in isolation (e.g. `amá` and `lo` from `amá-lo` should now both be flagged as spelling errors);
- working with mesoclitics is made significantly easier (e.g. `fá-lo-á` doesn't require **five** tokens, **three** of which shouldn't exist in isolation!);
- XML rules no longer require two extra (often optional) tokens for the hyphen and pronouns.

## Also in this PR

- tokenisation logic changes from defining breaking characters to defining word characters;
- extensive changes to XML rules in all dialects to account for new tokenisation and tagging schema;
- `EnclisisFilter` and `ProclisisFilter` to make synthesising verb forms with pronouns easier.
