### PR TITLE
feat(core): add Rule property includedInHiddenMatches

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RemoteRule.java
@@ -79,6 +79,8 @@ public abstract class RemoteRule extends Rule {
     whitespaceNormalisation = Boolean.parseBoolean(serviceConfiguration.getOptions().getOrDefault("whitespaceNormalisation", "true"));
     fixOffsets = Boolean.parseBoolean(serviceConfiguration.getOptions().getOrDefault("fixOffsets", "true"));
     premium = Boolean.parseBoolean(serviceConfiguration.getOptions().getOrDefault("premium", "false"));
+    boolean includedInHiddenMatches = Boolean.parseBoolean(serviceConfiguration.getOptions().getOrDefault("includedInHiddenMatches", "true"));
+    setIncludedInHiddenMatches(includedInHiddenMatches);
     try {
       if (serviceConfiguration.getOptions().containsKey("suppressMisspelledMatch")) {
         suppressMisspelledMatch = Pattern.compile(serviceConfiguration.getOptions().get("suppressMisspelledMatch"));

--- a/languagetool-core/src/main/java/org/languagetool/rules/Rule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/Rule.java
@@ -72,6 +72,7 @@ public abstract class Rule {
   private boolean defaultTempOff;
   private boolean officeDefaultOn = false;
   private boolean officeDefaultOff = false;
+  private boolean includedInHiddenMatches = true;
   private int minPrevMatches = 0; // minimum number of previous matches to show the rule
   private int distanceTokens = -1; // distance (number of tokens) between matches to consider a repetition
   private int priority = 0;
@@ -596,5 +597,24 @@ public abstract class Rule {
 
   public void setPriority(int priority) {
     this.priority = priority;
+  }
+
+  /**
+   * @since 6.5
+   * @return whether this rule should be run when hidden rules are enabled
+   * when Rule.isPremium is true and QueryParams.premium is false,
+   * this rule will only be run when both Rule.isIncludedInHiddenMatches and QueryParams.enableHiddenRules are true
+   * No effect otherwise
+   */
+  public boolean isIncludedInHiddenMatches() {
+    return includedInHiddenMatches;
+  }
+
+/**
+ * @since 6.5
+ * @param includedInHiddenMatches whether this rule should be run when hidden rules are enabled (if it's a Premium rule)
+ */
+  public void setIncludedInHiddenMatches(boolean includedInHiddenMatches) {
+    this.includedInHiddenMatches = includedInHiddenMatches;
   }
 }

--- a/languagetool-server/src/main/java/org/languagetool/server/PipelinePool.java
+++ b/languagetool-server/src/main/java/org/languagetool/server/PipelinePool.java
@@ -189,11 +189,14 @@ class PipelinePool implements KeyedPooledObjectFactory<PipelineSettings, Pipelin
           }
         }
         //System.out.println("Enabled " + premiumEnabled + " premium rules, disabled " + otherDisabled + " non-premium rules.");
-      } else if (!params.premium && !params.enableHiddenRules) { // compute premium matches locally to use as hidden matches
+      } else if (!params.premium) {
         if (!(premium instanceof PremiumOff)) {
           for (Rule rule : lt.getAllActiveRules()) {
             if (premium.isPremiumRule(rule)) {
-              lt.disableRule(rule.getFullId());
+              // compute premium matches locally to use as hidden matches if desired for a rule
+              if (!params.enableHiddenRules || !rule.isIncludedInHiddenMatches()) {
+                lt.disableRule(rule.getFullId());
+              }
             }
           }
         }


### PR DESCRIPTION
- allow controlling whether premium rules run as part of hidden matches
- expose setting as configuration option for RemoteRules
- respect setting when configuring rules in PipelinePool