### PR TITLE
[pt] Improve multi-token foreign word checks

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3772,7 +3772,7 @@
   <rulegroup id="IGNORE_ENGLISH_WORDS" name="Label English words">
       <rule> <!-- #1 -->
           <pattern>
-              <token regexp="yes">&english_common;</token>
+              <token regexp="yes" postag="UNKNOWN">&english_common;</token>
               <token regexp="yes">\p{L}+
                   <exception regexp="yes">&english_no;|&english_forward;</exception>
               </token>
@@ -3803,7 +3803,7 @@
               <token regexp="yes">\p{L}+
                   <exception regexp="yes">&english_no;|&english_forward;</exception>
               </token>
-              <token regexp="yes">&english_common;</token>
+              <token postag="UNKNOWN" regexp="yes">&english_common;</token>
           </pattern>
           <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:1,2"/>
           <disambig action="add">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/english.ent
@@ -1,5 +1,5 @@
 <!-- copied from French -->
-<!ENTITY english_no "nos?|as?|tos?|dos?|vi|pela|favor|por">
+<!ENTITY english_no "nos?|as?|tos?|dos?|vi|pela|favor|por|tod[oa]s?">
 
 <!ENTITY english_wh_words "what|when|where|whom?|whose|why|how|which">
 <!ENTITY english_prepositions "in|on|after|behind|before|off?|from|with|without|

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/misc.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/misc.ent
@@ -1,6 +1,6 @@
-<!ENTITY exceptions_multitoken_spell "[^\p{L}]|[\p{P}\+@©\|#_].*|you|the|were|here|we|was|they|are|and|will|love|it|is|let|make|may|by|at|su|sus|this|that|my|your|his|her|ours|theirs|all|time|dr|jr|if|iz|\d.*|en|per|sr|sra|dra">
+<!ENTITY exceptions_multitoken_spell "[^\p{L}]|[\p{P}\+@©\|#_].*|time|dr|jr|\d.*|per|sr|sra|dra">
 <!ENTITY exceptions_multitoken_spell2 "sa|l'|el|la|les|els|.">
-<!ENTITY particles_of "de|von|van|of|d'|di|du|da|ibn|des">
+<!ENTITY particles_of "de|von|van|of|d'|di|du|da|ibn|des|do">
 <!ENTITY exceptions_multitoken_sensitive "(?-i)[A-Z]+\d+|[a-z][a-z]?\d+">
 <!ENTITY adverbios_de_intensidade "(?:assaz|bastante|bem|demais|demasiado|imenso|mais|menos|mesmo|muita|muito|nada|não|pouca|pouco|quanto|quão|quase|tanto|tão|todo|tudo|várias|vários|.+mente)">
 <!ENTITY adverbios_de_lugar "(?:abaixo|acima|adentro|adiante|afora|aí|além|algures|alhures|ali|aquém|atrás|cá|dentro|embaixo|externamente|lá|longe|nenhures|perto)">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -43514,7 +43514,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
     <category id="MULTITOKEN_SPELLING" name="Erros ortográficos em nomes próprios" type="misspelling" default="on">
         <rulegroup id="PT_MULTITOKEN_SPELLING_FOUR" name="erros ortográficos em nomes próprios (4 tokens)" default="on">
-            <rule>
+            <rule> <!-- #1 -->
                 <pattern>
                     <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&particles_of;</exception></token>
                     <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
@@ -43526,6 +43526,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="The Dark Knight Rises"><marker>The Derk Knight Rises</marker>.</example>
                 <!-- <example correction="Rocky Mountain National Park"><marker>Rocky Mountains National Parrk</marker>.</example> -->
                 <!-- <example correction="La Gazzetta dello Sport"><marker>La Gazzeta dello Sport</marker></example> -->
+                <example correction="The Last of Us">Você já jogou <marker>the last of us</marker>?</example>
                 <example>Tokyo Marble Chocolate.</example>
                 <example>Ctrl + Shift + R</example>
                 <example>+=n</example>
@@ -43536,7 +43537,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>=mx+p</example>
                 <example>=2Fx/ρvS</example>
             </rule>
-            <rule>
+            <rule> <!-- #2 -->
                 <pattern>
                     <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&particles_of;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
@@ -43548,7 +43549,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="The Dark Knight Rises"><marker>The Derk Knight Rises</marker>.</example>
                 <example correction="Rocky Mountain National Park"><marker>Rocki Mountains National Park</marker>.</example>
             </rule>
