### PR TITLE
[pt] Remove 're' and 'auto' prefixes from tagger exceptions

### DIFF
--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
@@ -18,14 +18,12 @@
  */
 package org.languagetool.rules.pt;
 
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.languagetool.JLanguageTool;
 import org.languagetool.Languages;
 import org.languagetool.TestTools;
 import org.languagetool.rules.RuleMatch;
-import org.languagetool.rules.patterns.PatternRuleXmlCreatorTest;
 
 
 import java.io.IOException;
@@ -257,6 +255,7 @@ public class MorfologikPortugueseSpellerRuleTest {
   public void testPortugueseSpellerAcceptsVerbsWithProductivePrefixes() throws Exception {
     assertNoErrors("soto-pôr", ltBR, ruleBR);     // exists in speller, ignoreSpelling() from tagger
     assertNoErrors("soto-trepar", ltBR, ruleBR);  // NOT in speller, ignoreSpelling() from tagger
+    assertSingleError("reune", ltBR, ruleBR, "reúne");  // no 're' + 'unir'
   }
 
   @Test

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/tagging/pt/PortugueseTaggerTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/tagging/pt/PortugueseTaggerTest.java
@@ -100,9 +100,9 @@ public class PortugueseTaggerTest {
   public void testTagProductivePrefixesNotPresentInSpeller() throws IOException {
     // not a real prefix, must be null
     TestTools.myAssert("xoxotrepei", "xoxotrepei/[null]null", tokenizer, tagger);
-    // auto- and re- are Tiago's original prefixes
-    TestTools.myAssert("autotrepei", "autotrepei/[autotrepar]VMIS1S0", tokenizer, tagger);
-    TestTools.myAssert("retrepei", "retrepei/[retrepar]VMIS1S0", tokenizer, tagger);
+    // auto- and re- are Tiago's original prefixes; these were removed because of issues like 'reune' and 'autosabotar'
+//    TestTools.myAssert("autotrepei", "autotrepei/[autotrepar]VMIS1S0", tokenizer, tagger);
+//    TestTools.myAssert("retrepei", "retrepei/[retrepar]VMIS1S0", tokenizer, tagger);
     // new prefixes, to work with dict v0.13
     // include prefixes that always require a hyphen, like 'soto-'
     TestTools.myAssert("soto-trepei", "soto-trepei/[soto-trepar]VMIS1S0", tokenizer, tagger);


### PR DESCRIPTION
As per [Slack](https://languagetooler.slack.com/archives/C03MQKNKQG5/p1712731407229069).

The loss in the coverage of legitimate derivations that are not present in the dictionary should be far outweighed by the issues with the introduction of misspellings for valid verbs that are already present.