### PR TITLE
[LO extension / Standalone] add the possibility to define more than o…

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -2133,7 +2133,7 @@ public class JLanguageTool {
     }
   }
 
-  public void setConfigValues(Map<String, Integer> v) {
+  public void setConfigValues(Map<String, Object[]> v) {
     userConfig.insertConfigValues(v);
   }
 

--- a/languagetool-core/src/main/java/org/languagetool/UserConfig.java
+++ b/languagetool-core/src/main/java/org/languagetool/UserConfig.java
@@ -49,7 +49,7 @@ public class UserConfig {
   private final Long userDictCacheSize;
   private final String userDictName;
   private final Long premiumUid;
-  private final Map<String, Integer> configurableRuleValues = new HashMap<>();
+  private final Map<String, Object[]> configurableRuleValues = new HashMap<>();
   private final LinguServices linguServices;
   // needs to be in UserConfig so it is considered both in ResultCache and in PipelinePool
   private final boolean filterDictionaryMatches;
@@ -71,19 +71,19 @@ public class UserConfig {
     this(userSpecificSpellerWords, new HashMap<>());
   }
 
-  public UserConfig(Map<String, Integer> ruleValues) {
+  public UserConfig(Map<String, Object[]> ruleValues) {
     this(new ArrayList<>(), Objects.requireNonNull(ruleValues));
   }
 
-  public UserConfig(Map<String, Integer> ruleValues, LinguServices linguServices) {
+  public UserConfig(Map<String, Object[]> ruleValues, LinguServices linguServices) {
     this(new ArrayList<>(), Objects.requireNonNull(ruleValues), 0, 0L, null, 0L, linguServices);
   }
 
-  public UserConfig(List<String> userSpecificSpellerWords, Map<String, Integer> ruleValues) {
+  public UserConfig(List<String> userSpecificSpellerWords, Map<String, Object[]> ruleValues) {
     this(userSpecificSpellerWords, ruleValues, 0, null, null, null, null);
   }
 
-  public UserConfig(List<String> userSpecificSpellerWords, Map<String, Integer> ruleValues,
+  public UserConfig(List<String> userSpecificSpellerWords, Map<String, Object[]> ruleValues,
                     int maxSpellingSuggestions, Long premiumUid, String userDictName, Long userDictCacheSize,
                     LinguServices linguServices) {
     this(userSpecificSpellerWords, Collections.emptyList(), ruleValues, maxSpellingSuggestions, premiumUid, userDictName, userDictCacheSize, linguServices,
@@ -92,7 +92,7 @@ public class UserConfig {
 
   public UserConfig(List<String> userSpecificSpellerWords,
                     List<Rule> userSpecificRules,
-                    Map<String, Integer> ruleValues,
+                    Map<String, Object[]> ruleValues,
                     int maxSpellingSuggestions, Long premiumUid, String userDictName,
                     Long userDictCacheSize,
                     LinguServices linguServices, boolean filterDictionaryMatches,
@@ -103,7 +103,7 @@ public class UserConfig {
 
   public UserConfig(List<String> userSpecificSpellerWords,
                     List<Rule> userSpecificRules,
-                    Map<String, Integer> ruleValues,
+                    Map<String, Object[]> ruleValues,
                     int maxSpellingSuggestions, Long premiumUid, String userDictName,
                     Long userDictCacheSize,
                     LinguServices linguServices, boolean filterDictionaryMatches,
@@ -112,7 +112,7 @@ public class UserConfig {
                     boolean untrustedSource) {
     this.userSpecificSpellerWords = Objects.requireNonNull(userSpecificSpellerWords);
     this.userSpecificRules = Objects.requireNonNull(userSpecificRules);
-    for (Map.Entry<String, Integer> entry : ruleValues.entrySet()) {
+    for (Map.Entry<String, Object[]> entry : ruleValues.entrySet()) {
       this.configurableRuleValues.put(entry.getKey(), entry.getValue());
     }
     this.maxSpellingSuggestions = maxSpellingSuggestions;
@@ -174,21 +174,21 @@ public class UserConfig {
     return maxSpellingSuggestions;
   }
 
-  public Map<String, Integer> getConfigValues() {
+  public Map<String, Object[]> getConfigValues() {
     return configurableRuleValues;
   }
   
-  public void insertConfigValues(Map<String, Integer>  ruleValues) {
-    for (Map.Entry<String, Integer> entry : ruleValues.entrySet()) {
+  public void insertConfigValues(Map<String, Object[]>  ruleValues) {
+    for (Map.Entry<String, Object[]> entry : ruleValues.entrySet()) {
       this.configurableRuleValues.put(entry.getKey(), entry.getValue());
     }
   }
   
-  public int getConfigValueByID(String ruleID) {
+  public Object[] getConfigValueByID(String ruleID) {
     if (configurableRuleValues.containsKey(ruleID)) {
       return configurableRuleValues.get(ruleID);
     }
-    return -1;
+    return null;
   }
   
   public boolean hasLinguServices() {

--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractFillerWordsRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractFillerWordsRule.java
@@ -65,9 +65,9 @@ public abstract class AbstractFillerWordsRule extends TextLevelRule {
       setDefaultOff();
     }
     if (userConfig != null) {
-      int confPercent = userConfig.getConfigValueByID(getId());
-      if(confPercent >= 0) {
-        this.minPercent = confPercent;
+      Object[] cf = userConfig.getConfigValueByID(getId());
+      if (cf != null) {
+        this.minPercent = (int) cf[0];
       }
     }
     setLocQualityIssueType(ITSIssueType.Style);
@@ -87,32 +87,13 @@ public abstract class AbstractFillerWordsRule extends TextLevelRule {
     return RULE_ID;
   }
 
-  @Override
-  public int getDefaultValue() {
-    return minPercent;
-  }
-
-  @Override
-  public boolean hasConfigurableValue() {
-    return true;
-  }
-
-  @Override
-  public int getMinConfigurableValue() {
-    return 0;
-  }
-
-  @Override
-  public int getMaxConfigurableValue() {
-    return 100;
-  }
-
-  /* (non-Javadoc)
-   * @see org.languagetool.rules.Rule#getConfigureText()
+  /**
+   *  give the user the possibility to configure the function
    */
   @Override
-  public String getConfigureText() {
-    return messages.getString("filler_words_rule_opt_text");
+  public RuleOption[] getRuleOptions() {
+    RuleOption[] ruleOptions = { new RuleOption(minPercent, messages.getString("filler_words_rule_opt_text"), 0, 100) };
+    return ruleOptions;
   }
 
   public String getMessage() {

--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractStatisticSentenceStyleRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractStatisticSentenceStyleRule.java
@@ -71,7 +71,6 @@ public abstract class AbstractStatisticSentenceStyleRule extends TextLevelRule {
    */
   protected abstract String getLimitMessage(int limit, double percent);
   
-  @Override
   public abstract String getConfigureText();
 
   public AbstractStatisticSentenceStyleRule(ResourceBundle messages, Language lang, UserConfig userConfig, int minPercent, boolean defaultActive) {
@@ -88,9 +87,9 @@ public abstract class AbstractStatisticSentenceStyleRule extends TextLevelRule {
 
   private int getMinPercent(UserConfig userConfig, int minPercentDefault) {
     if (userConfig != null) {
-      int confPercent = userConfig.getConfigValueByID(getId());
-      if (confPercent >= 0) {
-        return confPercent;
+      Object[] cf = userConfig.getConfigValueByID(getId());
+      if (cf != null) {
+        return (int) cf[0];
       }
     }
     return minPercentDefault;
@@ -115,24 +114,13 @@ public abstract class AbstractStatisticSentenceStyleRule extends TextLevelRule {
     return 100.0;
   }
   
+  /**
+   *  give the user the possibility to configure the function
+   */
   @Override
-  public boolean hasConfigurableValue() {
-    return true;
-  }
-
-  @Override
-  public int getDefaultValue() {
-    return defaultMinPercent;
-  }
-
-  @Override
-  public int getMinConfigurableValue() {
-    return 0;
-  }
-
-  @Override
-  public int getMaxConfigurableValue() {
-    return 100;
+  public RuleOption[] getRuleOptions() {
+    RuleOption[] ruleOptions = { new RuleOption(defaultMinPercent, getConfigureText(), 0, 100) };
+    return ruleOptions;
   }
 
   public int getSentenceCount() {

--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractStatisticStyleRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractStatisticStyleRule.java
@@ -51,6 +51,7 @@ public abstract class AbstractStatisticStyleRule extends TextLevelRule {
   private int wordCount = 0;
   private int numMatches = 0;
   private boolean withoutDirectSpeech = false;
+  private boolean excludeDirectSpeech;
 
   /**
    * Condition to generate a hint (possibly including all exceptions)
@@ -80,11 +81,9 @@ public abstract class AbstractStatisticStyleRule extends TextLevelRule {
    */
   protected abstract String getSentenceMessage();
   
-  /* (non-Javadoc)
-   * @see org.languagetool.rules.Rule#getConfigureText()
-   */
-  @Override
-  public abstract String getConfigureText();
+  public abstract String getConfigurePercentText();
+
+  public abstract String getConfigureWithoutDirectSpeachText();
 
   public AbstractStatisticStyleRule(ResourceBundle messages, Language lang, UserConfig userConfig, int minPercent, boolean defaultActive) {
     super(messages);
@@ -95,17 +94,28 @@ public abstract class AbstractStatisticStyleRule extends TextLevelRule {
     }
     defaultMinPercent = minPercent;
     this.minPercent = getMinPercent(userConfig, minPercent);
+    excludeDirectSpeech = getExcludeDirectSpeech(userConfig);
     setLocQualityIssueType(ITSIssueType.Style);
   }
 
   private int getMinPercent(UserConfig userConfig, int minPercentDefault) {
     if (userConfig != null) {
-      int confPercent = userConfig.getConfigValueByID(getId());
-      if (confPercent >= 0) {
-        return confPercent;
+      Object[] cf = userConfig.getConfigValueByID(getId());
+      if (cf != null && cf.length > 0 && cf[0] != null && cf[0] instanceof Integer) {
+        return (int) cf[0];
       }
     }
     return minPercentDefault;
+  }
+
+  private boolean getExcludeDirectSpeech(UserConfig userConfig) {
+    if (userConfig != null) {
+      Object[] cf = userConfig.getConfigValueByID(getId());
+      if (cf != null && cf.length > 1 && cf[1] != null && cf[1] instanceof Boolean) {
+        return (boolean) cf[1];
+      }
+    }
+    return excludeDirectSpeech();
   }
 
   public AbstractStatisticStyleRule(ResourceBundle messages, Language lang, UserConfig userConfig, int minPercent) {
@@ -119,26 +129,18 @@ public abstract class AbstractStatisticStyleRule extends TextLevelRule {
     return 100.0;
   }
   
+  /**
+   *  give the user the possibility to configure the function
+   */
   @Override
-  public boolean hasConfigurableValue() {
-    return true;
+  public RuleOption[] getRuleOptions() {
+    RuleOption[] ruleOptions = { 
+        new RuleOption(defaultMinPercent, getConfigurePercentText(), 0, 100),
+        new RuleOption(excludeDirectSpeech, getConfigureWithoutDirectSpeachText())
+        };
+    return ruleOptions;
   }
 
-  @Override
-  public int getDefaultValue() {
-    return defaultMinPercent;
-  }
-
-  @Override
-  public int getMinConfigurableValue() {
-    return 0;
-  }
-
-  @Override
-  public int getMaxConfigurableValue() {
-    return 100;
-  }
-  
   public int getWordCount() {
     return wordCount;
   }
@@ -163,7 +165,6 @@ public abstract class AbstractStatisticStyleRule extends TextLevelRule {
     double percent;
     int pos = 0;
     wordCount = 0;
-    boolean excludeDirectSpeech = excludeDirectSpeech();
     boolean isDirectSpeech = false;
     for (AnalyzedSentence sentence : sentences) {
       AnalyzedTokenReadings[] tokens = sentence.getTokensWithoutWhitespace();

--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractStyleRepeatedWordRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractStyleRepeatedWordRule.java
@@ -62,9 +62,9 @@ public abstract class AbstractStyleRepeatedWordRule  extends TextLevelRule {
       if (linguServices != null) {
         linguServices.setThesaurusRelevantRule(this);
       }
-      int confDistance = userConfig.getConfigValueByID(getId());
-      if (confDistance >= 0) {
-        this.maxDistanceOfSentences = confDistance;
+      Object[] cf = userConfig.getConfigValueByID(getId());
+      if (cf != null) {
+        this.maxDistanceOfSentences = (int) cf[0];
       }
     } else {
       linguServices = null;
@@ -101,44 +101,13 @@ public abstract class AbstractStyleRepeatedWordRule  extends TextLevelRule {
    */
   protected abstract String messageSentenceAfter();
   
-  /*
-   * get maximal Distance of words in number of sentences
-   * @since 4.1
+  /**
+   *  give the user the possibility to configure the function
    */
   @Override
-  public int getDefaultValue() {
-    return maxDistanceOfSentences;
-  }
-  
-  /**
-   * @since 4.2
-   */
-  @Override
-  public boolean hasConfigurableValue() {
-    return true;
-  }
-
-  /**
-   * @since 4.2
-   */
-  @Override
-  public int getMinConfigurableValue() {
-    return 0;
-  }
-
-  /**
-   * @since 4.2
-   */
-  @Override
-  public int getMaxConfigurableValue() {
-    return 5;
-  }
-
-  /**
-   * @since 4.2
-   */
-  public String getConfigureText() {
-    return messages.getString("guiStyleRepeatedWordText");
+  public RuleOption[] getRuleOptions() {
+    RuleOption[] ruleOptions = { new RuleOption(maxDistanceOfSentences, messages.getString("guiStyleRepeatedWordText"), 0, 5) };
+    return ruleOptions;
   }
 
   /*

--- a/languagetool-core/src/main/java/org/languagetool/rules/AbstractStyleTooOftenUsedWordRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/AbstractStyleTooOftenUsedWordRule.java
@@ -83,35 +83,25 @@ public abstract class AbstractStyleTooOftenUsedWordRule extends TextLevelRule {
    */
   protected abstract String getLimitMessage(int minPercent);
   
-  /* (non-Javadoc)
-   * @see org.languagetool.rules.Rule#getConfigureText()
-   */
-  @Override
   public abstract String getConfigureText();
 
   private int getMinPercent(UserConfig userConfig, int minPercentDefault) {
     if (userConfig != null) {
-      int confPercent = userConfig.getConfigValueByID(getId());
-      if (confPercent >= 0) {
-        return confPercent;
+      Object[] cf = userConfig.getConfigValueByID(getId());
+      if (cf != null) {
+        return (int) cf[0];
       }
     }
     return minPercentDefault;
   }
 
+  /**
+   *  give the user the possibility to configure the function
+   */
   @Override
-  public boolean hasConfigurableValue() {
-    return true;
-  }
-
-  @Override
-  public int getDefaultValue() {
-    return defaultMinPercent;
-  }
-
-  @Override
-  public int getMinConfigurableValue() {
-    return 1;
+  public RuleOption[] getRuleOptions() {
+    RuleOption[] ruleOptions = { new RuleOption(defaultMinPercent, getConfigureText(), 1, 100) };
+    return ruleOptions;
   }
 
   public Map<String, Integer> getWordMap() {

--- a/languagetool-core/src/main/java/org/languagetool/rules/LongParagraphRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/LongParagraphRule.java
@@ -49,9 +49,9 @@ public class LongParagraphRule extends TextLevelRule {
       this.maxWords = defaultWords;
     }
     if (userConfig != null) {
-      int confWords = userConfig.getConfigValueByID(getId());
-      if (confWords > 0) {
-        this.maxWords = confWords;
+      Object[] cf = userConfig.getConfigValueByID(getId());
+      if (cf != null) {
+        this.maxWords = (int) cf[0];
       }
     }
     setLocQualityIssueType(ITSIssueType.Style);
@@ -77,28 +77,13 @@ public class LongParagraphRule extends TextLevelRule {
     return RULE_ID;
   }
 
+  /**
+   *  give the user the possibility to configure the function
+   */
   @Override
-  public int getDefaultValue() {
-    return maxWords;
-  }
-
-  @Override
-  public boolean hasConfigurableValue() {
-    return true;
-  }
-
-  @Override
-  public int getMinConfigurableValue() {
-    return 5;
-  }
-
-  @Override
-  public int getMaxConfigurableValue() {
-    return 300;
-  }
-
-  public String getConfigureText() {
-    return messages.getString("guiLongParagraphsText");
+  public RuleOption[] getRuleOptions() {
+    RuleOption[] ruleOptions = { new RuleOption(maxWords, messages.getString("guiLongParagraphsText"), 5, 300) };
+    return ruleOptions;
   }
 
   public String getMessage() {

--- a/languagetool-core/src/main/java/org/languagetool/rules/LongSentenceRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/LongSentenceRule.java
@@ -53,9 +53,9 @@ public class LongSentenceRule extends TextLevelRule {
     setTags(Collections.singletonList(Tag.picky));
     int tmpMaxWords = maxWords;
     if (userConfig != null) {
-      int confWords = userConfig.getConfigValueByID(getId());
-      if (confWords > 0) {
-        tmpMaxWords = confWords;
+      Object[] cf = userConfig.getConfigValueByID(getId());
+      if (cf != null) {
+        tmpMaxWords = (int) cf[0];
       }
     }
     this.maxWords = tmpMaxWords;
@@ -165,29 +165,13 @@ public class LongSentenceRule extends TextLevelRule {
     return 0;
   }
   
-// next functions give the user the possibility to configure the function
+  /**
+   *  give the user the possibility to configure the function
+   */
   @Override
-  public int getDefaultValue() {
-    return maxWords;
+  public RuleOption[] getRuleOptions() {
+    RuleOption[] ruleOptions = { new RuleOption(maxWords, messages.getString("guiLongSentencesText"), 5, 100) };
+    return ruleOptions;
   }
 
-  @Override
-  public boolean hasConfigurableValue() {
-    return true;
-  }
-
-  @Override
-  public int getMinConfigurableValue() {
-    return 5;
-  }
-
-  @Override
-  public int getMaxConfigurableValue() {
-    return 100;
-  }
-
-  @Override
-  public String getConfigureText() {
-    return messages.getString("guiLongSentencesText");
-  }
 }

--- a/languagetool-core/src/main/java/org/languagetool/rules/ReadabilityRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/ReadabilityRule.java
@@ -76,7 +76,10 @@ public class ReadabilityRule extends TextLevelRule {
     int tmpLevel = -1;
     if (userConfig != null) {
       linguServices = userConfig.getLinguServices();
-      tmpLevel = userConfig.getConfigValueByID(getId(tooEasyTest));
+      Object[] cf = userConfig.getConfigValueByID(getId());
+      if (cf != null) {
+        tmpLevel = (int) cf[0];
+      }
     } else {
       linguServices = null;
     }
@@ -111,33 +114,17 @@ public class ReadabilityRule extends TextLevelRule {
       return "Readability: Too difficult text";
     }
   }
-
-  @Override
-  public int getDefaultValue() {
-//    return (tooEasyTest ? 4 : 2);
-    return (3);
-  }
   
-  @Override
-  public boolean hasConfigurableValue() {
-    return true;
-  }
-
-  @Override
-  public int getMinConfigurableValue() {
-    return 0;
-  }
-
-  @Override
-  public int getMaxConfigurableValue() {
-    return 6;
-  }
-  
-  @Override
   public String getConfigureText() {
     return "Level of readability 0 (very difficult) to 6 (very easy):";
   }
-  
+
+  @Override
+  public RuleOption[] getRuleOptions() {
+    RuleOption[] ruleOptions = { new RuleOption(3, getConfigureText(), 0, 6) };
+    return ruleOptions;
+  }
+
   public int getAllSentences() {
     return nAllSentences;
   }

--- a/languagetool-core/src/main/java/org/languagetool/rules/Rule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/Rule.java
@@ -176,43 +176,11 @@ public abstract class Rule {
   }
 
   /**
-   * Overwrite this to return true, if a value may be configured by option panel
-   * @since 4.2
+   * Overwrite this to return configurable options for option panel
+   * @since 6.5
    */
-  public boolean hasConfigurableValue() {
-    return false;
-  }
-
-  /**
-   * Overwrite this to get a default Integer value by option panel
-   * @since 4.1
-   */
-  public int getDefaultValue() {
-    return 0;
-  }
-
-  /**
-   * Overwrite this to define the minimum of a configurable value
-   * @since 4.2
-   */
-  public int getMinConfigurableValue() {
-    return 0;
-  }
-
-  /**
-   * Overwrite this to define the maximum of a configurable value
-   * @since 4.2
-   */
-  public int getMaxConfigurableValue() {
-    return 100;
-  }
-
-  /**
-   * Overwrite this to define the Text in the option panel for the configurable value
-   * @since 4.2
-   */
-  public String getConfigureText() {
-    return "";
+  public RuleOption[] getRuleOptions() {
+    return null;
   }
 
   /**

--- a/languagetool-core/src/main/java/org/languagetool/rules/RuleOption.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RuleOption.java
@@ -1,0 +1,81 @@
+/* LanguageTool, a natural language style checker 
+ * Copyright (C) 2005 Daniel Naber (http://www.danielnaber.de)
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules;
+
+/**
+ * Class to configure rule option by option panel
+ * @author Fred Kruse
+ * @since 4.2
+ */
+public class RuleOption {
+  private final Object defaultValue;
+  private final String configureText;
+  private Object minConfigurableValue;
+  private Object maxConfigurableValue;
+  
+  public RuleOption(Object defaultValue, String configureText, Object minConfigurableValue, Object maxConfigurableValue) {
+    this.defaultValue = defaultValue;
+    this.configureText = configureText;
+    if (minConfigurableValue != null && maxConfigurableValue != null && 
+        (defaultValue instanceof Integer || defaultValue instanceof Character || 
+            defaultValue instanceof Float || defaultValue instanceof Double)) {
+      this.minConfigurableValue = minConfigurableValue;
+      this.maxConfigurableValue = maxConfigurableValue;
+    } else {
+      this.minConfigurableValue = 0;
+      this.maxConfigurableValue = 100;
+    }
+  }
+  
+  public RuleOption(Object defaultValue, String configureText) {
+    this(defaultValue, configureText, 0 , 100);
+  }
+
+  /**
+   * Get a default Value by option panel
+   */
+  public Object getDefaultValue() {
+    return defaultValue;
+  }
+
+  /**
+   * Get the Configuration Text by option panel
+   */
+  public String getConfigureText() {
+    return configureText;
+  }
+  /**
+   * Get the minimum of a configurable value
+   */
+  public Object getMinConfigurableValue() {
+    return minConfigurableValue;
+  }
+
+  /**
+   * Get the maximum of a configurable value
+   */
+  public Object getMaxConfigurableValue() {
+    return maxConfigurableValue;
+  }
+
+
+
+  
+  
+}

--- a/languagetool-core/src/main/java/org/languagetool/rules/RuleOption.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RuleOption.java
@@ -85,7 +85,7 @@ public class RuleOption {
    * (i for Integer, b for Boolean, etc.
    * Can be decoded by StringToObject
    */
-  public static String ObjectToString(Object o) {
+  public static String objectToString(Object o) {
     char c;
     if (o instanceof Integer) {
       c = 'i';
@@ -109,13 +109,13 @@ public class RuleOption {
    * separate the objects by ';'
    * Can be decoded by StringToObjects
    */
-  public static String ObjectsToString(Object[] o) {
+  public static String objectsToString(Object[] o) {
     String s = "";
     for (int i = 0; i < o.length; i++) {
       if (i > 0) {
         s += ";";
       }
-      s += ObjectToString(o[i]);
+      s += objectToString(o[i]);
     }
     return s;
   }
@@ -125,7 +125,7 @@ public class RuleOption {
    * Note: if there is no special encoding character at the beginning of the string
    *       an integer is assumed for compatibility with older versions of LT
    */
-  public static Object StringToObject(String s) {
+  public static Object stringToObject(String s) {
     Object o;
     char c = s.charAt(0);
     String str = s.substring(1);
@@ -150,12 +150,12 @@ public class RuleOption {
   /**
    * decodes an String to an array of object encoded by ObjectsToString
    */
-  public static Object[] StringToObjects(String s) {
+  public static Object[] stringToObjects(String s) {
     String[] strs = s.split(";");
     Object[] o = new Object[strs.length];
     for (int i = 0; i < strs.length; i++) {
       String str = strs[i].trim();
-      o[i] = StringToObject(str);
+      o[i] = stringToObject(str);
     }
     return o;
   }

--- a/languagetool-core/src/main/java/org/languagetool/rules/RuleOption.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RuleOption.java
@@ -21,9 +21,14 @@ package org.languagetool.rules;
 /**
  * Class to configure rule option by option panel
  * @author Fred Kruse
- * @since 4.2
+ * @since 6.5
  */
 public class RuleOption {
+  public final static String DEFAULT_VALUE = "defaultValue";
+  public final static String DEFAULT_TYPE = "defaultType";
+  public final static String MIN_CONF_VALUE = "minConfigurableValue";
+  public final static String MAX_CONF_VALUE = "maxConfigurableValue";
+  public final static String CONF_TEXT = "configureText";
   private final Object defaultValue;
   private final String configureText;
   private Object minConfigurableValue;
@@ -72,6 +77,87 @@ public class RuleOption {
    */
   public Object getMaxConfigurableValue() {
     return maxConfigurableValue;
+  }
+
+  /**
+   * Gives back a special String representation of an Object for save or communication
+   * add a character to characterize the type of object before its String value
+   * (i for Integer, b for Boolean, etc.
+   * Can be decoded by StringToObject
+   */
+  public static String ObjectToString(Object o) {
+    char c;
+    if (o instanceof Integer) {
+      c = 'i';
+    } else if (o instanceof Character) {
+      c = 'c';
+    } else if (o instanceof Boolean) {
+      c = 'b';
+    } else if (o instanceof Float) {
+      c = 'f';
+    } else if (o instanceof Double) {
+      c = 'd';
+    } else {
+      c = 's';
+    }
+    return c + o.toString();
+  }
+
+  /**
+   * Gives back a special String representation of an array of Objects for save or communication
+   * use ObjectToString for encoding the single objects
+   * separate the objects by ';'
+   * Can be decoded by StringToObjects
+   */
+  public static String ObjectsToString(Object[] o) {
+    String s = "";
+    for (int i = 0; i < o.length; i++) {
+      if (i > 0) {
+        s += ";";
+      }
+      s += ObjectToString(o[i]);
+    }
+    return s;
+  }
+
+  /**
+   * decodes an String to an object encoded by ObjectToString
+   * Note: if there is no special encoding character at the beginning of the string
+   *       an integer is assumed for compatibility with older versions of LT
+   */
+  public static Object StringToObject(String s) {
+    Object o;
+    char c = s.charAt(0);
+    String str = s.substring(1);
+    if (c == 's') {
+      o = str;
+    } else if (c == 'b') {
+      o = Boolean.parseBoolean(str);
+    } else if (c == 'f') {
+      o = Float.parseFloat(str);
+    } else if (c == 'd') {
+      o = Double.parseDouble(str);
+    } else if (c == 'c') {
+      o = str.charAt(0);
+    } else if (c == 'i') {
+      o = Integer.parseInt(str);
+    } else {  //  compatible to old version 
+      o = Integer.parseInt(s);
+    }
+    return o;
+  }
+
+  /**
+   * decodes an String to an array of object encoded by ObjectsToString
+   */
+  public static Object[] StringToObjects(String s) {
+    String[] strs = s.split(";");
+    Object[] o = new Object[strs.length];
+    for (int i = 0; i < strs.length; i++) {
+      String str = strs[i].trim();
+      o[i] = StringToObject(str);
+    }
+    return o;
   }
 
 

--- a/languagetool-core/src/test/java/org/languagetool/JLanguageToolTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/JLanguageToolTest.java
@@ -44,7 +44,7 @@ public class JLanguageToolTest {
     List<Rule> userRules = new ArrayList<>();
     List<PatternToken> patternTokens = Arrays.asList(PatternRuleBuilderHelper.token("my"), PatternRuleBuilderHelper.token("test"));
     userRules.add(new PatternRule("MY_TEST", lang, patternTokens, "test rule desc", "my test rule", "my test rule"));
-    Map<String, Integer> map = new HashMap<>();
+    Map<String, Object[]> map = new HashMap<>();
     UserConfig userConfig = new UserConfig(Collections.emptyList(), userRules, map, -1, 1L, "fake", null, null, false, null, null, false, null);
     JLanguageTool lt2 = new JLanguageTool(lang, null, userConfig);
     lt2.disableRule("test_unification_with_negation");

--- a/languagetool-gui-commons/src/main/java/org/languagetool/gui/Configuration.java
+++ b/languagetool-gui-commons/src/main/java/org/languagetool/gui/Configuration.java
@@ -45,6 +45,7 @@ import org.languagetool.Language;
 import org.languagetool.Languages;
 import org.languagetool.rules.ITSIssueType;
 import org.languagetool.rules.Rule;
+import org.languagetool.rules.RuleOption;
 
 /**
  * Configuration like list of disabled rule IDs, server mode etc.
@@ -1474,28 +1475,7 @@ public class Configuration {
           if (ruleAndValue.length != 2) {
             throw new RuntimeException("Could not parse rule and value, colon expected: '" + ruleToValue + "'");
           }
-          String[] values = ruleAndValue[1].split(";");
-          Object[] objects = new Object[values.length];
-          for (int i = 0; i < values.length; i++) {
-            String str = values[i].trim();
-            char c = values[i].charAt(0);
-            str = str.substring(1);
-            if (c == 's') {
-              objects[i] = str;
-            } else if (c == 'b') {
-              objects[i] = Boolean.parseBoolean(str);
-            } else if (c == 'f') {
-              objects[i] = Float.parseFloat(str);
-            } else if (c == 'd') {
-              objects[i] = Double.parseDouble(str);
-            } else if (c == 'c') {
-              objects[i] = str.charAt(0);
-            } else if (c == 'i') {
-              objects[i] = Integer.parseInt(str);
-            } else {  //  compatible to old version 
-              objects[i] = Integer.parseInt(values[i]);
-            }
-          }
+          Object[] objects = RuleOption.StringToObjects(ruleAndValue[1]);
           configurableRuleValues.put(ruleAndValue[0].trim(), objects);
         }
       }
@@ -1796,30 +1776,15 @@ public class Configuration {
     }
     if (!configurableRuleValues.isEmpty()) {
       StringBuilder sbRV = new StringBuilder();
+      int i = 0;
       for (Map.Entry<String, Object[]> entry : configurableRuleValues.entrySet()) {
         Object[] obs = entry.getValue();
         if (obs != null && obs.length > 0) {
-          StringBuilder sbOV = new StringBuilder();
-          char c;
-          for (int i = 0; i < obs.length; i++) {
-            Object o = entry.getValue()[i];
-            if (o instanceof Integer) {
-              c = 'i';
-            } else if (o instanceof Boolean) {
-              c = 'b';
-            } else if (o instanceof Float) {
-              c = 'f';
-            } else if (o instanceof Double) {
-              c = 'd';
-            } else {
-              c = 's';
-            }
-            if (i > 0) {
-              sbOV.append(";");
-            }
-            sbOV.append(c).append(o);
+          if (i > 0) {
+            sbRV.append(",");
           }
-          sbRV.append(entry.getKey()).append(':').append(sbOV.toString()).append(", ");
+          sbRV.append(entry.getKey()).append(':').append(RuleOption.ObjectsToString(obs));
+          i++;
         }
       }
       props.setProperty(prefix + CONFIGURABLE_RULE_VALUES_KEY + qualifier, sbRV.toString());

--- a/languagetool-gui-commons/src/main/java/org/languagetool/gui/Configuration.java
+++ b/languagetool-gui-commons/src/main/java/org/languagetool/gui/Configuration.java
@@ -1132,22 +1132,31 @@ public class Configuration {
 
   /**
    * Get the configurable value of a rule by ruleID
-   * returns -1 if no value is set by configuration
-   * @since 4.2
+   * returns default value if no value is set by configuration
+   * @since 6.5
    */
-  public Object[] getConfigurableValue(String ruleID) {
-    if (configurableRuleValues.containsKey(ruleID)) {
-      return configurableRuleValues.get(ruleID);
+  public <T> T getConfigValueByID(String ruleID, int index, Class<T> clazz, T defaultValue) {
+    Object[] value = configurableRuleValues.get(ruleID);
+    if (value == null || index >= value.length || !clazz.isInstance(value[index])) {
+      return defaultValue;
     }
-    return null;
+    return (T) value[index];
   }
 
   /**
-   * Set the value for a rule with ruleID
-   * @since 4.2
+   * Set the values for a rule by ruleID
+   * @since 6.5
    */
   public void setConfigurableValue(String ruleID, Object[] values) {
     configurableRuleValues.put(ruleID, values);
+  }
+
+  /**
+   * Remove the configuration values of a rule by ruleID
+   * @since 6.5
+   */
+  public void removeConfigurableValue(String ruleID) {
+    configurableRuleValues.remove(ruleID);
   }
 
   /**
@@ -1475,7 +1484,7 @@ public class Configuration {
           if (ruleAndValue.length != 2) {
             throw new RuntimeException("Could not parse rule and value, colon expected: '" + ruleToValue + "'");
           }
-          Object[] objects = RuleOption.StringToObjects(ruleAndValue[1]);
+          Object[] objects = RuleOption.stringToObjects(ruleAndValue[1]);
           configurableRuleValues.put(ruleAndValue[0].trim(), objects);
         }
       }
@@ -1783,7 +1792,7 @@ public class Configuration {
           if (i > 0) {
             sbRV.append(",");
           }
-          sbRV.append(entry.getKey()).append(':').append(RuleOption.ObjectsToString(obs));
+          sbRV.append(entry.getKey()).append(':').append(RuleOption.objectsToString(obs));
           i++;
         }
       }

--- a/languagetool-gui-commons/src/main/java/org/languagetool/gui/ConfigurationDialog.java
+++ b/languagetool-gui-commons/src/main/java/org/languagetool/gui/ConfigurationDialog.java
@@ -2031,6 +2031,7 @@ public class ConfigurationDialog implements ActionListener {
         }
         underlineType.setSelectedIndex(getUnderlineType(category, ruleId));
       }
+      config.removeConfigurableValue(ruleId);
     });
     cons1.gridx++;
     colorPanel.add(defaultButton);
@@ -2083,16 +2084,10 @@ public class ConfigurationDialog implements ActionListener {
               int n = i;
 
               Object defValue = ruleOption.getDefaultValue();
-              Object[] confValues = config.getConfigurableValue(rule.getId());
               
               if (defValue instanceof Boolean) {
                 JCheckBox isTrueBox = new JCheckBox(ruleOption.getConfigureText());
-                boolean value;
-                if (confValues != null && confValues.length > i && confValues[i] != null && confValues[i] instanceof Boolean) {
-                  value = (boolean) confValues[i];
-                } else {
-                  value = (boolean) defValue;
-                }
+                boolean value = config.getConfigValueByID(rule.getId(), i, Boolean.class, (Boolean) defValue);
                 isTrueBox.setSelected(value);
                 obj[n] = value;
                 isTrueBox.addItemListener(e1 -> {
@@ -2109,35 +2104,15 @@ public class ConfigurationDialog implements ActionListener {
                 ruleValueField.setMinimumSize(new Dimension(50, 28));  // without this the box is just a few pixels small, but why?
                 String fieldValue;
                 if (defValue instanceof Integer) {
-                  if (confValues != null && confValues.length > i && confValues[i] != null && confValues[i] instanceof Integer) {
-                    fieldValue = Integer.toString((int) confValues[i]);
-                  } else {
-                    fieldValue = Integer.toString((int) defValue);
-                  }
+                  fieldValue = Integer.toString(config.getConfigValueByID(rule.getId(), i, Integer.class, (Integer) defValue));
                 } else if (defValue instanceof Character) {
-                  if (confValues != null && confValues.length > i && confValues[i] != null && confValues[i] instanceof Character) {
-                    fieldValue = Character.toString((char) confValues[i]);
-                  } else {
-                    fieldValue = Character.toString((char) defValue);
-                  }
+                  fieldValue = Character.toString(config.getConfigValueByID(rule.getId(), i, Character.class, (Character) defValue));
                 } else if (defValue instanceof Double) {
-                  if (confValues != null && confValues.length > i && confValues[i] != null && confValues[i] instanceof Double) {
-                    fieldValue = Double.toString((double) confValues[i]);
-                  } else {
-                    fieldValue = Double.toString((double) defValue);
-                  }
+                  fieldValue = Double.toString(config.getConfigValueByID(rule.getId(), i, Double.class, (Double) defValue));
                 } else if (defValue instanceof Float) {
-                  if (confValues != null && confValues.length > i && confValues[i] != null && confValues[i] instanceof Float) {
-                    fieldValue = Float.toString((float) confValues[i]);
-                  } else {
-                    fieldValue = Float.toString((float) defValue);
-                  }
+                  fieldValue = Float.toString(config.getConfigValueByID(rule.getId(), i, Float.class, (Float) defValue));
                 } else {
-                  if (confValues != null && confValues.length > i && confValues[i] != null) {
-                    fieldValue = confValues[i].toString();
-                  } else {
-                    fieldValue = defValue.toString();
-                  }
+                  fieldValue = config.getConfigValueByID(rule.getId(), i, String.class, (String) defValue);
                 }
                 ruleValueField.setText(fieldValue);
                 obj[n] = fieldValue;
@@ -2248,7 +2223,6 @@ public class ConfigurationDialog implements ActionListener {
           colorPanel.setVisible(true);
           rule = null;
         }
-//        ruleOptionsPanel.repaint();
         ruleOptionsPanel.setVisible(true);
       }
     });

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanFillerWordsRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/GermanFillerWordsRule.java
@@ -198,8 +198,13 @@ public class GermanFillerWordsRule extends AbstractStatisticStyleRule {
   }
 
   @Override
-  public String getConfigureText() {
+  public String getConfigurePercentText() {
     return "Anzeigen wenn mehr als ...% eines Kapitels Füllwörter sind:";
+  }
+
+  @Override
+  public String getConfigureWithoutDirectSpeachText() {
+    return "Keine wörtliche Rede und Zitate berücksichtigen";
   }
 
 }

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/NonSignificantVerbsRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/NonSignificantVerbsRule.java
@@ -138,8 +138,13 @@ public class NonSignificantVerbsRule extends AbstractStatisticStyleRule {
   }
 
   @Override
-  public String getConfigureText() {
+  public String getConfigurePercentText() {
     return "Anzeigen wenn mehr als ...‰ eines Kapitels wenig aussagekräftige Verben sind:";
+  }
+
+  @Override
+  public String getConfigureWithoutDirectSpeachText() {
+    return "Keine direkte Rede und Zitate berücksichtigen";
   }
 
 }

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/UnnecessaryPhraseRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/UnnecessaryPhraseRule.java
@@ -132,8 +132,13 @@ public class UnnecessaryPhraseRule extends AbstractStatisticStyleRule {
   }
 
   @Override
-  public String getConfigureText() {
+  public String getConfigurePercentText() {
     return "Anzeigen wenn mehr als ...‱ eines Kapitels potenzielle Phrasen sind:";
+  }
+
+  @Override
+  public String getConfigureWithoutDirectSpeachText() {
+    return "Keine direkte Rede und Zitate berücksichtigen";
   }
 
 }

--- a/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/GermanFillerWordsRuleTest.java
+++ b/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/GermanFillerWordsRuleTest.java
@@ -54,8 +54,9 @@ public class GermanFillerWordsRuleTest {
     assertEquals(2, lt.check("Der Text enthält zu wenige Füllwörter, daher werden sie nicht angezeigt. Was sich an diesem Satz mit diesem relativ einfachen Füllwort zeigt. Dazu müssen noch eine Reihe von Sätzen geschrieben werden, um die Anzahl der Wörter zu erhöhen. Langsam sollten die Anzahl der Worte für das Drücken unter die kritische Grenze reichen. Jetzt schreibe ich einen Satz, der zwei Füllwörter hintereinander enthält, was allemal ziemlich ausreichend ist.").size());
     
     //  percentage set to zero - show all filler words
-    Map<String, Integer> ruleValues = new HashMap<>();
-    ruleValues.put("FILLER_WORDS_DE", 0);
+    Map<String, Object[]> ruleValues = new HashMap<>();
+    Object[] o = { 0 };  
+    ruleValues.put("FILLER_WORDS_DE", o);
     UserConfig userConfig = new UserConfig(ruleValues);
     setUpRule(lt, userConfig);
     assertEquals(1, lt.check("»Der Satz enthält augenscheinlich ein Füllwort«").size());

--- a/languagetool-language-modules/ru/src/main/java/org/languagetool/rules/ru/MorfologikRussianSpellerRule.java
+++ b/languagetool-language-modules/ru/src/main/java/org/languagetool/rules/ru/MorfologikRussianSpellerRule.java
@@ -33,6 +33,7 @@ import org.languagetool.AnalyzedTokenReadings;
 import org.languagetool.Language;
 import org.languagetool.UserConfig;
 import org.languagetool.rules.Example;
+import org.languagetool.rules.RuleOption;
 import org.languagetool.rules.spelling.morfologik.MorfologikSpellerRule;
 import org.languagetool.rules.SuggestedReplacement;
 
@@ -58,9 +59,9 @@ public final class MorfologikRussianSpellerRule extends MorfologikSpellerRule {
                    Example.fixed("Все счастливые семьи похожи друг на друга, <marker>каждая</marker> несчастливая семья несчастлива по-своему."));
 
     if (userConfig != null) {
-      int confValue = userConfig.getConfigValueByID(getId());
-      if(confValue >= 0) {
-        this.conf_ru_Value = confValue;
+      Object[] cf = userConfig.getConfigValueByID(getId());
+      if (cf != null) {
+        this.conf_ru_Value = (int) cf[0];
       }
     }
 
@@ -102,29 +103,15 @@ public final class MorfologikRussianSpellerRule extends MorfologikSpellerRule {
     return false;
   }
   
-  
-  @Override
-  public int getDefaultValue() {
-    return DEFAULT_MIN_RU_VALUE;
-  }
-
-  @Override
-  public boolean hasConfigurableValue() {
-    return true;
-  }
-
-  @Override
-  public int getMinConfigurableValue() {
-    return 0;
-  }
-
-  @Override
-  public int getMaxConfigurableValue() {
-    return 1;
-  }
-  
-    @Override
   public String getConfigureText() {
     return  "Проверять слова на латинице, только термины (0/1)";
   }
+    
+  @Override
+  public RuleOption[] getRuleOptions() {
+    RuleOption[] ruleOptions = { new RuleOption(DEFAULT_MIN_RU_VALUE, getConfigureText(), 0, 1) };
+    return ruleOptions;
+  }
+
+    
 }

--- a/languagetool-language-modules/ru/src/main/java/org/languagetool/rules/ru/MorfologikRussianYOSpellerRule.java
+++ b/languagetool-language-modules/ru/src/main/java/org/languagetool/rules/ru/MorfologikRussianYOSpellerRule.java
@@ -35,6 +35,7 @@ import org.languagetool.AnalyzedTokenReadings;
 import org.languagetool.Language;
 import org.languagetool.UserConfig;
 import org.languagetool.rules.Example;
+import org.languagetool.rules.RuleOption;
 import org.languagetool.rules.spelling.morfologik.MorfologikSpellerRule;
 import org.languagetool.rules.SuggestedReplacement;
 
@@ -70,9 +71,9 @@ public final class MorfologikRussianYOSpellerRule extends MorfologikSpellerRule 
                    Example.fixed("Все счастливые семьи похожи друг на друга, <marker>каждая</marker> несчастливая семья несчастлива по-своему."));
 
     if (userConfig != null) {
-      int confValue = userConfig.getConfigValueByID(getId());
-      if(confValue >= 0) {
-        this.conf_ru_Value = confValue;
+      Object[] cf = userConfig.getConfigValueByID(getId());
+      if (cf != null) {
+        this.conf_ru_Value = (int) cf[0];
       }
     }
   }
@@ -120,29 +121,14 @@ public final class MorfologikRussianYOSpellerRule extends MorfologikSpellerRule 
     return false;
   }
   
-  @Override
-  public int getDefaultValue() {
-    return DEFAULT_MIN_RU_VALUE;
-  }
-
-  @Override
-  public boolean hasConfigurableValue() {
-    return true;
-  }
-
-  @Override
-  public int getMinConfigurableValue() {
-    return 0;
-  }
-
-  @Override
-  public int getMaxConfigurableValue() {
-    return 1;
+  public String getConfigureText() {
+    return  "Проверять слова на латинице, только термины (0/1)";
   }
   
   @Override
-  public String getConfigureText() {
-    return  "Проверять слова на латинице, только термины (0/1)";
+  public RuleOption[] getRuleOptions() {
+    RuleOption[] ruleOptions = { new RuleOption(DEFAULT_MIN_RU_VALUE, getConfigureText(), 0, 1) };
+    return ruleOptions;
   }
   
 }

--- a/languagetool-office-extension/src/main/java/org/languagetool/openoffice/LORemoteLanguageTool.java
+++ b/languagetool-office-extension/src/main/java/org/languagetool/openoffice/LORemoteLanguageTool.java
@@ -316,7 +316,7 @@ class LORemoteLanguageTool {
     for (String rule : rules) {
       Object[] obs = configurableValues.get(rule);
       if (obs != null && obs.length > 0) {
-        String rOptions = RuleOption.ObjectsToString(obs);
+        String rOptions = RuleOption.objectsToString(obs);
         if (rOptions.charAt(0) == 'i') {  // for compatibility with older server versions
           rOptions = rOptions.substring(1);
         }

--- a/languagetool-office-extension/src/main/java/org/languagetool/openoffice/SingleDocument.java
+++ b/languagetool-office-extension/src/main/java/org/languagetool/openoffice/SingleDocument.java
@@ -1398,7 +1398,7 @@ public class SingleDocument {
         MessageHandler.printToLogFile("SingleDocument: getSynonymMap: Find Synonyms for word:" + word);
       }
 //      List<String> lemmas = lt.getLemmasOfWord(word);
-      List<String> lemmas = lt.getLemmasOfParagraph(para, error.nErrorStart);
+      List<String> lemmas = lt.isRemote() ? lt.getLemmasOfWord(word) : lt.getLemmasOfParagraph(para, error.nErrorStart);
       for (String lemma : lemmas) {
         if (debugMode > 1) {
           MessageHandler.printToLogFile("SingleDocument: getSynonymMap: Find Synonyms for lemma:" + lemma);

--- a/languagetool-office-extension/src/main/java/org/languagetool/openoffice/stylestatistic/LevelRule.java
+++ b/languagetool-office-extension/src/main/java/org/languagetool/openoffice/stylestatistic/LevelRule.java
@@ -195,7 +195,7 @@ public class LevelRule {
   }
 
   private int getDefaultRuleStep() {
-    int defValue = rule.getDefaultValue();
+    int defValue = (int)rule.getRuleOptions()[0].getDefaultValue();
     int defStep = (int) ((defValue / 3.) + 0.5);
     if (defStep < 1) {
       defStep = 1;

--- a/languagetool-office-extension/src/main/java/org/languagetool/openoffice/stylestatistic/StatAnConfiguration.java
+++ b/languagetool-office-extension/src/main/java/org/languagetool/openoffice/stylestatistic/StatAnConfiguration.java
@@ -171,11 +171,11 @@ public class StatAnConfiguration {
   private int getDefaultStep(TextLevelRule rule) {
     int defaultStep;
     if (rule instanceof AbstractStatisticSentenceStyleRule) {
-      defaultStep = (int) (((((AbstractStatisticSentenceStyleRule) rule).getDefaultValue() - 1) / 3.) + 0.5);
+      defaultStep = (int) ((((int)((AbstractStatisticSentenceStyleRule) rule).getRuleOptions()[0].getDefaultValue() - 1) / 3.) + 0.5);
     } else if (rule instanceof AbstractStatisticStyleRule) {
-      defaultStep = (int) (((((AbstractStatisticStyleRule) rule).getDefaultValue() - 1) / 3.) + 0.5);
+      defaultStep = (int) ((((int)((AbstractStatisticStyleRule) rule).getRuleOptions()[0].getDefaultValue() - 1) / 3.) + 0.5);
     } else if (rule instanceof AbstractStyleTooOftenUsedWordRule) {
-      defaultStep = (int) (((((AbstractStyleTooOftenUsedWordRule) rule).getDefaultValue() - 1) / 3.) + 0.5);
+      defaultStep = (int) ((((int)((AbstractStyleTooOftenUsedWordRule) rule).getRuleOptions()[0].getDefaultValue() - 1) / 3.) + 0.5);
     } else {
       return -1;
     }

--- a/languagetool-office-extension/src/main/java/org/languagetool/openoffice/stylestatistic/StatAnDialog.java
+++ b/languagetool-office-extension/src/main/java/org/languagetool/openoffice/stylestatistic/StatAnDialog.java
@@ -147,11 +147,13 @@ public class StatAnDialog extends Thread  {
     Language lang = document.getLanguage();
     if (lang != null) {
       try {
-        Map<String, Integer> ruleValues = new HashMap<>();
+        Map<String, Object[]> ruleValues = new HashMap<>();
         for (Rule rule : lang.getRelevantRules(JLanguageTool.getMessageBundle(), null, lang, null)) {
           if (rule instanceof AbstractStatisticSentenceStyleRule || rule instanceof AbstractStatisticStyleRule ||
               rule instanceof ReadabilityRule || rule instanceof AbstractStyleTooOftenUsedWordRule) {
-            ruleValues.put(rule.getId(), 0);
+            Object[] o = new Object[1];
+            o[0] = 0;
+            ruleValues.put(rule.getId(), o);
           }
         }
         UserConfig userConfig = new UserConfig(ruleValues);

--- a/languagetool-office-extension/src/main/java/org/languagetool/openoffice/stylestatistic/UsedWordRule.java
+++ b/languagetool-office-extension/src/main/java/org/languagetool/openoffice/stylestatistic/UsedWordRule.java
@@ -199,7 +199,7 @@ public class UsedWordRule {
   }
 
   private int getDefaultRuleStep() {
-    int defValue = rule.getDefaultValue();
+    int defValue = (int) rule.getRuleOptions()[0].getDefaultValue();
     int defStep = (int) ((defValue / 3.) + 0.5);
     if (defStep < 1) {
       defStep = 1;

--- a/languagetool-server/src/main/java/org/languagetool/server/ApiV2.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/ApiV2.java
@@ -579,10 +579,10 @@ class ApiV2 {
           //  Compatibility to old version (< 6.5)
           if (ruleOptions[0].getDefaultValue() instanceof Integer) {
             g.writeStringField("hasConfigurableValue", "yes");
-            g.writeStringField("configureText", ruleOptions[0].getConfigureText());
-            g.writeStringField("maxConfigurableValue", Integer.toString((int) ruleOptions[0].getMaxConfigurableValue()));
-            g.writeStringField("minConfigurableValue", Integer.toString((int) ruleOptions[0].getMinConfigurableValue()));
-            g.writeStringField("defaultValue", Integer.toString((int)ruleOptions[0].getDefaultValue()));
+            g.writeStringField(RuleOption.CONF_TEXT, ruleOptions[0].getConfigureText());
+            g.writeStringField(RuleOption.MAX_CONF_VALUE, Integer.toString((int) ruleOptions[0].getMaxConfigurableValue()));
+            g.writeStringField(RuleOption.MIN_CONF_VALUE, Integer.toString((int) ruleOptions[0].getMinConfigurableValue()));
+            g.writeStringField(RuleOption.DEFAULT_VALUE, Integer.toString((int)ruleOptions[0].getDefaultValue()));
           }
           //  new Version (>= 6.5)
           g.writeArrayFieldStart("ruleOptions");
@@ -590,37 +590,37 @@ class ApiV2 {
             g.writeStartObject();
             Object o = rOption.getDefaultValue();
             if (o instanceof Integer) {
-              g.writeStringField("defaultType", "Integer");
-              g.writeNumberField("defaultValue", (int) o);
-              g.writeNumberField("minConfigurableValue", (int) rOption.getMinConfigurableValue());
-              g.writeNumberField("maxConfigurableValue", (int) rOption.getMaxConfigurableValue());
+              g.writeStringField(RuleOption.DEFAULT_TYPE, "Integer");
+              g.writeNumberField(RuleOption.DEFAULT_VALUE, (int) o);
+              g.writeNumberField(RuleOption.MIN_CONF_VALUE, (int) rOption.getMinConfigurableValue());
+              g.writeNumberField(RuleOption.MAX_CONF_VALUE, (int) rOption.getMaxConfigurableValue());
             } else if (o instanceof Character) {
-              g.writeStringField("defaultType", "Character");
-              g.writeStringField("defaultValue", o.toString());
-              g.writeStringField("defaultValue", rOption.getMinConfigurableValue().toString());
-              g.writeStringField("defaultValue", rOption.getMaxConfigurableValue().toString());
+              g.writeStringField(RuleOption.DEFAULT_TYPE, "Character");
+              g.writeStringField(RuleOption.DEFAULT_VALUE, o.toString());
+              g.writeStringField(RuleOption.DEFAULT_VALUE, rOption.getMinConfigurableValue().toString());
+              g.writeStringField(RuleOption.DEFAULT_VALUE, rOption.getMaxConfigurableValue().toString());
             } else if (o instanceof Boolean) {
-              g.writeStringField("defaultType", "Boolean");
-              g.writeBooleanField("defaultValue", (boolean) o);
-              g.writeNumberField("minConfigurableValue", (int) rOption.getMinConfigurableValue());
-              g.writeNumberField("maxConfigurableValue", (int) rOption.getMaxConfigurableValue());
+              g.writeStringField(RuleOption.DEFAULT_TYPE, "Boolean");
+              g.writeBooleanField(RuleOption.DEFAULT_VALUE, (boolean) o);
+              g.writeNumberField(RuleOption.MIN_CONF_VALUE, (int) rOption.getMinConfigurableValue());
+              g.writeNumberField(RuleOption.MAX_CONF_VALUE, (int) rOption.getMaxConfigurableValue());
             } else if (o instanceof Float) {
-              g.writeStringField("defaultType", "Float");
-              g.writeNumberField("defaultValue", (float) o);
-              g.writeNumberField("minConfigurableValue", (float) rOption.getMinConfigurableValue());
-              g.writeNumberField("maxConfigurableValue", (float) rOption.getMaxConfigurableValue());
+              g.writeStringField(RuleOption.DEFAULT_TYPE, "Float");
+              g.writeNumberField(RuleOption.DEFAULT_VALUE, (float) o);
+              g.writeNumberField(RuleOption.MIN_CONF_VALUE, (float) rOption.getMinConfigurableValue());
+              g.writeNumberField(RuleOption.MAX_CONF_VALUE, (float) rOption.getMaxConfigurableValue());
             } else if (o instanceof Double) {
-              g.writeStringField("defaultType", "Double");
-              g.writeNumberField("defaultValue", (double) o);
-              g.writeNumberField("minConfigurableValue", (double) rOption.getMinConfigurableValue());
-              g.writeNumberField("maxConfigurableValue", (double) rOption.getMaxConfigurableValue());
+              g.writeStringField(RuleOption.DEFAULT_TYPE, "Double");
+              g.writeNumberField(RuleOption.DEFAULT_VALUE, (double) o);
+              g.writeNumberField(RuleOption.MIN_CONF_VALUE, (double) rOption.getMinConfigurableValue());
+              g.writeNumberField(RuleOption.MAX_CONF_VALUE, (double) rOption.getMaxConfigurableValue());
             } else {
-              g.writeStringField("defaultType", "String");
-              g.writeStringField("defaultValue", o.toString());
-              g.writeStringField("minConfigurableValue", rOption.getMinConfigurableValue().toString());
-              g.writeStringField("maxConfigurableValue", rOption.getMaxConfigurableValue().toString());
+              g.writeStringField(RuleOption.DEFAULT_TYPE, "String");
+              g.writeStringField(RuleOption.DEFAULT_VALUE, o.toString());
+              g.writeStringField(RuleOption.MIN_CONF_VALUE, rOption.getMinConfigurableValue().toString());
+              g.writeStringField(RuleOption.MAX_CONF_VALUE, rOption.getMaxConfigurableValue().toString());
             }
-            g.writeStringField("configureText", rOption.getConfigureText());
+            g.writeStringField(RuleOption.CONF_TEXT, rOption.getConfigureText());
             g.writeEndObject();
           }
           g.writeEndArray();

--- a/languagetool-server/src/main/java/org/languagetool/server/Pipeline.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/Pipeline.java
@@ -196,7 +196,7 @@ class Pipeline extends JLanguageTool {
   }
 
   @Override
-  public void setConfigValues(Map<String, Integer> v) {
+  public void setConfigValues(Map<String, Object[]> v) {
     preventModificationAfterSetup();
     super.setConfigValues(v);
   }

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -741,27 +741,7 @@ abstract class TextChecker {
     String[] pairs = parameterString.split(",");
     for (String pair : pairs) {
       String[] ruleAndValue  = pair.split(":");
-      String[] values = ruleAndValue[1].split(";");
-      Object[] objects = new Object[values.length];
-      for (int i = 0; i < values.length; i++) {
-        char c = values[i].charAt(0);
-        String str = values[i].substring(1);
-        if (c == 's') {
-          objects[i] = str;
-        } else if (c == 'b') {
-          objects[i] = Boolean.parseBoolean(str);
-        } else if (c == 'f') {
-          objects[i] = Float.parseFloat(str);
-        } else if (c == 'd') {
-          objects[i] = Double.parseDouble(str);
-        } else if (c == 'c') {
-          objects[i] = str.charAt(0);
-        } else if (c == 'i') {
-          objects[i] = Integer.parseInt(str);
-        } else {  //  compatible to old version 
-          objects[i] = Integer.parseInt(values[i]);
-        }
-      }
+      Object[] objects = RuleOption.StringToObjects(ruleAndValue[1]);
       ruleValues.put(ruleAndValue[0], objects);
     }
     return ruleValues;

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -732,8 +732,8 @@ abstract class TextChecker {
     return ruleMatchCount;
   }
 
-  private Map<String, Integer> getRuleValues(Map<String, String> parameters) {
-    Map<String, Integer> ruleValues = new HashMap<>();
+  private Map<String, Object[]> getRuleValues(Map<String, String> parameters) {
+    Map<String, Object[]> ruleValues = new HashMap<>();
     String parameterString = parameters.get("ruleValues");
     if (parameterString == null) {
       return ruleValues;
@@ -741,7 +741,28 @@ abstract class TextChecker {
     String[] pairs = parameterString.split(",");
     for (String pair : pairs) {
       String[] ruleAndValue  = pair.split(":");
-      ruleValues.put(ruleAndValue[0], Integer.parseInt(ruleAndValue[1]));
+      String[] values = ruleAndValue[1].split(";");
+      Object[] objects = new Object[values.length];
+      for (int i = 0; i < values.length; i++) {
+        char c = values[i].charAt(0);
+        String str = values[i].substring(1);
+        if (c == 's') {
+          objects[i] = str;
+        } else if (c == 'b') {
+          objects[i] = Boolean.parseBoolean(str);
+        } else if (c == 'f') {
+          objects[i] = Float.parseFloat(str);
+        } else if (c == 'd') {
+          objects[i] = Double.parseDouble(str);
+        } else if (c == 'c') {
+          objects[i] = str.charAt(0);
+        } else if (c == 'i') {
+          objects[i] = Integer.parseInt(str);
+        } else {  //  compatible to old version 
+          objects[i] = Integer.parseInt(values[i]);
+        }
+      }
+      ruleValues.put(ruleAndValue[0], objects);
     }
     return ruleValues;
   }

--- a/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/TextChecker.java
@@ -741,7 +741,7 @@ abstract class TextChecker {
     String[] pairs = parameterString.split(",");
     for (String pair : pairs) {
       String[] ruleAndValue  = pair.split(":");
-      Object[] objects = RuleOption.StringToObjects(ruleAndValue[1]);
+      Object[] objects = RuleOption.stringToObjects(ruleAndValue[1]);
       ruleValues.put(ruleAndValue[0], objects);
     }
     return ruleValues;


### PR DESCRIPTION
The change creates the ability to define more than one custom option per rule.
All existing rules with custom options have been adjusted. The options panel has been expanded accordingly.
The API and the HTTP server (ConfigurationInfo) have been adapted. Upward and downward compatibility between versions lower than 6.5 and higher than 6.4 was ensured.
A second option was added for the GermanFillerWordsRule as a test case.
All changes were tested.
To-do: Some more rules should be expanded to include additional options.
A merge can be performed. 