### PR TITLE
[pt] Major fix in verbs/nouns detection in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -240,8 +240,21 @@
     </rule>
     <rule> <!-- Used ChatGPT 4o to verify the 31048 results -->
       <pattern>
-        <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+'/></token>
+        <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>
         <token postag="(SPS00:)?D[AI].+|PP.+|Z0.+" postag_regexp="yes"><exception postag_regexp='yes' postag='PI.+'/></token>
+        <marker>
+          <and>
+            <token postag="VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0|VMIP1S0|VMP00SM" postag_regexp="yes"/>
+            <token postag="NC.+" postag_regexp="yes"/>
+          </and>
+        </marker>
+      </pattern>
+      <disambig action="remove" postag="V.*"/>
+    </rule>
+    <rule> <!-- Used ChatGPT 4o to verify the 3217 results -->
+      <pattern>
+        <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>
+        <token regexp='yes' inflected='yes'>um|muito|pouco|vários|diversos|tal</token> <!-- Special PI.* that don't break rules -->
         <marker>
           <and>
             <token postag="VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0|VMIP1S0|VMP00SM" postag_regexp="yes"/>


### PR DESCRIPTION
Hello!

Another major enhancement and also fixed:
`“Ele a ama e ela o ama também.”`
“ele” and “ela” were being detected as a verb, thus incorrectly removing the “ama” verb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new disambiguation rule for Portuguese verb forms to improve grammar checking accuracy.
  
- **Bug Fixes**
  - Updated existing disambiguation rules to enhance coverage for specific grammatical structures.

- **Chores**
  - Cleaned up the codebase by removing outdated commented-out rule groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->