### PR TITLE
[fr] ignore adding punctuation at the sentence end

### DIFF
--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/French.java
@@ -431,6 +431,16 @@ public class French extends Language implements AutoCloseable {
     RuleMatch previousMatch = null;
     for (int i = 0; i < ruleMatches.size(); i++) {
       RuleMatch currentMatch = adjustFrenchRuleMatch(ruleMatches.get(i), enabledRules);
+      List<String> suggestions = currentMatch.getSuggestedReplacements();
+      // ignore adding punctuation at the sentence end
+      if (suggestions.size()==1 && currentMatch.getRule().getId().startsWith("AI_FR_GGEC")) {
+        String suggestion = suggestions.get(0);
+        if (currentMatch.getRule().getId().equals("AI_FR_GGEC_MISSING_PUNCTUATION_PERIOD") && suggestion.endsWith(".")) {
+          if (currentMatch.getSentence().getText().replaceAll("\\s+$", "").endsWith(suggestion.substring(0, suggestion.length() - 1))) {
+            continue;
+          }
+        }
+      }
       if (previousMatch != null && previousMatch.getRule().getId().startsWith("AI_FR_GGEC") &&
               currentMatch.getRule().getId().startsWith("AI_FR_GGEC")) {
         if (previousMatch.getToPos() > currentMatch.getFromPos()) {


### PR DESCRIPTION
@GillouLT 
AI_FR_GGEC_MISSING_PUNCTUATION_PERIOD creates undesired matches, for example, in bulleted lists. We can rely on other rules, with proper exceptions, for this. 