### PR TITLE
speed up spelling rules on single words (as they're invoked in IntelliJ)

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/AnalyzedSentence.java
+++ b/languagetool-core/src/main/java/org/languagetool/AnalyzedSentence.java
@@ -164,6 +164,14 @@ public final class AnalyzedSentence {
   }
 
   /**
+   * Get the length of the array returned by {@link #getTokensWithoutWhitespace()} without additional allocations.
+   */
+  @ApiStatus.Internal
+  public int getNonWhitespaceTokenCount() {
+    return nonBlankTokens.length;
+  }
+
+  /**
    * @since 4.5
    */
   public AnalyzedTokenReadings[] getPreDisambigTokensWithoutWhitespace() {

--- a/languagetool-core/src/main/java/org/languagetool/rules/Rule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/Rule.java
@@ -190,12 +190,14 @@ public abstract class Rule {
    * @since 3.1
    */
   protected AnalyzedSentence getSentenceWithImmunization(AnalyzedSentence sentence) {
-    if (!getAntiPatterns().isEmpty()) {
+    List<DisambiguationPatternRule> antiPatterns = getAntiPatterns();
+    if (!antiPatterns.isEmpty()) {
       //we need a copy of the sentence, not reference to the old one
       AnalyzedSentence immunizedSentence = sentence.copy(sentence);
-      for (DisambiguationPatternRule patternRule : getAntiPatterns()) {
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0; i < antiPatterns.size(); i++) {
         try {
-          immunizedSentence = patternRule.replace(immunizedSentence);
+          immunizedSentence = antiPatterns.get(i).replace(immunizedSentence);
         } catch (IOException e) {
           throw new RuntimeException(e);
         }


### PR DESCRIPTION
Quickly discard antipatterns if they're longer than the sentence. In spelling rules, antipatterns always have more than one token, so such a check speeds up getSentenceWithImmunization considerably.

This changes the output of `testSeparateCorrectWordPerformance` from 12-20 seconds to 2.7 seconds on my machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to count non-whitespace tokens in analyzed sentences for improved text processing.
	- Added a mechanism to enforce a minimum token requirement for rule applicability in language processing.

- **Bug Fixes**
	- Enhanced performance and readability in the handling of anti-patterns within rule evaluations.

- **Tests**
	- Implemented a new performance test for the Hunspell rule to evaluate processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->