### PR TITLE
[pt-PT] Rewrote rule ID:PRAZER_EM_CONVIDAR to ID:PRAZER_GOSTO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -141,18 +141,22 @@ USA
     </rule>
 
 
-    <rule id='PRAZER_EM_CONVIDAR' name="[pt-PT] 'prazer' em convidar → 'gosto'" tone_tags="formal" default="temp_off">
+    <rule id='PRAZER_GOSTO' name="[pt-PT] 'prazer' em → 'gosto'" tone_tags="formal" default="temp_off">
         <pattern>
+            <token skip='4' regexp='yes' inflected='yes'>ser|ter</token>
             <marker>
-                <token>prazer</token>
+                <token>prazer
+                    <exception scope='previous' postag_regexp='yes' postag='V.+'/>
+                </token>
             </marker>
-            <token skip='4' regexp='yes'>em|que</token>
-            <token inflected='yes'>convidar</token>
+            <token regexp='yes'>de|em|que</token>
         </pattern>
-        <message>&informal_msg;</message>
+        <message>Se não estiver relacionado com a prática de atividades prazerosas, use &quot;gosto&quot;.</message>
         <suggestion>gosto</suggestion>
         <example correction="gosto">Terei o maior <marker>prazer</marker> em convidá-los para a festa.</example>
         <example correction="gosto">É com enorme <marker>prazer</marker> que os convido para a festa.</example>
+        <example correction="gosto">Terei o <marker>prazer</marker> de revê-lo?</example>
+        <example>Será que é possível uma mulher ter prazer em sentir-se submissa sexualmente?</example>
     </rule>
 
 


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

I have rewritten the complete rule, and now it should work very well.

```
Portuguese (Portugal): 73 total matches
Portuguese (Portugal): 854003 total sentences considered
Portuguese (Portugal): ø0.00 rule matches per sentence
```

[2.txt](https://github.com/user-attachments/files/15859782/2.txt)
