### PR TITLE
[pt-PT] Removed "temp_off" from rule ID:CONCLUIR_UM_CURSO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -2909,7 +2909,7 @@ USA
     </rule>
 
 
-    <rule id='CONCLUIR_UM_CURSO' name="[pt-PT] 'acabar/terminar' um curso → 'concluir'" type='style' tone_tags="academic" default="temp_off">
+    <rule id='CONCLUIR_UM_CURSO' name="[pt-PT] 'acabar/terminar' um curso → 'concluir'" type='style' tone_tags="academic">
         <pattern>
             <marker>
                 <token regexp="yes" inflected='yes'>acabar|terminar</token>
@@ -2920,7 +2920,7 @@ USA
             </token>
             <token inflected='yes' regexp="yes">bacharela[dt]o|curso|doutorado|doutoramento|especialização|faculdade|graduação|licenciatura|mestrado|PhD|pós-doutoramento|pós-graduação|universidade</token>
         </pattern>
-        <message>Relativamente a cursos e a graus universitários, é mais corrente escrever &quot;concluir&quot;.</message>
+        <message>Relativamente a cursos e a graus universitários, é mais formal escrever &quot;concluir&quot;.</message>
         <suggestion><match no='1' postag='V.+' postag_regexp='yes'>concluir</match></suggestion>
         <example correction="concluir">Vou <marker>acabar</marker> o meu doutoramento.</example>
         <example correction="concluiu">Ele <marker>terminou</marker> um mestrado em gestão.</example>


### PR DESCRIPTION
Heya, @p-goulart and @susanaboatto ,

Like Pedro suggested, for simple pt-PT rules, I may create pull requests and press “merge” myself after the test finish.

This rule only has 11 hits:
https://internal1.languagetool.org/regression-tests/via-http/2024-05-02/pt-PT_full/result_style_CONCLUIR_UM_CURSO%5B1%5D.html

and I changed: “é mais corrente” to “é mais formal” in the suggestion.

In an hour or two, I will give another look in the pt-PT .XMLs to see what more rules can have the temp_off removed.