### PR TITLE
[pt] Removed "temp_off" from rule ID:DEMASIADO_INVARIAVEL

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -1060,7 +1060,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='DEMASIADO_INVARIAVEL' name="Demasiada → demasiado" default='temp_off'>
+        <rule id='DEMASIADO_INVARIAVEL' name="Demasiada → demasiado">
             <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
             <pattern>
                 <token regexp='yes' inflected='yes'>andar|continuar|estar|ficar|manter|parecer|revelar|ser|soar|tornar</token>


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

This one seems to work perfectly:
https://internal1.languagetool.org/regression-tests/via-http/2024-10-01/pt-BR/result_grammar_DEMASIADO_INVARIAVEL%5B1%5D.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The grammar rule "Demasiada → demasiado" is now enabled by default in the Portuguese language module, enhancing language correction capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->