### PR TITLE
[pt-PT] Removed "temp_off" from rule ID:VERBO_PARA_PRONOME_PESSOAL_V2

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -4853,7 +4853,7 @@ USA
     </rulegroup>
 
 
-<rulegroup id='VERBO_PARA_PRONOME_PESSOAL_V2' name="[pt-PT][Simplificar] Verbo + para + pronome pessoal → Verbo + -me/te/lhe/nos/vos/lhes" type="style" tone_tags="formal" default="temp_off">
+<rulegroup id='VERBO_PARA_PRONOME_PESSOAL_V2' name="[pt-PT][Simplificar] Verbo + para + pronome pessoal → Verbo + -me/te/lhe/nos/vos/lhes" type="style" tone_tags="formal">
         <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
 
         <antipattern> <!-- Limit the rule to specific verbs (ChatGPT 4o) -->


### PR DESCRIPTION
Removed "temp_off".

Results fixed:
https://internal1.languagetool.org/regression-tests/via-http/2024-10-13/pt-PT/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new grammar and style rules for Portuguese, enhancing accuracy and clarity in suggestions.
	- Added rules to promote formal language alternatives and avoid informal expressions.
	- Simplified language recommendations for various phrases to improve user experience.
  
- **Bug Fixes**
	- Cleaned up redundant expressions and improved organization of rules for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->