### PR TITLE
[pt] Added AP to rule ID:PHD_TESE_PROCURAR_PROVAR_PROVARA

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -10313,6 +10313,15 @@ USA
             Vamos dormir, tomámos a medicação demasiado cedo.
             -->
             <antipattern>
+                <token postag='SENT_START'/>
+                <token postag='V.+' postag_regexp='yes'/>
+                <token postag='VMN0000'/>
+                <token postag='SENT_END'/>
+                <example>A publicação está o máximo! Vou roubar!</example>
+                <example>Não sei. Vamos descobrir!</example>
+                <example>Vamos comer. Estou morrendo de fome.</example>
+            </antipattern>
+            <antipattern>
                 <token skip='-1' regexp='yes'>&tracos_de_separacao;</token>
                 <token inflected="yes">ir</token>
                 <token postag='VMN0000'/>


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart 

This antipattern fixes tons of false positives.

BEFORE:
`Portuguese (Portugal): 16143 total matches`

AFTER:
`Portuguese (Portugal): 16103 total matches`
