### PR TITLE
[pt] Removed "temp_off" from rule ID:OS_DOIS_AS_DUAS_AMBOS_AMBAS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3652,7 +3652,7 @@ USA
         </rule>
 
 
-        <rulegroup id='OS_DOIS_AS_DUAS_AMBOS_AMBAS' name="os dois → ambos" tone_tags='formal' tags='picky' default='temp_off'>
+        <rulegroup id='OS_DOIS_AS_DUAS_AMBOS_AMBAS' name="os dois → ambos" tone_tags='formal' tags='picky'>
             <!-- TODO: in 2025 expand the rule to accept: CC|RM|SENT_START|_PUNCT because they produce too many hits. -->
 
             <!-- Subrule 1: NOT using nouns/adjectives after "as duas"/"os dois" -->

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3658,7 +3658,9 @@ USA
             <!-- Subrule 1: NOT using nouns/adjectives after "as duas"/"os dois" -->
             <rule>
                 <pattern>
-                    <token postag='V.+|RG|CS' postag_regexp='yes'><exception postag_regexp='yes' postag='SPS.+'/></token>
+                    <token postag='V.+|RG|CS' postag_regexp='yes'>
+                        <exception postag_regexp='yes' postag='SPS.+'/>
+                        <exception regexp='no' inflected='yes'>precisar</exception></token>
                     <marker>
                         <token regexp='yes'>[ao]s</token>
                         <token regexp='yes'>duas|dois
@@ -3680,12 +3682,15 @@ USA
                 <example>Cantuária e Winchester eram as duas mais ricas Sés na Inglaterra.</example>
                 <example>Este livro contém as duas mil palavras mais comuns na língua portuguesa.</example>
                 <example>Algumas pessoas na cidade têm os dois mil.</example>
+                <example>Bem, agora você precisa as duas.</example>
             </rule>
 
             <!-- Subrule 2: USING nouns/adjectives after "as duas"/"os dois" -->
             <rule>
                 <pattern>
-                    <token postag='V.+|RG|CS' postag_regexp='yes'><exception postag_regexp='yes' postag='SPS.+'/></token>
+                    <token postag='V.+|RG|CS' postag_regexp='yes'>
+                        <exception postag_regexp='yes' postag='SPS.+'/>
+                        <exception regexp='no' inflected='yes'>precisar</exception></token>
                     <marker>
                         <token regexp='yes'>[ao]s</token>
                         <token regexp='yes'>duas|dois</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3652,26 +3652,41 @@ USA
         </rule>
 
 
-        <rulegroup id='OS_DOIS_AS_DUAS_AMBOS_AMBAS' name="os dois → ambos" tone_tags='formal' tags='picky'>
+        <rulegroup id='OS_DOIS_AS_DUAS_AMBOS_AMBAS' name="os dois → ambos" tone_tags='formal' tags='picky' default='temp_off'>
             <!-- TODO: in 2025 expand the rule to accept: CC|RM|SENT_START|_PUNCT because they produce too many hits. -->
+
+            <antipattern>
+                <token skip='-1' regexp='yes'>quem|quando|aonde|onde|como</token>
+                <token postag='PUNCT_INTERROGATION'/>
+                <example>Quem escreveu ambas as cartas?</example>
+            </antipattern>
+            <antipattern>
+                <token regexp='yes'>[ao]s</token>
+                <token regexp='yes'>duas|dois</token>
+                <token min='1' max='2' postag='V.+|N.+|AQ.+' postag_regexp='yes'>
+                    <exception regexp='yes'>mais|menos|melhor(es)?|pior(es)?|maior(es)?|menor(es)?</exception></token>
+                <token regexp='yes'>mais|menos|melhor(es)?|pior(es)?|maior(es)?|menor(es)?</token>
+                <example>Diz-se que as duas capitais mais próximas uma da outra são Viena (Áustria) e Bratislava (Eslováquia).</example>
+                <example>No entanto, a Airbus equipou os dois motores mais próximos da fuselagem com reversos.</example>
+                <example>Scott e Reeves se tornaram os dois astros mais conceituados deste gênero.</example>
+                <example>Uma fase de qualificatórias onde as duas melhores duplas de cada uma seguiram para as semifinais.</example>
+            </antipattern>
 
             <!-- Subrule 1: NOT using nouns/adjectives after "as duas"/"os dois" -->
             <rule>
                 <pattern>
                     <token postag='V.+|RG|CS' postag_regexp='yes'>
                         <exception postag_regexp='yes' postag='SPS.+'/>
-                        <exception regexp='no' inflected='yes'>precisar</exception></token>
+                        <exception regexp='yes' inflected='yes'>formar|precisar|só</exception></token> <!-- "ser" removed in rule #1 -->
                     <marker>
                         <token regexp='yes'>[ao]s</token>
                         <token regexp='yes'>duas|dois
