### PR TITLE
[pt-PT] Removed "temp_off" from rule ID:VERBO_PRONOMINAL_DE_V3

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -5157,7 +5157,7 @@ USA
     </rulegroup>
 
 
-    <rule id='VERBO_PRONOMINAL_DE_V3' name="[pt-PT][Simplificar] 'V. Pronominal + de' → V. Pronominal" type="style" tone_tags="formal" default='temp_off'>
+    <rule id='VERBO_PRONOMINAL_DE_V3' name="[pt-PT][Simplificar] 'V. Pronominal + de' → V. Pronominal" type="style" tone_tags="formal">
         <!-- IDEA shorten_it -->
         <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
         <pattern>


### PR DESCRIPTION
Heya,

I have just removed the "temp_off" after removing false positives a couple of days ago or so:
https://internal1.languagetool.org/regression-tests/via-http/2024-10-01/pt-PT/result_style_VERBO_PRONOMINAL_DE_V3%5B1%5D.html

Total results:
https://internal1.languagetool.org/regression-tests/via-http/2024-10-01/pt-PT_full/result_style_VERBO_PRONOMINAL_DE_V3%5B1%5D.html

This rule is a lot better than the previous one we had.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new language rules to enhance grammatical correctness and stylistic quality in Portuguese.
	- Added rules to simplify common redundancies and promote formal language usage.
	- Implemented rules to avoid informal expressions and encourage concise alternatives.

- **Improvements**
	- Enhanced existing rules for better detection of specific linguistic structures.
	- Reorganized rule groups for improved clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->