### PR TITLE
[pt] Improve behaviour of compound measurements

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3473,6 +3473,13 @@
         <disambig action="ignore_spelling"/>
     </rule>
 
+    <rule id="DICE_ROLL_NOTATION">
+        <pattern>
+            <token regexp="yes">\d+d(4|6|8|10|12|20)</token>
+        </pattern>
+        <disambig action="ignore_spelling"/>
+    </rule>
+
     <rule id="NONSTANDARD_DURATION_IGNORE">
          <pattern>
             <token regexp="yes">\d+h(\d+min)?(\d+s(ec)?)?</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3466,6 +3466,13 @@
         <disambig action="ignore_spelling"/>
     </rule>
 
+    <rule id="X_AS_MULTIPLICATION_SIGN_IGNORE">
+        <pattern>
+            <token regexp="yes">&number_token;x&number_token;[a-zA-Z]*</token>
+        </pattern>
+        <disambig action="ignore_spelling"/>
+    </rule>
+
     <rule id="NONSTANDARD_DURATION_IGNORE">
          <pattern>
             <token regexp="yes">\d+h(\d+min)?(\d+s(ec)?)?</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -41728,7 +41728,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <rulegroup id='MULTIPLICATION_SIGN' name="Matemático: Multiplicação: x - × " tags="picky">
-            <!-- Created by Tiago F. Santos, 2017-03-27 -->
             <rule>
                 <antipattern>
                     <token regexp='yes'>x|\*</token>
@@ -41772,13 +41771,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>UHCI: a versão USB 1.x</example>
             </rule>
             <rule>