-            <rule>
+            <rule> <!-- #3 -->
                 <pattern>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&particles_of;</exception></token>
                     <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
@@ -43560,7 +43561,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="The Dark Knight Rises"><marker>The Derk Knight Rises</marker>.</example>
                 <example correction="Rocky Mountain National Park"><marker>Rocki Mountains National Park</marker>.</example>
             </rule>
-            <rule>
+            <rule> <!-- #4 -->
                 <pattern>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&particles_of;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
@@ -43572,7 +43573,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="The Dark Knight Rises"><marker>The Derk Knight Rises</marker>.</example>
                 <example correction="Rocky Mountain National Park"><marker>Rocki Mountains National Park</marker>.</example>
             </rule>
-            <rule>
+            <rule> <!-- #5 -->
                 <pattern>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&particles_of;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
@@ -43604,7 +43605,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <token><match no="0"/></token>
                 <token><match no="0"/></token>
             </antipattern>
-            <rule>
+            <rule> <!-- #1 -->
                 <pattern>
                     <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
@@ -43616,7 +43617,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="Osama bin Laden"><marker>Ousama Bin Laden</marker></example>
                 <example correction="Johann Sebastian Bach"><marker>Johan Sebastián Bach</marker>.</example>
             </rule>
-            <rule>
+            <rule> <!-- #2 -->
                 <pattern>
                     <token regexp="yes">\p{Lu}.*<exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_spell2;|&exceptions_multitoken_sensitive;</exception></token>
                     <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
@@ -43629,7 +43630,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="Johann Sebastian Bach"><marker>Johann Sebastián Bach</marker>.</example>
                 <example correction="Osama bin Laden"><marker>Ossama bin Laden</marker></example>
             </rule>
-            <rule>
+            <rule> <!-- #3 -->
                 <antipattern>
                     <token postag="NPMSSP0"/>
                     <token postag="NPMSSP0"/>
@@ -43650,7 +43651,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <message>Possível erro ortográfico.</message>
                 <example correction="Yuval Noah Harari"><marker>Yuval Noha hariri</marker>.</example>
             </rule>
-            <rule>
+            <rule> <!-- #4 -->
                 <pattern>
                     <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
                     <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
@@ -43659,6 +43660,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <filter class="org.languagetool.rules.spelling.multitoken.MultitokenSpellerFilter" args="none:none"/>
                 <message>Possível erro ortográfico.</message>
                 <example correction="Yuval Noah Harari"><marker>Yuvl Noha Hariri</marker>.</example>
+                <example correction="My Chemical Romance">Ela gosta de <marker>my chemical romence</marker>.</example>
+                <example correction="The Mountain Goats">Eu fui no show dos <marker>the mountain goats</marker>.</example>
                 <example>Tokyo Marble Chocolate.</example>
                 <example>Ctrl + Shift + R</example>
                 <example>+=n</example>
@@ -43667,7 +43670,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>University of the Arts London</example>
                 <example>Montse Saez | Administración | Web master: FA? | Administración |</example>
             </rule>
-            <rule>
+            <rule> <!-- #5 -->
                 <pattern>
                     <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"><exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|&exceptions_multitoken_sensitive;</exception></token>
                     <token regexp="yes">&particles_of;|e|&amp;</token>
@@ -43681,7 +43684,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>sierra de Sa Verdera</example>
                 <example>Rey de Roma</example>
             </rule>
-            <rule>
+            <rule> <!-- #6 -->
                 <antipattern>
                     <token postag="NPMSSP0"/>
                     <token postag="NPMSSP0"/>
@@ -43712,7 +43715,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <token>-</token>
                 <token spacebefore="no"/>
             </antipattern>
-            <rule>
+            <antipattern>
+                <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"/>
+                <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"/>
+                <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_"/>
+            </antipattern>
+            <rule> <!-- #1 -->
                 <antipattern>
                     <token regexp="yes">\p{Lu}.*<exception postag="D.*" postag_regexp="yes"/></token>
                     <token regexp="yes">\p{Lu}.*</token>
@@ -43735,6 +43743,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="García Márquez"><marker>Garcìa Mraquez</marker>.</example>
                 <example correction="Lluís Llach"><marker>Lluís Lach</marker>.</example>
                 <example correction="SÃO PAULO"><marker>SAO PAULO</marker></example>
