### PR TITLE
[de] add gGEC AP AI_DE_GGEC_UNNECESSARY_SPACE

### DIFF
--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/remote-rule-filters.xml
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/rules/de/remote-rule-filters.xml
@@ -2145,6 +2145,20 @@ To ignore a remote rule match, set the <marker> so that it exactly covers the te
             </rule>
         </rulegroup>
 
+        <rulegroup name="" id="AI_DE_GGEC_UNNECESSARY_SPACE.*"><!--gGEC wants to remove space after listing character-->
+            <rule>
+                <pattern>
+                    <marker>
+                        <token regexp="yes">-|\*|\+</token>
+                    </marker>
+                    <token spacebefore="yes" regexp="yes">.+</token>
+                </pattern>
+                <example correction=""><marker>- </marker>Aufzählung</example>
+                <example correction=""><marker>+ </marker>Aufzählung</example>
+                <example correction=""><marker>* </marker>Aufzählung</example>
+            </rule>
+        </rulegroup>
+
         <rulegroup name="" id="AI_DE_GGEC_UNNECESSARY_DETERMINER">
             <rule>
                 <pattern>


### PR DESCRIPTION
https://quillbot.slack.com/archives/C07NBB5JWKZ/p1727171343171819

@danielnaber ich bin mir nicht sicher, ob das AP so funktioniert, da ich ja kein `spaceafter="yes"` einfügen kann. Eine Idee? 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new rule for the German language module to correct unnecessary spaces after listing characters like `-`, `*`, or `+`.
  
- **Bug Fixes**
	- Improved formatting of enumerations by addressing spacing issues related to specific listing characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->