### PR TITLE
[pt] Removed "temp_off" from rule ID:OS_DOIS_AS_DUAS_AMBOS_AMBAS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3652,7 +3652,7 @@ USA
         </rule>
 
 
-        <rulegroup id='OS_DOIS_AS_DUAS_AMBOS_AMBAS' name="os dois → ambos" tone_tags='formal' tags='picky' default='temp_off'>
+        <rulegroup id='OS_DOIS_AS_DUAS_AMBOS_AMBAS' name="os dois → ambos" tone_tags='formal' tags='picky'>
             <!-- TODO: in 2025 expand the rule to accept: CC|RM|SENT_START|_PUNCT because they produce too many hits. -->
 
             <antipattern>


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

I have removed the “temp_off”.

Fixes/removals:
https://internal1.languagetool.org/regression-tests/via-http/2024-09-16/pt-BR/result_style_OS_DOIS_AS_DUAS_AMBOS_AMBAS%5B1%5D.html
https://internal1.languagetool.org/regression-tests/via-http/2024-09-16/pt-BR/result_style_OS_DOIS_AS_DUAS_AMBOS_AMBAS%5B2%5D.html

Current results:
https://internal1.languagetool.org/regression-tests/via-http/2024-09-16/pt-BR_full/result_style_OS_DOIS_AS_DUAS_AMBOS_AMBAS%5B1%5D.html
https://internal1.languagetool.org/regression-tests/via-http/2024-09-16/pt-BR_full/result_style_OS_DOIS_AS_DUAS_AMBOS_AMBAS%5B2%5D.html

😛 😛 😛 😛 😛 😛 😛 

Thanks!

