### PR TITLE
[pt-PT] Replaced rule ID:VERBO_PARA_PRONOME_PESSOAL with rule ID:VERBO_PARA_PRONOME_PESSOAL_V2

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -4831,304 +4831,89 @@ USA
     </rulegroup>
 
 
-<rulegroup id='VERBO_PARA_PRONOME_PESSOAL' name="[pt-PT][Simplificar] Verbo + para + pronome pessoal → Verbo + -me/te/lhe/nos/vos/lhes" type="style" tone_tags="formal">
-<!-- IDEA shorten_it -->
-<!-- Created by Marco A.G.Pinto, Portuguese rule 2023-01-17 (Checked/Enhanced) (25-JUL-2022+) -->
-<!--
-    Telefonei para si. → Telefonei-lhe.
+<rulegroup id='VERBO_PARA_PRONOME_PESSOAL_V2' name="[pt-PT][Simplificar] Verbo + para + pronome pessoal → Verbo + -me/te/lhe/nos/vos/lhes" type="style" tone_tags="formal" default="temp_off">
+        <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
 
-    Notes from Marco A.G.Pinto:
-    This rule was very hard to code, and some antipatterns have hardcoded verbs/words since the rule produced tons of unfixable false positives.
-    <token regexp='yes'>mim|ti|si|vocês?|nós|vós|el[ae]s?</token>
-
-    On 2023-01-17 I came up with a better approach for a future rule rewriting: place in the patterns to only accept the valid verbs,
-    this way it will remove tons of antipatterns, placing the valid verbs in an entity to be easily improved and used.
-    Or create an antipattern for all V.+ and use exception_negate_validverbs to avoid using an entity.
--->
-    <!--
-        MARCOAGPINTO inserted global antipatterns for all subrules on top using the logic (25-JUL-2022+)
-    -->
-
-    <!-- Quick fix: 2024-08-28: When rewriting the rule, remember to add "V......:.+" as an exception, or use these two APs for all subrules-->
-    <antipattern>
-        <token postag='V......:.+|VMP00P.+' postag_regexp='yes'/>
-        <token>para</token>
-        <token postag='PP.+' postag_regexp='yes'/>
-        <example>Os mais especiais estão sempre guardados para mim.</example>
-        <example>Ela virou-se para ele e sorriu.</example>
-        <example>Segure-o para mim.</example>
-        <example>Tom não pode dá-lo para você agora.</example>
-        <example>Vou pegá-lo para você.</example>
-        <example>Você pode explicá-lo para mim?</example>
-    </antipattern>
-    <antipattern>
-        <token postag='V.+' postag_regexp='yes'/>
-        <token>para</token>
-        <token postag='PP.+' postag_regexp='yes'/>
-        <token postag='VMN0000' postag_regexp='no'/>
-        <example>O médico dele disse para ele descansar.</example>
-        <example>Eu implorei para ele parar.</example>
-        <example>Deve ser por isso que pediu para ela morar com você.</example>
-        <example>Ela está de pé firme. Eu geralmente pode conduzi-la onde quiser para ela ir, mas não desta vez.</example>
-        <example>Quantas vezes preciso dizer para você acreditar?</example>
-        <example>Tom fez exatamente tudo que pedimos para ele fazer.</example>
-    </antipattern>
-
-    <!-- Quick fix - 2023-04-05 -->
-    <antipattern>
-        <token postag='VMIM3.+' postag_regexp='yes'/>
-        <token>para</token>
-        <token regexp='yes'>mim|ti|si|vocês?|nós|vós|el[ae]s?</token>
-        <token postag='SPS00|CC' postag_regexp='yes'>
-            <exception>para</exception> <!-- SPS00 -->
-        </token>
-        <token postag='NC.+|AQ.+|NP.+' postag_regexp='yes'/>
-        <example>Dois, avançaram para mim com cara de poucos amigos.</example>
-    </antipattern>
-
-    <antipattern>
-        <token postag='DD.+|SPS00:DD.+|VMN0000|P[DI].+|SPS00:P[DI].+|PP3CN000|AO.+|VMIC.+|VMII.+|VMIM.+|VMIP.+|VMIS.+|VMM0.+|VMP00.+|VMSP.+|I|RN|RG|NC.+|AQ.+|NP.+|SPS00' postag_regexp='yes'>
-            <exception regexp='yes'>já|mais|sempre</exception>
-        </token>
-        <token postag='VMIP.+|VMIS.+|VMM0.+|VMP00.+|VMSI.+|VMSP.+|DI.+|SPS00:DI.+|PI.+|SPS00:PI.+|RG|NC.+|AQ.+|RN|VMG0000|NP.+' postag_regexp='yes'>
-            <!-- Hardcoded: line below, verb forms to remove false positives, not the greatest way of doing it. -->
-            <exception regexp='yes'>acenando|contei|contou|escreva|escreve|escrevemos|escrevendo|escreveram|escreveu|escrevi|falar|meneou|mentem|menti|mentido|mentimos|mentindo|mentiu|ofereceu|olhes|pedimos|pergunta|piscando|rosnou|sorriu|telefonando|telefonou|trago|trouxe|trouxemos|valia</exception>
-        </token>
-        <token>para</token>
-        <token regexp='yes'>mim|ti|si|vocês?|nós|el[ae]s?
-        <exception scope="next" regexp='yes'>sobre</exception>
-        <exception scope="next" postag_regexp='yes' postag='RG|DI.+|SPS00:DI.+'/>
-    </token>
-    <example>Traga aquele livro para mim.</example>
-    <example>Isso não faz muito sentido para mim.</example>
-    <example>Isso é para ti, minha deusa.</example>
-    <example>Tom, tenho uma surpresa para ti.</example>
-    <example>Em questão de poucos minutos, um terrível acidente modifica todo o rumo da vida que ela havia planejado para si mesma.</example>
-    <example>Aquilo que não deseja para si, não o faça às outras pessoas.</example>
-    <example>Está tudo acabado para ela.</example>
-    <example>Ele enviou flores para ela, junto com um belo cartão.</example>
-    <example>A cadeira é demasiado baixa para ele.</example>
-    <example>Eles estão olhando para nós?</example>
-    <example>Ver um fusca de vidro blindado foi uma surpresa para nós.</example>
-    <example>Esta receita foi testada para vocês por uma das melhores equipes de gourmets da Romênia.</example>
-    <example>Por isso esse post foi feito para você!</example>
-</antipattern>
-
-<antipattern>
-    <token postag='DA.+|DP.+|DI.+|PP.+|SPS00|SPS00:DA.+|SPS00:DP.+|SPS00:DI.+|SPS00:PP.+|_PUNCT|CS' postag_regexp='yes'/>
-    <token min="1" max="3" postag='NC.+|AQ.+|NP.+|PP.+|CS|RN' postag_regexp='yes'/>
-    <token postag='V.+' postag_regexp='yes'>
-        <!-- Hardcoded: line below, verb forms to remove false positives, not the greatest way of doing it. -->
-        <exception regexp='yes'>comprei|digo|emprestou|escreve|escreveram|escrever|escreveu|escrevi|escrevia|fez|fizeram|mente|menti|mentirei|mentiria|mentiu|minta|telefonou|ofereceu|trouxe</exception>
-    </token>
-    <token>para</token>
-    <token regexp='yes'>mim|ti|si|vocês?|nós|vós|el[ae]s?</token>
-    <token postag='_PUNCT|CC' postag_regexp='yes'/>
-    <example>O cartão Auchan fica para mim?</example>
-    <example>O Tom não gosta do jeito que a Mary olha para ele.</example>
-    <example>O Tomás olha para mim.</example>
-    <example>O Tomás olha para ele.</example>
-    <example>O Tomás olha para nós.</example>
-    <example>O Tomás olha para vós.</example>
-    <example>O próximo é para você.</example>
-    <example>Tom pediu para que a Mary trabalhasse para ele.</example>
-    <example>Um única lei e um só direito haja para vós e para o estrangeiro que habite convosco.</example>
-    <example>A Sra. Harshwhinny diz que a coisa mais importante é mostrar o que a cidade significa para eles e então ela deixa a sala.</example>
-    <example>Um única lei e um só direito haja para vós e para o estrangeiro que habite convosco.</example>
-    <example>Que trecho você quer que eu leia para você?</example>
-    <example>"Preciso que você abasteça para mim." "Claro, me dá o carro."</example>
-    <example>– Ao receber esse cumprimento era óbvio que nós dois nos ajoelharíamos para ela, porém rapidamente fomos ordenados para levantar-nos.</example>
-    <example>Se você tivesse uma bola de cristal o que perguntaria para ela?</example>
-    <example>Espero que Tom goste do bolo que fiz para ele.</example>
-    <example>Se Jesus Cristo estivesse na sua frente, o que você diria para ele?</example>
-    <example>A Mary não quer comer nada que eu cozinhe para ela.</example>
-    <example>O que você gostaria que eu fizesse para eles?</example>
-</antipattern>
-
-<antipattern>
-    <token postag='VMN0000|VMG0000' postag_regexp='yes'/>
-    <token postag='V.+' postag_regexp='yes'>
-        <!-- Hardcoded: line below, verb forms to remove false positives, not the greatest way of doing it. -->
-        <exception regexp='yes'>mentido|telefonar</exception>
-    </token>
-    <token>para</token>
-    <token regexp='yes'>mim|vocês?|el[ae]s?</token>
-    <example>Se de fato descendo será para mim uma alegria inenarrável.</example>
-    <example>Você pode tomar notas para mim enquanto o professor fala?</example>
-    <example>Queria poder ter falado para ela o que sinto.</example>
-    <example>Eu queria ter dito para ela o que aconteceu.</example>
-</antipattern>
-
-<antipattern>
-    <token postag='DA.+|DP.+|DI.+|PP.+|SPS00:DA.+|SPS00:DP.+|SPS00:DI.+|SPS00:PP.+' postag_regexp='yes'>
-        <exception scope="previous" postag_regexp='yes' postag='RG|VMM03.+|VMSP3.+'/>
-    </token>
-    <token min="1" max="3" postag='NC.+|AQ.+|NP.+' postag_regexp='yes'/>
-    <token postag='SPS00|PP3CN000|CC|CS|RG|I|RM|RN' postag_regexp='yes'/>
-    <token postag='V.+' postag_regexp='yes'>
-        <!-- Hardcoded: line below, verb forms to remove false positives, not the greatest way of doing it. -->
-        <exception regexp='yes'>comprei|contar|dei</exception>
-    </token>
-    <token>para</token>
-    <token regexp='yes'>mim|vocês?|nós|el[ae]s?</token>
-    <token postag='_PUNCT|CC' postag_regexp='yes'/>
-    <example>Eu ainda amo a sua maneira de sorrir para mim.</example>
-    <example>Parece que as portas do céu se abriram para mim.</example>
-    <example>A pergunta era impossível de responder para nós.</example>
-    <example>...Gogh foi acusado de se forçar para cima dela, com o padre do vilarejo proibindo seus paroquianos de posarem para ele.</example>
-    <example>Tom está pagando uma rodada de bebidas para nós.</example>
-</antipattern>
-
-<antipattern>
-    <token postag='RG|NC.+|AQ.+|NP.+' postag_regexp='yes'>
-        <exception regexp='no'>são</exception>
-        <!-- Hardcoded: line below, verb forms to remove false positives, not the greatest way of doing it. -->
-        <exception regexp='no'>mostra</exception>
-    </token>
-    <token>para</token>
-    <token regexp='yes'>mim|ti|si|vocês?|nós|el[ae]s?
-    <exception scope='next' regexp='yes'>[ao]s?|alguns|enquanto|hoje|uma?</exception>
-</token>
-<example>Eu digo isso sobre Joaçaba que com certeza vão liberar o sinal digital antes para ela do que para Videira (50.000)e Caçador (80.000).Obrigado!</example>
-<example>Nós temos o direito de exigir um futuro seguro para nós e para as gerações futuras.</example>
-<example>Parabéns adorei este site mto rico e de grande valia para nós que participamos de Pastorais .</example>
-<example>Ah e a todos os que visitam este blog.... Sim também são para ti que estás a ler neste momento!</example>
-<example>Só os vejo quando vendo uma tela e compro presentes para eles e vou visitá-los.</example>
-<example>Telefone para você.</example>
-<example>Por isso, estamos disponíveis para o ajudar a descobrir qual o produto perfeito para si e para a sua familia.</example>
-<example>Independente de qual seja a sua plataforma o nosso sistema é completamente simplificado e preparado para você que não tem conhecimento em código ou programação consiga instalar a SmartHint sem dificuldade.</example>
-<example>É estranho para você que até eu seja um homem?</example>
-<example>Lidar com essa dinâmica faz sentido para você e o que você busca profissionalmente, por exemplo?</example>
-<example>Recomendado para você: Muçulmanos podem celebrar festas não-religiosas?</example>
-<example>...Brasil mudou e o governo em que eu também acreditei naufragou., não são pessoas confiáveis, desejam poder para si e seu grupo.</example>
-<example>Moldado para mim, pra me fazer mulher?</example>
-<example>...envolvido sob medida, com as análises necessárias para desenvolver um projeto muito bem planejado e qualificado para você e sua família.</example>
-<example>É estranho para você que até eu seja um homem?</example>
-<example>O dinheiro está curto para mim este mês.</example>
-<example>Há espaço para mim no seu carro?</example>
-<example>São para mim?</example>
-<example>Me dê a mão. Se você o fizer, eu vou comprar uma bebida para você mais tarde.</example>
-            </antipattern>
-
-            <!-- Special verbs at start of sentence: são, etc. -->
-            <antipattern>
-                <token postag='SENT_START|_PUNCT' postag_regexp='yes'/>
-                <token min="0" max="2" postag='RN|NP.+|NC.+|AQ.+|PP.+|DA.+|RG|CS' postag_regexp='yes'/>
-                <and>
-                    <token postag='VMIF.+|VMII.+|VMIM.+|VMIP.+|VMIS.+|VMM0.+|VMN0000|VMP00.+|VMSP.+' postag_regexp='yes'/>
-                    <token regexp='yes' inflected='yes'>abastecer|apresentar|arrumar|cantar|correr|cozinhar|cuidar|dar|descrever|dizer|escolher|fazer|fossar|funcionar|ir|jogar|ligar|listar|olhar|pedir|perfumar|piscar|pôr|ser|significar|sofrer|sorrir|ter|trabalhar|voltar</token>
-                </and>
-                <token>para</token>
-                <token regexp='yes'>mim|ti|si|vocês?|nós|vós|el[ae]s?</token>
-                <token>
-                    <exception postag_regexp='yes' postag='DI.+'/>
-                </token>
-                <example>São para mim?</example>
-                <example>Foi para mim, uma experiência muito legal.</example>
-                <example>Deixa para mim.</example>
-                <example>Por favor, olhe para mim.</example>
-                <example>Ai, meu Deus! Tom olhou para mim!</example>
-                <example>Mas é para ti que hoje escrevo, meu príncipe.</example>
-                <example>Quem faz o mal, faz para si mesmo.</example>
-                <example>Ela sorriu para si mesma no espelho.</example>
-                <example>Eu trabalho para você.</example>
-                <example>Dá para você me dizer que dia é hoje?</example>
-                <example>Ele olhou para eles com um sorriso, que logo se converteu numa risada.</example>
-                <example>Ele piscou para ela.</example>
-            </antipattern>
-
-            <!-- Other verbs at start of sentence - WITHOUT WORD AFTER _PUNCT -->
-            <antipattern>
-                <token postag='SENT_START|_PUNCT' postag_regexp='yes'/>
-                <token postag='VMM03S0|VMSP[13]S.+' postag_regexp='yes'>
-                    <!-- Hardcoded: line below, verb forms to remove false positives, not the greatest way of doing it. -->
-                    <exception regexp='yes'>conte|diga|escreve|dá|mande|telefone</exception>
-                </token>
-                <token>para</token>
-                <token regexp='yes'>mim|nós|el[ae]s?</token>
-                <token>
-                    <exception postag_regexp='yes' postag='SPS00|DA.+|PP3CN000|DD.+|_PUNCT|CC'/>
-                    <exception regexp='yes'>d[ao]s?|de|depois|por|um|uns|umas?</exception> <!-- It doesn't work using the postags, or the postags get too many wrong words -->
-                </token>
-                <example>Olhe para mim quando eu falar com você!</example>
-                <example>Olhe para mim quando eu falo com você, seu covarde!</example>
-                <example>Depois de ter encontrado seu número de telefone, ele ligou para ela.</example>
-                <example>Pedi para ele parar, ele continuou.</example>
-                <example>Sim, ligo para você às nove. Você vai estar?</example>
-            </antipattern>
-
-            <antipattern>
-                <token postag='VMIS3.+|VMIP.+|VMN03.+|VMN0000|VMG0000|VMIM3.+|NC.+|AQ.+|NP.+|RG' postag_regexp='yes'/>
-                <token min="1" max="2" postag='CS|SPS00|CC|I|RM|RN|DA.+|PD.+|PP.+' postag_regexp='yes'> <!-- RG removed "sempre" -->
-                    <exception postag_regexp='yes' postag='V.+'/>
-                </token>
-                <token postag='VMIP.+|VMN03.+|VMN0000|VMG0000|VMIM.+|VMIS3.+' postag_regexp='yes'>
-                    <!-- Hardcoded: line below, verb forms to remove false positives, not the greatest way of doing it. -->
-                    <exception regexp='yes'>comprar|compra|compro|comprou|contar|conta|conto|contou|dar|dá|dou|deu|dizer|diz|digo|disse|emprestar|empresta|empresto|emprestou|escrever|escreve|escrevo|escreveu|falar|fala|falo|falou|fotografar|fotografa|fotografo|fotografou|mentir|mente|mentimos|minto|mentiu</exception>
-                </token>
-                <token>para</token>
-                <token regexp='yes'>mim|vocês?|nós|vós|el[ae]s?</token>
-                <token postag='_PUNCT|CC' postag_regexp='yes'/>
-                <example>Você acha que trabalha para mim?</example>
-                <example>Vocês acham que trabalham para mim?</example>
-                <example>...Porque é que não posso ficar sempre com eles, das nossas viagens, só penso neles, a sorrirem e a olharem para mim.</example>
-                <example>Bem...Agora estou a tentar ver o que resulta para mim.</example>
-            </antipattern>
-
-            <!-- Start of sentence with a token, followed by two verbs -->
-            <antipattern>
-                <token postag='SENT_START|_PUNCT' postag_regexp='yes'/>
-                <token min="0" max="3" postag='PP.+|SPS00:PP.+|RG|RM|RN|NC.+|AQ.+|NP.+|DP.+|_QUOT|PI.+|CC|CS|DI.+' postag_regexp='yes'/>
-                <token postag='VMII.+|VMIP.+|VMIS.+|VMSP.+' postag_regexp='yes'/>
-                <token min="0" max="2" postag='SPS00|DA.+|CS|RN|RG' postag_regexp='yes'/> <!-- "de", "o", "mais", "que" and "não" -->
-                <token postag='VMN0000|VMG0000' postag_regexp='yes'>
-                    <!-- Hardcoded: line below, verb forms to remove false positives, not the greatest way of doing it. -->
-                    <exception regexp='yes'>apresentar|apresentando|contar|contando|dando|esclarecer|esclarecendo|escrever|escrevendo|explicar|explicando|falar|falando|mentir|mentindo|mostrar|mostrando|perguntar|perguntando|sugerir|sugerindo|telefonar|telefonando|transferir|transferindo</exception>
-                </token>
-                <token>para</token>
-                <token regexp='yes'>mim|ti|si|vocês?|nós|vós|el[ae]s?
-                <exception scope="next" postag_regexp='yes' postag='PI.+'/> <!-- "alguém", "Vou fazer para ele alguém que o ajude" - 2023-01-17 -->
-            </token>
-            <example>Ela ligou para ele assim que chegou em casa.</example>
-            <example>Vou ligar para você amanhã pela manhã.</example>
-            <example>Vou arranjar para mim tanto quanto puder.</example>
-            <example>Vou repetir para você não esquecer isso.</example>
-            <example>Meu pai costumava ler para mim antes de eu dormir.</example>
-            <example>Tom decidiu arranjar para ele uma vida melhor.</example>
-            <example>"Devo dizer para ele te ligar quando chegar?" "Sim, por favor"</example>
-            <example>Eu não quero mais trabalhar para você.</example>
-            <example>Ninguém pode exigir para si o respeito que não dedicam aos outros… Só acho.</example>
-            <example>Se você não quiser colocar protetor solar, isso é problema seu. Só não venha reclamar para mim quando você ficar com uma queimadura por causa do sol.</example>
-            <example>Aconselhamos a aprender a fundo as nove palavras aqui mostradas, porque delas se pode formar para si uma grande série de outros pronomes e advérbios.</example>
-            <example>É como se o que está para trás não importasse já, deixa lá, alguma coisa havia de haver para ti caramba, já chega de esperar.</example>
-            <example>Imaginar o paradigma necessário para programar uma máquina que não lembra do “pixel” que acabou de desenhar para mim seria muito difícil.</example>
-            <example>Esqueci de ligar para ele ontem.</example>
-            <example>Tom começou a trabalhar para nós na última segunda-feira.</example>
-            <example>...te ordem: Daqui em diante não mais fornecereis palha ao povo para fazer tijolos. Eles que tratem de ajuntar para si a palha.</example>
+        <antipattern>
+            <token postag='V.+' postag_regexp='yes'>
+                <exception inflected='yes' regexp='yes'>agradecer|anunciar|apresentar|atribuir|avisar|cobrar|comunicar|confessar|confiar|contar|dar|devolver|dizer|emprestar|ensinar|entregar|enviar|escrever|explicar|informar|ligar|mostrar|oferecer|pagar|pedir|perguntar|prometer|propor|recomendar|responder|telefonar</exception></token>
+            <token>para</token>
+            <token regexp='yes'>mim|tu|ti|si|vocês?|el[ae]s?|nós|vós</token>
         </antipattern>
 
