### PR TITLE
[pt] Fixed FPs in rule ID:OS_DOIS_AS_DUAS_AMBOS_AMBAS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3692,7 +3692,7 @@ USA
                     </marker>
                     <token min='0' postag='_QUOT' postag_regexp='no'/>
                     <token postag='N.+|AQ.+' postag_regexp='yes'>
-                        <exception postag_regexp='yes' postag='AO.+|Z0.+'/>
+                        <exception postag_regexp='yes' postag='AO.+|Z0.+|CS'/>
                         <exception regexp='yes'>mais|menos</exception> <!-- RG -->
                         <exception regexp='yes'>junt[ao]s|homens|mulheres|&expressoes_de_tempo;</exception> <!-- Postags remove valid sentences -->
                     </token>


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

This improvement fixes more false positives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced exception handling for Portuguese language rules, allowing for broader criteria in grammar and style checks.
  
- **Bug Fixes**
	- Adjusted processing of certain phrases to improve accuracy in grammar checks and style suggestions for Portuguese text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->