### PR TITLE
[pt] Added APs to rule ID:MORRER_PERECER_FALECER

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3650,7 +3650,7 @@ USA
                     <example>Tom está morrendo de rir.</example>
                 </antipattern>
                 <antipattern>
-                    <token skip='4' inflected='yes' regexp='yes'>árvore|bateria|budismo|chip|computador|cristianismo|ecrã|écran|flor|laptop|memória|motherboard|paganismo|PC|peixe|planta|satanismo|TV</token> <!-- Add exception words here -->
+                    <token skip='4' inflected='yes' regexp='yes'>árvore|bateria|budismo|chip|computador|cristianismo|ecrã|écran|flor|laptop|LCD|memória|motherboard|monitor|paganismo|PC|peixe|pilha|planta|portátil|satanismo|televisão|TV</token> <!-- Add exception words here -->
                     <token inflected='yes'>morrer<exception regexp='yes'>mort[ao]s?</exception>
                         <exception scope='previous' postag='P.+' postag_regexp='yes'/>
                         <exception scope='previous' regexp='no'>para</exception>
@@ -3684,6 +3684,7 @@ USA
                 </antipattern>
                 <antipattern>
                     <token postag='SENT_START|V.+' postag_regexp='yes'/>
+                    <token min='0' max='1' postag='_QUOT' postag_regexp='no'/>
                     <token inflected='yes'>morrer<exception regexp='yes'>mort[ao]s?</exception></token>
                     <token min='0' max='1' postag='RG' postag_regexp='no'/>
                     <token postag='_PUNCT' postag_regexp='no'/>
@@ -3696,25 +3697,48 @@ USA
                     <example>Se vc gosta de trekkings, pedalar morro acima, morro abaixo, Maiorca tb é uma ótima opção!</example>
                     <example>Ela dirá para o mundo ouvir: “Fraqueza, medo e desespero morreram; força, poder e coragem nasceram”.</example>
                     <example>É que eu não quero morrer hoje, só isso.</example>
+                    <example>"Morre, danado!"</example>
+                    <example>Por exemplo, a palavra alemã "Sterben" e outras que significam «morrer» são cognados da palavra inglesa.</example>
                 </antipattern>
                 <antipattern>
                     <token postag='SENT_START' postag_regexp='no'/>
+                    <token min='0' max='1' postag='_QUOT|_PUNCT' postag_regexp='yes'/>
                     <token inflected='yes'>morrer<exception regexp='yes'>mort[ao]s?</exception></token>
-                    <token min='0' max='1' postag='RG' postag_regexp='no'/>
-                    <token postag='SENT_END' postag_regexp='no'/>
+                    <token min='0' max='1' postag='_PUNCT' postag_regexp='no'/>
+                    <token min='0' max='1' postag='RG|NC.+|AQ.+|NP.+' postag_regexp='yes'/>
+                    <token postag='SENT_END|_PUNCT_EXCLAMATION|_PUNCT_INTERROGATION' postag_regexp='yes'/>
                     <example>Morra！</example>
                     <example>Morremos.</example>
                     <example>Morre logo!</example>
+                    <example>Morre Tory.</example>
+                    <example>Morrerei sozinho.</example>
+                    <example>- Morra, Omar.</example>
+                    <example>Cruïlles em Terrés lo Barbut e, depois de saqueá-la a incendiaram gritando: "Morram cavalheiros!!!</example>
+                </antipattern>
+                <antipattern>
+                    <token inflected='yes'>morrer</token>
+                    <token regexp='no'>de</token>
+                    <token regexp='yes'>alegria|cansaço|fome|inveja|saudades?|sede|tristeza|velho</token>
+                    <example>Onze mil prisioneiros morreram de fome.</example>
+                    <example>O idoso morreu de fome.</example>
+                    <example>Muitas crianças morrem de fome na África.</example>
+                    <example>Devido à falta de comida, o gado morreu de fome.</example>
+                    <example>Ele morreu de sede durante a seca.</example>
+                    <example>O seguro morreu de velho.</example>
                 </antipattern>
                 <pattern>
                     <token inflected='yes'>morrer<exception regexp='yes'>mort[ao]s?</exception>
                         <exception regexp='no' case_sensitive='yes'>Morro</exception> <!-- Proper names -->
+                        <exception scope='next' regexp='yes'>falido|miserável|pobre|rico</exception>
                     </token>
                 </pattern>
                 <message>Num contexto formal, é preferível escrever &quot;perecer&quot; ou &quot;falecer&quot;.</message>
                 <suggestion><match no='1' postag='V.+' postag_regexp='yes'>perecer</match></suggestion>
                 <suggestion><match no='1' postag='V.+' postag_regexp='yes'>falecer</match></suggestion>
                 <example correction="pereceu|faleceu">O pai dele <marker>morreu</marker> no ano passado.</example>
