### PR TITLE
[pt] Fixed and removed "temp_off" from rule ID:PARA_NADA_DESNECESSARIAMENTE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -3179,7 +3179,7 @@ USA
         </rule>
 
 
-        <rule id='PARA_NADA_DESNECESSARIAMENTE' name="Para nada → desnecessariamente" tone_tags='formal'>
+        <rule id='PARA_NADA_DESNECESSARIAMENTE' name="[pt-PT][Formal] Para nada → desnecessariamente" tone_tags='formal'>
             <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
             <antipattern>
                 <token>não</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -3179,6 +3179,31 @@ USA
         </rule>
 
 
+        <rule id='PARA_NADA_DESNECESSARIAMENTE' name="Para nada → desnecessariamente" tone_tags='formal'>
+            <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
+            <antipattern>
+                <token>não</token>
+                <token regexp='yes' inflected='yes'>conceder|concluir|determinar|esperar|finalizar|obter</token> <!-- Exceptions for below -->
+                <token min='0' max='1' postag='V.+' postag_regexp='yes'/>
+                <token min='0' regexp='yes'>[ao]s?|u(m|ns)|umas?|nu(m|ns)|numas?</token>
+                <token postag='N.[MF].+' postag_regexp='yes'/>
+                <example>Quando você vai para o treinamento de futebol, não espera conseguir nomeações presidenciais para nada.</example>
+            </antipattern>
+            <pattern>
+                <token regexp='yes' inflected='yes'>adjudicar|administrar|afligir|aguardar|ajudar|analisar|antecipar|aplicar|arranjar|assentar|assistir|assumir|atuar|atribuir|auxiliar|avaliar|causar|coagir|comandar|completar|complicar|conceder|concluir|conduzir|conseguir|conservar|considerar|consumir|coordenar|criar|decidir|delegar|desenvolver|desenhar|desencadear|despender|desperdiçar|determinar|dirigir|dispor|dissipar|efec?tuar|elaborar|embaralhar|embaraçar|empregar|encarregar|entregar|entravar|esbanjar|esculpir|esperar|estimular|estruturar|exercer|executar|explicar|ficar|finalizar|forçar|formular|funcionar|gerar|gerenciar|gerir|governar|guiar|incentivar|induzir|iniciar|insistir|justificar|lidar|liderar|manipular|manusear|misturar|modelar|moldar|motivar|obrigar|obter|operar|optar|organizar|originar|permanecer|performar|persuadir|planear|planejar|praticar|preservar|preparar|prever|produzir|programar|projec?tar|provocar|realizar|reafirmar|resolver|reiterar|solucionar|suportar|suscitar|teimar|terminar|tratar|utilizar|usar</token>
+                <token min='0' regexp='yes'>[ao]s?|u(m|ns)|umas?|nu(m|ns)|numas?</token>
+                <token skip='4' postag='N.[MF].+' postag_regexp='yes'/>
+                <marker>
+                    <token>para</token>
+                    <token>nada</token>
+                </marker>
+            </pattern>
+            <message>Num contexto formal empregue <suggestion>desnecessariamente</suggestion>.</message>
+            <example correction="desnecessariamente">A Ana utiliza equações complicadas <marker>para nada</marker>.</example>
+            <example correction="desnecessariamente">O Pedro cria os mapas com demasiadas cores <marker>para nada</marker>.</example>
+        </rule>
+
+
         <rulegroup id='PASSAR_TEMPO_DECORRER_TEMPO' name="[pt-PT][Formal] 'passar' tempo → decorrer">
 
             <antipattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3617,10 +3617,18 @@ USA
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
 
-        <rule id='PARA_NADA_DESNECESSARIAMENTE' name="Para nada → desnecessariamente" tone_tags='formal' default='temp_off'>
+        <rule id='PARA_NADA_DESNECESSARIAMENTE' name="Para nada → desnecessariamente" tone_tags='formal'>
             <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
+            <antipattern>
+                <token>não</token>
+                <token regexp='yes' inflected='yes'>conceder|concluir|determinar|esperar|finalizar|obter</token> <!-- Exceptions for below -->
+                <token min='0' max='1' postag='V.+' postag_regexp='yes'/>
+                <token min='0' regexp='yes'>[ao]s?|u(m|ns)|umas?|nu(m|ns)|numas?</token>
+                <token postag='N.[MF].+' postag_regexp='yes'/>
+                <example>Quando você vai para o treinamento de futebol, não espera conseguir nomeações presidenciais para nada.</example>
+            </antipattern>
             <pattern>
