### PR TITLE
Update abtest

### DIFF
--- a/languagetool-server/src/main/java/org/languagetool/server/tools/AbTestService.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/tools/AbTestService.java
@@ -1,0 +1,12 @@
+package org.languagetool.server.tools;
+
+import org.jetbrains.annotations.Nullable;
+import org.languagetool.server.HTTPServerConfig;
+
+import java.util.List;
+import java.util.Map;
+
+public interface AbTestService {
+  @Nullable
+  List<String> getActiveAbTestForClient(Map<String, String> params, HTTPServerConfig config);
+}

--- a/languagetool-server/src/main/java/org/languagetool/server/tools/LocalAbTestService.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/tools/LocalAbTestService.java
@@ -1,0 +1,33 @@
+package org.languagetool.server.tools;
+
+import org.languagetool.server.HTTPServerConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class LocalAbTestService implements AbTestService {
+
+  @Override
+  public List<String> getActiveAbTestForClient(Map<String, String> params, HTTPServerConfig config) {
+    List<String> abTest = null;
+    String agent = params.getOrDefault("useragent", "unknown");
+    String paramActivatedAbTest = params.get("abtest");
+    Pattern abTestClients = config.getAbTestClients();
+    if (paramActivatedAbTest != null && abTestClients != null && abTestClients.matcher(agent).matches()) {
+      String[] abParams = paramActivatedAbTest.trim().split(",");
+      List<String> tmpAb = new ArrayList<>();
+      for (String abParam : abParams) {
+        if (config.getAbTest().contains(abParam)) {
+          tmpAb.add(abParam.trim());
+        }
+      }
+      if (!tmpAb.isEmpty()) {
+        abTest = Collections.unmodifiableList(tmpAb);
+      }
+    }
+    return abTest;
+  }
+}


### PR DESCRIPTION
Create AbTestService to reduce complexity of checkText
Reuse the abTestClients property to enable only specific user-agents in our abtests.