-        <!-- EU -->
-        <rule>
+        <antipattern>
+            <token postag='NC.+' postag_regexp='yes'/>
+            <token>para</token>
+            <token regexp='yes'>ti|si|vocês?|vós</token>
+            <example>Recomendado para você: Muçulmanos podem celebrar festas não-religiosas?</example>
+            <example>Telefone para você.</example>
+            <example>Eu tomei conta para você.</example>
+            <example>"Mary, telefone para ti." "Deixa-me adivinhar: é o Tom?"</example>
+            <example>É bom utilizar essas guloseimas como um disfarce, caso não dê para você escovar os dentes e a língua.</example>
+        </antipattern>
+
+        <antipattern>
+            <token postag='V......:.+' postag_regexp='yes'/>
+            <token>para</token>
+            <token postag='PP.+' postag_regexp='yes'/>
+            <example>Mostre-o para mim no mapa.</example>
+            <example>Por favor, envie-o para mim por fax.</example>
+            <example>Mostre-o para mim.</example>
+            <example>Não, eu não vou dá-lo para você.</example>
+            <example>Vou dá-los para você.</example>
+            <example>Você pode explicá-lo para mim?</example>
+            <example>Enviá-lo para mim.</example>
+        </antipattern>
+
+        <antipattern>
+            <token postag='V.+' postag_regexp='yes'/>
+            <token>para</token>
+            <token min='1' max='4' postag='PP.+|RN|CS' postag_regexp='yes'><exception regexp='yes'>como|mim|quando</exception></token>
+            <token postag='VMN0000|VMN03.+' postag_regexp='yes'><exception scope='previous' regexp='yes'>[ao]s?|que</exception></token>
+            <example>Pedi para ele parar, ele continuou.</example>
+            <example>O médico dele disse para ele descansar.</example>
+            <example>Eu sempre pensei que ter um ataque do coração era a forma da natureza dizer para você morrer.</example>
+            <example>Tom está na porta. Por favor peça para ele entrar.</example>
+            <example>Não dava para ele conseguir o emprego.</example>
+            <example>Incontáveis vezes pedi para ele não mentir pra mim, ser sempre sincero.</example>
+            <example>"Devo dizer para ele te ligar quando chegar?" "Sim, por favor."</example>
+            <example>Por favor peça para ele me ligar.</example>
+            <example>Eu disse para ela não soltar a corda, mas foi isso o que ela fez.</example>
+            <example>Pedi para ele não falar alto.</example>
+            <example>Olhe nos olhos dele, diga o nome dele, e depois peça para ele se sentar.</example>
+            <example>Sabia que às vezes eu peço para ela me chamar de Kevin?</example>
+            <example>Peça para eles não brigarem.</example>
+            <example>Eu disse para vocês irem embora.</example>
+            <example>Pedi para eles consertarem o meu carro.</example>
+        </antipattern>
+
+        <antipattern>
+            <token postag='VMP00.+|VMI[FS]3.+' postag_regexp='yes'/>
+            <token postag='VMP00.+' postag_regexp='yes'/>
+            <token>para</token>
+            <token postag='PP.+' postag_regexp='yes'/>
+            <example>A história deste livro foi escrita para ela.</example>
+            <example>Essa canção parece ter sido escrita para nós dois.</example>
+            <example>... em vez de um formulário regular da empresa de custódia (este formulário será enviado para você).</example>
+            <example>A carta foi escrita para ela.</example>
+        </antipattern>
+
+        <rule> <!-- EU -->
             <pattern>
