### PR TITLE
[pt] disambiguation.xml fix

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -226,6 +226,15 @@
   </rule>
   <rulegroup id="RARE_POS" name="rare POS tags">
     <rule>
+      <pattern>
+        <token postag="Z0FP0" postag_regexp="no"/>
+        <marker>
+          <token postag="VMIP2S0" postag_regexp="no"/>
+        </marker>
+      </pattern>
+      <disambig action="remove" postag="V.*"/>
+    </rule>
+    <rule>
       <antipattern>
         <token>damos</token>
         <token postag="NC.+"/>


### PR DESCRIPTION
Heya, @susanaboatto , @p-goulart and @jaumeortola ,

I have fixed rare verbs detecting:
```
Quero duas garotas.
Quero duas partes.
```

"garotas" and "partes" no longer appear as verbs.

But it will impact in the whole core of PT.

That is why I am always scared to change the disambiguator.

But if you believe it is okay, then it is a major improvement, and it will fix tons of false positives in our rules.