### PR TITLE
[pt-PT] Disambiguator changes fixed rule ID:CONCLUIR_UM_CURSO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -3357,11 +3357,6 @@ USA
 
     <rule id='CONCLUIR_UM_CURSO' name="[pt-PT] 'acabar/terminar' um curso → 'concluir'" type='style' tone_tags='academic'>
         <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
-        <!-- Notice that some keywords appear as verbs and need to be fixed in the Disambiguator for the rule to work completely:
-             1. "Eu terminei o curso."
-             2. "Terminado o curso, fundou o jornal O Distrito de Évora, em 1866, órgão no qual iniciou a sua experiência jorn..."
-             3. "Até no aspecto amoroso influencia, possuo uma colega humilde que conseguiu terminar o doutorado."
-        -->
         <pattern>
             <marker>
                 <token skip='4' regexp="yes" inflected='yes'>acabar|finalizar|terminar<exception scope='next' postag_regexp='yes' postag='V.+'/></token>


### PR DESCRIPTION
Removed the comments saying that the disambiguator wasn't able to detect the example sentences I wrote there.

New disambiguator changes fixed the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced multiple new language rules for Portuguese (Portugal) to enhance clarity and formality in writing.
	- Added rules addressing common confusions and recommending simpler alternatives for complex phrases.
	- Included a variety of examples to illustrate the application of new rules.

- **Bug Fixes**
	- Refined existing rules to align with contemporary usage and formal standards, improving overall accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->