### PR TITLE
[fr] AI_FR_GGEC_PICKY_TEST

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/remote-rule-filters.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/rules/fr/remote-rule-filters.xml
@@ -633,6 +633,16 @@ To ignore a remote rule match, set the <marker> so that it exactly covers the te
                 </pattern>
                 <example correction="">Elle avait les yeux <marker>marron</marker>.</example>
             </rule>
+            <rule>
+                <pattern>
+                    <token postag="V etre.*" postag_regexp="yes"/>
+                    <token postag="A|C coor" postag_regexp="yes" min="0" max="3"/>
+                    <marker>
+                        <token regexp="yes">partante?s?</token>
+                    </marker>
+                </pattern>
+                <example correction="">Tu es <marker>partant</marker> ?</example>
+            </rule>
         </rulegroup>
         <rulegroup id="AI_FR_GGEC_REPLACEMENT_VERB_FORM.*" name="">
             <rule>
@@ -658,6 +668,18 @@ To ignore a remote rule match, set the <marker> so that it exactly covers the te
                     </marker>
                 </pattern>
                 <example correction="">Tu es <marker>partant</marker> ?</example>
+            </rule>
+            <rule>
+                <pattern>
+                    <token postag="SENT_START|M nonfin" postag_regexp="yes"/>
+                    <token>que</token>
+                    <token postag="R pers suj 1 p|R pers suj 2 p" postag_regexp="yes"/>
+                    <marker>
+                        <token postag="V inf"/>
+                    </marker>
+                    <token postag="SENT_END" regexp="yes">[.!?]</token>
+                </pattern>
+                <example correction="">Que vous <marker>souhaiter</marker> ?</example>
             </rule>
         </rulegroup>
         <rulegroup id="AI_FR_GGEC_UNNECESSARY_ORTHOGRAPHY_SPACE.*" name="">


### PR DESCRIPTION
Related to: https://github.com/languagetooler-gmbh/languagetool-premium/issues/7072

- Adding missing APs from some categories in the remote-rule-filter
- 2 gGEC IDs with picky added to French.java (quotation marks + si on >> si l'on)