### PR TITLE
[pt-PT] Removed 'temp_off' from rules ID:AUTO-FALANTE and CRIAR_QUERER

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -4138,7 +4138,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id='AUTO-FALANTE' name="[pt-PT] Confusão: Auto-falante/Altifalante" default="temp_off">
+    <rule id='AUTO-FALANTE' name="[pt-PT] Confusão: Auto-falante/Altifalante">
         <pattern>
             <token>auto</token>
             <token regexp='yes' min='0'>&tracos_de_separacao;</token>
@@ -4152,7 +4152,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id='CRIAR_QUERER' name="[pt-PT] Confusão: Criar/Querer" default="temp_off">
+    <rule id='CRIAR_QUERER' name="[pt-PT] Confusão: Criar/Querer">
         <pattern>
             <marker>
                 <token regexp='yes'>cria[ms]?|criamos</token>


### PR DESCRIPTION
Hi @susanaboatto and @p-goulart ,

It is time to start removing 'temp_off' from the rules.

The two rules here:
AUTO-FALANTE has only one hit: https://internal1.languagetool.org/regression-tests/via-http/2024-04-25/pt-PT_full/result_grammar_AUTO-FALANTE%5B1%5D.html

CRIAR_QUERER has zero hits.

Thanks!