### PR TITLE
[pt-PT] Removed temp_off from rule ID:PÔR_FIM_TERMO and ID:DIFICULDADES_PROVAÇÕES

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -160,7 +160,7 @@ USA
     </rule>
 
 
-    <rule id='PÔR_FIM_TERMO' name="[pt-PT][Formal] pôr 'fim' → 'termo/término'" tags="picky" tone_tags="formal" default="temp_off">
+    <rule id='PÔR_FIM_TERMO' name="[pt-PT][Formal] pôr 'fim' → 'termo/término'" tags="picky" tone_tags="formal">
         <pattern>
             <token skip='4' inflected='yes'>pôr</token>
             <marker>
@@ -3734,7 +3734,7 @@ USA
     <category id='FORMAL_SPEECH_PT_PT' name='[pt-PT] Linguagem Formal' type='register' tone_tags="formal">
 
 
-        <rule id='DIFICULDADES_PROVAÇÕES' name="[pt-PT][Formal] Passar 'dificuldades' → 'provações'" tags='picky' tone_tags='formal' default='temp_off'>
+        <rule id='DIFICULDADES_PROVAÇÕES' name="[pt-PT][Formal] Passar 'dificuldades' → 'provações'" tags='picky' tone_tags='formal'>
             <pattern>
                 <token skip='4' inflected='yes'>passar</token>
                 <marker>


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

PÔR_FIM_TERMO (25 hits)
https://internal1.languagetool.org/regression-tests/via-http/2024-07-01/pt-PT_full/result_style_P%C3%94R_FIM_TERMO%5B1%5D.html

DIFICULDADES_PROVAÇÕES (0 hits)

After the checks I will press “merge” since they are pt-PT rules (Pedro).

Thanks!