### PR TITLE
[pt] Added rule ID:DIFICULDADES_PROVAÇÕES

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3634,6 +3634,23 @@ USA
         </rule>
 
 
+        <rule id='DIFICULDADES_PROVAÇÕES' name="Passar 'dificuldades' → 'provações'" tags='picky' tone_tags='formal' default='temp_off'>
+            <pattern>
+                <token skip='4' inflected='yes'>passar</token>
+                <marker>
+                    <token regexp='yes'>dificuldades?
+                        <exception scope='previous' regexp='yes' inflected='yes'>ter</exception>
+                        <exception scope='next' regexp='yes'>acrescidas?</exception>
+                    </token>
+                </marker>
+            </pattern>
+            <message>Num contexto formal empregue <suggestion><match no='2' postag='NCF(.)000' postag_replace='NCF$1000'>provação</match></suggestion>.</message>
+            <example correction="provações">Eles passaram muitas <marker>dificuldades</marker> ao longo da vida.</example>
+            <example>Para aqueles que passaram por muitos anos tiveram dificuldades na colaboração entre projetos.</example>
+            <example>Tomava esteroides para ganhar massa muscular e foi por isso que passou a ter dificuldades para emagrecer.</example>
+         </rule>
+
+
         <rulegroup id='MORRER_PERECER_FALECER' name="morrer → perecer/falecer" tags='picky' tone_tags='formal'>
 
             <!-- Subrule 1: not using "mort[ao]s?" -->


### PR DESCRIPTION
Hello @susanaboatto and @p-goulart ,

Here is a new formal rule.

It had very few hits:
```
Portuguese (Portugal): 17 total matches
Portuguese (Portugal): 854003 total sentences considered
Portuguese (Portugal): ø0.00 rule matches per sentence
```

[2.txt](https://github.com/user-attachments/files/15978002/2.txt)


Some more hits could be removed if I placed “financeiras?” in the exceptions, but I asked ChatGPT:
![Screenshot 2024-06-25 at 16-42-15 ChatGPT](https://github.com/languagetool-org/languagetool/assets/5192600/b96212dc-431b-4df5-83f9-1fe8f9fcf395)

