### PR TITLE
[de] ignore adding punctuation at the sentence end

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
@@ -616,7 +616,7 @@ public class German extends Language implements AutoCloseable {
       // ignore adding punctuation at the sentence end
       if (suggestions.size()==1 && currentMatch.getRule().getId().startsWith("AI_DE_GGEC")) {
         String suggestion = suggestions.get(0);
-        if (currentMatch.getRule().getId().equals("AI_DE_GGEC_MISSING_PUNCTUATION") && suggestion.endsWith(".")) {
+        if (currentMatch.getRule().getId().equals("AI_DE_GGEC_MISSING_PUNCTUATION_PERIOD") && suggestion.endsWith(".")) {
           if (currentMatch.getSentence().getText().replaceAll("\\s+$", "").endsWith(suggestion.substring(0, suggestion.length() - 1))) {
             continue;
           }

--- a/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/language/German.java
@@ -612,6 +612,16 @@ public class German extends Language implements AutoCloseable {
     RuleMatch previousMatch = null;
     for (int i = 0; i < ruleMatches.size(); i++) {
       RuleMatch currentMatch = ruleMatches.get(i);
+      List<String> suggestions = currentMatch.getSuggestedReplacements();
+      // ignore adding punctuation at the sentence end
+      if (suggestions.size()==1 && currentMatch.getRule().getId().startsWith("AI_DE_GGEC")) {
+        String suggestion = suggestions.get(0);
+        if (currentMatch.getRule().getId().equals("AI_DE_GGEC_MISSING_PUNCTUATION") && suggestion.endsWith(".")) {
+          if (currentMatch.getSentence().getText().replaceAll("\\s+$", "").endsWith(suggestion.substring(0, suggestion.length() - 1))) {
+            continue;
+          }
+        }
+      }
       if (previousMatch != null && previousMatch.getRule().getId().startsWith("AI_DE_GGEC") &&
         currentMatch.getRule().getId().startsWith("AI_DE_GGEC")) {
         if (previousMatch.getToPos() > currentMatch.getFromPos()) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced rule matching for German language checks, improving accuracy by filtering punctuation suggestions and merging overlapping matches.
- **Bug Fixes**
	- Improved handling of rule matches to avoid redundant suggestions, leading to a more streamlined user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->