-                <marker>
-                    <token postag='V.+' postag_regexp='yes'/>
-                    <token>para</token>
-                    <token>mim</token>
-                </marker>
+                <token postag='V.+' postag_regexp='yes'/>
+                <token>para</token>
+                <token>mim</token>
             </pattern>
             <message>&simplify_msg;</message>
             <suggestion>\1-me</suggestion>
             <example correction="Telefona-me"><marker>Telefona para mim</marker>.</example>
         </rule>
 
-        <!-- TU/VOCÊ -->
-        <rule>
+        <rule> <!-- TU/VOCÊ -->
             <pattern>
-                <marker>
-                    <token postag='V.+' postag_regexp='yes'/>
-                    <token>para</token>
-                    <token regexp='yes'>tu|ti|si|você</token>
-                </marker>
+                <token postag='V.+' postag_regexp='yes'/>
+                <token>para</token>
+                <token regexp='yes'>tu|ti|si|você</token>
             </pattern>
             <message>&simplify_msg;</message>
             <suggestion>\1-te</suggestion>
@@ -5136,63 +4921,51 @@ USA
             <example correction="Telefonei-te|Telefonei-lhe"><marker>Telefonei para ti</marker>.</example>
         </rule>
 
-        <!-- ELE -->
-        <rule>
+        <rule> <!-- ELE/ELA -->
             <pattern>
