### PR TITLE
[pt] Fix hexadecimal number bug

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/RegexAntiPatternFilter.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/RegexAntiPatternFilter.java
@@ -44,7 +44,7 @@ public class RegexAntiPatternFilter extends RegexRuleFilter {
     for (String antiPattern : antiPatterns) {
       Pattern p = Pattern.compile(antiPattern);
       Matcher matcher = p.matcher(sentenceObj.getText());
-      if (matcher.find()) {
+      while (matcher.find()) {
         // partial overlap is enough to filter out a match:
         if (matcher.start() <= match.getToPos() && matcher.end() >= match.getToPos() ||
             matcher.start() <= match.getFromPos() && matcher.end() >= match.getFromPos()) {

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3466,6 +3466,20 @@
         <disambig action="ignore_spelling"/>
     </rule>
 
+    <rule id="HEXADECIMAL_NOTATION">
+        <pattern>
+            <token regexp="yes" case_sensitive="yes">0x[0-9A-Fa-f]+</token>
+        </pattern>
+        <disambig action="ignore_spelling"/>
+    </rule>
+
+    <rule id="OCTAL_NOTATION">
+        <pattern>
+            <token regexp="yes" case_sensitive="yes">0o[0-7]+</token>
+        </pattern>
+        <disambig action="ignore_spelling"/>
+    </rule>
+
     <rule id="X_AS_MULTIPLICATION_SIGN_IGNORE">
         <pattern>
             <token regexp="yes">&number_token;x&number_token;[a-zA-Z]*</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -41780,7 +41780,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>UHCI: a versão USB 1.x</example>
             </rule>
             <rule>
-                <regexp>(?&lt;!([a-vyz]|[a-vyz]\d|[a-vyz]\d{2}|[a-vyz]\d{3}|[a-vyz]\d{4}|[a-vyz]\d{5}))((?!(?:[,;\(\.][x\*]([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)|(?:[\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)[x\*][,;\.\)\!\?]))([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)[x\*]([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+))</regexp>
+                <regexp>(?&lt;!([a-vyz]|[a-vyz]\d|[a-vyz]\d{2}|[a-vyz]\d{3}|[a-vyz]\d{4}|[a-vyz]\d{5}))((?!(?:[,;\(\.][x\*]([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)|(?:[\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)[x\*][,;\.\)\!\?]))([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?)[x\*]([\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+[a-zA-Z]*))</regexp>
+                <filter class="org.languagetool.rules.patterns.RegexAntiPatternFilter" args="antipatterns:\b0x[a-fA-F0-9]{2,4}"/>
                 <message>Prefira o símbolo de multiplicação.</message>
                 <suggestion>\4×\5</suggestion>
                 <suggestion>\4·\5</suggestion>
@@ -41788,12 +41789,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="6.626×10⁻³⁴|6.626·10⁻³⁴">h = <marker>6.626x10⁻³⁴</marker> J.s</example>
                 <example correction="5×2|5·2"><marker>5*2</marker> = 10</example>
                 <!-- unit spacing rule will need to apply independently, and only after this is accepted -->
-                <example correction="10,5×17,2|10,5·17,2">Uma área de <marker>10,5x17,2</marker>km.</example>
+                <example correction="10,5×17,2km|10,5·17,2km">Uma área de <marker>10,5x17,2km</marker>.</example>
                 <example>a=2·x²+5</example>
                 <example>4,5×2,5=11,25</example>
                 <example>Oxihalídeos do Amerício na forma de AmVIO2X2, AmVO2X, AmIVOX2 e AmIIIOX…</example>
                 <example>Número 1Z1141X30370035113</example>
                 <example>- 1 X, 2 X, 4 X</example>
+                <example>Qualquer octeto 0x00 - 0x20 ou 0x7F - 0x9F2</example>
+                <example correction="0×5Q|0·5Q">No entanto, <marker>0x5Q</marker> não é um octal ou um hexadecimal.</example>
             </rule>
             <rule>
                 <regexp>([a-z]|[\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?[a-z]{0,1})\*([a-z]|[\d\.,⁻¹²³⁴⁵⁶⁷⁸⁹⁰]+?[a-z]{0,1})</regexp>

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRuleTest.java
@@ -553,6 +553,20 @@ public class MorfologikPortugueseSpellerRuleTest {
   }
 
   @Test
+  public void testPortugueseSpellerIgnoresHexadecimalAndOctalNumbers() throws Exception {
+    // Disambiguator rule
+    assertNoErrors("0x1A", ltBR, ruleBR);
+    assertNoErrors("0x9f", ltBR, ruleBR);
+    assertNoErrors("0xdeadbeef", ltBR, ruleBR);
+    assertNoErrors("0x5F6A", ltBR, ruleBR);
+    assertNoErrors("0o23", ltBR, ruleBR);
+    assertNoErrors("0o777", ltBR, ruleBR);
+    assertSingleError("0o8", ltBR, ruleBR, new String[]{});  // bad octal
+    assertSingleError("0xQ34", ltBR, ruleBR, new String[]{});  // bad hexadecimal
+    assertNoErrors("0x34Q", ltBR, ruleBR);  // this is accepted because of stuff like "5x5m"
+  }
+
+  @Test
   public void testPortugueseSpellerIgnoresNonstandardTimeFormat() throws Exception {
     // Disambiguator rule; this is a style/typography issue to be taken care of in XML rules
     assertNoErrors("31h40min", ltBR, ruleBR);


### PR DESCRIPTION
This PR fixes a few FPs with valid hexadecimals like `0x5A` stemming from the multiplication rule<sup>1</sup>.

To achieve that, we:

- fix a logic bug in `RegexAntiPatternFilter` (@jaumeortola);
- add a `RegexAntiPatternFilter` to `MULTIPLICATION_SIGN`;
- add a couple of hexadecimal examples to `MULTIPLICATION_SIGN`;
- add `HEXADECIMAL_NOTATION` and `OCTAL_NOTATION` rules to the disambiguator so we can reliably ignore spelling for valid hexadecimal and octal numerals<sup>2</sup>;
- add tests to the speller rule to make sure we're ignoring what we should be ignoring.

---

<sup>**1**: this is not a new issue, but the matches appear as new because of the recent improvements to the disambiguator.</sup>

<sup>**2**: I decided to only ignore spelling of C-style hexadecimal and C-inspired octal numerals (i.e. `0x...` and `0o...`, respectively). Most other notations seemed like they'd conflict with legitimate spelling issues, and I didn't want to be too aggressive.</sup>