### PR TITLE
[pt] Added ENTITY colloquialism_msg to messages.ent

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/messages.ent
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/entities/messages.ent
@@ -10,6 +10,7 @@
 <!ENTITY MSG_ECN "Possível erro de concordância de número.">
 <!ENTITY cliche_msg "Para enriquecer seu texto, evite frases-feitas.">
 <!ENTITY pleonasm_msg "&clarity_intro; evite pleonasmos.">
+<!ENTITY colloquialism_msg "&clarity_intro; evite expressões orais.">
 <!ENTITY simplify_msg "&clarity_intro; busque usar uma linguagem mais concisa.">
 <!ENTITY vulgar_msg "Esta expressão pode ser considerada de baixo calão. Use-a apenas nos contextos mais informais.">
 <!ENTITY informal_msg "Esta expressão pode ser considerada demasiado coloquial em contextos mais formais.">


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

I have added this message because of the dozens of pt-PT rules such as:

```
        <rule>
            <pattern>
                <token inflected='yes'>o</token>
                <token>nem-nem</token>
            </pattern>
            <message>Esta é uma expressão oral. Reveja.</message>
            <url>https://pt.wiktionary.org/wiki/a_nem-nem</url>
            <short>Coloquialismo</short>
            <example correction=''><marker>a nem-nem</marker></example>
        </rule>
```

Also, would it be a good idea for me to remove all `<short>` messages in pt-PT, since they are terrible? A person is revising a document, and it shows a suggestion with just one or two words which is completely unclear and not useful at all… I prefer longer explaining messages.

`<short>Coloquialismo</short>`



