### PR TITLE
[pt] Removed the "hacky" example from grammar.xml since it will break my next disambiguator.xml update

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -12465,7 +12465,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example correction="venhais">Proponho que <marker>vindes</marker>.</example>
                 <example correction="produzam">Espera-se que se <marker>produzem</marker> bom resultados.</example>
                 <example correction="possa">Desejam que no final <marker>posso</marker> vir.</example>
-                <example correction="vejamos">Estamos à espera que nos <marker>vemos</marker> nesta sexta-feira.</example> <!-- this is hacky, that's not a verb -->
                 <example correction="bebam">Proíbo que <marker>bebem</marker> café depois das cinco da tarde!</example>
                 <example correction="saiba">Não suponho que ele realmente <marker>sabe</marker> a verdade.</example>
                 <!--example correction="possa">Se espera que no final <marker>posso</marker> vir.</example--><!-- TODO disambiguate 'se' CS|PP3CN000 -->


### PR DESCRIPTION
Fix: it will break my next disambiguator improvement, since the word will be recognised as a noun.

It had a comment saying "hacky".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed an invalid example entry from Portuguese language rules to enhance accuracy in verb form corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->