### PR TITLE
[code] fixed typo in the --help and examples

### DIFF
--- a/languagetool-rpm-package/src/main/resources/server.properties.sample
+++ b/languagetool-rpm-package/src/main/resources/server.properties.sample
@@ -14,7 +14,7 @@ password = keystorepwd
 # 'languageModel' - a directory with '1grams', '2grams', '3grams' sub directories which contain a Lucene index
 #   each with ngram occurrence counts; activates the confusion rule if supported (optional)
 # 'maxWorkQueueSize' - reject request if request queue gets larger than this (optional)
-# 'rulesFile' - a file containing rules configuration, such as .langugagetool.cfg (optional)
+# 'rulesFile' - a file containing rules configuration, such as .languagetool.cfg (optional)
 
 # Maximum text length. Optional - longer texts will cause an error.
 maxTextLength = 120000

--- a/languagetool-server/src/main/java/org/languagetool/server/Server.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/Server.java
@@ -140,7 +140,7 @@ abstract class Server {
     System.out.println("                 'fasttextBinary' - compiled fasttext executable for language detection (optional), see");
     System.out.println("                                    https://fasttext.cc/docs/en/support.html");
     System.out.println("                 'maxWorkQueueSize' - reject request if request queue gets larger than this (optional)");
-    System.out.println("                 'rulesFile' - a file containing rules configuration, such as .langugagetool.cfg (optional)");
+    System.out.println("                 'rulesFile' - a file containing rules configuration, such as .languagetool.cfg (optional)");
     System.out.println("                 'blockedReferrers' - a comma-separated list of HTTP referrers (and 'Origin' headers) that are blocked and will not be served (optional)");
     System.out.println("                 'premiumOnly' - activate only the premium rules (optional)");
     System.out.println("                 'disabledRuleIds' - a comma-separated list of rule ids that are turned off for this server (optional)");


### PR DESCRIPTION
aef6779ac838 CHANGELOG was mentioning .languagetool.cfg

so I assume it's a typo

bd64e2e4bc55 the typo is there since the feature was added