### PR TITLE
[pt] Removed "temp_off" from rule ID:BÁSICO_ELEMENTAR and ID:MUITO_BASTANTE_EXTENSIVAMENTE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -8672,7 +8672,7 @@ USA
         </rule>
 
 
-        <rule id='BÁSICO_ELEMENTAR' name="[Universitário][Científico] Básico → Elementar" tone_tags="academic" is_goal_specific="true" default="temp_off">
+        <rule id='BÁSICO_ELEMENTAR' name="[Universitário][Científico] Básico → Elementar" tone_tags="academic" is_goal_specific="true">
             <antipattern>
                 <token regexp='yes'>unidades?</token>
                 <token regexp='yes'>básicas?</token>
@@ -8703,7 +8703,7 @@ USA
         </rule>
 
 
-        <rule id='MUITO_BASTANTE_EXTENSIVAMENTE' name="[Universitário][Científico] Muito/bastante/enormemente → Extensivamente/amplamente" tone_tags="academic" is_goal_specific="true" tags="picky" default="temp_off">
+        <rule id='MUITO_BASTANTE_EXTENSIVAMENTE' name="[Universitário][Científico] Muito/bastante/enormemente → Extensivamente/amplamente" tone_tags="academic" is_goal_specific="true" tags="picky">
             <pattern>
                 <token inflected='yes' regexp='yes'>ter|ser</token>
                 <token min='0' regexp='yes'>sido|es[st][ae]s?|aquel[ae]s?</token>


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

I guess that maybe it is time to start removing “temp_off” from rules created weeks or months ago:
BÁSICO_ELEMENTAR
https://internal1.languagetool.org/regression-tests/via-http/2024-07-22/pt-BR_full/result_style_B%C3%81SICO_ELEMENTAR%5B1%5D.html

MUITO_BASTANTE_EXTENSIVAMENTE
https://internal1.languagetool.org/regression-tests/via-http/2024-07-22/pt-BR_full/result_style_MUITO_BASTANTE_EXTENSIVAMENTE%5B1%5D.html

😛 😛 😛 😛 😛 😛 😛 😛 