+                <example correction="The Guardian">Ele lê o jornal <marker>the guardian</marker> toda manhã.</example>
+                <example>Ele disse the guardian is in the garden.</example>
                 <example>y venderlo</example>
                 <example>Massachusetts Institute of Technology</example>
                 <example>el piano inicial d'I want you back</example>
@@ -43748,7 +43758,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>Notáveis são o signor Gabriele Leone, Giovanni Battista Gervasio, Pietro Denis, que viajou muito entre 1750 e 1810.</example>
                 <example>MICHAEL JORDAN</example>
             </rule>
-            <rule>
+            <rule> <!-- #2 -->
                 <antipattern>
                     <token regexp="yes">\p{Lu}.*</token>
                     <token postag="NP.*" postag_regexp="yes"/>
@@ -43796,7 +43806,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>Notáveis são o signor Gabriele Leone, Giovanni Battista Gervasio, Pietro Denis, que viajou muito entre 1750 e 1810.</example>
                 <example>O MacBook é uma linha de computadores portáteis Macintosh da Apple Inc. lançada originalmente em 16 de maio de 2006 e relançada em 9 de março de 2015.</example>
             </rule>
-            <rule>
+            <rule> <!-- #3 -->
                 <antipattern>
                     <token regexp="yes">\p{Lu}.*</token>
                     <token regexp="yes">\p{Lu}.*</token>
@@ -43839,7 +43849,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>Boo-Boo</example>
                 <example>Fei-fei</example>
             </antipattern>
-            <rule>
+            <rule> <!-- #1 -->
                 <pattern>
                     <token regexp="yes" case_sensitive="yes">\p{Lu}..*
                         <exception regexp="yes">&exceptions_multitoken_spell;|&particles_of;|.*\d.*</exception>
@@ -43853,7 +43863,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="Sacher-Masoch"><marker>Sacher - Masoch</marker></example>
                 <!--Time-Life-->
             </rule>
-            <rule>
+            <rule> <!-- #2 -->
                 <pattern>
                     <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_" regexp="yes">\p{L}..*<exception regexp="yes">&prefixos;|&exceptions_multitoken_spell;|&particles_of;|.*\d.*</exception></token>
                     <token>-</token>
@@ -43868,7 +43878,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>sub-taça</example>
                 <example>sub-pratos</example>
             </rule>
-            <rule>
+            <rule> <!-- #3 -->
                 <pattern>
                     <token postag_regexp="yes" postag="UNKNOWN|_english_ignore_" regexp="yes">\p{L}..*
                         <exception regexp="yes">&prefixos;&exceptions_multitoken_spell;|&particles_of;|.*\d.*</exception>


### PR DESCRIPTION
This PR contains improvements to the multi-token spelling corrections.

- now that we actively ignore possible English words with the `_english_ignore_` tag, the entity containing multi-token exceptions could be significantly simplified;
- instead of FPs with `the`, we were getting tonnes of **FNs** — e.g.:
  - _Ela lê o jornal the guardian toda manhã._
  - the two-token sequence _the guardian_ is tagged (comme il faut) with `_english_ignore_`;
  - because 'the' was present in the `exceptions_multitoken_spell` entity, 'the guardian' was **not** matched by `PT_MULTITOKEN_SPELLING_TWO`;
  - this left the user with an **uncorrected** lowercase 'the guardian'.

Removing those English words from `exceptions_multitoken_spell` ensures that we correct the letter case of global multi-token entites beginning with words like 'the' and 'my'.

A couple more improvements:
- tweaked to the logic of the `IGNORE_ENGLISH_WORDS` disambiguation rule so we no longer have words with **multiple** `_english_ignore_` tags;
- added an AP to `PT_MULTITOKEN_SPELLING_TWO` to block matching of 3+ tokens;
- added relevant examples<sup>1</sup>.

---

The results look okay — we will probably gain a few FPs, but I think that will far be outweighed by the decrease in FNs. That said, it's probably better to only merge next week, I don't want to push hotfixes at the weekend.

<sup>**1:** note that, since the pattern rule tests run **without** the English module, those examples rely on `NULL` tagging, rather than `_english_ignore_` tagging; the effect should be the same, but I did make sure to test those sentences in a live environment just to be sure they'd behave the same way.</sup>