### PR TITLE
[pt] Move ACENTUAÇÃO_VOGAL_ÊNCLISE to before COLOCACAO_PRONOMINAL_COM_ATRATOR_SIMPLES

### DIFF
--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
@@ -297,6 +297,14 @@ public class Portuguese extends Language implements AutoCloseable {
     if (id.startsWith("PT_MULTITOKEN_SPELLING")) {
       return -49;
     }
+    // enclitic diacritics always take precedence over pronoun placement
+    if (id.startsWith("ACENTUAÇÃO_VOGAL_ÊNCLISE")) {
+      return -51;
+    }
+    if (id.startsWith("COLOCACAO_PRONOMINAL_COM_ATRATOR")) {
+      return -52;
+    }
+
     Integer prio = id2prio.get(id);
     if (prio != null) {
       return prio;

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -12438,6 +12438,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <suggestion><match no="1" postag="VMIP2S0:(PP.+)" postag_regexp="yes" postag_replace="VMN0000:$1"/></suggestion>
             <example correction="escrevê-lo">Ele vai <marker>escreve-lo</marker> amanhã.</example>
             <example correction="puxá-las">O ímpeto de <marker>puxa-las</marker>.</example>
+            <example correction="abraçá-la">Quero <marker>abraça-la</marker>.</example>
             <example>Quero revê-la.</example>
         </rule>
 

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -12431,7 +12431,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <!-- p-goulart@2024-03-27 - DESC: this rule technically matches correct forms such as "canta-la", but they're rare enough in pt-BR that we can be certain "cantá-la" is meant -->
             <pattern>
                 <marker>
-                    <token postag='VMIP2S0:PP3..A00' postag_regexp='yes' regexp="yes">.+[aeo]-l[oa]s?</token>
+                    <token postag='VMIP2S0:PP3..A00' postag_regexp='yes' regexp="yes">.+([aeo]|[aeou]i)-l[oa]s?</token>
                 </marker>
             </pattern>
             <message>Possível erro de acentuação.</message>
@@ -12439,6 +12439,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="escrevê-lo">Ele vai <marker>escreve-lo</marker> amanhã.</example>
             <example correction="puxá-las">O ímpeto de <marker>puxa-las</marker>.</example>
             <example correction="abraçá-la">Quero <marker>abraça-la</marker>.</example>
+            <example correction="distraí-los">Não quero <marker>distrai-los</marker>.</example>
             <example>Quero revê-la.</example>
         </rule>
 
@@ -12550,6 +12551,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>O caso tornou-se um escândalo de saúde após a morte de várias crianças imunizadas…</example>
             </antipattern>
             <!-- Must be placed AFTER the rules that correct improper enclitic/mesoclitic pronoun forms. -->
+
+            <antipattern>
+                <token postag='VMIP2S0:PP3..A00' postag_regexp='yes' regexp="yes">.+([aeo]|[aeou]i)-l[oa]s?</token>
+                <example>Você quer abraça-la?</example>
+                <example>Não quero mais observa-lo.</example>
+                <example>Nunca distrai-lo.</example>
+            </antipattern>
 
             <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_SIMPLES" default="on">
                 <antipattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -824,25 +824,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="desde essa">Isso acontece <marker>des dessa</marker> época.</example>
         </rule>
 
-        <rule id='ACENTUAÇÃO_VOGAL_ÊNCLISE' name="Acentuação vogal ênclise">
-            <antipattern>
-                <token>tu</token>
-                <token postag_regexp="yes" postag="R." min="0" max="2"/>
-                <token postag='VMIP2S0:PP3..A00' postag_regexp='yes' regexp="yes">.+-l[oa]s?</token>
-                <example>Tu canta-la bem.</example>
-            </antipattern>
-            <!-- p-goulart@2024-03-27 - DESC: this rule technically matches correct forms such as "canta-la", but they're rare enough in pt-BR that we can be certain "cantá-la" is meant -->
-            <pattern>
-                <marker>
-                    <token postag='VMIP2S0:PP3..A00' postag_regexp='yes' regexp="yes">.+[aeo]-l[oa]s?</token>
-                </marker>
-            </pattern>
-            <message>Possível erro de acentuação.</message>
-            <suggestion><match no="1" postag="VMIP2S0:(PP.+)" postag_regexp="yes" postag_replace="VMN0000:$1"/></suggestion>
-            <example correction="escrevê-lo">Ele vai <marker>escreve-lo</marker> amanhã.</example>
-            <example correction="puxá-las">O ímpeto de <marker>puxa-las</marker>.</example>
-            <example>Quero revê-la.</example>
-        </rule>
 
 
         <rulegroup id='AUXILIARY_VERB_INFINITIVE' name="Erro de concordância: Verbo auxiliar + verbo no infinitivo">
@@ -12440,6 +12421,25 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example>Segue os ditames de tua consciência.</example>
         </rule>
 
+        <rule id='ACENTUAÇÃO_VOGAL_ÊNCLISE' name="Acentuação vogal ênclise">
+            <antipattern>
+                <token>tu</token>
+                <token postag_regexp="yes" postag="R." min="0" max="2"/>
+                <token postag='VMIP2S0:PP3..A00' postag_regexp='yes' regexp="yes">.+-l[oa]s?</token>
+                <example>Tu canta-la bem.</example>
+            </antipattern>
+            <!-- p-goulart@2024-03-27 - DESC: this rule technically matches correct forms such as "canta-la", but they're rare enough in pt-BR that we can be certain "cantá-la" is meant -->
+            <pattern>
+                <marker>
+                    <token postag='VMIP2S0:PP3..A00' postag_regexp='yes' regexp="yes">.+[aeo]-l[oa]s?</token>
+                </marker>
+            </pattern>
+            <message>Possível erro de acentuação.</message>
+            <suggestion><match no="1" postag="VMIP2S0:(PP.+)" postag_regexp="yes" postag_replace="VMN0000:$1"/></suggestion>
+            <example correction="escrevê-lo">Ele vai <marker>escreve-lo</marker> amanhã.</example>
+            <example correction="puxá-las">O ímpeto de <marker>puxa-las</marker>.</example>
+            <example>Quero revê-la.</example>
+        </rule>
 
         <rule id='WRONG_REFLEXIVE_MOS' name='Conjugação verbal: Reflexivo -mos em lugar da primeira pessoa do plural'>
             <!-- Created by Tiago F. Santos, 2017-11-13 -->


### PR DESCRIPTION
Per [Slack comment](https://languagetooler.slack.com/archives/C058BK14VND/p1712749903029809).

First we fix the incorrect enclitic verb form (e.g. `abraça-la` -> `abraçá-la`) and only then do we move pronouns around.