### PR TITLE
[pt] Update dictionary to v1.1.0

### DIFF
--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
@@ -134,6 +134,7 @@ public class Portuguese extends Language implements AutoCloseable {
             //Specific to Portuguese:
             new PostReformPortugueseCompoundRule(messages, this, userConfig),
             new PortugueseColourHyphenationRule(messages, this, userConfig),
+            new PortugueseOrthographyReplaceRule(messages, this),
             new PortugueseReplaceRule(messages, this),
             new PortugueseBarbarismsRule(messages, "/pt/barbarisms.txt", this),
             //new PortugueseArchaismsRule(messages, "/pt/archaisms-pt.txt"),   // see https://github.com/languagetool-org/languagetool/issues/3095
@@ -288,17 +289,23 @@ public class Portuguese extends Language implements AutoCloseable {
   
   @Override
   protected int getPriorityForId(String id) {
+    // generic spelling rule
     if (id.startsWith("MORFOLOGIK_RULE")) {
       return -50;
     }
-    if (id.startsWith("AI_PT_GGEC_REPLACEMENT_ORTHOGRAPHY_SPELL")) {
+    // simple replace spelling rule
+    if (id.startsWith("PT_SIMPLE_REPLACE_ORTHOGRAPHY")) {
       return -49;
+    }
+    // AI spelling rule
+    if (id.startsWith("AI_PT_GGEC_REPLACEMENT_ORTHOGRAPHY_SPELL")) {
+      return -48;
+    }
+    if (id.startsWith("PT_MULTITOKEN_SPELLING")) {
+      return -48;
     }
     if (id.startsWith("AI_PT_GGEC_REPLACEMENT_OTHER")) {
       return -4;
-    }
-    if (id.startsWith("PT_MULTITOKEN_SPELLING")) {
-      return -49;
     }
     // enclitic diacritics always take precedence over pronoun placement
     if (id.startsWith("ACENTUAÇÃO_VOGAL_ÊNCLISE")) {

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRule.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRule.java
@@ -18,6 +18,7 @@
  */
 package org.languagetool.rules.pt;
 
+import com.google.errorprone.annotations.concurrent.LazyInit;
 import org.languagetool.*;
 import org.languagetool.rules.RuleMatch;
 import org.languagetool.rules.SuggestedReplacement;
@@ -38,6 +39,8 @@ import static org.languagetool.JLanguageTool.getDataBroker;
 public class MorfologikPortugueseSpellerRule extends MorfologikSpellerRule {
 
   private final Language spellerLanguage;
+  // Used for suggestions to words tagged as _english_ignore_. This should be lazy-initialised or memoised somehow.
+  private static final MorfologikSpellerRule englishSpeller = loadEnglishSpeller();
   private final String dictFilepath;
   // Path, in pt/resources, where the list of words to be removed from the suggestion list is to be found.
   private static final String doNotSuggestWordsFilepath = "/pt/do_not_suggest.txt";
@@ -234,6 +237,17 @@ public class MorfologikPortugueseSpellerRule extends MorfologikSpellerRule {
     dialectAlternationMapping = getDialectAlternationMapping();
   }
 
+  @Nullable
+  private static MorfologikSpellerRule loadEnglishSpeller() {
+    try {
+      Language english = Languages.getLanguageForShortCode("en");
+      return (MorfologikSpellerRule) english.getDefaultSpellingRule();
+    } catch (IllegalArgumentException e) {
+      System.err.println("English is not available, so we can't use it for suggestions in the Portuguese speller.");
+      return null;
+    }
+  }
+
   @Override
   protected List<SuggestedReplacement> filterNoSuggestWords(List<SuggestedReplacement> suggestedReplacements) {
     return suggestedReplacements.stream().filter(
@@ -300,7 +314,15 @@ public class MorfologikPortugueseSpellerRule extends MorfologikSpellerRule {
                                         List<RuleMatch> ruleMatchesSoFar, int idx,
                                         AnalyzedTokenReadings[] tokens) throws IOException {
     List<RuleMatch> ruleMatches = super.getRuleMatches(word, startPos, sentence, ruleMatchesSoFar, idx, tokens);
-    if (tokens[idx].hasPosTag("_english_ignore_")) {
+    if (englishSpeller != null && tokens[idx].hasPosTag("_english_ignore_")) {
+      if (englishSpeller.isMisspelled(word)) {
+        List<String> englishSuggestions = englishSpeller.getSpellingSuggestions(word);
+        String msg = "Se for um termo em inglês, parece haver um erro de ortografia.";
+        RuleMatch match = ruleMatches.get(0);
+        match.setSuggestedReplacements(englishSuggestions);
+        match.setMessage(msg);
+        return Collections.singletonList(match);
+      }
       return Collections.emptyList();
     }
     if (!ruleMatches.isEmpty()) {

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRule.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/MorfologikPortugueseSpellerRule.java
@@ -317,7 +317,7 @@ public class MorfologikPortugueseSpellerRule extends MorfologikSpellerRule {
     if (englishSpeller != null && tokens[idx].hasPosTag("_english_ignore_")) {
       if (englishSpeller.isMisspelled(word)) {
         List<String> englishSuggestions = englishSpeller.getSpellingSuggestions(word);
-        String msg = "Se for um termo em inglês, parece haver um erro de ortografia.";
+        String msg = "Este parece ser um termo em inglês. Se for o caso, há um erro de ortografia.";
         RuleMatch match = ruleMatches.get(0);
         match.setSuggestedReplacements(englishSuggestions);
         match.setMessage(msg);

--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseOrthographyReplaceRule.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/rules/pt/PortugueseOrthographyReplaceRule.java
@@ -1,0 +1,88 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2005-2015 Daniel Naber (http://www.danielnaber.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.pt;
+
+import org.languagetool.Language;
+import org.languagetool.rules.AbstractSimpleReplaceRule;
+import org.languagetool.rules.Categories;
+import org.languagetool.rules.ITSIssueType;
+import org.languagetool.tools.Tools;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+import java.net.URL;
+
+/**
+ * Rule for simple and frequent one-to-one spelling fixes in Portuguese.
+ *
+ * @author p-goulart
+ */
+public class PortugueseOrthographyReplaceRule extends AbstractSimpleReplaceRule {
+
+  public static final String PORTUGUESE_SIMPLE_REPLACE_ORTHOGRAPHY_RULE = "PT_SIMPLE_REPLACE_ORTHOGRAPHY";
+
+  private static final Map<String, List<String>> wrongWords = loadFromPath("/pt/replace_orthography.txt");
+  private static final Locale PT_LOCALE = new Locale("pt");
+
+  @Override
+  public Map<String, List<String>> getWrongWords() {
+    return wrongWords;
+  }
+
+  public PortugueseOrthographyReplaceRule(ResourceBundle messages, Language language) {
+    super(messages, language);
+    super.setCategory(Categories.TYPOS.getCategory(messages));
+    setLocQualityIssueType(ITSIssueType.Misspelling);
+    useSubRuleSpecificIds();
+  }
+
+  @Override
+  public String getId() {
+    return PORTUGUESE_SIMPLE_REPLACE_ORTHOGRAPHY_RULE;
+  }
+
+  @Override
+  public boolean isCaseSensitive() {
+    return false;
+  }
+
+  @Override
+  public Locale getLocale() {
+    return PT_LOCALE;
+  }
+
+  @Override
+  public String getDescription() {
+    return messages.getString("desc_spelling");
+  }
+
+  @Override
+  public String getShort() {
+    return messages.getString("desc_spelling_short");
+  }
+
+  @Override
+  public String getMessage(String token, List<String> replacements) {
+    return messages.getString("spelling");
+  }
+
+}

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4019,23 +4019,55 @@
                   </token>
               </marker>
           </pattern>
-          <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:2"/>
+          <!-- <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:2"/> -->
           <disambig action="add"><wd pos="_english_ignore_"/></disambig>
       </rule>
       <rule> <!-- #2 -->
           <pattern>
               <marker>
-                  <token regexp="yes" postag="UNKNOWN">\p{L}+
+                  <token regexp="yes" postag="UNKNOWN">\p{L}+|'s
                       <exception regexp="yes">&english_no;|&english_forward;</exception>
                       <exception postag="_english_ignore_"/>
                   </token>
               </marker>
               <token postag="_english_ignore_"/>
           </pattern>
-          <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:1"/>
+          <!-- <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:2"/> -->
           <disambig action="add"><wd pos="_english_ignore_"/></disambig>
       </rule>
-      <rule> <!-- #3, unknown single-word parenthetical -->
+      <rule> <!-- #3 -->
+          <pattern>
+              <marker>
+                  <token regexp="yes" postag="UNKNOWN">\p{L}+
+                      <exception regexp="yes">&english_no;|&english_forward;</exception>
+                      <exception postag="_english_ignore_"/>
+                  </token>
+                  <token regexp="yes">&english_common;</token>
+              </marker>
+          </pattern>
+          <!-- <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:1"/> -->
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #4 -->
+          <pattern>
+              <marker>
+                  <token regexp="yes">&english_common;</token>
+                  <token regexp="yes" postag="UNKNOWN">\p{L}+
+                      <exception regexp="yes">&english_no;|&english_forward;</exception>
+                      <exception postag="_english_ignore_"/>
+                  </token>
+              </marker>
+          </pattern>
+          <!-- <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:1"/> -->
+          <disambig action="add">
+              <wd pos="_english_ignore_"/>
+              <wd pos="_english_ignore_"/>
+          </disambig>
+      </rule>
+      <rule> <!-- #5, unknown single-word parenthetical -->
           <!-- This is for when we have a bunch of English words and then a single word in parenthesis,
                99% of the time it's also English or it's some kind of English acronym. -->
           <pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3530,6 +3530,13 @@
           </pattern>
           <disambig action="ignore_spelling"/>
       </rule>
+
+      <rule id="IGNORE_SPELLING_RS_LAUGHTER">
+          <pattern>
+              <token regexp="yes">(rs){2,15}</token>
+          </pattern>
+          <disambig action="ignore_spelling"/>
+      </rule>
   </rulegroup>
   
   <rulegroup name="Add interjection tag to common laughter onomatopoeia" id="INTERJ_LAUGHTER">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
@@ -201,7 +201,7 @@
   supposed|surgery|survey|swimming|team's|anyway|anyhow|anywhere|
   somewhere|somebody|somehow|whatever|whoever|whosever|whomever|
   whichever|whenever|wherever|however|art|miss|mister|whats|theyre|
-  weve|theyve|shes|im|Im|youre|whos|wouldve|couldve|whens|wheres|hows
+  weve|theyve|shes|im|Im|youre|whos|wouldve|couldve|whens|wheres|hows|
   dictionary
 ">
 

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
@@ -202,7 +202,7 @@
   somewhere|somebody|somehow|whatever|whoever|whosever|whomever|
   whichever|whenever|wherever|however|art|miss|mister|whats|theyre|
   weve|theyve|shes|im|Im|youre|whos|wouldve|couldve|whens|wheres|hows|
-  dictionary|cards?
+  dictionary|cards?|services?
 ">
 
 <!ENTITY english_common "&english_wh_words;|&english_prepositions;|&english_adverbs;|&english_pronouns;|&english_determiners;|&english_common_verbs;|&english_conjunctions;|&english_word_list;|&english_suffixed_word;">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
@@ -202,7 +202,7 @@
   somewhere|somebody|somehow|whatever|whoever|whosever|whomever|
   whichever|whenever|wherever|however|art|miss|mister|whats|theyre|
   weve|theyve|shes|im|Im|youre|whos|wouldve|couldve|whens|wheres|hows|
-  dictionary
+  dictionary|cards?
 ">
 
 <!ENTITY english_common "&english_wh_words;|&english_prepositions;|&english_adverbs;|&english_pronouns;|&english_determiners;|&english_common_verbs;|&english_conjunctions;|&english_word_list;|&english_suffixed_word;">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
@@ -200,7 +200,9 @@
   spending|spoke|stream|studying|submarine|sufficient|suggest|suitable|
   supposed|surgery|survey|swimming|team's|anyway|anyhow|anywhere|
   somewhere|somebody|somehow|whatever|whoever|whosever|whomever|
-  whichever|whenever|wherever|however|art|miss|mister
+  whichever|whenever|wherever|however|art|miss|mister|whats|theyre|
+  weve|theyve|shes|im|Im|youre|whos|wouldve|couldve|whens|wheres|hows
+  dictionary
 ">
 
 <!ENTITY english_common "&english_wh_words;|&english_prepositions;|&english_adverbs;|&english_pronouns;|&english_determiners;|&english_common_verbs;|&english_conjunctions;|&english_word_list;|&english_suffixed_word;">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
@@ -34,7 +34,7 @@
   during|going|such|many|then|year|became|later|well|including|area|both|make|name|
   called|until|while|against|may|number|season|several|team|work|born|
   early|family|now|based|life|released|since|began|century|each|end|
-  following|found|located|town|around|day|government|named|
+  following|found|located|town|around|government|named|
   often|three|too|up|along|built|career|include|left|own|still|
   took|held|last|members|much|than|within|another|company|death|
   down|even|five|however|published|received|served|become|best|died|history|
@@ -56,7 +56,7 @@
   success|successful|track|units|white|added|attack|below|brought|census|changed|
   county|decided|ever|fact|generally|hand|households|instead|introduced|least|
   mid|mother|outside|private|professional|provide|provided|saw|seven|soon|space|
-  study|systems|teams|thus|women|september|allowed|battle|beginning|
+  study|systems?|teams|thus|women|september|allowed|battle|beginning|
   books|director|eight|female|find|ground|higher|industry|interest|
   league|lived|market|night|owned|placed|previous|primary|reached|related|
   reported|runs|strong|winning|august|january|july|march|always|approximately|
@@ -106,7 +106,7 @@
   agreement|allowing|applied|attacks|ball|bank|birth|claim|compared|
   conducted|connected|critical|dead|designated|develop|enemy|
   entitled|estate|estimated|existing|expanded|expected|fellow|fighting|
-  floor|follow|forward|founder|fully|goes|granted|hands|hour|
+  floor|follow|forward|founder|fully?|goes|granted|hands|hour|
   ice|leaves|literature|necessary|newly|occupied|occur|occurred|
   oldest|organizations|organized|owner|paid|parish|powers|promoted|providing|
   read|receive|reduced|refers|refused|respectively|say|settled|settlement|
@@ -175,7 +175,7 @@
   advertising|animated|anyone|appeal|apply|appointment|artillery|
   asks|assault|assembly|attributed|benefits|blocks|buy|championships|
   chapter|circumstances|claiming|closer|colony|colors|continuous|corporate|
-  crowd|crown|customers|dated|daughters|debuted|defeating|departure|
+  crowd|crown|customers?|dated|daughters|debuted|defeating|departure|
   destroy|detailed|drawing|drugs|electrical|eleven|else|encouraged|
   essentially|everyone|evil|expensive|facing|fighter|generated|governments|
   identical|infantry|integrated|journey|junction|latest|lawyer|
@@ -202,7 +202,11 @@
   somewhere|somebody|somehow|whatever|whoever|whosever|whomever|
   whichever|whenever|wherever|however|art|miss|mister|whats|theyre|
   weve|theyve|shes|im|Im|youre|whos|wouldve|couldve|whens|wheres|hows|
-  dictionary|cards?|services?|kids?
+  dictionary|cards?|services?|kids?|groups?|skills?|news?|news?|
+  tomorrow|yesterday|(sun|mon|tues|wednes|thurs|fri|satur)?days?|
+  thanks?|welcome|black|yellow|orange|green|purple|gr[ae]y|blue|express|
+  coffee|academy|gold|golden|tech|clean|dirty|users?|sellers?|buyers?|
+  release|headlines?|points?|transfers?|foot|feet
 ">
 
 <!ENTITY english_common "&english_wh_words;|&english_prepositions;|&english_adverbs;|&english_pronouns;|&english_determiners;|&english_common_verbs;|&english_conjunctions;|&english_word_list;|&english_suffixed_word;">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
@@ -202,7 +202,7 @@
   somewhere|somebody|somehow|whatever|whoever|whosever|whomever|
   whichever|whenever|wherever|however|art|miss|mister|whats|theyre|
   weve|theyve|shes|im|Im|youre|whos|wouldve|couldve|whens|wheres|hows|
-  dictionary|cards?|services?
+  dictionary|cards?|services?|kids?
 ">
 
 <!ENTITY english_common "&english_wh_words;|&english_prepositions;|&english_adverbs;|&english_pronouns;|&english_determiners;|&english_common_verbs;|&english_conjunctions;|&english_word_list;|&english_suffixed_word;">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/multiwords.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/multiwords.txt
@@ -12045,3 +12045,8 @@ José Luiz	NPMSS00_
 Sofia Kovalevskaya	NPFSS00_
 Maya Plisetskaia	NPFSS00_
 Campos Elísios	NPMP000
+
+QR code	NCMS000_
+QR codes	NCMP000_
+code review	NCCS000_
+code reviews	NCCP000_

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -43508,10 +43508,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <rulegroup id="PT_MULTITOKEN_SPELLING_FOUR" name="erros ortográficos em nomes próprios (4 tokens)" default="on">
             <rule>
                 <pattern>
-                    <token postag="UNKNOWN"><exception regexp="yes">&particles_of;</exception></token>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&particles_of;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
                 </pattern>
                 <filter class="org.languagetool.rules.spelling.multitoken.MultitokenSpellerFilter" args="none:none"/>
                 <message>Possível erro ortográfico.</message>
@@ -43530,7 +43530,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
             <rule>
                 <pattern>
-                    <token postag="UNKNOWN"><exception regexp="yes">&particles_of;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&particles_of;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
@@ -43543,7 +43543,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <rule>
                 <pattern>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&particles_of;</exception></token>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
                 </pattern>
@@ -43556,7 +43556,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <pattern>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&particles_of;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
                 </pattern>
                 <filter class="org.languagetool.rules.spelling.multitoken.MultitokenSpellerFilter" args="none:none"/>
@@ -43569,7 +43569,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&particles_of;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
                 </pattern>
                 <filter class="org.languagetool.rules.spelling.multitoken.MultitokenSpellerFilter" args="none:none"/>
                 <message>Possível erro ortográfico.</message>
@@ -43579,10 +43579,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
         <rulegroup id="PT_MULTITOKEN_SPELLING_THREE" name="erros ortográficos em nomes próprios (3 tokens)" default="on">
             <antipattern>
-                <token postag="UNKNOWN"/>
-                <token postag="UNKNOWN"/>
-                <token postag="UNKNOWN"/>
-                <token postag="UNKNOWN"/>
+                <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"/>
+                <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"/>
+                <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"/>
+                <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"/>
             </antipattern>
             <antipattern>
                 <token regexp="yes">\p{Lu}.+</token>
@@ -43598,7 +43598,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </antipattern>
             <rule>
                 <pattern>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                 </pattern>
@@ -43611,7 +43611,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <rule>
                 <pattern>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                 </pattern>
                 <filter class="org.languagetool.rules.spelling.multitoken.MultitokenSpellerFilter" args="none:none"/>
@@ -43625,18 +43625,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <antipattern>
                     <token postag="NPMSSP0"/>
                     <token postag="NPMSSP0"/>
-                    <token postag="UNKNOWN"/>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"/>
                     <example>José María Cuevas</example>
                 </antipattern>
                 <antipattern>
                     <token postag="NPFSSP0"/>
                     <token postag="NPFSSP0"/>
-                    <token postag="UNKNOWN"/>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"/>
                 </antipattern>
                 <pattern>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
                 </pattern>
                 <filter class="org.languagetool.rules.spelling.multitoken.MultitokenSpellerFilter" args="none:none"/>
                 <message>Possível erro ortográfico.</message>
@@ -43644,9 +43644,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
             <rule>
                 <pattern>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
                 </pattern>
                 <filter class="org.languagetool.rules.spelling.multitoken.MultitokenSpellerFilter" args="none:none"/>
                 <message>Possível erro ortográfico.</message>
@@ -43661,7 +43661,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
             <rule>
                 <pattern>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">&particles_of;|e|&amp;</token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                 </pattern>
@@ -43689,7 +43689,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <pattern>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">&particles_of;|e|&amp;</token>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
                 </pattern>
                 <filter class="org.languagetool.rules.spelling.multitoken.MultitokenSpellerFilter" args="requireRegexp:&particles_of;"/>
                 <message>Possível erro ortográfico.</message>
@@ -43711,13 +43711,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <token regexp="yes">\p{Lu}.*</token>
                 </antipattern>
                 <antipattern>
-                    <token postag="UNKNOWN"/>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"/>
                     <token regexp="yes">\p{Lu}.*</token>
                     <token regexp="yes">\p{Lu}.*</token>
                 </antipattern>
                 <pattern>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
                 </pattern>
                 <filter class="org.languagetool.rules.spelling.multitoken.MultitokenSpellerFilter" args="keepSpaces:true"/>
                 <message>Possível erro ortográfico.</message>
@@ -43757,7 +43757,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 </antipattern>
                 <pattern>
                     <token postag="N[PC].*" postag_regexp="yes" regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
-                    <token postag="UNKNOWN"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception><exception regexp="yes" case_sensitive="yes">[A-Z]{1,3}</exception><exception regexp="yes">[A-Z][A-Z\d]?</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception><exception regexp="yes" case_sensitive="yes">[A-Z]{1,3}</exception><exception regexp="yes">[A-Z][A-Z\d]?</exception></token>
                 </pattern>
                 <filter class="org.languagetool.rules.spelling.multitoken.MultitokenSpellerFilter" args="keepSpaces:true"/>
                 <message>Possível erro ortográfico.</message>
@@ -43800,12 +43800,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <token regexp="yes">\p{Lu}.*</token>
                 </antipattern>
                 <antipattern>
-                    <token postag="UNKNOWN"/>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"/>
                     <token regexp="yes">\p{Lu}.*</token>
                     <token regexp="yes">\p{Lu}.*</token>
                 </antipattern>
                 <pattern>
-                    <token postag="UNKNOWN" regexp="yes">\p{L}..*<exception regexp="yes">sir|don</exception><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_" regexp="yes">\p{L}..*<exception regexp="yes">sir|don</exception><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">\p{Lu}\p{Ll}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                 </pattern>
                 <filter class="org.languagetool.rules.spelling.multitoken.MultitokenSpellerFilter" args="none:none"/>
@@ -43837,7 +43837,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                         <exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|.*\d.*</exception>
                     </token>
                     <token>-</token>
-                    <token postag="UNKNOWN" regexp="yes">\p{L}..*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|.*\d.*</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_" regexp="yes">\p{L}..*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|.*\d.*</exception></token>
                 </pattern>
                 <filter class="org.languagetool.rules.spelling.multitoken.MultitokenSpellerFilter" args="requireRegexp:- keepSpaces:false"/>
                 <message>Possível erro ortográfico.</message>
@@ -43847,9 +43847,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
             <rule>
                 <pattern>
-                    <token postag="UNKNOWN" regexp="yes">\p{L}..*<exception regexp="yes">&prefixos;|&exceptions_multitoken_spell;|&particles_of;|.*\d.*</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_" regexp="yes">\p{L}..*<exception regexp="yes">&prefixos;|&exceptions_multitoken_spell;|&particles_of;|.*\d.*</exception></token>
                     <token>-</token>
-                    <token postag="UNKNOWN" regexp="yes">\p{L}..*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|.*\d.*</exception></token>
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_" regexp="yes">\p{L}..*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|.*\d.*</exception></token>
                 </pattern>
                 <filter class="org.languagetool.rules.spelling.multitoken.MultitokenSpellerFilter" args="requireRegexp:- keepSpaces:false"/>
                 <message>Possível erro ortográfico.</message>
@@ -43862,7 +43862,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
             <rule>
                 <pattern>
-                    <token postag="UNKNOWN" regexp="yes">\p{L}..*
+                    <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_" regexp="yes">\p{L}..*
                         <exception regexp="yes">&prefixos;&exceptions_multitoken_spell;|&particles_of;|.*\d.*</exception>
                     </token>
                     <token>-</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/replace_orthography.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/replace_orthography.txt
@@ -1,0 +1,32 @@
+# This file is used for the PT_SIMPLE_REPLACE_ORTHOGRAPHY rule.
+#
+# It must only be used for words that are:
+# 1. spelt the same across *all* dialects of Portuguese;
+# 2. relatively short and frequent (there's no numeric criterion here, just be reasonable);
+# 3. the corrections listed here are the only conceivable ones (within reason).
+#
+# The other orthography rule targets foreign terms and should generally not be used for such cases.
+
+ja=já
+sao=são
+nao=não
+tao=tão
+dao=dão
+hao=hão
+vao=vão
+poe=põe
+voce=você
+
+acao=ação
+mao=mão|mau
+pao=pão|pau
+maos=mãos|maus
+chao=chão
+cao=cão|caô
+grao=grão|grau
+graca=graça
+razao=razão
+periodo=período
+periodos=períodos
+servico=serviço
+servicos=serviços

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -19394,5 +19394,13 @@ USA
             <url>https://pt.wikipedia.org/wiki/Kelvin</url>
             <example correction="kelvins">O sol tem a temperatura de 15,7 milhões de <marker>graus kelvin</marker>.</example>
         </rule>
+
+        <rule id="OK_EM_MINUSCULA" name="Preferência por 'OK' em vez de 'ok'" tags="picky">
+            <pattern>
+                <token case_sensitive="yes">ok</token>
+            </pattern>
+            <message>Prefira <suggestion>OK</suggestion>.</message>
+            <example correction="OK">Está tudo <marker>ok</marker> com ela?</example>
+        </rule>
     </category>
 </rules>

--- a/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/PortugueseOrthographyReplaceRuleTest.java
+++ b/languagetool-language-modules/pt/src/test/java/org/languagetool/rules/pt/PortugueseOrthographyReplaceRuleTest.java
@@ -1,0 +1,78 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2020 Jaume Ortolà (http://www.languagetool.org)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.pt;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.languagetool.JLanguageTool;
+import org.languagetool.TestTools;
+import org.languagetool.language.Portuguese;
+import org.languagetool.rules.RuleMatch;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class PortugueseOrthographyReplaceRuleTest {
+  private static PortugueseOrthographyReplaceRule rule;
+  private static JLanguageTool lt;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    lt = new JLanguageTool(new Portuguese());
+    rule = new PortugueseOrthographyReplaceRule(TestTools.getMessages("pt"), lt.getLanguage());
+  }
+
+  @Test
+  public void testRule() throws IOException {
+    assertNoMatches("Já volto.");
+    assertSingleMatch("Ja volto.", "Já");
+
+    assertNoMatches("Gosto de você.");
+    assertSingleMatch("Gosto de voce.", "você");
+    assertNoMatches("Disse-me sotto voce.");  // multi-token spelling of Italian expression
+
+    assertSingleMatch("Me dê a sua mao.", "mão", "mau");
+    assertNoMatches("Você conhece Mao Tsé-Tung?");  // multi-token spelling of proper name
+
+    assertNoMatches("ELES ME DÃO FOLGA.");
+    assertSingleMatch("ELES ME DAO FOLGA.", "DÃO");
+  }
+
+  private void assertRuleId(RuleMatch match) {
+    assert match.getRule().getId().startsWith("PT_SIMPLE_REPLACE_ORTHOGRAPHY");
+  }
+
+  private void assertNoMatches(String sentence) throws IOException {
+    RuleMatch[] matches = rule.match(lt.getAnalyzedSentence(sentence));
+    assertEquals(0, matches.length);
+  }
+
+  private void assertSingleMatch(String sentence, String ...suggestions) throws IOException {
+    RuleMatch[] matches = rule.match(lt.getAnalyzedSentence(sentence));
+    assertEquals(1, matches.length);
+    assertRuleId(matches[0]);
+    List<String> returnedSuggestions = matches[0].getSuggestedReplacements();
+    assertEquals(suggestions.length, returnedSuggestions.size());
+    for (int i = 0; i < suggestions.length; i++) {
+      assertEquals(suggestions[i], returnedSuggestions.get(i));
+    }
+  }
+}

--- a/languagetool-standalone/src/test/java/org/languagetool/JLanguageToolTest.java
+++ b/languagetool-standalone/src/test/java/org/languagetool/JLanguageToolTest.java
@@ -564,6 +564,38 @@ public class JLanguageToolTest {
     lt.disableRules(lt.getAllRules().stream().map(Rule::getId).collect(Collectors.toList()));
     lt.enableRule("MORFOLOGIK_RULE_PT_BR");
     lt.enableRule("PT_BARBARISMS_REPLACE");
+
+    // Isolated English words should *not* be tagged with _english_ignore_, and should be corrected by the *Portuguese*
+    // spelling checker, if necessary.
+    HashMap<String, String> errorSentences = new HashMap<>();
+    errorSentences.put("Foi uma melhora substantial.", "substancial");  // single word
+    errorSentences.put("A comunidade do ghetto de Veneza.", "gueto");  // in isolation, it is not tagged with _english_ignore_
+    for (Map.Entry<String, String> entry : errorSentences.entrySet()) {
+      List<RuleMatch> matches = lt.check(entry.getKey());
+      assert !matches.isEmpty();
+      assertEquals(entry.getValue(), matches.get(0).getSuggestedReplacements().get(0));
+    }
+
+    // Null-tagged words adjacent to _english_ignore_ words should be corrected by the *English* spelling checker.
+    String existingSuggestionErrorSentence = "Ele gosta de The Strkoes.";
+    List<RuleMatch> existingSuggestionMatches = lt.check(existingSuggestionErrorSentence);
+    assert !existingSuggestionMatches.isEmpty();
+    assertEquals("Strokes", existingSuggestionMatches.get(0).getSuggestedReplacements().get(0));
+
+    // Dialect differences are considered — the default returned Language for "en" will be taken into account here.
+    // At some point I'd like to ignore the dialect differences, but that's a different (and minor) issue.
+    String dialectErrorSentence = "A iniciativa Print In All Colours.";
+    List<RuleMatch> dialectMatches = lt.check(dialectErrorSentence);
+    assert !dialectMatches.isEmpty();
+    assertEquals("Colors", dialectMatches.get(0).getSuggestedReplacements().get(0));
+
+    // Sometimes there are no suggestions, and that's fine, the likelihood the Portuguese speller will have a valid
+    // suggestion is low.
+    String missingSuggestionErrorSentence = "Esta palavra não existe: the whateverness.";
+    List<RuleMatch> missingSuggestionMatches = lt.check(missingSuggestionErrorSentence);
+    assert !missingSuggestionMatches.isEmpty();
+    assert missingSuggestionMatches.get(0).getSuggestedReplacements().isEmpty();
+
     String[] noErrorSentences = new String[]{
       "Ontem vi A New Hope pela primeira vez.",
       "Ela gosta de The Empire Strikes Back.",
@@ -589,17 +621,7 @@ public class JLanguageToolTest {
     };
     for (String sentence : noErrorSentences) {
       List<RuleMatch> matches = lt.check(sentence);
-      assert matches.isEmpty();
-    }
-    HashMap<String, String> errorSentences = new HashMap<>();
-    errorSentences.put("Foi uma melhora substantial.", "substancial");  // single word
-    // match the suffix, but 'whateverness' is not tagged in English, so it's a spelling error
-    errorSentences.put("Esta palavra não existe: the whateverness.", "lhe");
-    errorSentences.put("A comunidade do ghetto de Veneza.", "gueto");  // in isolation, it is not tagged with _english_ignore_
-    for (Map.Entry<String, String> entry : errorSentences.entrySet()) {
-      List<RuleMatch> matches = lt.check(entry.getKey());
-      assert !matches.isEmpty();
-      assertEquals(entry.getValue(), matches.get(0).getSuggestedReplacements().get(0));
+      assert matches.isEmpty() : "Unexpected match for sentence: " + sentence + " -> " + matches;
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <optimaize.languagedetector.language-detector.version>0.6</optimaize.languagedetector.language-detector.version>
         <!-- see https://github.com/languagetool-org/languagetool/issues/4088 before you upgrade this -->
         <spanish-pos-dict.version>2.2</spanish-pos-dict.version>
-        <portuguese-pos-dict.version>1.0.1</portuguese-pos-dict.version>
+        <portuguese-pos-dict.version>1.1.0</portuguese-pos-dict.version>
         <dutch-pos-dict.version>0.1</dutch-pos-dict.version>
         <english-pos-dict.version>0.3</english-pos-dict.version>
         <belarusian-pos-dict.version>1.0.2</belarusian-pos-dict.version>


### PR DESCRIPTION
**This PR:**
- updates the version of the POS dict to `v1.1.0`;
- adds `PT_SIMPLE_REPLACE_ORTHOGRAPHY`...
  - this is a rule that adds a simple replace to certain pairs of words (e.g. `ja -> já`, `nao -> não`) to counteract a bit of the Morfologik noise and, hopefully, improve acceptance rate for basic corrections like `voce -> você`;
  - this rule has higher priority than the base Morfologik rule, but lower than the gGEC spelling rule (those suggestions tend to be better in context);
  - it uses the `replace_orthography.txt` file, which can be freely modified;
- adds English suggestions to `_english_ignore_`-tagged words;
- adds a spelling ignore rule to laughter like `rsrsrs` (was already done for `hahaha` and `kkkkk`);
- adds a silly style rule to enforce `ok` -> `OK` (issues with dictionary meant people kept having to add `ok` to personal dicts);
- adds new entries to the English words entity based on Grafana patterns.

## Still to do:
- [x] double-check English spelling error message;
- [x] actually change POM file with the new released version, of le course :p