### PR TITLE
[nl] add compound parts

### DIFF
--- a/languagetool-language-modules/nl/src/main/resources/org/languagetool/resource/nl/compound_acceptor/needs_s.txt
+++ b/languagetool-language-modules/nl/src/main/resources/org/languagetool/resource/nl/compound_acceptor/needs_s.txt
@@ -18,6 +18,7 @@ duikers
 eindejaars
 etens
 fabrieks
+faillissements
 fatsoens
 gebruiks
 gebruikers

--- a/languagetool-language-modules/nl/src/main/resources/org/languagetool/resource/nl/compound_acceptor/no_s.txt
+++ b/languagetool-language-modules/nl/src/main/resources/org/languagetool/resource/nl/compound_acceptor/no_s.txt
@@ -1,4 +1,5 @@
 aandeel
+aanjaag
 aangifte
 aanname
 aard
@@ -42,6 +43,7 @@ baard
 baby
 bagage
 bagger
+bakfiets
 bal
 balkon
 balustrade
@@ -110,6 +112,7 @@ cabaret
 café
 campagne
 camping
+campus
 cantate
 caravan
 cassette
@@ -135,6 +138,7 @@ cosmetica
 crisis
 cross
 cruise
+crypto
 cult
 cultuur
 curve
@@ -277,6 +281,7 @@ helikopter
 heren
 herfst
 herten
+hidjab
 hitte
 hobby
 hoek
@@ -483,6 +488,7 @@ muziek
 mythe
 nacht
 natuur
+nep
 nest
 netwerk
 neus
@@ -654,6 +660,7 @@ span
 spiegel
 spier
 spinnen
+spoed
 spons
 sponsor
 spoor
@@ -724,6 +731,7 @@ tol
 tombe
 toneel
 toon
+tram
 trans
 transfer
 transport
@@ -743,6 +751,7 @@ uitvoer
 uur
 uurloon
 uurwerk
+vaccinatie
 vader
 vakantie
 vang
@@ -803,7 +812,6 @@ warmte
 water
 waterstof
 wiel
-wieler
 wind
 winter
 wijn
@@ -825,6 +833,7 @@ woord
 wortel
 zand
 zang
+zeespiegel
 zeil
 zet
 zetmeel

--- a/languagetool-language-modules/nl/src/test/java/org/languagetool/rules/nl/CompoundAcceptorTest.java
+++ b/languagetool-language-modules/nl/src/test/java/org/languagetool/rules/nl/CompoundAcceptorTest.java
@@ -52,6 +52,17 @@ public class CompoundAcceptorTest {
 
     assertTrue(acceptor.acceptCompound("webschoolboek"));
     assertFalse(acceptor.acceptCompound("gezondheidsomlijningssvervangingsinfluencers"));
+    assertTrue(acceptor.acceptCompound("cryptodebacle"));
+    assertTrue(acceptor.acceptCompound("bakfietsbedrijf"));
+    assertTrue(acceptor.acceptCompound("campustheater"));
+    assertTrue(acceptor.acceptCompound("tramschutter"));
+    assertTrue(acceptor.acceptCompound("zeespiegelonderzoeker"));
+    assertTrue(acceptor.acceptCompound("nepsupporters"));
+    assertTrue(acceptor.acceptCompound("hidjabverplichting"));
+    assertTrue(acceptor.acceptCompound("faillissementspoging"));
+    assertTrue(acceptor.acceptCompound("spoedaanwijzingen"));
+    assertTrue(acceptor.acceptCompound("vaccinatieorganisaties"));
+    assertTrue(acceptor.acceptCompound("aanjaagpartij"));
 
     // test areas
     assertTrue(acceptor.acceptCompound("Zuidoost-Turkije"));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new compound words to the Dutch language resource, including "faillissements," enhancing text processing capabilities.
	- Expanded vocabulary with additional terms such as "aanjaag," "bakfiets," "campus," "crypto," "hidjab," "nep," "spoed," "tram," and "vaccinatie."
  
- **Bug Fixes**
	- Removed the term "wieler" from the vocabulary list to improve accuracy. 

- **Tests**
	- Introduced new test cases for better coverage of compound word acceptance in Dutch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->