### PR TITLE
[pt] Skip foreign terms rule for _english_ignore_

### DIFF
--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseBarbarismsRule.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseBarbarismsRule.java
@@ -18,13 +18,11 @@
  */
 package org.languagetool.rules.pt;
 
+import org.languagetool.AnalyzedSentence;
 import org.languagetool.AnalyzedTokenReadings;
 import org.languagetool.Language;
 import org.languagetool.language.Portuguese;
-import org.languagetool.rules.AbstractSimpleReplaceRule2;
-import org.languagetool.rules.Categories;
-import org.languagetool.rules.Example;
-import org.languagetool.rules.ITSIssueType;
+import org.languagetool.rules.*;
 import org.languagetool.tools.Tools;
 
 import java.util.*;
@@ -100,7 +98,6 @@ public class PortugueseBarbarismsRule extends AbstractSimpleReplaceRule2 {
   @Override
   protected boolean isTokenException(AnalyzedTokenReadings atr) {
     // proper nouns tagged in multiwords are exceptions
-    return atr.hasPosTagStartingWith("NP") || atr.isImmunized();
+    return atr.isImmunized() || atr.hasPosTagStartingWith("NP") || atr.hasPosTagStartingWith("_english_ignore_");
   }
-
 }

--- a/languagetool-standalone/src/test/java/org/languagetool/JLanguageToolTest.java
+++ b/languagetool-standalone/src/test/java/org/languagetool/JLanguageToolTest.java
@@ -563,6 +563,7 @@ public class JLanguageToolTest {
     JLanguageTool lt = new JLanguageTool(new BrazilianPortuguese());
     lt.disableRules(lt.getAllRules().stream().map(Rule::getId).collect(Collectors.toList()));
     lt.enableRule("MORFOLOGIK_RULE_PT_BR");
+    lt.enableRule("PT_BARBARISMS_REPLACE");
     String[] noErrorSentences = new String[]{
       "Ontem vi A New Hope pela primeira vez.",
       "Ela gosta de The Empire Strikes Back.",
@@ -583,7 +584,8 @@ public class JLanguageToolTest {
       "Mas mandou mensagem que she is waiting for your brother.",  // "for"
       "E se for business?",  // "for"
       "Em português é Conduzindo a Miss Daisy, não é?",  // "a"
-      "A organização Law Enforcement Agent Protection (Leap)."  // single-word parenthetical
+      "A organização Law Enforcement Agent Protection (Leap).",  // single-word parenthetical
+      "Mais sucessos seguiram, com os álbuns \"Ghetto Dictionary: The Art of War\""  // ghetto
     };
     for (String sentence : noErrorSentences) {
       List<RuleMatch> matches = lt.check(sentence);
@@ -593,6 +595,7 @@ public class JLanguageToolTest {
     errorSentences.put("Foi uma melhora substantial.", "substancial");  // single word
     // match the suffix, but 'whateverness' is not tagged in English, so it's a spelling error
     errorSentences.put("Esta palavra não existe: the whateverness.", "lhe");
+    errorSentences.put("A comunidade do ghetto de Veneza.", "gueto");  // in isolation, it is not tagged with _english_ignore_
     for (Map.Entry<String, String> entry : errorSentences.entrySet()) {
       List<RuleMatch> matches = lt.check(entry.getKey());
       assert !matches.isEmpty();


### PR DESCRIPTION
 - when tokens are tagged with _english_ignore_, the 'barbarism' rule should not be triggered;

 - add a couple of tests to make sure it is working.

---

@jaumeortola @GillouLT 

I've just noticed this issue also affects French:

![Screenshot 2024-05-07 at 11 52 06 AM](https://github.com/languagetool-org/languagetool/assets/50704700/20397d94-daaa-4618-9d5e-8bef1246858c)

The first sentence here should match, since it triggers the vanilla Anglicism replacement rule. But the second sentence shouldn't trigger — 'screencast' is tagged with `_english_ignore_`, and it is in an English sentence.
