### PR TITLE
Bump up French dict to v0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
         <optimaize.languagedetector.language-detector.version>0.6</optimaize.languagedetector.language-detector.version>
         <!-- see https://github.com/languagetool-org/languagetool/issues/4088 before you upgrade this -->
         <spanish-pos-dict.version>2.3</spanish-pos-dict.version>
-        <french-pos-dict.version>0.6</french-pos-dict.version>
+        <french-pos-dict.version>0.7</french-pos-dict.version>
         <languagetool-ga-dicts.version>0.02</languagetool-ga-dicts.version>
         <portuguese-pos-dict.version>1.2.0</portuguese-pos-dict.version>
         <dutch-pos-dict.version>0.1</dutch-pos-dict.version>


### PR DESCRIPTION
This PR updates the LT POM to use the latest release of the French POS dictionary binaries (`v0.7`). Tests pass locally, we should be gucci.

cc @LucieSteib fyi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `french-pos-dict` dependency to enhance compatibility and functionality.
	- Added comments for better management and documentation of dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->