### PR TITLE
[pt] Improve hour format rule

### DIFF
--- a/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
+++ b/languagetool-language-modules/pt/src/main/java/org/languagetool/language/Portuguese.java
@@ -294,6 +294,9 @@ public class Portuguese extends Language implements AutoCloseable {
     if (id.startsWith("AI_PT_GGEC_REPLACEMENT_ORTHOGRAPHY_SPELL")) {
       return -49;
     }
+    if (id.startsWith("AI_PT_GGEC_REPLACEMENT_OTHER")) {
+      return -4;
+    }
     if (id.startsWith("PT_MULTITOKEN_SPELLING")) {
       return -49;
     }

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -21250,29 +21250,17 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <rulegroup id='HOURS_ABREVIATION' name="Abreviatura de horas">
             <!-- Localized from Catalan, by Tiago F. Santos, 2017-05-16 -->
             <url>https://ciberduvidas.iscte-iul.pt/artigos/rubricas/idioma/sobre-a-escrita-dos-numeros-das-horas-e-de-outras-representacoes/3267</url>
-            <rule>
+            <rule> <!-- #1: single token, number + hrs/hs -->
                 <pattern>
                     <token regexp="yes">\d+&#160;?(?:hr?s|hrs?|horas?)</token>
                 </pattern>
                 <message>Abreviatura de horas incorreta – prefira sempre &quot;h&quot;.</message>
-                <suggestion><match no='1' regexp_match="(\d+)h.*" regexp_replace="$1&#160;h"/></suggestion>
+                <suggestion><match case_conversion="alllower" no='1' regexp_match="(\d+)[hH].*" regexp_replace="$1&#160;h"/></suggestion>
                 <short>Erro de abreviação</short>
                 <example correction="15&#160;h">Às <marker>15hs</marker> em ponto.</example>
+                <example correction="12&#160;h">Chegamos às <marker>12HRS</marker>.</example>
             </rule>
-            <!-- doesn't work due to sentence splitting
-      <rule>
-        <pattern>
-          <token regexp="yes">\d+&#160;?(?:hr?s|horas?)</token>
-          <token>.
-            <exception postag='SENT_END'/></token>
-        </pattern>
-        <message>Abreviatura de horas não tem ponto.</message>
-        <suggestion><match no='1' regexp_match="(\d+)h.*" regexp_replace="$1&#160;h"/></suggestion>
-        <short>Erro de abreviação</short>
-        <example correction="15&#160;h">Às <marker>15hs.</marker> em ponto.</example>
-      </rule>
-      -->
-            <rule>
+            <rule> <!-- #2: two tokens, number + hrs/hs -->
                 <pattern>
                     <token regexp="yes">\d+</token>
                     <token regexp="yes">hr?s|hrs?</token>
@@ -21282,27 +21270,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <short>Erro de abreviação</short>
                 <example correction="15&#160;h">Às <marker>15 hs</marker> em ponto.</example>
                 <example correction="1&#160;h">Vai durar <marker>1 hr</marker>.</example>
+                <example correction="22&#160;h">Começa às <marker>22 Hrs</marker>.</example>
             </rule>
-            <!-- doesn't work due to sentence splitting
-      <rule>
-        <pattern>
-          <token regexp="yes">\d+</token>
-          <token regexp="yes">hr?s</token>
-          <token>.
-            <exception postag='SENT_END'/></token>
-        </pattern>
-        <message>Abreviatura de horas não tem ponto.</message>
-        <suggestion>\1&#160;h</suggestion>
-        <short>Erro de abreviação</short>
-        <example correction="15&#160;h">Às <marker>15 hs.</marker> em ponto.</example>
-      </rule>
-      -->
-            <rule>
+            <rule> <!-- #3: with dot -->
                 <pattern>
                     <token regexp="yes">(?:[012]?\d:)?[012345]?\d</token>
                     <token>h</token>
                     <token>.
-                        <exception postag='SENT_END'/></token>
+                        <exception postag='SENT_END'/>
+                    </token>
                 </pattern>
                 <message>Se é uma indicação horária, não é pontuada.</message>
                 <suggestion>\1 h</suggestion>
@@ -21311,6 +21287,51 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="5:30 h">Às <marker>5:30 h.</marker> será a festa.</example>
                 <example>Chegará às 15:30 h.</example>
                 <!--example>Chegaram às 15 h. Eram de diferentes nacionalidades.</example--><!-- XXX This example works in practice but, it doesn't work in test rules. -->
+            </rule>
+            <!-- Both HH:MM and HH h MM min should be accepted, just not at the same time.  -->
+            <rule> <!-- #4: HH:MM + h/hr/hrs, single token -->
+                <pattern>
+                    <token regexp="yes">([01]?[0-9]|2[0-3]):[0-5][0-9](hr?s?|horas?)</token>
+                </pattern>
+                <message>Evite misturar formatos em indicações horárias.</message>
+                <suggestion><match no="1" regexp_match="(\d+):(\d+).+" regexp_replace="$1&#160;h&#160;$2"/></suggestion>
+                <suggestion><match no="1" regexp_match="(\d+):(\d+).+" regexp_replace="$1&#160;h&#160;$2&#160;min"/></suggestion>
+                <suggestion><match no="1" regexp_match="(\d+:\d+).+" regexp_replace="$1"/></suggestion>
+                <example correction="14&#160;h&#160;30|14&#160;h&#160;30&#160;min|14:30">Vamos às <marker>14:30h</marker>.</example>
+            </rule>
+            <rule> <!-- #5: HH:MM + h/hr/hrs, two tokens -->
+                <pattern>
+                    <token regexp="yes">([01]?[0-9]|2[0-3]):[0-5][0-9]</token>
+                    <token regexp="yes">hr?s?|horas?</token>
+                </pattern>
+                <message>Evite misturar formatos em indicações horárias.</message>
+                <suggestion><match no="1" regexp_match="(\d+):(\d+)" regexp_replace="$1&#160;h&#160;$2"/></suggestion>
+                <suggestion><match no="1" regexp_match="(\d+):(\d+)" regexp_replace="$1&#160;h&#160;$2&#160;min"/></suggestion>
+                <suggestion><match no="1" regexp_match="(\d+:\d+)" regexp_replace="$1"/></suggestion>
+                <example correction="14&#160;h&#160;30|14&#160;h&#160;30&#160;min|14:30">Vamos às <marker>14:30 hrs</marker>.</example>
+            </rule>
+            <rule> <!-- #6: simple number with a capital H, which *could* be a henry (unit of electrical inductance) -->
+                <pattern>
+                    <token regexp="yes" skip="3" inflected="yes">às?|hora|horário|chegar|começar|início|fim|terminar|acabar|término|relógio|duração|durar|demorar|levar|evento|reunião|agenda</token>
+                    <marker>
+                        <token regexp="yes" case_sensitive="yes">\d+H</token>
+                    </marker>
+                </pattern>
+                <message>Horas devem abreviar-se com um &quot;h&quot; minúsculo.</message>
+                <suggestion><match case_conversion="alllower" no="2" regexp_match="(\d+)H" regexp_replace="$1&#160;h"/></suggestion>
+                <example correction="12&#160;h">Começa às <marker>12H</marker>.</example>
+            </rule>
+            <rule> <!-- #7: simple number with a capital H, which *could* be a henry (unit of electrical inductance) -->
+                <pattern>
+                    <token regexp="yes" skip="3" inflected="yes">às?|hora|horário|chegar|começar|início|fim|terminar|acabar|término|relógio|duração|durar|demorar|levar|evento|reunião|agenda</token>
+                    <marker>
+                        <token regexp="yes">\d+</token>
+                        <token case_sensitive="yes">H</token>
+                    </marker>
+                </pattern>
+                <message>Horas devem abreviar-se com um &quot;h&quot; minúsculo.</message>
+                <suggestion><match case_conversion="alllower" no="2" regexp_match="(\d+)" regexp_replace="$1&#160;h"/></suggestion>
+                <example correction="12&#160;h">Começa às <marker>12 H</marker>.</example>
             </rule>
         </rulegroup>
 


### PR DESCRIPTION
The gGEC model is not very good at understanding what kinds of things are meant to be **hour** abbreviations, results are very inconsistent. This PR aims to remedy that.

Users frequently see stuff like this, where the `hs` element, instead of being converted to the appropriate `h`, is completely deleted:

![Screenshot 2024-05-27 at 2 17 39 PM](https://github.com/languagetool-org/languagetool/assets/50704700/24215537-dbd6-464b-8150-de7580948338)

---

The updated rule will:
- make sure to operate on uppercase `H` (in isolation, `H` is technically a Henry, but I think most of the time we can be pretty certain users are talking about hours rather than henries);
  - failure to account for uppercase `H` in the replacement regex was also leading to empty suggestions in some cases, e.g.:

![Screenshot 2024-05-27 at 2 22 13 PM](https://github.com/languagetool-org/languagetool/assets/50704700/0cf03170-2129-45e3-a661-ef0bd3e51908)

- make sure we don't allow mixing formats (**either** `13:45` **or** `13 h 45`, but never both at the same time, as in \*`13:45 h`); gGEC does catch the incorrect abbreviation, but also suggests `h` even when it should be deleted entirely, e.g.:

![Screenshot 2024-05-27 at 2 28 11 PM](https://github.com/languagetool-org/languagetool/assets/50704700/409e5ceb-8359-4eba-aa03-e6cc5cf64ad4)


---

I'm also lowering the priority of the offending gGEC rule `AI_PT_GGEC_REPLACEMENT_OTHER` to -4, so it is lower than the default value of `HOURS_ABREVIATION` <sup>(the typo in the rule name is deeply triggering 😱😡)</sup>.