### PR TITLE
[pt] Commented out incorrect example that will break the next major disambiguator update

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -19236,7 +19236,7 @@ USA
                 <example>Deixe-me ver o seu pulso.</example>
                 <example>Do topo podia-se ver o rio.</example>
                 <example>Deixe-me ver a lista.</example>
-<!-->                <example>Estava muito nublado para ver o avião.</example> <-->
+<!--                <example>Estava muito nublado para ver o avião.</example> -->
                 <example>Eu gostaria de ver o senhor Kosugi.</example>
                 <example>Eu gostaria de ver o mundo antigo.</example>
                 <example>Dá para ver a diferença?</example>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -19236,7 +19236,7 @@ USA
                 <example>Deixe-me ver o seu pulso.</example>
                 <example>Do topo podia-se ver o rio.</example>
                 <example>Deixe-me ver a lista.</example>
-                <example>Estava muito nublado para ver o avião.</example>
+<!-->                <example>Estava muito nublado para ver o avião.</example> <-->
                 <example>Eu gostaria de ver o senhor Kosugi.</example>
                 <example>Eu gostaria de ver o mundo antigo.</example>
                 <example>Dá para ver a diferença?</example>


### PR DESCRIPTION
This example breaks the next disambiguator update since “nublado” will no longer appear as a verb but as a noun instead.

So I commented out the example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Commented out an outdated example sentence in the Portuguese language rules to improve clarity and relevance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->