-                <regexp>(?&lt;!([a-vyz]|[a-vyz]\d|[a-vyz]\d{2}|[a-vyz]\d{3}|[a-vyz]\d{4}|[a-vyz]\d{5}))((?!(?:[,;\(\.][x\*]([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)|(?:[\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)[x\*][,;\.\)\!\?]))([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)[x\*]([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+))</regexp>
+                <regexp>(?&lt;!([a-vyz]|[a-vyz]\d|[a-vyz]\d{2}|[a-vyz]\d{3}|[a-vyz]\d{4}|[a-vyz]\d{5}))((?!(?:[,;\(\.][x\*]([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)|(?:[\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)[x\*][,;\.\)\!\?]))([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)[x\*]([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+[a-zA-Z]*))</regexp>
                 <message>Prefira o símbolo de multiplicação.</message>
                 <suggestion>\4×\5</suggestion>
                 <suggestion>\4·\5</suggestion>
                 <example correction='2,998×10⁸|2,998·10⁸'>c=<marker>2,998x10⁸</marker> m/s</example>
                 <example correction="6.626×10⁻³⁴|6.626·10⁻³⁴">h = <marker>6.626x10⁻³⁴</marker> J.s</example>
                 <example correction="5×2|5·2"><marker>5*2</marker> = 10</example>
+                <!-- unit spacing rule will need to apply independently, and only after this is accepted -->
+                <example correction="10,5×17,2km|10,5·17,2km">Uma área de <marker>10,5x17,2km</marker>.</example>
                 <example>a=2·x²+5</example>
                 <example>4,5×2,5=11,25</example>
                 <example>Oxihalídeos do Amerício na forma de AmVIO2X2, AmVO2X, AmIVOX2 e AmIIIOX…</example>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -41771,7 +41771,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>UHCI: a versão USB 1.x</example>
             </rule>
             <rule>
-                <regexp>(?&lt;!([a-vyz]|[a-vyz]\d|[a-vyz]\d{2}|[a-vyz]\d{3}|[a-vyz]\d{4}|[a-vyz]\d{5}))((?!(?:[,;\(\.][x\*]([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)|(?:[\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)[x\*][,;\.\)\!\?]))([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)[x\*]([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+[a-zA-Z]*))</regexp>
+                <regexp>(?&lt;!([a-vyz]|[a-vyz]\d|[a-vyz]\d{2}|[a-vyz]\d{3}|[a-vyz]\d{4}|[a-vyz]\d{5}))((?!(?:[,;\(\.][x\*]([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)|(?:[\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)[x\*][,;\.\)\!\?]))([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)[x\*]([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+))</regexp>
                 <message>Prefira o símbolo de multiplicação.</message>
                 <suggestion>\4×\5</suggestion>
                 <suggestion>\4·\5</suggestion>
@@ -41779,7 +41779,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="6.626×10⁻³⁴|6.626·10⁻³⁴">h = <marker>6.626x10⁻³⁴</marker> J.s</example>
                 <example correction="5×2|5·2"><marker>5*2</marker> = 10</example>
                 <!-- unit spacing rule will need to apply independently, and only after this is accepted -->
-                <example correction="10,5×17,2km|10,5·17,2km">Uma área de <marker>10,5x17,2km</marker>.</example>
+                <example correction="10,5×17,2|10,5·17,2">Uma área de <marker>10,5x17,2</marker>km.</example>
                 <example>a=2·x²+5</example>
                 <example>4,5×2,5=11,25</example>
                 <example>Oxihalídeos do Amerício na forma de AmVIO2X2, AmVO2X, AmIVOX2 e AmIIIOX…</example>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -41293,7 +41293,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/simbolos-de-unidades/11572</url>
             <rule>
                 <regexp case_sensitive='yes'>(\-?[0-9]+[0-9,\.]{0,10}(°C|°F|°De?|°R[éeøa]?|(Z|E|P|T|G|M|k|h|da|d|c|m|µ|n|p|f|a|z|y)?m|(Z|E|P|T|G|M|k|h|da|d|c|m|µ|n|p|f|a|z|y)?N|[kKMGTPEZY]i?B|[kmµnp]g|[Mk]t|kWh|GWa|MWd|MWh))\b</regexp>
-                <message>Deve dar um espaço entre o valor e a unidade de medida: <suggestion><match no='1' regexp_match="((\-)?[0-9]+[0-9,.]*{1,})" regexp_replace="$1 "/></suggestion></message>
+                <message>Deve-se dar um espaço entre o valor e a unidade de medida: <suggestion><match no='1' regexp_match="((\-)?[0-9]+[0-9,.]*{1,})" regexp_replace="$1 "/></suggestion></message>
                 <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/simbolos-de-unidades/11572</url>
                 <example correction="25 °C">Fazem <marker>25°C</marker>.</example>
                 <example correction="-25 °C">Fazem <marker>-25°C</marker>.</example>
@@ -41319,7 +41319,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
             <rule>
                 <regexp>((\-)?[0-9]+[0-9.,]{1,10}) (°[^CFK])</regexp>
-                <message>Não existe espaçamento a preceder o símbolo de grau. Utilize <suggestion>\1°</suggestion> ou adicione a unidade de medida térmica (p.ex. <suggestion>\1 °C</suggestion>).</message>
+                <message>Não se põe espaço antes do símbolo de grau. Utilize <suggestion>\1°</suggestion> ou adicione a unidade de medida térmica (p.ex. <suggestion>\1 °C</suggestion>).</message>
                 <example correction="25°|25 °C">O ângulo é <marker>25 ° </marker></example>
                 <example correction="-25,5°|-25,5 °C">Fazem <marker>-25,5 ° </marker>de temperatura.</example>
                 <example correction="-25°|-25 °C">Fazem <marker>-25 ° </marker>de temperatura.</example>
@@ -41328,7 +41328,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
             <rule>
                 <regexp>((\-)?[0-9]+[0-9.,]*{1,10}) (″)</regexp>
-                <message>O sinal de segundos (\2) não é espaçado.</message>
+                <message>Não se escreve espaço antes do sinal de segundos (\2).</message>
                 <suggestion>\1\2\3</suggestion>
                 <example>3°14′ 45,54″</example>
                 <example correction="45″"><marker>45 ″</marker> E</example>

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
@@ -538,6 +538,10 @@ public class MorfologikPortugueseSpellerRuleTest {
     // Disambiguator rule; this is a style/typography issue to be taken care of in XML rules
     assertNoErrors("180g", ltBR, ruleBR);
     assertNoErrors("16.2kW", ltBR, ruleBR);
+    assertNoErrors("6x6", ltBR, ruleBR);
+    assertNoErrors("100x100mm", ltBR, ruleBR);
+    assertNoErrors("5,5x6.7km", ltBR, ruleBR);
+    assertNoErrors("5×10×50cm", ltBR, ruleBR);
   }
 
   @Test

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
@@ -545,6 +545,14 @@ public class MorfologikPortugueseSpellerRuleTest {
   }
 
   @Test
+  public void testPortugueseSpellerIgnoresDiceRollNotation() throws Exception {
+    // Disambiguator rule
+    assertNoErrors("1d20", ltBR, ruleBR);
+    assertNoErrors("3d6", ltBR, ruleBR);
+    assertNoErrors("20d10", ltBR, ruleBR);
+  }
+
+  @Test
   public void testPortugueseSpellerIgnoresNonstandardTimeFormat() throws Exception {
     // Disambiguator rule; this is a style/typography issue to be taken care of in XML rules
     assertNoErrors("31h40min", ltBR, ruleBR);

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/tokenizers/pt/PortugueseWordTokenizerTest.java
@@ -278,4 +278,11 @@ public class PortugueseWordTokenizerTest {
   public void testTokeniseComplexEmoji() {
     testTokenise("🧝🏽‍♀️", "🧝", "🏽", "‍", "♀️");
   }
+
+  @Test
+  public void testTokeniseUnitsOfMeasure() {
+    testTokenise("100mm", "100mm");
+    testTokenise("10x10mm", "10x10mm");
+    testTokenise("10×10mm", "10", "×", "10mm");
+  }
 }


### PR DESCRIPTION
For measurements that include multiplication signs, our disambiguator is not adding an `ignore_spelling` flag, which results in stuff like this:

![Screenshot 2024-05-16 at 11 41 01 AM](https://github.com/languagetool-org/languagetool/assets/50704700/5843178c-7104-4617-9bc5-c79cd799a9b0)

From the speller dashboard:

![Screenshot 2024-05-16 at 11 49 57 AM](https://github.com/languagetool-org/languagetool/assets/50704700/7e8412a3-32e3-4647-9714-02e4263eadbd)

<sup>Note that here they **look** like proper multiplication signs, but if you look at the regex and inspect the values, you'll see they are really just `x`. Probably the browser being clever when rendering stuff.</sup>

---

This PR:
- adds `X_AS_MULTIPLICATION_SIGN_IGNORE` to the disambiguator (this the most important thing);
- adds tests to the speller and tokeniser (just to be on the safe side);
- add an example to `MULTIPLICATION_SIGN` picky rule (to make sure the `x` can properly be changed to a `×` even before unspaced units);
- improves the messages for `UNITS_OF_MEASURE_SPACING` picky rule (chapter 7,103 of 'our messages all sound like `pt-PT`).

Note that, because of our current tokenisation logic, unit spacing will **not** be fixed for tokens like `500x500mm`. For it to work, one would first need to apply the `MULTIPLICATION_SIGN` suggestion. (IMO that's probably fine, since these are picky rules. The most crucial thing here was no longer flagging stuff like `5x5` and `5x5mm` as spelling errors.)
