### PR TITLE
[pt] Fix English ignore disambig logic

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3772,9 +3772,12 @@
   <rulegroup id="IGNORE_ENGLISH_WORDS" name="Label English words">
       <rule> <!-- #1 -->
           <pattern>
-              <token regexp="yes" postag="UNKNOWN">&english_common;</token>
+              <token regexp="yes">&english_common;
+                  <exception postag="_english_ignore_"/>
+              </token>
               <token regexp="yes">\p{L}+
                   <exception regexp="yes">&english_no;|&english_forward;</exception>
+                  <exception postag="_english_ignore_"/>
               </token>
           </pattern>
           <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:1,2"/>
@@ -3802,8 +3805,11 @@
           <pattern>
               <token regexp="yes">\p{L}+
                   <exception regexp="yes">&english_no;|&english_forward;</exception>
+                  <exception postag="_english_ignore_"/>
               </token>
-              <token postag="UNKNOWN" regexp="yes">&english_common;</token>
+              <token regexp="yes">&english_common;
+                  <exception postag="_english_ignore_"/>
+              </token>
           </pattern>
           <filter class="org.languagetool.rules.IsEnglishWordFilter" args="formPositions:1,2"/>
           <disambig action="add">

--- a/languagetool-standalone/src/test/java/org/languagetool/JLanguageToolTest.java
+++ b/languagetool-standalone/src/test/java/org/languagetool/JLanguageToolTest.java
@@ -587,7 +587,18 @@ public class JLanguageToolTest {
       "E se for business?",  // "for"
       "Em português é Conduzindo a Miss Daisy, não é?",  // "a"
       "A organização Law Enforcement Agent Protection (Leap).",  // single-word parenthetical
-      "Mais sucessos seguiram, com os álbuns \"Ghetto Dictionary: The Art of War\""  // ghetto
+      "Mais sucessos seguiram, com os álbuns \"Ghetto Dictionary: The Art of War\"",  // ghetto
+      // Making sure disambiguation works properly per recent FPs
+      "A Abaddon Books, subsidiária e editora dos livros.",
+      "Smokers in Airplanes é o segundo álbum do artista brasileiro.",
+      "Obteve um doutorado em física pela American University.",
+      "O American Sociological Review é um jornal acadêmico bimensal.",
+      "Código do Bletchley Park na Inglaterra.",
+      "Sobre Batman, Broken City (apesar do Coringa).",
+      "Birmingham City Football Club.",
+      "Narra, segundo o historiador americano Will Durant, uma das maiores aventuras da história humana.",
+      "Duas décadas mais tarde, os Gipsy Kings incorporaram aquilo.",
+      "Valente teve três irmãos, um dos quais, Silvio Francesco, também esteve no show business."
     };
     for (String sentence : noErrorSentences) {
       List<RuleMatch> matches = lt.check(sentence);


### PR DESCRIPTION
The original attempt was to prevent multiple `_english_ignore_` tags, but it had the unintended effect of removing a bunch of them (e.g. valid Portuguese words that are *also* common English words, like `book`). Not a *huge* issue for users, since most of those words are in English anyway, so it probably won't *feel* like too much of a failure, but we should still sort it out.

I'm adding some tests (from the recent nightly FPs) to make sure I don't screw up the `_english_ignore_` disambiguation logic in the future again.