### PR TITLE
[fr] PFAS_dict_addition

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
@@ -83,17 +83,17 @@ Scarponais;Scarponais;N m sp
 Scarponaise;Scarponais;N f s
 Scarponaises;Scarponais;N f p
 PFAS;PFAS;N f p
-perfluoroalkylée;J f s
-polyfluoroalkylée;J f s
-perfluoroalkylées;J f p
-polyfluoroalkylées;J f p
-polyfluoroalkylique;J m s
-polyfluoroalkyliques;J m p
-perfluoré;J m s
-perfluorée;J f s
-perfluorés;J m p
-perfluorées;J f p
-perfluorocarbure; N m s
-perfluorocarbures; N m p
-fluorocarbure; N m s
-fluorocarbures; N m p
+perfluoroalkylée;perfluoroalkylé;J f s
+polyfluoroalkylée;polyfluoroalkylé;J f s
+perfluoroalkylées;perfluoroalkylé;J f p
+polyfluoroalkylées;polyfluoroalkylé;J f p
+polyfluoroalkylique;polyfluoroalkylique;J m s
+polyfluoroalkyliques;polyfluoroalkyliques;J m p
+perfluoré;perfluoré;J m s
+perfluorée;perfluoré;J f s
+perfluorés;perfluoré;J m p
+perfluorées;perfluoré;J f p
+perfluorocarbure;perfluorocarbure;N m s
+perfluorocarbures;perfluorocarbure;N m p
+fluorocarbure;fluorocarbure;N m s
+fluorocarbures;fluorocarbure;N m p

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/added.txt
@@ -82,3 +82,18 @@ Pixtiennes;Pixtien;N f p
 Scarponais;Scarponais;N m sp
 Scarponaise;Scarponais;N f s
 Scarponaises;Scarponais;N f p
+PFAS;PFAS;N f p
+perfluoroalkylée;J f s
+polyfluoroalkylée;J f s
+perfluoroalkylées;J f p
+polyfluoroalkylées;J f p
+polyfluoroalkylique;J m s
+polyfluoroalkyliques;J m p
+perfluoré;J m s
+perfluorée;J f s
+perfluorés;J m p
+perfluorées;J f p
+perfluorocarbure; N m s
+perfluorocarbures; N m p
+fluorocarbure; N m s
+fluorocarbures; N m p

--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/hunspell/ignore.txt
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/hunspell/ignore.txt
@@ -1264,3 +1264,5 @@ Webhelp
 eSIM
 Agrawal
 FNSKU
+per- et polyfluoroalkylées
+per- et polyfluoroalkyliques


### PR DESCRIPTION
Mostly from https://vitrinelinguistique.oqlf.gouv.qc.ca/fiche-gdt/fiche/26561185/substances-perfluoroalkylees-et-polyfluoroalkylees

Masculine statement from https://dictionnaire.lerobert.com/definition/pfas is probably wrong

Adding @LucieSteib as reviewer to double-check or add more related words if necessary