-                <marker>
-                    <token postag='V.+' postag_regexp='yes'/>
-                    <token>para</token>
-                    <token regexp='yes'>el[ae]</token>
-                </marker>
+                <token postag='V.+' postag_regexp='yes'/>
+                <token>para</token>
+                <token regexp='yes'>el[ae]</token>
             </pattern>
             <message>&simplify_msg;</message>
             <suggestion>\1-lhe</suggestion>
             <example correction="Telefonei-lhe"><marker>Telefonei para ela</marker>.</example>
         </rule>
 
-        <!-- NÓS -->
-        <rule>
+        <rule> <!-- NÓS -->
             <pattern>
-                <marker>
-                    <token postag='V.+' postag_regexp='yes'/>
-                    <token>para</token>
-                    <token>nós</token>
-                </marker>
+                <token postag='V.+' postag_regexp='yes'/>
+                <token>para</token>
+                <token>nós</token>
             </pattern>
             <message>&simplify_msg;</message>
             <suggestion>\1-nos</suggestion>
             <example correction="Telefonaram-nos"><marker>Telefonaram para nós</marker>.</example>
         </rule>
 
-        <!-- VÓS/VOCÊS -->
-        <rule>
+        <rule> <!-- VÓS/VOCÊS -->
             <pattern>
