### PR TITLE
[pt] Added formal rule ID:ESTAR_AQUI_PARA_INF_VIR_INF

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3634,6 +3634,21 @@ USA
         </rule>
 
 
+        <rule id='ESTAR_AQUI_PARA_INF_VIR_INF' name="'Estar aqui para' Inf. → 'Vir Inf.'" tone_tags='formal' default="temp_off">
+            <pattern>
+                <marker>
+                    <token inflected='yes'>estar</token>
+                    <token>aqui</token>
+                    <token>para</token>
+                    <token regexp='yes' inflected='yes'>ajudar|apresentar|buscar|debater|defender|discutir|entregar|esclarecer|negociar|oferecer|participar|propor|reclamar|resolver|solicitar</token> <!-- Add verbs as they are found. -->
+                </marker>
+            </pattern>
+            <message>&informal_msg;</message>
+            <suggestion><match no='1' postag='V.+' postag_regexp='yes'>vir</match> \4</suggestion>
+            <example correction="venho defender">Bom dia, <marker>estou aqui para defender</marker> a minha tese.</example>
+        </rule>
+
+
         <rulegroup id='MORRER_PERECER_FALECER' name="morrer → perecer/falecer" tags='picky' tone_tags='formal'>
 
             <!-- Subrule 1: not using "mort[ao]s?" -->


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

Here is the rule.

Notice that all hits except one happened with the verb “ajudar”:
```
Portuguese (Portugal): 27 total matches
Portuguese (Portugal): 854003 total sentences considered
Portuguese (Portugal): ø0.00 rule matches per sentence
```
Results file .txt:
[0.txt](https://github.com/user-attachments/files/16589402/0.txt)

Here is the ChatGPT 4o “background”:
![Screenshot 2024-08-12 at 16-59-53 Diferença entre verbos](https://github.com/user-attachments/assets/6b5c56cf-c022-4372-af40-9eb5ad819c1d)


![Screenshot 2024-08-12 at 16-54-32 Diferença entre verbos](https://github.com/user-attachments/assets/8ca8510c-3958-4900-8c92-aee6a720a772)

