### PR TITLE
[pt] Add OQ_O_QUE_ORTHOGRAPHY rule

### DIFF
--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
@@ -253,6 +253,7 @@ public class Portuguese extends Language implements AutoCloseable {
     id2prio.put("PT_COMPOUNDS_POST_REFORM", -45);
     id2prio.put("AUX_VERBO", -45);
     id2prio.put("ENSINO_A_DISTANCIA", -45);
+    id2prio.put("OQ_O_QUE_ORTHOGRAPHY", -45);
     id2prio.put("EMAIL_SEM_HIFEN_ORTHOGRAPHY", -45); // HIGHER THAN SPELLER
     // MORFOLOGIK SPELLER FITS HERE AT -50 ---------------------  // SPELLER (-50)
     id2prio.put("PRETERITO_PERFEITO", -51);  // LOWER THAN SPELLER

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -36888,6 +36888,38 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
     <category id='MISSPELLING' name="Erros Ortográficos" type="misspelling">
+        <rulegroup id="OQ_O_QUE_ORTHOGRAPHY" name="Sugerir 'o que' no lugar de 'oq'">
+            <rule> <!-- before sent-final punct -->
+                <pattern>
+                    <marker>
+                        <token>oq</token>
+                    </marker>
+                    <and>
+                        <token postag="SENT_END"/>
+                        <token postag="_PUNCT"/>
+                    </and>
+                </pattern>
+                <message>Evite abreviações informais.</message>
+                <suggestion>o quê</suggestion>
+                <example correction="o quê">Você quer <marker>oq</marker>?</example>
+            </rule>
+            <rule> <!-- sent-final, no punct -->
+                <pattern>
+                    <token postag="SENT_END">oq</token>
+                </pattern>
+                <message>Evite abreviações informais.</message>
+                <suggestion>o quê</suggestion>
+                <example correction="o quê">Sabe <marker>oq</marker></example>
+            </rule>
+            <rule> <!-- middle of sentence -->
+                <pattern>
+                    <token>oq</token>
+                </pattern>
+                <message>Evite abreviações informais.</message>
+                <suggestion>o que</suggestion>
+                <example correction="o que">Não sei <marker>oq</marker> eles querem.</example>
+            </rule>
+        </rulegroup>
         <rule id="ENSINO_A_DISTANCIA" name="Sugerir EaD para ensino a distância">
             <!-- p-goulart@2024-02-27 - DESC: must have higher priority than the speller rule! -->
             <pattern>


### PR DESCRIPTION
Hotfix for `oq`. As you can see, it is the 10th most frequent add event, and both gGEC and our own speller fail to provide the appropriate correction.

---

![Screenshot 2024-03-19 at 10 16 59 AM](https://github.com/languagetool-org/languagetool/assets/50704700/f7ba36a0-15b6-4c4f-a03b-977f4a2b88a3)

![Screenshot 2024-03-19 at 10 17 56 AM](https://github.com/languagetool-org/languagetool/assets/50704700/989969bc-0b87-462b-95cc-4295e561fa03)

![Screenshot 2024-03-19 at 10 20 05 AM](https://github.com/languagetool-org/languagetool/assets/50704700/fd2ee112-c3d7-463a-8b54-339fb87ca170)
