### PR TITLE
[pt] Removed "temp_off" in rule ID:ESTAR_AQUI_PARA_INF_VIR_INF

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3634,7 +3634,7 @@ USA
         </rule>
 
 
-        <rule id='ESTAR_AQUI_PARA_INF_VIR_INF' name="'Estar aqui para' Inf. → 'Vir Inf.'" tone_tags='formal' default="temp_off">
+        <rule id='ESTAR_AQUI_PARA_INF_VIR_INF' name="'Estar aqui para' Inf. → 'Vir Inf.'" tone_tags='formal'>
             <pattern>
                 <marker>
                     <token postag='VMIP.+' postag_regexp='yes' inflected='yes'>estar<exception scope='previous' postag_regexp='no' postag='RG'/></token>


### PR DESCRIPTION
Heya, @p-goulart and @susanaboatto ,

What about now?:
https://internal1.languagetool.org/regression-tests/via-http/2024-08-20/pt-BR/result_style_ESTAR_AQUI_PARA_INF_VIR_INF%5B1%5D.html

Thanks!

