### PR TITLE
[pt-PT] Removed temp_off from rule ID:PERANTE_O_MESMO_IDENTICO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -4863,7 +4863,7 @@ USA
         </rulegroup>
 
 
-        <rule id='PERANTE_O_MESMO_IDENTICO' name="[pt-PT][Formal] Perante 'o mesmo' → idêntico" default="temp_off">
+        <rule id='PERANTE_O_MESMO_IDENTICO' name="[pt-PT][Formal] Perante 'o mesmo' → idêntico">
             <pattern>
                 <token regexp='yes'>ante|diante|perante</token>
                 <marker>


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

It had zero hits, so I am removing the “temp_off”.

Since it is pt-PT, I will merge it after the checks.
