### PR TITLE
[de] remove 'bet' so e.g. 'Betwäsche' doesn't get accepted

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/verb_stems.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/verb_stems.txt
@@ -7885,7 +7885,7 @@ besser
 besteh
 bestell
 bestimm
-bet
+#bet
 beton
 betonier
 betreff


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the representation of the verb "bet" in the language processing resource to include a comment notation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->