### PR TITLE
[pt] Added/improved APs in rule ID:GENERAL_NUMBER_AGREEMENT_ERRORS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -4250,7 +4250,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       -->
             <antipattern>
                 <token>para</token>
-                <token>tal</token>
+                <token regexp='yes'>tal|tanto</token>
                 <token postag='(SPS00:)?[DP]...[PN].+|VM...P.+' postag_regexp='yes'/>
                 <token postag="AQ..[PN].+|N..[PN].+|Z0.[PN].+|(SPS00:)?[DP]...[PN].+|VM...P.+" postag_regexp="yes"/>
                 <example>Quero para tal esses dois telemóveis.</example>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -4249,19 +4249,26 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
            MARCOAGPINTO inserted global antipatterns for all subrules on top using the logic (2-MAR-2023+)
       -->
             <antipattern>
+                <token>para</token>
+                <token>tal</token>
+                <token postag='(SPS00:)?[DP]...[PN].+|VM...P.+' postag_regexp='yes'/>
+                <token postag="AQ..[PN].+|N..[PN].+|Z0.[PN].+|(SPS00:)?[DP]...[PN].+|VM...P.+" postag_regexp="yes"/>
+                <example>Quero para tal esses dois telemóveis.</example>
+            </antipattern>
+            <antipattern>
                 <token>a</token>
                 <token>nós</token>
                 <token postag="AQ..S.+|N..S.+" postag_regexp="yes"/>
-                <token postag='RM|RG|CS|CC|SPS00|(SPS00)?:[DP]...[SN].+|VM...S.+' postag_regexp='yes'/>
+                <token postag='RM|RG|CS|CC|SPS00|(SPS00:)?[DP]...[SN].+|VM...S.+' postag_regexp='yes'/>
                 <example>Assim que partimos, juntou-se a nós Jesus com pequeno grupo de seguidores.</example>
                 <example>A nós Jesus disse estar cansado de pregar.</example>
             </antipattern>
             <antipattern>
-                <token postag='VMI.3S.+' postag_regexp='yes'/>
+                <token postag='VM..3S.+' postag_regexp='yes'/>
                 <token>possível</token>
-                <token min='0' max='1' postag='CS|SPS00|(SPS00)?:[DP]...P.+' postag_regexp='yes'/>
+                <token min='0' max='1' postag='CS|SPS00|(SPS00:)?[DP]...P.+' postag_regexp='yes'/>
                 <token postag="AQ..P.+|NC.P.+" postag_regexp="yes"/>
-                <token postag='RM|RG|CS|CC|SPS00|(SPS00)?:[DP]...[SN].+' postag_regexp='yes'/>
+                <token postag='RM|RG|CS|CC|SPS00|(SPS00:)?[DP]...[SN].+' postag_regexp='yes'/>
                 <example>É possível alunos da mesma universidade e turma terem notas diferentes?</example>
                 <example>É possível que alunos da mesma universidade e turma tenham notas diferentes?</example>
                 <example>É possível a alunos da mesma universidade e turma terem notas diferentes?</example>


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

I have added an AP and fixed/improved two others.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new antipattern for the phrase "para tal" to improve grammar detection in Portuguese.

- **Improvements**
	- Enhanced accuracy of grammar checking by normalizing postag patterns across multiple tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->