### PR TITLE
[pt-PT] Removed "temp_off" from rules

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -86,7 +86,7 @@ USA
     <category id="STYLE" name="[pt-PT] Regras de Estilo" type="style">
 
 
-    <rule id='VERBO_SER_ÚTIL_PARA_SERVIR_PARA' name="[pt-PT][Simplificar] V.Ser útil para → V.Servir para" type="style" default="temp_off">
+    <rule id='VERBO_SER_ÚTIL_PARA_SERVIR_PARA' name="[pt-PT][Simplificar] V.Ser útil para → V.Servir para" type="style">
         <pattern>
             <marker>
                 <token inflected='yes'>ser</token>
@@ -3378,7 +3378,7 @@ USA
     </rule>
 
 
-    <rule id='SIMPLIFICAR_A_XXX_DE_VOCÊS' name="[pt-PT][Simplificar] A XXX de vocês → a vossa XXX" tone_tags="objective" default="temp_off"> 
+    <rule id='SIMPLIFICAR_A_XXX_DE_VOCÊS' name="[pt-PT][Simplificar] A XXX de vocês → a vossa XXX" tone_tags="objective"> 
         <!-- IDEA shorten_it -->
         <antipattern>
             <token regexp='yes'>[ao]s?</token>
@@ -3647,7 +3647,7 @@ USA
     <category id='ACADEMIC_SCIENTIFIC_PT_PT' name="[pt-PT] Regras académicas e científicas" type="other">
 
 
-        <rule id='CIENTÍFICO_DETERMINADAS_ESPECÍFICAS' name="[pt-PT][Científico] Determinados → Específicos" type="style" tone_tags="academic" default="temp_off">
+        <rule id='CIENTÍFICO_DETERMINADAS_ESPECÍFICAS' name="[pt-PT][Científico] Determinados → Específicos" type="style" tone_tags="academic">
             <pattern>
                 <token regexp="yes">para|como|por</token>
                 <token skip='4' postag='V.+' postag_regexp='yes'/>


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

I have removed the temp_off of:
SIMPLIFICAR_A_XXX_DE_VOCES
https://internal1.languagetool.org/regression-tests/via-http/2024-07-17/pt-PT_full/result_style_SIMPLIFICAR_A_XXX_DE_VOC%C3%8AS%5B1%5D.html


CIENTÍFICO_DETERMINADAS_ESPECÍFICAS
https://internal1.languagetool.org/regression-tests/via-http/2024-07-17/pt-PT_full/result_style_CIENT%C3%8DFICO_DETERMINADAS_ESPEC%C3%8DFICAS%5B1%5D.html


VERBO_SER_ÚTIL_PARA_SERVIR_PARA
https://internal1.languagetool.org/regression-tests/via-http/2024-07-17/pt-PT_full/result_style_VERBO_SER_%C3%9ATIL_PARA_SERVIR_PARA%5B1%5D.html



After it passes the checks, I will merge it since it is pt-PT.

Thanks!


