### PR TITLE
[pt-PT] Removed "temp_off" from subrule in ID:INFORMALITIES

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -1843,7 +1843,7 @@ USA
         <short>Coloquialismo</short>
         <example correction=''><marker>ver-se à brocha</marker></example>
     </rule>
-    <rule default="temp_off">
+    <rule>
         <pattern>
             <token>para</token>
             <token inflected='yes'>ver</token>


### PR DESCRIPTION
Just a "temp_off" removal from a colloquialism subrule I created days ago.