### PR TITLE
[pt-PT] Improved rule ID:CONFUSÃO_CAIXA_EMBALAGEM and cleaned other rule

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -86,7 +86,7 @@ USA
     <category id="STYLE" name="[pt-PT] Regras de Estilo" type="style">
 
 
-    <rule id='CONFUSÃO_CAIXA_EMBALAGEM' name="[pt-PT] Confusão: Caixa/embalagem" tone_tags="objective" default="temp_off">
+    <rule id='CONFUSÃO_CAIXA_EMBALAGEM' name="[pt-PT] Confusão: Caixa/embalagem (fármacos)" tone_tags="objective" default="temp_off">
         <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
         <pattern>
             <token skip='4' regexp='yes' inflected='yes'>administrar|dosar|ingerir|injec?tar|prescrever|ministrar|tomar</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -86,12 +86,12 @@ USA
     <category id="STYLE" name="[pt-PT] Regras de Estilo" type="style">
 
 
-    <rule id='CONFUSÃO_CAIXA_EMBALAGEM' name="[pt-PT] Confusão: Caixa/embalagem" tone_tags="objective">
+    <rule id='CONFUSÃO_CAIXA_EMBALAGEM' name="[pt-PT] Confusão: Caixa/embalagem" tone_tags="objective" default="temp_off">
+        <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
         <pattern>
-            <token skip='4' inflected='yes'>tomar</token>
+            <token skip='4' regexp='yes' inflected='yes'>administrar|dosar|ingerir|injec?tar|prescrever|ministrar|tomar</token>
             <marker>
-                <token regexp='yes'>caixas?
-                    <exception scope='previous' postag='_PUNCT'/></token>
+                <token regexp='yes'>caixas?<exception scope='previous' postag='_PUNCT'/></token>
             </marker>
         </pattern>
         <message>Se estiver a referir-se a fármacos ou afins, empregue o termo &quot;embalagem&quot;.</message>
@@ -105,9 +105,7 @@ USA
         <pattern>
             <token skip='4' regexp='yes' inflected='yes'>ser|ter</token>
             <marker>
-                <token>prazer
-                    <exception scope='previous' postag_regexp='yes' postag='V.+'/>
-                </token>
+                <token>prazer<exception scope='previous' postag_regexp='yes' postag='V.+'/></token>
             </marker>
             <token regexp='yes'>de|em|que</token>
         </pattern>


### PR DESCRIPTION
Improved the rule with more verbs, but it still has zero hits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new rules to enhance formal language use in Portuguese, including suggestions for replacing informal phrases.
	- Added a rule to suggest replacing "ciclo vicioso" with "círculo vicioso" for clarity.
	- Expanded rules to discourage the use of gerunds and avoid redundancy in phrases.
	- New suggestions for more formal alternatives to common informal phrases.

- **Improvements**
	- Updated existing rules for better specificity and clarity in language processing, including refined exceptions for certain parts of speech.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->