-                <token regexp='yes' inflected='yes'>adjudicar|administrar|afligir|aguardar|ajudar|analisar|antecipar|aplicar|arranjar|assentar|assistir|assumir|atuar|atribuir|auxiliar|avaliar|causar|coagir|comandar|completar|complicar|conceder|concluir|conduzir|conseguir|conservar|considerar|consumir|coordenar|criar|decidir|delegar|desenvolver|desenhar|desencadear|despender|desperdiçar|determinar|dirigir|dispor|dissipar|efec?tuar|elaborar|embaralhar|embaraçar|empregar|encarregar|entregar|entravar|esbanjar|esculpir|esperar|estimular|estruturar|exercer|executar|explicar|ficar|finalizar|forçar|formular|funcionar|gerar|gerenciar|gerir|governar|guiar|incentivar|induzir|iniciar|insistir|justificar|lidar|liderar|manipular|manusear|misturar|modelar|moldar|motivar|obrigar|obter|operar|optar|organizar|originar|permanecer|performar|persuadir|planear|planejar|praticar|preservar|preparar|prever|produzir|programar|projec?tar|provocar|realizar|reafirmar|resolver|reiterar|solucionar|suportar|suscitar|teimar|terminar|tratar|utilizar|usar</token> 
+                <token regexp='yes' inflected='yes'>adjudicar|administrar|afligir|aguardar|ajudar|analisar|antecipar|aplicar|arranjar|assentar|assistir|assumir|atuar|atribuir|auxiliar|avaliar|causar|coagir|comandar|completar|complicar|conceder|concluir|conduzir|conseguir|conservar|considerar|consumir|coordenar|criar|decidir|delegar|desenvolver|desenhar|desencadear|despender|desperdiçar|determinar|dirigir|dispor|dissipar|efec?tuar|elaborar|embaralhar|embaraçar|empregar|encarregar|entregar|entravar|esbanjar|esculpir|esperar|estimular|estruturar|exercer|executar|explicar|ficar|finalizar|forçar|formular|funcionar|gerar|gerenciar|gerir|governar|guiar|incentivar|induzir|iniciar|insistir|justificar|lidar|liderar|manipular|manusear|misturar|modelar|moldar|motivar|obrigar|obter|operar|optar|organizar|originar|permanecer|performar|persuadir|planear|planejar|praticar|preservar|preparar|prever|produzir|programar|projec?tar|provocar|realizar|reafirmar|resolver|reiterar|solucionar|suportar|suscitar|teimar|terminar|tratar|utilizar|usar</token>
                 <token min='0' regexp='yes'>[ao]s?|u(m|ns)|umas?|nu(m|ns)|numas?</token>
                 <token skip='4' postag='N.[MF].+' postag_regexp='yes'/>
                 <marker>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3617,31 +3617,6 @@ USA
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
 
-        <rule id='PARA_NADA_DESNECESSARIAMENTE' name="Para nada → desnecessariamente" tone_tags='formal'>
-            <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
-            <antipattern>
-                <token>não</token>
-                <token regexp='yes' inflected='yes'>conceder|concluir|determinar|esperar|finalizar|obter</token> <!-- Exceptions for below -->
-                <token min='0' max='1' postag='V.+' postag_regexp='yes'/>
-                <token min='0' regexp='yes'>[ao]s?|u(m|ns)|umas?|nu(m|ns)|numas?</token>
-                <token postag='N.[MF].+' postag_regexp='yes'/>
-                <example>Quando você vai para o treinamento de futebol, não espera conseguir nomeações presidenciais para nada.</example>
-            </antipattern>
-            <pattern>
-                <token regexp='yes' inflected='yes'>adjudicar|administrar|afligir|aguardar|ajudar|analisar|antecipar|aplicar|arranjar|assentar|assistir|assumir|atuar|atribuir|auxiliar|avaliar|causar|coagir|comandar|completar|complicar|conceder|concluir|conduzir|conseguir|conservar|considerar|consumir|coordenar|criar|decidir|delegar|desenvolver|desenhar|desencadear|despender|desperdiçar|determinar|dirigir|dispor|dissipar|efec?tuar|elaborar|embaralhar|embaraçar|empregar|encarregar|entregar|entravar|esbanjar|esculpir|esperar|estimular|estruturar|exercer|executar|explicar|ficar|finalizar|forçar|formular|funcionar|gerar|gerenciar|gerir|governar|guiar|incentivar|induzir|iniciar|insistir|justificar|lidar|liderar|manipular|manusear|misturar|modelar|moldar|motivar|obrigar|obter|operar|optar|organizar|originar|permanecer|performar|persuadir|planear|planejar|praticar|preservar|preparar|prever|produzir|programar|projec?tar|provocar|realizar|reafirmar|resolver|reiterar|solucionar|suportar|suscitar|teimar|terminar|tratar|utilizar|usar</token>
-                <token min='0' regexp='yes'>[ao]s?|u(m|ns)|umas?|nu(m|ns)|numas?</token>
-                <token skip='4' postag='N.[MF].+' postag_regexp='yes'/>
-                <marker>
-                    <token>para</token>
-                    <token>nada</token>
-                </marker>
-            </pattern>
-            <message>Num contexto formal empregue <suggestion>desnecessariamente</suggestion>.</message>
-            <example correction="desnecessariamente">A Ana utiliza equações complicadas <marker>para nada</marker>.</example>
-            <example correction="desnecessariamente">O Pedro cria os mapas com demasiadas cores <marker>para nada</marker>.</example>
-        </rule>
-
-
         <rule id='AGORA_ATUAL' name="Agora → Atual" tone_tags='formal'>
             <pattern>
                 <token inflected='yes'>ter</token>


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

Susana, the rule only gave one hit, and it was a false positive, and I have just fixed it:
![Screenshot 2024-10-02 at 06-35-05 ChatGPT](https://github.com/user-attachments/assets/cdc6dee6-dc03-4707-8969-6d4e4ff17ef7)

RESULTS URL: https://internal1.languagetool.org/regression-tests/via-http/2024-10-01/pt-BR/result_style_PARA_NADA_DESNECESSARIAMENTE%5B1%5D.html

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced language rule for improved accuracy in identifying incorrect usages of "não" followed by specific verbs and nouns.
  
- **Bug Fixes**
	- Removed the temporary deactivation of the rule, ensuring it is always active for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->