### PR TITLE
[en] improve NEITHER_NOR_SUPERFLUOUS_COMMA

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/remote-rule-filters.xml
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/rules/en/remote-rule-filters.xml
@@ -1980,6 +1980,18 @@ To ignore a remote rule match, set the <marker> so that it exactly covers the te
         <rulegroup id="AI_HYDRA_LEO_MISSING_COMMA" name="">
             <rule>
                 <pattern>
+                    <token>neither</token>
+                    <token min="0" max="3" chunk_re="[BI]-NP.*" />
+                    <marker>
+                        <token chunk_re="E-NP.*" />
+                    </marker>
+                    <token>nor</token>
+                    <token chunk_re=".-NP.*" />
+                </pattern>
+                <example correction="">But neither <marker>deployment</marker> nor the local development flow, is containerized yet.</example>
+            </rule>
+            <rule>
+                <pattern>
                     <token postag="SENT_START|CC|PCT|TO" postag_regexp="yes" />
                     <token regexp="yes">an?|another|more|one</token>
                     <token min="0" max="2" chunk="I-NP-singular" />


### PR DESCRIPTION
For the internal feedback here:
https://languagetooler.slack.com/archives/CG7ULA9T6/p1721383643012519

>But neither deployment, nor the local development flow, is containerized yet.

I believe there are two solutions here, and I'm not sure if my change is the best one.
Either an AP to block the match for the first subrule (which is what I did), or expand the second subrule to remove the second comma (after 'flow') and write an AP to block the HydraLeo match.

Do you have a preference or another idea?