### PR TITLE
[pt] disambiguation.xml, improved rule ID:RARE_POS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -227,7 +227,7 @@
   <rulegroup id="RARE_POS" name="rare POS tags">
     <rule>
       <pattern>
-        <token postag="Z0[FM]P0" postag_regexp="yes"/>
+        <token postag="Z0.[PN].+" postag_regexp="yes"/>
         <marker>
           <and>
             <token postag="VMIP2S0|VMN02S0|VMSF2S0" postag_regexp="yes"/>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -240,10 +240,13 @@
     <rule>
       <pattern>
         <token postag="V.+" postag_regexp="yes"/>
-        <token min='1' max='2' postag="[DP].+" postag_regexp="yes"/>
-        <token postag="Z0[FM]P0" postag_regexp="yes"/>
+        <token min='1' max='2' postag="SPS00|(SPS00:)?[DP].+|RG|CS|VMG0000|VMN0000" postag_regexp="yes"/>
+        <token postag="Z0.[PN].+" postag_regexp="yes"/>
         <marker>
-          <token regexp="yes">como|logo</token>
+          <and>
+            <token postag="VMIP1S0" postag_regexp="no"/>
+            <token postag="RG" postag_regexp="no"/>
+          </and>
         </marker>
       </pattern>
       <disambig action="remove" postag="[NV].*"/>


### PR DESCRIPTION
Heya, @jaumeortola , @susanaboatto and @p-goulart ,

I have enhanced the disambiguation rule, which I created weeks ago.

Back then I added two rules, right now, I am only improving one, to do it slowly.

I created a dummy rule just to check the results.
```
<rulegroup id='MARCOAGPINTO_DIS_DUAS_VERB' name="Disambiguator: Duas + verb">
    <rule>
      <pattern>
        <token postag="Z0.[PN].+" postag_regexp="yes"/>
        <marker>
          <and>
            <token postag="VMIP2S0|VMN02S0|VMSF2S0" postag_regexp="yes"/>
            <token postag="NC.+" postag_regexp="yes"/>
          </and>
        </marker>
      </pattern>
        <message>Regra a testar o Disambiguator.</message>
        <short>Testar o Disambiguator.</short>
        <example correction=''>duas <marker>comes</marker></example>
    </rule>
</rulegroup>

```


RULE BEFORE:
```
Portuguese (Portugal): 902 total matches
Portuguese (Portugal): 854003 total sentences considered
```
[0.txt](https://github.com/user-attachments/files/17173871/0.txt)


RULE AFTER (NOW):
```
Portuguese (Portugal): 3099 total matches
Portuguese (Portugal): 854003 total sentences considered
```
[1.txt](https://github.com/user-attachments/files/17173873/1.txt)

The hits are so many that I couldn't check one by one, so I gave a quick look in the results and they looked valid.

Thanks!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced token matching for the Portuguese language module, improving accuracy in grammar and style checks.

- **Bug Fixes**
	- Adjusted regex pattern for better flexibility in identifying part-of-speech tags, allowing for a broader range of matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->