### PR TITLE
[pt] Verb/noun improvements (pela/como) in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -230,8 +230,8 @@ USA
   <rulegroup id="RARE_POS" name="rare POS tags">
     <rule> <!-- Used ChatGPT 4o to verify the results -->
       <pattern>
-        <token postag='VMP00.+' postag_regexp="yes"/>
-        <token postag='RM' postag_regexp="no"/>
+        <token postag='VMP00.+' postag_regexp="yes"><exception postag_regexp='yes' postag='NC.+|AQ.+'/></token>
+        <token min='0' max='1' postag='RM' postag_regexp="no"/>
         <marker>
           <and>
             <token postag="VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0|VMIP1S0|VMP00SM" postag_regexp="yes"/>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -230,6 +230,20 @@ USA
   <rulegroup id="RARE_POS" name="rare POS tags">
     <rule> <!-- Used ChatGPT 4o to verify the results -->
       <pattern>
+        <token postag='VMP00.+' postag_regexp="yes"/>
+        <token postag='RM' postag_regexp="no"/>
+        <marker>
+          <and>
+            <token postag="VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0|VMIP1S0|VMP00SM" postag_regexp="yes"/>
+            <token postag="NC.+" postag_regexp="yes"/>
+          </and>
+        </marker>
+        <token postag='NC.+|AQ.+' postag_regexp='yes'/>
+      </pattern>
+      <disambig action="remove" postag="V.*"/>
+    </rule>
+    <rule> <!-- Used ChatGPT 4o to verify the results -->
+      <pattern>
         <token>à</token>
         <marker>
           <and>


### PR DESCRIPTION
Heya,

Fixes in "pela(s)/pelo(s)/como" that were appearing as verbs.

[_0_utf8.txt](https://github.com/user-attachments/files/17686834/_0_utf8.txt)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new disambiguation rule for handling specific Portuguese postags, enhancing language processing accuracy.
- **Documentation**
	- Added comments to existing rules to indicate verification using ChatGPT 4.0, improving transparency in the review process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->