### PR TITLE
[pt] Removed temp_off and added AP to rule ID:FAZER_VERBO_VERBO_INFINITIVO_V2

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -15939,8 +15939,15 @@ USA
         </rule>
 
 
-        <rule id='FAZER_VERBO_VERBO_INFINITIVO_V2' name="[Simplificar] V.Fazer + V. → V.Inf." type="style" tags="picky" default="temp_off">
+        <rule id='FAZER_VERBO_VERBO_INFINITIVO_V2' name="[Simplificar] V.Fazer + V. → V.Inf." type="style" tags="picky">
             <!--IDEA shorten_it-->
+            <antipattern>
+                <token>fazer</token>
+                <token postag='VMIP2S0' postag_regexp='no'/>
+                <token>para</token>
+                <token postag='V.+' postag_regexp='yes'/>
+                <example>Quando éramos crianças gostávamos de fazer fisgas para sermos bons.</example>
+            </antipattern>
             <pattern>
                 <marker>
                     <token>fazer


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

The rule has zero hits in the nightly results.

So, I have removed the “temp_off” and also added an antipattern.

Thanks!