### PR TITLE
[pt-PT] Removed "temp_off" from rule ID:CONCLUIR_UM_CURSO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -3353,7 +3353,7 @@ USA
     <category id='ACADEMIC_SCIENTIFIC_PT_PT' name="[pt-PT] Regras académicas e científicas" type="other">
 
 
-    <rule id='CONCLUIR_UM_CURSO' name="[pt-PT] 'acabar/terminar' um curso → 'concluir'" type='style' tone_tags="academic" default="temp_off">
+    <rule id='CONCLUIR_UM_CURSO' name="[pt-PT] 'acabar/terminar' um curso → 'concluir'" type='style' tone_tags="academic">
         <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
         <!-- Notice that some keywords appear as verbs and need to be fixed in the Disambiguator for the rule to work completely:
              1. "Eu terminei o curso."

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -3353,7 +3353,7 @@ USA
     <category id='ACADEMIC_SCIENTIFIC_PT_PT' name="[pt-PT] Regras académicas e científicas" type="other">
 
 
-    <rule id='CONCLUIR_UM_CURSO' name="[pt-PT] 'acabar/terminar' um curso → 'concluir'" type='style' tone_tags="academic">
+    <rule id='CONCLUIR_UM_CURSO' name="[pt-PT] 'acabar/terminar' um curso → 'concluir'" type='style' tone_tags='academic'>
         <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
         <!-- Notice that some keywords appear as verbs and need to be fixed in the Disambiguator for the rule to work completely:
              1. "Eu terminei o curso."


### PR DESCRIPTION
Removed the "temp_off"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new grammar and style rules for Portuguese, enhancing clarity and accuracy.
	- Added suggestions for replacing informal terms with more formal alternatives in academic contexts.
	- Implemented new rules to address redundancy and improve phrase simplification.

- **Bug Fixes**
	- Activated previously disabled rules to improve functionality and user guidance.

- **Refinements**
	- Enhanced suggestions for better precision in grammar and style checks, including clearer recommendations for specific terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->