### PR TITLE
[pt] Removed "temp_off" from rule ID:AGORA_ATUAL

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3617,7 +3617,7 @@ USA
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
 
-        <rule id='AGORA_ATUAL' name="Agora → Atual" tone_tags='formal' default='temp_off'>
+        <rule id='AGORA_ATUAL' name="Agora → Atual" tone_tags='formal'>
             <pattern>
                 <token inflected='yes'>ter</token>
                 <token regexp='yes'>[ao]s?</token>


### PR DESCRIPTION
Hello @susanaboatto and @p-goulart ,

The rule only has one hit:
https://internal1.languagetool.org/regression-tests/via-http/2024-05-14/pt-BR_full/result_style_AGORA_ATUAL%5B1%5D.html

It is a very low-impact rule.