### PR TITLE
[pt-PT] Removed "temp_off" from rule ID:ALUGAR_CASA

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -2896,7 +2896,7 @@ USA
     </rule>
 
 
-    <rule id='ALUGAR_CASA' name="[pt-PT] 'alugar' imóvel → 'arrendar'" type='style' tone_tags="objective" default="temp_off">
+    <rule id='ALUGAR_CASA' name="[pt-PT] 'alugar' imóvel → 'arrendar'" type='style' tone_tags="objective">
         <pattern>
             <marker>
                 <token skip='4' inflected='yes'>alugar</token>


### PR DESCRIPTION
Heya,

I removed the “temp_off” from this rule.

https://internal1.languagetool.org/regression-tests/via-http/2024-04-08/pt-PT_full/result_style_ALUGAR_CASA%5B1%5D.html

❤️ ❤️ ❤️ ❤️ 
