### PR TITLE
[pt-PT] Added subrule to rulegroup:INFORMALITIES + depreciative words

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -75,7 +75,7 @@ USA
 <!ENTITY barbarismos_rev3 "afición|aficiones|blockchains?|bodyboarders?|bolds?|buffers?|bugs?|builds?|bunkai|cents?|check-ins?|chipsets?|clusters?|cookie-cutters?|cover-ups?|crowdfundings?|crowdsourcings?|default|desktops?|drafts?|emojis?|emoticons?|fanzines?|feedbacks?|flags?|footnotes?|frameworks?|friendly|futons?|gaps?|geocachers?|geocaching|gilberts?|health|heights?|hotspots?|hoverboards?|icebergs?|input-output|interfaces?|jetpacks?|knowing-doing|logs?|LEDs?|likes?|marketplaces?|nudes?|open-source|overclockings?|pidgins?|podcasts?|previews?|rankings?|rap|reviews?|scams?|scammers?|scripts?|skippers?|smileys?|snipers?|spoofing|spreads?|sticks?|sudokus?|takeovers?|tatamis?|tokens?|top-down|trackpads?|thrashers?|trackings?|tweets?|underground|Unicode|uploads?|walkie-talkies?|warm-ups?|webcams?|webinars?|webmail|webmasters?|whalewatching|widths?|woks?|yeah|yes-man|zen|zooms?">
 
 <!-- Termos depreciativos específicos pt_PT - the rule uses inflected='yes' to get all forms -->
-<!ENTITY depreciativo_pt_pt "alarve|badalhoco|badameco|baianada|bandalho|betinho|bimbalhada|bimbo|bosta|brasuca|brega|bumbo|chacha|caguinchas|campónio|chico-esperto|china|chinoca|choninhas|chulo|chunga|chungaria|chunguice|ciganada|ciganagem|coirão|coninhas|crápula|cretino|escarumba|escória|escumalha|espertalhão|espertinho|fufa|gagá|gandulo|generaleco|gentalha|gentiaga|gordalhão|imbecil|indigente|japa|labrego|lamechas|larilas?|lorpa|maldito|maltrapilho|maniento|maricão|mariconço|mariquinhas|mentecapto|mitra|molenga|molengão|monhé|morcão|negralhada|nhurrice|nhurro|otário|pacóvio|palerma|panasca|panilas|parolo|patego|pelintra|pindérico|portuga|pretalhada|pretaria|pulha|rabeta|ralé|reles|sacana|tanso|tótó|tuga|velhaco|Zé-ninguém">
+<!ENTITY depreciativo_pt_pt "alarve|badalhoco|badameco|baianada|bandalho|betinho|bimbalhada|bimbo|bosta|brasuca|brega|bumbo|cabrão|caguinchas|campónio|caralhão|chacha|chico-esperto|china|chinoca|choninhas|chulo|chunga|chungaria|chunguice|ciganada|ciganagem|coirão|coninhas|crápula|cretino|escarumba|escória|escumalha|espertalhão|espertinho|fufa|gagá|gandulo|generaleco|gentalha|gentiaga|gordalhão|imbecil|indigente|japa|labrego|lamechas|larilas|lorpa|maldito|maltrapilho|maniento|maricão|mariconço|mariquinhas|mentecapto|mitra|molenga|molengão|monhé|morcão|negralhada|nhurrice|nhurro|otário|pacóvio|palerma|panasca|panilas|parolo|patego|pelintra|pindérico|portuga|pretalhada|pretaria|pulha|puta|rabeta|ralé|reles|sacana|tanso|tótó|tuga|velhaco|Zé-ninguém">
 
 <!ENTITY verbos_informais "és|estás|tens|tenhas">
 
@@ -1852,6 +1852,16 @@ USA
         <message>Esta é uma expressão oral. Reveja.</message>
         <short>Coloquialismo</short>
         <example correction=''><marker>para ver se</marker></example>
+    </rule>
+    <rule default='temp_off'>
+        <pattern>
+            <token>à</token>
+            <token>coisa</token>
+            <token>de</token>
+        </pattern>
+        <message>Esta é uma expressão oral. Reveja.</message>
+        <short>Coloquialismo</short>
+        <example correction=''><marker>à coisa de</marker></example>
     </rule>
 </rulegroup>
 


### PR DESCRIPTION
A pt-PT subrule plus some depreciative words.

Will merge after the checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded list of derogatory terms in Portuguese for improved language detection.
	- Introduced a new rule to flag the informal expression "à coisa de," encouraging users to reconsider its usage.
- **Improvements**
	- Enhanced overall functionality of LanguageTool in recognizing informal and potentially offensive language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->