-                            <exception postag_regexp='no' postag='RG'/> <!-- Removes "duas vezes" false positive -->
-                        </token>
+                            <exception postag_regexp='no' postag='RG'/></token> <!-- Removes "duas vezes" false positive -->
                     </marker>
                     <token min='0' postag='_QUOT' postag_regexp='no'/>
                     <token>
-                        <exception postag_regexp='yes' postag='N.+|AQ.+|AO.+|Z0.+'/>
-                        <exception regexp='yes'>mais|menos</exception> <!-- RG -->
-                    </token>
+                        <exception postag_regexp='yes' postag='N.+|AQ.+|AO.+|Z0.+|PE.+'/>
+                        <exception regexp='yes'>mais|menos|melhor(es)?|pior(es)?|maior(es)?|menor(es)?</exception></token>
                 </pattern>
                 <message>&informal_msg;</message>
                 <suggestion><match no='2' postag='DA0(..)0' postag_replace='DI0$10'>ambos</match></suggestion>
@@ -3683,6 +3698,7 @@ USA
                 <example>Este livro contém as duas mil palavras mais comuns na língua portuguesa.</example>
                 <example>Algumas pessoas na cidade têm os dois mil.</example>
                 <example>Bem, agora você precisa as duas.</example>
+                <example>Em uma partida de futebol os árbitros assistentes são os dois que ficam bem à margem do campo.</example>
             </rule>
 
             <!-- Subrule 2: USING nouns/adjectives after "as duas"/"os dois" -->
@@ -3690,7 +3706,7 @@ USA
                 <pattern>
                     <token postag='V.+|RG|CS' postag_regexp='yes'>
                         <exception postag_regexp='yes' postag='SPS.+'/>
-                        <exception regexp='no' inflected='yes'>precisar</exception></token>
+                        <exception regexp='yes' inflected='yes'>formar|precisar|ser|só</exception></token>
                     <marker>
                         <token regexp='yes'>[ao]s</token>
                         <token regexp='yes'>duas|dois</token>
@@ -3698,7 +3714,7 @@ USA
                     <token min='0' postag='_QUOT' postag_regexp='no'/>
                     <token postag='N.+|AQ.+' postag_regexp='yes'>
                         <exception postag_regexp='yes' postag='AO.+|Z0.+|CS'/>
-                        <exception regexp='yes'>mais|menos</exception> <!-- RG -->
+                        <exception regexp='yes'>mais|menos|melhor(es)?|pior(es)?|maior(es)?|menor(es)?</exception>
                         <exception regexp='yes'>junt[ao]s|homens|mulheres|&expressoes_de_tempo;</exception> <!-- Postags remove valid sentences -->
                     </token>
                 </pattern>
@@ -3715,6 +3731,12 @@ USA
                 <example>Findos os dois anos, retornou à Europa.</example>
                 <example>No terceiro ano, transferiu-se para a Universidade de Tulsa, onde jogou os dois anos seguintes na NCAA.</example>
                 <example>Muitos apostavam que disputariam a final, foram os dois menos votados no top 04.</example>
+                <example>Só as duas fábricas ocupam juntas uma superfície de mais de 60.000m2 de área construída.</example>
+                <example>O tétum e o português formam as duas línguas oficiais do país.</example>
+                <example>Essas foram as duas melhores HQs de 2015, na minha opinião.</example>
+                <example>Os filhos eram os dois únicos homens a quem ela se dedicava.</example>
+                <example>Estas são as duas únicas palavras que não compreendemos.</example>
+                <example>Já em 1904 seriam as duas maiores ferrovias da República, da central e nacional através da cidade.</example>
             </rule>
 
         </rulegroup>


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

I have removed the temp_off:
https://internal1.languagetool.org/regression-tests/via-http/2024-09-09/pt-BR_full/result_style_OS_DOIS_AS_DUAS_AMBOS_AMBAS%5B1%5D.html

https://internal1.languagetool.org/regression-tests/via-http/2024-09-09/pt-BR_full/result_style_OS_DOIS_AS_DUAS_AMBOS_AMBAS%5B2%5D.html

The results are too many for me to focus on checking one by one, but they look okay.

Thanks!

😛 😛 😛 😛 😛 😛 😛 😛 😛 😛 😛 😛 😛 😛 😛 😛 😛 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated language rules to enable the rule group for "os dois → ambos" by default, enhancing language processing capabilities.
	- Improved specificity of language rules by adding exceptions for the term "precisar" and introducing new antipatterns to reduce false positives.

- **Bug Fixes**
	- Removed temporary off state for the specified rule group, ensuring more consistent application of language rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->