### PR TITLE
[pt] Removed "temp_off" from Rule IDs:DAR_EXEMPLO_EXEMPLIFICAR, SER_CONSISTIR_RESIDIR and PAÍSES_DO_TERCEIRO_MUNDO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3617,7 +3617,7 @@ USA
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
 
-        <rule id='PAÍSES_DO_TERCEIRO_MUNDO' name="'aos/os países do terceiro mundo' → 'ao/o Terceiro Mundo'" default="temp_off">
+        <rule id='PAÍSES_DO_TERCEIRO_MUNDO' name="'aos/os países do terceiro mundo' → 'ao/o Terceiro Mundo'">
             <pattern>
                 <marker>
                     <token regexp='yes'>aos|os</token>
@@ -8578,7 +8578,7 @@ USA
         </rulegroup>
 
 
-       <rulegroup id='DAR_EXEMPLO_EXEMPLIFICAR' name="Simplificar: 'Dar exemplo' → exemplificar" tone_tags="academic" is_goal_specific="true" default="temp_off">
+       <rulegroup id='DAR_EXEMPLO_EXEMPLIFICAR' name="Simplificar: 'Dar exemplo' → exemplificar" tone_tags="academic" is_goal_specific="true">
 
             <!-- #1 - Without d[ao]s? -->
             <rule>
@@ -8744,7 +8744,7 @@ USA
             </rule>
         </rulegroup>
 
-       <rule id='SER_CONSISTIR_RESIDIR' name="[Universitário][Científico] V.Ser → V.Consistir/V.Residir" tone_tags="academic" is_goal_specific="true" default="temp_off">
+       <rule id='SER_CONSISTIR_RESIDIR' name="[Universitário][Científico] V.Ser → V.Consistir/V.Residir" tone_tags="academic" is_goal_specific="true">
             <pattern>
                 <token regexp='yes' inflected='yes'>assimetria|diferença|dissemelhança|disparidade|distinção|oposição|oposto</token>
                 <token min='0' max='1' postag='NC.+|AQ.+|V.+' postag_regexp='yes'>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -11035,7 +11035,7 @@ USA
                     <token>mundo</token>
                 </marker>
             </pattern>
-            <message>Num contexto formal pode omitir &quot;países&quot; e empregar <suggestion><match no='1' regexp_match='(.+)(s)' regexp_replace='$1'/> Terceiro Mundo</suggestion>.</message>
+            <message>Para uma frase mais objetiva, considere omitir &quot;países&quot; e empregar <suggestion><match no='1' regexp_match='(.+)(s)' regexp_replace='$1'/> Terceiro Mundo</suggestion>.</message>
             <example correction="o Terceiro Mundo">Ensine sobre <marker>os países do terceiro mundo</marker>.</example>
             <example correction="ao Terceiro Mundo">Ele pertence <marker>aos países do terceiro mundo</marker>.</example>
         </rule>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3616,23 +3616,6 @@ USA
     </category>
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
-
-        <rule id='PAÍSES_DO_TERCEIRO_MUNDO' name="'aos/os países do terceiro mundo' → 'ao/o Terceiro Mundo'">
-            <pattern>
-                <marker>
-                    <token regexp='yes'>aos|os</token>
-                    <token>países</token>
-                    <token>do</token>
-                    <token>terceiro</token>
-                    <token>mundo</token>
-                </marker>
-            </pattern>
-            <message>Num contexto formal pode omitir &quot;países&quot; e empregar <suggestion><match no='1' regexp_match='(.+)(s)' regexp_replace='$1'/> Terceiro Mundo</suggestion>.</message>
-            <example correction="o Terceiro Mundo">Ensine sobre <marker>os países do terceiro mundo</marker>.</example>
-            <example correction="ao Terceiro Mundo">Ele pertence <marker>aos países do terceiro mundo</marker>.</example>
-        </rule>
-
-
         <rulegroup id='MORRER_PERECER_FALECER' name="morrer → perecer/falecer" tags='picky' tone_tags='formal' default='temp_off'>
 
             <!-- Subrule 1: not using "mort[ao]s?" -->
@@ -11041,6 +11024,22 @@ USA
     </category>
 
     <category id='OBJECTIVE' name='Linguagem objetiva' type='style' tone_tags="objective">
+
+        <rule id='PAÍSES_DO_TERCEIRO_MUNDO' name="'aos/os países do terceiro mundo' → 'ao/o Terceiro Mundo'" tone_tags="objective">
+            <pattern>
+                <marker>
+                    <token regexp='yes'>aos|os</token>
+                    <token>países</token>
+                    <token>do</token>
+                    <token>terceiro</token>
+                    <token>mundo</token>
+                </marker>
+            </pattern>
+            <message>Num contexto formal pode omitir &quot;países&quot; e empregar <suggestion><match no='1' regexp_match='(.+)(s)' regexp_replace='$1'/> Terceiro Mundo</suggestion>.</message>
+            <example correction="o Terceiro Mundo">Ensine sobre <marker>os países do terceiro mundo</marker>.</example>
+            <example correction="ao Terceiro Mundo">Ele pertence <marker>aos países do terceiro mundo</marker>.</example>
+        </rule>
+
         <!-- DE N EM N a cada N -->
         <!--      Created by Marco A.G.Pinto, Portuguese rule 2020-10-22 (21-OCT-2020+)     -->
         <rule id='DE_N_EM_N-A_CADA_N' name="A cada N" tone_tags="objective">


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

I see no reason for keeping these three rules in “temp_off” since the results seem all valid and two of them only have one hit in the nightly diff (very low-impact rules):

DAR_EXEMPLO_EXEMPLIFICAR
31 hits
https://internal1.languagetool.org/regression-tests/via-http/2024-05-04/pt-BR_full/result_style_DAR_EXEMPLO_EXEMPLIFICAR%5B1%5D.html

SER_CONSISTIR_RESIDIR
1 hit
https://internal1.languagetool.org/regression-tests/via-http/2024-05-04/pt-BR_full/result_style_SER_CONSISTIR_RESIDIR%5B1%5D.html

PAÍSES_DO_TERCEIRO_MUNDO
1 hit
https://internal1.languagetool.org/regression-tests/via-http/2024-05-04/pt-BR_full/result_style_PA%C3%8DSES_DO_TERCEIRO_MUNDO%5B1%5D.html

😛 😛 😛 😛 😛 😛 😛 😛 😛 

Thanks!
