### PR TITLE
[pt-PT] Removed temp_off of ID:FAZER_DESPORTO and ID:SIMPLIFICAR_É_NECESSÁRIO_TER_REQUER

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -531,7 +531,7 @@ USA
         </rule>
 
 
-        <rule id='FAZER_DESPORTO' name="[pt-PT] 'Fazer' desporto → Praticar" tone_tags="formal" default="temp_off">
+        <rule id='FAZER_DESPORTO' name="[pt-PT] 'Fazer' desporto → Praticar" tone_tags="formal">
             <pattern>
                 <marker>
                     <token skip='4' inflected='yes'>fazer</token>
@@ -2860,7 +2860,7 @@ USA
         </rule>
 
 
-    <rule id='SIMPLIFICAR_É_NECESSÁRIO_TER_REQUER' name="[pt-PT][Simplificar] é necessário ter → requer" type='style' default="temp_off">
+    <rule id='SIMPLIFICAR_É_NECESSÁRIO_TER_REQUER' name="[pt-PT][Simplificar] é necessário ter → requer" type='style'>
         <!-- IDEA shorten_it -->
         <pattern>
             <marker>


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

ID:FAZER_DESPORTO has zero hits.

ID:SIMPLIFICAR_É_NECESSÁRIO_TER_REQUER has four hits:
https://internal1.languagetool.org/regression-tests/via-http/2024-07-20/pt-PT/result_style_SIMPLIFICAR_%C3%89_NECESS%C3%81RIO_TER_REQUER%5B1%5D.html

Removing temp_off and merging after it passes the checks, since it is pt-PT.