### PR TITLE
[fr] PERSOS_fix

### DIFF
--- a/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/disambiguation.xml
+++ b/languagetool-language-modules/fr/src/main/resources/org/languagetool/resource/fr/disambiguation.xml
@@ -914,6 +914,10 @@ RB => Règles Brutes
             <token postag="R pers obj.*" postag_regexp="yes" min="1" max="3"/>
             <token regexp="yes" inflected="yes">point|produit|permis|courbe|vernis|suivis</token>
         </antipattern>
+        <antipattern>
+            <token regexp="yes">je|tu</token>
+            <token>chéris</token>
+        </antipattern>
         <rule>
             <pattern>
                 <marker>


### PR DESCRIPTION
Simple, quick and safe fix for: https://app.asana.com/0/1207342200148885/1208022931754948/f

PERSOS[1] rule in the disambiguation file was changing "chéris" POS to Noun automatically, causing issues when it's used as a verb.