### PR TITLE
[pt-PT] Removed "temp_off" from subrule in ID:INFORMALITIES

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -1863,7 +1863,7 @@ USA
         <short>Coloquialismo</short>
         <example correction=''><marker>à coisa de</marker></example>
     </rule>
-   <rule default='temp_off'>
+   <rule>
         <pattern>
             <token inflected='yes'>valer</token>
             <token>de</token>


### PR DESCRIPTION
Just removed the “temp_off” from a pt-PT rule that has no hits in the nightly diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled a previously inactive rule for checking the usage of the phrase "valer de" in Portuguese text.
  
- **Bug Fixes**
	- Improved text analysis by ensuring that the relevant rule is now applied during language processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->