-                <marker>
-                    <token postag='V.+' postag_regexp='yes'/>
-                    <token>para</token>
-                    <token regexp='yes'>vocês|vós</token>
-                </marker>
+                <token postag='V.+' postag_regexp='yes'/>
+                <token>para</token>
+                <token regexp='yes'>vocês|vós</token>
             </pattern>
             <message>&simplify_msg;</message>
             <suggestion>\1-vos</suggestion>
             <example correction="Telefonaram-vos"><marker>Telefonaram para vocês</marker>.</example>
         </rule>
 
-        <!-- ELES -->
-        <rule>
+        <rule> <!-- ELES/ELAS -->
             <pattern>
-                <marker>
-                    <token postag='V.+' postag_regexp='yes'/>
-                    <token>para</token>
-                    <token regexp='yes'>el[ae]s</token>
-                </marker>
+                <token postag='V.+' postag_regexp='yes'/>
+                <token>para</token>
+                <token regexp='yes'>el[ae]s</token>
             </pattern>
             <message>&simplify_msg;</message>
             <suggestion>\1-lhes</suggestion>
             <example correction="Telefonei-lhes"><marker>Telefonei para elas</marker>.</example>
         </rule>
 
-    </rulegroup>
+</rulegroup>
 
 
     <rule id='VERBO_PRONOMINAL_DE_V3' name="[pt-PT][Simplificar] 'V. Pronominal + de' → V. Pronominal" type="style" tone_tags="formal">


### PR DESCRIPTION
Replaced the old rule completely.

Now it is limited to a few verbs told by ChatGPT, so almost no false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new grammar and style rules for Portuguese to enhance clarity and conciseness in writing.
	- Added rules to differentiate between formal and informal language usage.
	- Implemented antipatterns to flag common errors in formal writing.

- **Improvements**
	- Updated examples and suggestions for better guidance on preferred language usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->