### PR TITLE
[pt] Removed "temp_off" from rule ID:QUE_TER_COMO_POR_NOME_ADJ

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -19319,7 +19319,7 @@ USA
         </rule>
 
 
-        <rule id='QUE_TER_COMO_POR_NOME_ADJ' name="cujo(a) + substantivo + verbo ser" default="temp_off">
+        <rule id='QUE_TER_COMO_POR_NOME_ADJ' name="cujo(a) + substantivo + verbo ser">
             <pattern>
                 <marker>
                     <token>que</token>


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

I have removed the “temp_off”.

I gave a quick look at the nightly diff, and it seems okay?:
https://internal1.languagetool.org/regression-tests/via-http/2024-08-23/pt-BR_full/result_style_QUE_TER_COMO_POR_NOME_ADJ%5B1%5D.html

I will try to remove as many “temp_off”'s as possible before the next release of LanguageTool.

Thanks!