### PR TITLE
[pt-PT] Added subrule to rule ID:INFORMALITIES

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -1863,6 +1863,19 @@ USA
         <short>Coloquialismo</short>
         <example correction=''><marker>à coisa de</marker></example>
     </rule>
+   <rule default='temp_off'>
+        <pattern>
+            <token inflected='yes'>valer</token>
+            <token>de</token>
+            <token>pouco</token>
+        </pattern>
+        <message>Esta é uma expressão oral. Reveja.</message>
+        <suggestion><match no='1' postag='V.+' postag_regexp='yes'>ter</match> pouco valor</suggestion>
+        <suggestion><match no='1' postag='V.+' postag_regexp='yes'>ter</match> pouca importância</suggestion>
+        <short>Coloquialismo</short>
+        <example correction='tem pouco valor|tem pouca importância'>O que ele disse <marker>vale de pouco</marker>.</example>
+        <example correction='tem pouco valor|tem pouca importância'>Essa opinião <marker>vale de pouco</marker> no contexto atual.</example>
+    </rule>
 </rulegroup>
 
 


### PR DESCRIPTION
Just added a colloquialism rule to pt-PT.

Will merge it after it passes the checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new rule in the Portuguese language module to discourage the use of the colloquial expression "vale de pouco," suggesting more formal alternatives.
	- Provided examples of incorrect usage to enhance clarity and promote formal writing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->