### PR TITLE
[pt] Added AP to rule ID:GENERAL_NUMBER_AGREEMENT_ERRORS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -4248,7 +4248,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <!--
            MARCOAGPINTO inserted global antipatterns for all subrules on top using the logic (2-MAR-2023+)
       -->
-
+            <antipattern>
+                <token postag='VMI.3S.+' postag_regexp='yes'/>
+                <token>possível</token>
+                <token min='0' max='1' postag='CS|SPS00|(SPS00)?:[DP]...P.+' postag_regexp='yes'/>
+                <token postag="AQ..P.+|NC.P.+" postag_regexp="yes"/>
+                <token postag='RM|RG|CS|CC|SPS00|(SPS00)?:[DP]...[SN].+' postag_regexp='yes'/>
+                <example>É possível alunos da mesma universidade e turma terem notas diferentes?</example>
+                <example>É possível que alunos da mesma universidade e turma tenham notas diferentes?</example>
+                <example>É possível a alunos da mesma universidade e turma terem notas diferentes?</example>
+            </antipattern>
             <antipattern>
                 <token postag="SPS00">
                     <exception regexp='yes' inflected='yes'>com|em</exception> <!-- The SPS00 that cause false positives -->


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

I had to use the word “possível” for the AP to work properly.

Using adjectives and nouns would work badly.
