### PR TITLE
[pt-PT] Removed "temp_off" from subrule in ID:INFORMALITIES

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -1853,7 +1853,7 @@ USA
         <short>Coloquialismo</short>
         <example correction=''><marker>para ver se</marker></example>
     </rule>
-    <rule default='temp_off'>
+    <rule>
         <pattern>
             <token>à</token>
             <token>coisa</token>


### PR DESCRIPTION
Not much, just removing a “temp_off” from a pt-PT subrule with no hits in the nightly diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The Portuguese language module now includes an active rule for evaluating the usage of the phrase "à coisa," enhancing language checking accuracy.
  
- **Bug Fixes**
	- Resolved an issue by activating a previously disabled rule, improving the overall text evaluation process in Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->