### PR TITLE
[pt] Make EMAIL_SEM_HIFEN picky

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -36309,17 +36309,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="EaD">Professores de <marker>EAD</marker> têm várias dificuldades.</example>
         </rule>
 
-        <rule id="EMAIL_SEM_HIFEN_ORTHOGRAPHY" name="Corrigir email para e-mail">
-            <!-- p-goulart@2024-02-27 - DESC: the _ORTHOGRAPHY suffix is to get a red underline -->
-            <pattern>
-                <token regexp="yes">emails?</token>
-            </pattern>
-            <message>A palavra <suggestion><match no="1" regexp_match="(?i)email(s)?" regexp_replace="e-mail$1"/></suggestion> se escreve com hífen.</message>
-            <example correction="e-mail">Ele me enviou outro <marker>email</marker>.</example>
-            <example correction="e-mails">Não vejo <marker>emails</marker> novos.</example>
-            <example correction="E-mail"><marker>Email</marker>: foo@bar.com</example>
-        </rule>
-
         <rulegroup id="DIACRITICS" name="Confusão com diacríticos">
             <!--      Created by Jaume Ortolà, Portuguese rule 2021-01-08      -->
             <!--

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -36241,6 +36241,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
     <category id='MISSPELLING' name="Erros Ortográficos" type="misspelling">
 
+        <rule id="EMAIL_SEM_HIFEN" name="Corrigir email para e-mail" tags="picky">
+            <!-- p-goulart@2024-02-27 - DESC: the _ORTHOGRAPHY suffix is to get a red underline -->
+            <!-- p-goulart@2024-04-24 - DESC: removed the _ORTHOGRAPHY suffix, and made rule picky (cf. portuguese-pos-dict#27) -->
+            <pattern>
+                <token regexp="yes">emails?</token>
+            </pattern>
+            <message>Em contextos oficiais ou formais, prefira escrever  <suggestion><match no="1" regexp_match="(?i)email(s)?" regexp_replace="e-mail$1"/></suggestion> com hífen.</message>
+            <example correction="e-mail">Ele me enviou outro <marker>email</marker>.</example>
+            <example correction="e-mails">Não vejo <marker>emails</marker> novos.</example>
+            <example correction="E-mail"><marker>Email</marker>: foo@bar.com</example>
+        </rule>
+
         <rulegroup id="SERIAR_VERB" name="Possível erro de acentuação: seriamos (seriar) no lugar de seríamos (ser).">
             <rule>
                 <pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3622,7 +3622,7 @@ USA
             <pattern>
                 <token regexp="yes">emails?</token>
             </pattern>
-            <message>Em contextos oficiais ou formais, prefira escrever  <suggestion><match no="1" regexp_match="(?i)email(s)?" regexp_replace="e-mail$1"/></suggestion> com hífen.</message>,
+            <message>Em contextos oficiais ou formais, prefira escrever  <suggestion><match no="1" regexp_match="(?i)email(s)?" regexp_replace="e-mail$1"/></suggestion> com hífen.</message>
             <example correction="e-mail">Ele me enviou outro <marker>email</marker>.</example>
             <example correction="e-mails">Não vejo <marker>emails</marker> novos.</example>
             <example correction="E-mail"><marker>Email</marker>: foo@bar.com</example>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3616,6 +3616,17 @@ USA
     </category>
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
+        <rule id="EMAIL_SEM_HIFEN" name="Corrigir email para e-mail" tags="picky" tone_tags="academic" is_goal_specific="true">
+            <!-- p-goulart@2024-02-27 - DESC: the _ORTHOGRAPHY suffix is to get a red underline -->
+            <!-- p-goulart@2024-04-24 - DESC: removed the _ORTHOGRAPHY suffix, and made rule picky (cf. portuguese-pos-dict#27) -->
+            <pattern>
+                <token regexp="yes">emails?</token>
+            </pattern>
+            <message>Em contextos oficiais ou formais, prefira escrever  <suggestion><match no="1" regexp_match="(?i)email(s)?" regexp_replace="e-mail$1"/></suggestion> com hífen.</message>,
+            <example correction="e-mail">Ele me enviou outro <marker>email</marker>.</example>
+            <example correction="e-mails">Não vejo <marker>emails</marker> novos.</example>
+            <example correction="E-mail"><marker>Email</marker>: foo@bar.com</example>
+        </rule>
 
         <rule id='PAÍSES_DO_TERCEIRO_MUNDO' name="'aos/os países do terceiro mundo' → 'ao/o Terceiro Mundo'" default="temp_off">
             <pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3616,18 +3616,6 @@ USA
     </category>
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
-        <rule id="EMAIL_SEM_HIFEN" name="Corrigir email para e-mail" tags="picky" tone_tags="academic" is_goal_specific="true">
-            <!-- p-goulart@2024-02-27 - DESC: the _ORTHOGRAPHY suffix is to get a red underline -->
-            <!-- p-goulart@2024-04-24 - DESC: removed the _ORTHOGRAPHY suffix, and made rule picky (cf. portuguese-pos-dict#27) -->
-            <pattern>
-                <token regexp="yes">emails?</token>
-            </pattern>
-            <message>Em contextos oficiais ou formais, prefira escrever  <suggestion><match no="1" regexp_match="(?i)email(s)?" regexp_replace="e-mail$1"/></suggestion> com hífen.</message>
-            <example correction="e-mail">Ele me enviou outro <marker>email</marker>.</example>
-            <example correction="e-mails">Não vejo <marker>emails</marker> novos.</example>
-            <example correction="E-mail"><marker>Email</marker>: foo@bar.com</example>
-        </rule>
-
         <rule id='PAÍSES_DO_TERCEIRO_MUNDO' name="'aos/os países do terceiro mundo' → 'ao/o Terceiro Mundo'" default="temp_off">
             <pattern>
                 <marker>


### PR DESCRIPTION
 - remove '_ORTHOGRAPHY' suffix to allow users more control;

 - add 'picky' tag;

 - this should only really work as of v0.16 of the dictionary, where 'email' is accepted in pt-BR.

---

@susanaboatto please decide on the precise UX in terms of tone tags and pickiness.

Closes languagetool-org/portuguese-pos-dict#27 (together with languagetool-org/portuguese-pos-dict#33).