+                <example>Talvez não fique rico, mas pra morrer pobre já basta onde estou.</example>
+                <example>Teve uma história triste: nasceu rico e morreu miserável.</example>
+                <example>É melhor viver rico, do que morrer rico.</example>
             </rule>
 
             <!-- Subrule 2: using only "mort[ao]s?" -->
@@ -3761,25 +3785,38 @@ USA
                     <example>Tem um gigante morto no nosso quintal.</example>
                 </antipattern>
                 <antipattern>
-                    <token postag='VMSP3.+' postag_regexp='yes'/>
+                    <token postag='VMSP3.+|VMN0000' postag_regexp='yes'/>
+                    <token min='0' max='1' postag='D.+' postag_regexp='yes'/>
                     <token regexp='yes'>mort[ao]s?</token>
-                    <token regexp='yes'>em|n[ao]s?</token>
-                    <token min='1' max='2' postag='NC.+|AQ.+|NP.+|Z0.+' postag_regexp='yes'/>
+                    <token regexp='yes'>de|em|n[ao]s?</token>
+                    <token min='1' max='3' postag='NC.+|AQ.+|NP.+|Z0.+|(SPS00:)?D.+' postag_regexp='yes'/>
                     <token postag='_PUNCT|SENT_END' postag_regexp='yes'/>
                     <example>O batalhão vence caso os seus elementos não se encontrem mortos na totalidade.</example>
                     <example>O batalhão vence caso os seus elementos não se encontrem mortos em Portugal.</example>
                     <example>O batalhão vence caso os seus elementos não se encontrem mortos em duas cidades.</example>
+                    <example>Planeja roubar o colar de Dixie, que pode trazer os mortos de volta à vida.</example>
+                </antipattern>
+                <antipattern>
+                    <token regexp='yes'>mort[ao]s?</token>
+                    <token regexp='no'>de</token>
+                    <token regexp='yes'>alegria|cansaço|fome|inveja|saudades?|sede|tristeza|velho</token>
+                    <example>Embalado pelo balanço da carroça e morto de cansaço, Tom adormeceu.</example>
+                    <example>Eu me sinto morto de cansaço.</example>
+                    <example>Ele ficou morto de inveja.</example>
+                    <example>Ele retorna morto de fome, ou nunca mais retorna.</example>
+                    <example>O pobre desgraçado abandona o seu povo... com uma família morta de fome em busca de trabalho.</example>
+                    <example>A senhora nos deixará mortos de saudade.</example>
                 </antipattern>
                 <pattern>
                     <marker>
                         <token regexp='yes'>mort[ao]s?
                             <exception regexp='no' case_sensitive='yes'>Mortos</exception> <!-- Proper names -->
-                            <exception scope='previous' postag='_PUNCT|VMII3.+|SPS00' postag_regexp='yes'/>
+                            <exception scope='previous' postag='_PUNCT|VMII3.+|VMP.+|SPS00' postag_regexp='yes'/>
                         </token>
                     </marker>
                     <token min='0' max='1' postag='RM' postag_regexp='no'/>
-                    <token regexp='yes'>em|n[ao]s?
-                        <exception scope='next' postag='Z0.+|PP.+' postag_regexp='yes'/>
+                    <token regexp='yes'>de|em|n[ao]s?
+                        <exception scope='next' postag='Z0.+|PP.+|D.+|RG' postag_regexp='yes'/>
                     </token>
                 </pattern>
                 <message>Num contexto formal, é preferível escrever &quot;perecer&quot; ou &quot;falecer&quot;.</message>
@@ -3802,6 +3839,10 @@ USA
                 <example>O número de mortos no terremoto italiano cresceu a 247, talvez mais.</example>
                 <example>O número total de mortos no conflito ainda é incerto.</example>
                 <example>Os clássicos sempre chamam uma atenção a mais e há vários casos de mortos em regiões mais distantes.</example>
+                <example>Taxista encontrado morto em Candeias é sepultado e... </example>
+                <example>Uma natureza morta de um pintor holandês está pendurada no quarto dele.</example>
+                <example>O morto de agora, cuja ação na propaganda bastara a popularizá-lo, era conhecido ao longe.</example>
+                <example>HaSeul segurando um pássaro morto em suas mãos, com o menino HaSeul em nenhuma parte para ser encontrado.</example>
             </rule>
         </rulegroup>
 


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

Here is the rule with tons of FPs fixed.

I found a way for the Wikipedia tool to have more hits… it was ignoring sentences in the wordlist with four or fewer tokens, so I used Notepad++ to add a few tokens to the end of each line. It gave an extra 40 000 or 50 000 sentences valid for checking.
