### PR TITLE
[pt] Fix SENT_END bug with PortugueseProclisisFilter

### DIFF
--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseProclisisFilter.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseProclisisFilter.java
@@ -21,7 +21,7 @@ public class PortugueseProclisisFilter extends RuleFilter {
     HashSet<String> suggestions = new HashSet<>(Collections.emptyList());
     for (AnalyzedToken at : encliticVerbTokenReadings.getReadings()) {
       String posTag = at.getPOSTag();
-      if (posTag == null || (!posTag.startsWith("V") && !posTag.contains(":"))) {
+      if (posTag == null || !posTag.startsWith("V") || !posTag.contains(":")) {
         continue;
       }
       String oldToken = at.getToken();

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseProclisisFilter.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseProclisisFilter.java
@@ -5,11 +5,9 @@ import org.languagetool.AnalyzedTokenReadings;
 import org.languagetool.rules.RuleMatch;
 import org.languagetool.rules.patterns.RuleFilter;
 import org.languagetool.synthesis.pt.PortugueseSynthesizer;
-import org.languagetool.tools.StringTools;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.function.Predicate;
 
 public class PortugueseProclisisFilter extends RuleFilter {
   protected PortugueseSynthesizer getSynthesizer() {
@@ -23,8 +21,10 @@ public class PortugueseProclisisFilter extends RuleFilter {
     HashSet<String> suggestions = new HashSet<>(Collections.emptyList());
     for (AnalyzedToken at : encliticVerbTokenReadings.getReadings()) {
       String posTag = at.getPOSTag();
+      if (posTag == null || (!posTag.startsWith("V") && !posTag.contains(":"))) {
+        continue;
+      }
       String oldToken = at.getToken();
-      assert posTag != null;
       String[] tagParts = posTag.split(":");
       String verbTag = tagParts[0];
       String newVerb = getSynthesizer().synthesize(at, verbTag)[0];

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -12582,21 +12582,25 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <token regexp="yes">por|do</token>
                     <token>que</token>
                     <token postag_regexp="yes" postag="R." min="0" max="2"/>
-                    <token postag_regexp="yes" postag="(VMN.+|V.SF3S0):PP.+"/>
+                    <token postag_regexp="yes" postag="(VMN0000|VMIP2S0):PP.+"/>
                     <example>Por que não ensiná-los?</example>
                     <example>É melhor confiá-la a ti do que entregá-la a um estranho.</example>
                 </antipattern>
                 <antipattern>
-                    <token inflected="yes">saber</token>
-                    <token regexp="yes">quando|onde</token>
+                    <token regexp="yes">onde|como|para|porque</token>
                     <token postag_regexp="yes" postag="R." min="0" max="2"/>
-                    <token postag_regexp="yes" postag="(VMN.+|V.SF3S0):PP.+"/>
+                    <token postag_regexp="yes" postag="(VMN0000|VMIP2S0):PP.+"/>
                     <example>Não sei onde achá-lo.</example>
+                    <example>É preciso estudar para entendê-lo.</example>
+                    <example>Não sei como usá-lo.</example>
+                    <example>Não sei como dizê-lo.</example>
+                    <!-- typo, but we still need to ignore -->
+                    <example>Ainda não sabe como usa-los.</example>
                 </antipattern>
                 <antipattern>
                     <token inflected="yes">ter</token>
                     <token>que</token>
-                    <token postag_regexp="yes" postag="(VMN.+|V.SF3S0):PP.+"/>
+                    <token postag_regexp="yes" postag="(VMN0000|VMIP2S0):PP.+"/>
                     <example>Temos que achá-lo.</example>
                     <example>Você terá que adicioná-los um a um.</example>
                 </antipattern>
@@ -12659,6 +12663,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction='me diga'>Não <marker>diga-me</marker> isso.</example>
             <example correction='te farei'>Nunca <marker>farei-te</marker> essa promessa.</example>
             <example correction='se propôs'>Ninguém <marker>propôs-se</marker> a fazer o relatório de contas.</example>
+            <!-- specifically test verb tagged with SENT_END -->
+            <example correction="o entendi">Sei que <marker>entendi-o</marker></example>
         </rule>
 
         <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO" default="temp_off">


### PR DESCRIPTION
Fix bug described [here](https://languagetooler.slack.com/archives/C02R689CQ1W/p1713361355114399).

That filter was being too naïve about verb tags. Now it's more restrictive. Added an example to test it — should work.

@SteVio89 & @susanaboatto — I suppose you can decide if this is worth a redeploy.