### PR TITLE
[pt-PT] Removed temp_off from subrule in rule ID:INFORMALITIES

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -1876,7 +1876,7 @@ USA
         <example correction='tem pouco valor|tem pouca importância'>O que ele disse <marker>vale de pouco</marker>.</example>
         <example correction='tem pouco valor|tem pouca importância'>Essa opinião <marker>vale de pouco</marker> no contexto atual.</example>
     </rule>
-    <rule default='temp_off'>
+    <rule>
         <pattern>
             <token inflected='yes'>dar</token>
             <token>uma</token>


### PR DESCRIPTION
Just removed “temp_off”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced several new style rules for Portuguese, enhancing clarity and formality.
		- New rules include discouraging gerund usage and recommending more formal expressions.
- **Rule Modifications**
	- Updated existing rules for improved clarity and specificity, ensuring better language guidance.
- **Bug Fixes**
	- Temporarily deactivated certain rules for ongoing evaluation of their effectiveness.
- **Suggestions**
	- Added antipatterns to prevent common stylistic errors, promoting a more formal tone in writing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->