### PR TITLE
[pt] Check English words in speller

### DIFF
--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRule.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRule.java
@@ -296,6 +296,9 @@ public class MorfologikPortugueseSpellerRule extends MorfologikSpellerRule {
                                         List<RuleMatch> ruleMatchesSoFar, int idx,
                                         AnalyzedTokenReadings[] tokens) throws IOException {
     List<RuleMatch> ruleMatches = super.getRuleMatches(word, startPos, sentence, ruleMatchesSoFar, idx, tokens);
+    if (tokens[idx].hasPosTag("_english_ignore_")) {
+      return Collections.emptyList();
+    }
     if (!ruleMatches.isEmpty()) {
       if (isValidCliticVerb(word)) {
         ruleMatches = Collections.emptyList();

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -33,6 +33,7 @@
         <!ENTITY % languages SYSTEM "../../resource/pt/entities/languages.ent">
         <!ENTITY % postal    SYSTEM "../../resource/pt/entities/postal.ent"   >
         <!ENTITY % chars     SYSTEM "../../resource/pt/entities/chars.ent"    >
+        <!ENTITY % english   SYSTEM "../../resource/pt/entities/english.ent"  >
         %datetime;
         %misc;
         %abbrev;
@@ -41,6 +42,7 @@
         %languages;
         %postal;
         %chars;
+        %english;
 ]>
 
 <rules lang="pt" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/resource/disambiguation.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -3729,14 +3731,296 @@
       </rule>
   </rulegroup>
 
-          <!-- p-goulart@2024-03-07 - DESC: all tags that contain verbs *and* pronouns come from our tagger and need to be accepted...
-          the only exception being -ámos verbs in pt-BR, but I feel like this is a super edge case...-->
-  <!-- <rulegroup id="VERBS_WITH_CLITICS" name="Ignore spelling issues in verbs tagged with clitics"> -->
-      <!-- <rule> -->
-      <!--     <pattern> -->
-      <!--         <token postag_regexp="yes" postag="V.+:P.+"/> -->
-      <!--     </pattern> -->
-      <!--     <disambig action="ignore_spelling"/> -->
-      <!-- </rule> -->
-  <!-- </rulegroup> -->
+  <rulegroup id="IGNORE_ENGLISH_WORDS" name="Label English words">
+      <rule> <!-- #1 -->
+          <pattern>
+              <token regexp="yes">&english_common;</token>
+              <token regexp="yes">\p{L}+
+                  <exception regexp="yes">&english_no;|&english_forward;</exception>
+              </token>
+          </pattern>
+          <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:1,2"/>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #2 -->
+          <pattern>
+              <token postag="_english_ignore_"/>
+              <marker>
+                  <token regexp="yes">\p{L}+
+                      <exception regexp="yes">&english_no;|&english_forward;</exception>
+                      <exception postag="_english_ignore_"/>
+                  </token>
+              </marker>
+          </pattern>
+          <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:2"/>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #3 -->
+          <pattern>
+              <token regexp="yes">\p{L}+
+                  <exception regexp="yes">&english_no;|&english_forward;</exception>
+              </token>
+              <token regexp="yes">&english_common;</token>
+          </pattern>
+          <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:1,2"/>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #4 -->
+          <pattern>
+              <marker>
+                  <token regexp="yes">\p{L}+
+                      <exception regexp="yes">&english_no;|&english_forward;</exception>
+                      <exception postag="_english_ignore_"/>
+                  </token>
+              </marker>
+              <token postag="_english_ignore_|allow_saxon_genitive" postag_regexp="yes"/>
+          </pattern>
+          <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:1"/>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #5 -->
+          <pattern>
+              <token>to</token>
+              <token regexp="yes" postag="UNKNOWN">\p{L}+</token>
+          </pattern>
+          <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:2 postags:VB"/>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #6 -->
+          <pattern>
+              <token case_sensitive="yes">I</token>
+              <token regexp="yes" postag="UNKNOWN">\p{L}+
+                  <exception regexp="yes">&english_no;|&english_forward;</exception>
+              </token>
+          </pattern>
+          <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:2 postags:VB[PD]"/>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <!--<rule>
+          <pattern>
+          <token postag="_english_ignore_|UNKNOWN" postag_regexp="yes" regexp="yes">[a-z]+<exception regexp="yes">saint|anti|&english_no;</exception></token>
+          <token spacebefore="no">-</token>
+          <token spacebefore="no" regexp="yes">[a-z]+<exception regexp="yes">&english_no;|&english_forward;</exception></token>
+          </pattern>
+          <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:1,3"/>
+          <disambig action="add">
+          <wd pos="_english_ignore_"/>
+          <wd pos="_english_ignore_"/>
+          <wd pos="_english_ignore_"/>
+          </disambig>
+          </rule>
+          <rule>
+          <pattern>
+          <token regexp="yes">[a-z]+<exception regexp="yes">saint|anti|&english_no;</exception></token>
+          <token spacebefore="no">-</token>
+          <token postag="_english_ignore_|UNKNOWN" postag_regexp="yes" spacebefore="no" regexp="yes">[a-z]+<exception regexp="yes">&english_no;|&english_forward;</exception></token>
+          </pattern>
+          <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:1,3"/>
+          <disambig action="add">
+          <wd pos="_english_ignore_"/>
+          <wd pos="_english_ignore_"/>
+          <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>-->
+      <rule> <!-- #7 -->
+          <pattern>
+              <token postag="_english_ignore_"/>
+              <marker>
+                  <token regexp="yes">to</token>
+                  <token regexp="yes" postag="UNKNOWN">\p{L}+
+                      <exception regexp="yes">&english_no;|&english_forward;</exception>
+                      <exception postag="_english_ignore_"/>
+                  </token>
+              </marker>
+          </pattern>
+          <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:3"/>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #8 -->
+          <pattern>
+              <token postag="_english_ignore_"/>
+              <marker>
+                  <token regexp="yes">to</token>
+              </marker>
+              <token postag="_english_ignore_"/>
+          </pattern>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #9 -->
+          <pattern>
+              <token>from</token>
+              <token/>
+              <marker>
+                  <token>to</token>
+              </marker>
+          </pattern>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #10, contractions -->
+          <pattern>
+              <token regexp="yes">&english_contracted_not;</token>
+              <token regexp="yes">&apostrophes;</token>
+              <token>t</token>
+          </pattern>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #11, contractions -->
+          <pattern>
+              <token regexp="yes">&english_contracted_is;</token>
+              <token regexp="yes">&apostrophes;</token>
+              <token>s</token>
+          </pattern>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #12, contractions -->
+          <pattern>
+              <token regexp="yes">&english_contracted_are;</token>
+              <token regexp="yes">&apostrophes;</token>
+              <token>re</token>
+          </pattern>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #13, contractions -->
+          <pattern>
+              <token regexp="yes">&english_contracted_have;</token>
+              <token regexp="yes">&apostrophes;</token>
+              <token>ve</token>
+          </pattern>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #14, contractions -->
+          <pattern>
+              <token regexp="yes">&english_contracted_will;</token>
+              <token regexp="yes">&apostrophes;</token>
+              <token>ll</token>
+          </pattern>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #15, contractions -->
+          <pattern>
+              <token regexp="yes">&english_contracted_would;</token>
+              <token regexp="yes">&apostrophes;</token>
+              <token>d</token>
+          </pattern>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+
+      <rule> <!-- #16, risky -->
+          <pattern>
+              <token regexp="yes">&english_forward;
+                  <exception postag="_english_ignore_"/>
+              </token>
+              <token regexp="yes" negate_pos="yes" postag="_english_ignore_">&english_common;</token>
+          </pattern>
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #17, risky -->
+          <pattern>
+              <marker>
+                  <token regexp="yes">&english_forward;
+                      <exception postag="_english_ignore_"/>
+                  </token>
+              </marker>
+              <token postag="_english_ignore_"/>
+          </pattern>
+          <disambig action="add"><wd pos="_english_ignore_"/></disambig>
+      </rule>
+  </rulegroup>
+
+  <rulegroup id="IGNORE_WORDS_AROUND_ENGLISH_WORDS" name="Label unknown words as English when adjacent to English-labelled words">
+      <rule> <!-- #1 -->
+          <pattern>
+              <token postag="_english_ignore_"/>
+              <marker>
+                  <token regexp="yes" postag="UNKNOWN">\p{L}+|'s
+                      <exception regexp="yes">&english_no;|&english_forward;</exception>
+                      <exception postag="_english_ignore_"/>
+                  </token>
+              </marker>
+          </pattern>
+          <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:2"/>
+          <disambig action="add"><wd pos="_english_ignore_"/></disambig>
+      </rule>
+      <rule> <!-- #2 -->
+          <pattern>
+              <marker>
+                  <token regexp="yes" postag="UNKNOWN">\p{L}+
+                      <exception regexp="yes">&english_no;|&english_forward;</exception>
+                      <exception postag="_english_ignore_"/>
+                  </token>
+              </marker>
+              <token postag="_english_ignore_"/>
+          </pattern>
+          <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:1"/>
+          <disambig action="add"><wd pos="_english_ignore_"/></disambig>
+      </rule>
+      <rule> <!-- #3, unknown single-word parenthetical -->
+          <!-- This is for when we have a bunch of English words and then a single word in parenthesis,
+               99% of the time it's also English or it's some kind of English acronym. -->
+          <pattern>
+              <token postag="_english_ignore_"/>  <!-- refused to work with min="3", idk why -->
+              <token postag="_english_ignore_"/>
+              <token postag="_english_ignore_"/>
+              <token>(</token>
+              <marker>
+                  <token spacebefore="no" postag="UNKNOWN">
+                      <exception postag="_english_ignore_"/>
+                  </token>
+              </marker>
+              <token spacebefore="no">)</token>
+          </pattern>
+          <disambig action="add"><wd pos="_english_ignore_"/></disambig>
+      </rule>
+  </rulegroup>
+
 </rules>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/chars.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/chars.ent
@@ -8,6 +8,7 @@
 <!ENTITY separadores_de_oracoes "(?:[,;:…–—\(\)«“]|\-|\[\]\{\})">
 <!ENTITY tracos_de_separacao "(?:[-‑]|–|—|ㅡ)">
 <!ENTITY minus_sign "−">
+<!ENTITY apostrophes "['’]">
 
 <!-- ORDINALS, SUPERSCRIPTS, DEGREE SIGNS, AND OTHER NONSENSE 😩 -->
 <!-- For some reason, entities with special characters do NOT work in the disambiguation.xml file 

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
@@ -1,0 +1,206 @@
+<!-- copied from French -->
+<!ENTITY english_no "nos?|as?|tos?|dos?|vi|pela">
+
+<!ENTITY english_wh_words "what|when|where|whom?|whose|why|how|which">
+<!ENTITY english_prepositions "in|on|after|behind|before|off?|from|with|without|
+                               by|over|under|above|below|between|among|through|about">
+<!ENTITY english_pronouns "I|you|s?he|him|it|we|us|the[ym]|yours|hers|ours|theirs">
+<!ENTITY english_adverbs "here|there|again|back|more|most|very|not">
+<!ENTITY english_determiners "the|an|my|your|his|her|its|our|their|this|these|that|those">
+<!ENTITY english_common_verbs "be|am|are|is|was|were|been|being|have|has|had|
+                               having|did|does|done|doing|can|cannot|should|must|
+                               ought|will|could|would|shall">
+<!ENTITY english_conjunctions "and|but">
+
+<!-- copied from French and adapted -->
+<!ENTITY english_forward "as?|no|[cs]ome|for|(?-i)I">
+
+<!-- Portuguese-specific -->
+<!ENTITY english_suffixes "((ing|hood|ship|ction)s?|(ness)(es)?|ed|ly|ity|ary|ish)">
+<!ENTITY english_suffixed_word "\p{L}+&english_suffixes;">
+
+<!ENTITY english_contracted_not "don|doesn|isn|aren|wasn|weren|ain|hasn|haven|hadn|
+                                 can|shouldn|shan|wouldn|won|mustn|didn|couldn|needn">
+<!ENTITY english_contracted_is "that|it|s?he|what|when|where|who|why|how|let">
+<!ENTITY english_contracted_are "you|they|we">
+<!ENTITY english_contracted_have "I|you|we|they|who|would|could">
+<!ENTITY english_contracted_will "I|you|s?he|we|they|who|what">
+<!ENTITY english_contracted_would "I|you|s?he|we|they|who|that|what">
+
+
+<!-- Largely taken from French, but some words have been removed and others added -->
+<!ENTITY english_word_list "
+  first|any|two|get|other|into|time|all|only|years|used|look|
+  during|going|such|many|then|year|became|later|well|including|area|both|make|name|
+  called|until|while|against|may|number|season|several|team|work|born|
+  early|family|now|based|life|released|since|began|century|each|end|
+  following|found|located|town|around|day|government|named|
+  often|three|too|up|along|built|career|include|left|own|still|
+  took|held|last|members|much|than|within|another|company|death|
+  down|even|five|however|published|received|served|become|best|died|history|
+  included|near|old|order|play|power|side|students|third|way|among|
+  average|book|children|every|few|given|got|moved|period|south|using|various|
+  wait|went|although|created|established|games|law|next|political|
+  produced|species|started|take|title|written|appeared|community|
+  considered|continued|father|himself|level|married|military|player|returned|
+  right|run|though|together|amount|available|common|days|east|
+  formed|founded|half|head|income|making|men|never|others|result|see|
+  thou|usually|works|wrote|character|current|currently|developed|
+  elected|families|field|further|joined|largest|less|opened|party|playing|
+  recorded|seen|size|story|worked|away|church|either|eventually|meet|originally|
+  release|schools|sorry|taken|throughout|wife|working|above|across|announced|
+  described|designed|featured|features|followed|help|includes|lead|months|
+  remained|research|return|road|songs|upon|win|aircraft|almost|appointed|brother|
+  completed|countries|daughter|especially|famous|females|involved|itself|killed|
+  leading|older|performed|players|project|rather|replaced|signed|sometimes|
+  success|successful|track|units|white|added|attack|below|brought|census|changed|
+  county|decided|ever|fact|generally|hand|households|instead|introduced|least|
+  mid|mother|outside|private|professional|provide|provided|saw|seven|soon|space|
+  study|systems|teams|thus|women|september|allowed|battle|beginning|
+  books|director|eight|female|find|ground|higher|industry|interest|
+  league|lived|market|night|owned|placed|previous|primary|reached|related|
+  reported|runs|strong|winning|august|january|july|march|always|approximately|
+  army|awarded|campaign|characters|earlier|finished|lower|maybe|money|
+  natural|network|north|northern|numerous|particularly|past|practice|referred|
+  required|rights|southern|start|stated|student|taking|ten|
+  today|told|wide|world|writing|english|according|activities|already|
+  also|appearance|appears|associated|attended|better|caused|closed|coming|
+  companies|contains|defeated|density|directed|economic|ended|energy|
+  food|forced|fourth|give|highest|individuals|known|larger|length|limited|
+  lines|majority|mostly|movie|municipality|names|previously|
+  programs|remains|shown|spent|themselves|theory|thought|towards|want|week|
+  february|access|additional|attempt|becoming|believed|board|child|claimed|
+  create|effect|entered|feature|finally|forms|health|hence|hours|household|
+  housing|husband|increased|individual|mainly|material|meaning|might|nearly|
+  need|noted|offered|opening|operated|park|passed|personal|plays|problems|
+  property|provides|railway|ran|recently|red|relationship|religious|room|
+  scored|sea|separate|sound|takes|trade|turn|turned|variety|view|german|
+  london|actually|allow|alone|annual|appear|artists|author|call|carried|
+  cities|consists|cost|directly|eastern|enough|failed|friend|helped|highly|
+  hold|increase|launched|loss|makes|mean|middle|month|numbers|policy|quickly|
+  recording|represented|results|spread|studies|subject|supported|troops|
+  university|victory|weeks|whole|words|england|arrived|artist|asked|
+  broadcast|commonly|covered|cut|despite|discovered|fall|fight|financial|
+  foreign|friends|function|historical|initially|leave|levels|listed|managed|
+  nearby|presented|primarily|produce|products|raised|remaining|responsible|
+  retired|rule|school|seasons|serving|ships|sister|smaller|society|studied|
+  subsequently|technology|tracks|typically|whether|widely|yet|ability|basis|
+  cast|chief|coast|composed|constructed|destroyed|divided|earned|
+  effects|except|facilities|growth|hear|immediately|intended|issued|
+  keep|largely|leaving|likely|mentioned|needed|offers|officer|please|
+  prior|probably|proposed|quality|response|selected|simply|starting|stories|
+  thee|therefore|true|wanted|war|accepted|acquired|actor|adopted|becomes|
+  championship|channel|clear|council|defined|difficult|equipment|
+  extended|feet|flight|follows|formerly|gained|giving|greater|grew|host|
+  inside|lack|minor|models|moving|newspaper|officers|officially|operating|
+  ordered|overall|paper|pass|physical|poor|producer|product|projects|
+  purpose|remain|removed|revealed|soldiers|someone|tournament|upper|voice|
+  california|european|account|activity|agreed|allows|appearances|approach|
+  arms|assigned|begins|blood|blue|capacity|captured|claims|color|combined|
+  communities|completely|crew|declared|dedicated|defeat|featuring|fell|
+  fifth|frequently|gives|graduated|growing|heart|kept|know|knowledge|little|
+  mass|offer|planned|potential|powerful|purchased|reach|reason|recognized|
+  relatively|renamed|resulted|resulting|rules|saying|says|scale|secondary|
+  security|situated|suffered|surrounding|territory|things|titles|transferred|
+  treatment|tried|wing|workers|america|australia|india|academic|acting|
+  agreement|allowing|applied|attacks|ball|bank|birth|claim|compared|
+  conducted|connected|critical|dead|designated|develop|enemy|
+  entitled|estate|estimated|existing|expanded|expected|fellow|fighting|
+  floor|follow|forward|founder|fully|goes|granted|hands|hour|
+  ice|leaves|literature|necessary|newly|occupied|occur|occurred|
+  oldest|organizations|organized|owner|paid|parish|powers|promoted|providing|
+  read|receive|reduced|refers|refused|respectively|say|settled|settlement|
+  share|something|spring|stone|succeeded|suggested|taught|titled|towns|
+  travel|twenty|twice|website|worldwide|japanese|achieved|advanced|
+  airport|alongside|analysis|animals|attempted|attempts|authority|awards|
+  believe|bought|bring|broke|buried|cell|cells|chosen|contemporary|derived|
+  disease|dropped|economy|employed|facility|felt|fish|fought|functions|
+  gun|headquarters|highway|holds|hosted|identified|kind|laws|letters|
+  losing|marked|materials|matter|memory|methods|mixed|morning|mountain|
+  opposed|performing|politics|poverty|prevent|programming|proved|ranked|
+  scientific|sector|showed|sides|sign|tax|teacher|teaching|tree|urban|
+  ways|winter|younger|youth|australian|germany|acts|attacked|authorities|
+  beyond|birds|brothers|choice|citizens|classical|comedy|contained|containing|
+  creating|daily|deep|drug|easily|ending|ends|entirely|exchange|firm|fleet|
+  gift|guest|heard|heavily|historic|hope|incorporated|increasing|
+  influenced|inspired|knew|lake|library|medal|murder|needs|nominated|
+  notably|nuclear|obtained|officials|online|onto|participated|peace|
+  perhaps|platform|politician|professor|rank|reasons|regarded|returning|
+  rise|risk|safety|scoring|screen|search|seats|seems|selling|serious|
+  setting|shortly|silver|slightly|supply|toward|tower|trees|unable|unknown|
+  vehicles|visited|weapons|weight|winner|write|yeah|canadian|indian|japan|
+  abandoned|actress|aired|arrested|avoid|band's|block|calls|captain|
+  castle|closely|commissioned|consisted|contain|contributed|converted|
+  determined|developing|display|duty|educational|equal|extremely|
+  failure|finds|governor|greatest|herself|honor|horse|ideas|identity|
+  independence|inhabitants|injury|internal|kill|learning|maintained|
+  minister|occurs|orders|passing|possibly|price|producing|refer|
+  resources|review|shape|shared|sought|speaking|specifically|stay|
+  strength|successfully|technical|trying|typical|african|chinese|spanish|
+  approved|argued|armed|boat|brief|briefly|businesses|
+  causing|chain|chairman|committee|competed|confirmed|critics|describes|
+  device|door|drawn|earliest|edge|educated|expressed|farm|flat|flow|
+  founding|genus|getting|graduate|guns|headed|height|hoping|
+  humans|hundred|improved|islands|key|launch|literary|looking|maintain|
+  makeup|merged|mind|nothing|operate|opportunity|painting|partner|
+  passenger|peak|philosophy|popularity|properties|protect|racing|reaching|
+  really|rear|receiving|require|residential|retained|reviews|rooms|
+  separated|shaped|significantly|stood|stopped|sub|subjects|talk|tho|
+  translated|universities|wins|wood|greek|irish|navy|accompanied|achieve|
+  amongst|anything|appearing|banks|behavior|calling|category|celebrated|
+  charts|children's|coal|components|criticism|crossing|damaged|delivered|
+  depending|driven|effectively|ensure|equipped|evening|existed|exists|
+  experienced|faculty|falls|fashion|father's|finishing|fishing|forests|
+  forming|greatly|grow|hill|hosts|influential|injured|interested|
+  landing|loved|markets|meets|meters|modified|mountains|movies|offering|
+  participate|presidential|railroad|rapidly|recordings|registered|
+  request|requirements|responsibility|restored|returns|rivers|scholars|ship|
+  song|southeast|southwest|speak|squad|stayed|storm|strongly|
+  suggests|task|teachers|testing|threat|threatened|understanding|unusual|
+  visitors|wave|weekly|whereas|wind|wounded|congress|god|jewish|
+  accounts|actors|adapted|adding|agency|ahead|arranged|authors|beautiful|
+  benefit|bird|borders|boundary|bringing|broad|changing|coastal|cold|
+  concerns|concluded|constituency|continuing|counties|coverage|covering|
+  crisis|criticized|dating|declined|distinguished|dog|dominated|earth|
+  easy|edited|engineer|enjoyed|entering|extent|favor|feel|finding|flows|
+  formally|happened|historian|hundreds|investment|kingdom|lasted|
+  learn|leg|longest|manufacturing|measures|medicine|mining|missing|
+  mounted|mouth|movements|musician|narrow|ownership|painted|paintings|
+  partnership|powered|practices|printed|prize|produces|progress|ranks|
+  rarely|ready|remainder|replacing|rescue|roots|secretary|sees|
+  settlers|shares|shooting|signs|snow|soundtrack|steam|substantial|suburb|
+  surviving|tail|temporary|thing|thirty|thousand|throne|tied|tools|
+  treated|tribes|turning|vessels|viewed|walk|weapon|wearing|whilst|
+  widespread|window|wooden|worth|britain|pennsylvania|wales|acted|
+  advertising|animated|anyone|appeal|apply|appointment|artillery|
+  asks|assault|assembly|attributed|benefits|blocks|buy|championships|
+  chapter|circumstances|claiming|closer|colony|colors|continuous|corporate|
+  crowd|crown|customers|dated|daughters|debuted|defeating|departure|
+  destroy|detailed|drawing|drugs|electrical|eleven|else|encouraged|
+  essentially|everyone|evil|expensive|facing|fighter|generated|governments|
+  identical|infantry|integrated|journey|junction|latest|lawyer|
+  limits|locally|mathematics|matters|municipalities|networks|opportunities|
+  origins|partly|percentage|perfect|personality|picked|poems|
+  possibility|practical|priest|producers|proposal|qualified|ranking|
+  relationships|riding|row|school's|scientists|seek|seem|shore|struggle|
+  suffering|tall|territories|toured|traditionally|traveled|tribe|truth|
+  understand|unlike|unsuccessful|victims|wants|wings|writes|asian|democratic|
+  dutch|ncaa|polish|scotland|spain|abilities|abroad|advice|affiliated|
+  answer|arrest|attending|bear|bed|believes|belonged|boundaries|ceased|
+  chamber|characterized|circle|civilian|commanded|conventional|copy|
+  country's|dangerous|deaths|devoted|diameter|displayed|dynasty|eighth|
+  elsewhere|emperor|employment|erected|essential|evolved|exactly|
+  exclusively|exposed|falling|false|fear|feed|filed|fled|flights|fund|
+  funded|hearing|hunting|identify|inch|increases|indeed|innings|
+  insurance|landed|lists|literally|looked|lose|manufactured|
+  mechanical|merger|minority|operational|operator|originated|outer|
+  painter|parliamentary|partially|prices|publicly|ranging|rebuilt|
+  recommended|recovered|renowned|repeated|retail|ruling|sailed|
+  schedule|seeing|seeking|seemed|settlements|shall|signing|slowly|
+  spending|spoke|stream|studying|submarine|sufficient|suggest|suitable|
+  supposed|surgery|survey|swimming|team's|anyway|anyhow|anywhere|
+  somewhere|somebody|somehow|whatever|whoever|whosever|whomever|
+  whichever|whenever|wherever|however|art|miss|mister
+">
+
+<!ENTITY english_common "&english_wh_words;|&english_prepositions;|&english_adverbs;|&english_pronouns;|&english_determiners;|&english_common_verbs;|&english_conjunctions;|&english_word_list;|&english_suffixed_word;">


### PR DESCRIPTION
@susanaboatto I've sent you on Slack a sample diff showing the performance of the speller after tagging English words with `_english_ignore_`. If you need a different test set, do let me know.

@jaumeortola this logic seems to work for me. The one annoying thing about it is that, since we need the English tagger for the filter to work, I cannot add Java tests without making English a dependency. Any ideas? I'd really like to add some proper tests here.