### PR TITLE
[pt] Improved the disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -238,6 +238,17 @@
       <disambig action="remove" postag="V.*"/>
     </rule>
     <rule>
+      <pattern>
+        <token postag="V.+" postag_regexp="yes"/>
+        <token min='1' max='2' postag="[DP].+" postag_regexp="yes"/>
+        <token postag="Z0[FM]P0" postag_regexp="yes"/>
+        <marker>
+          <token postag="VMIP1S0" postag_regexp="no"/>
+        </marker>
+      </pattern>
+      <disambig action="remove" postag="[NV].*"/>
+    </rule>
+    <rule>
       <antipattern>
         <token>damos</token>
         <token postag="NC.+"/>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -243,7 +243,7 @@
         <token min='1' max='2' postag="[DP].+" postag_regexp="yes"/>
         <token postag="Z0[FM]P0" postag_regexp="yes"/>
         <marker>
-          <token postag="VMIP1S0" postag_regexp="no"/>
+          <token regexp="yes">como|logo</token>
         </marker>
       </pattern>
       <disambig action="remove" postag="[NV].*"/>


### PR DESCRIPTION
Heya, @jaumeortola , @susanaboatto and @p-goulart ,

This enhancement fixes sentences like:

```
A equipe fundiu as duas como uma forma de meio-termo.
A equipe fundiu as suas duas como uma forma de meio-termo.
A equipe fundiu umas duas como uma forma de meio-termo.
```

“como” no longer appears as a noun nor as a verb.

It should be a low-impact change since it is a strict rule, but one must look at the nightly diffs.

😛 😛 😛 😛 😛 😛 😛 😛 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new disambiguation rule for the Portuguese language module to enhance grammatical accuracy by refining the handling of specific verb forms in context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->