### PR TITLE
[pt-PT] Removed "temp_off" from rule ID:PRAZER_GOSTO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -141,7 +141,7 @@ USA
     </rule>
 
 
-    <rule id='PRAZER_GOSTO' name="[pt-PT] 'prazer' em → 'gosto'" tone_tags="formal" default="temp_off">
+    <rule id='PRAZER_GOSTO' name="[pt-PT] 'prazer' em → 'gosto'" tone_tags="formal">
         <pattern>
             <token skip='4' regexp='yes' inflected='yes'>ser|ter</token>
             <marker>


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

I have removed the temp_off from the rule:
https://internal1.languagetool.org/regression-tests/via-http/2024-06-17/pt-PT_full/result_style_PRAZER_GOSTO%5B1%5D.html

There isn't much magic in this rule as the suggestion sentence says: if it is used for pleasure/sex activities one uses “prazer” and in all other cases “gosto”.
