### PR TITLE
[pt] Fix for "ela o ama" in disambiguation.xml rule ID:RARE_POS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -240,7 +240,7 @@
     </rule>
     <rule> <!-- Used ChatGPT 4o to verify the 31048 results -->
       <pattern>
-        <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+'/></token>
+        <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>
         <token postag="(SPS00:)?D[AI].+|PP.+|Z0.+" postag_regexp="yes"><exception postag_regexp='yes' postag='PI.+'/></token>
         <marker>
           <and>


### PR DESCRIPTION
Fix for "Ela o ama" in verbs/nouns rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced disambiguation rules for Portuguese language processing, including new rules and refined existing ones.
	- Added new examples to clarify rule applications.

- **Bug Fixes**
	- Improved handling of specific tokens and patterns for better accuracy in language processing. 

- **Documentation**
	- Commented sections indicate areas for future review, aiding in ongoing development efforts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->