### PR TITLE
[pt] Improved even more the verbs/nouns rule in disambiguation.xml, rule ID:RARE_POS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -230,7 +230,7 @@ USA
   <rulegroup id="RARE_POS" name="rare POS tags">
     <rule> <!-- Used ChatGPT 4o to verify the results -->
       <pattern>
-        <token postag='VMP00.+' postag_regexp="yes"><exception postag_regexp='yes' postag='NC.+|AQ.+'/></token>
+        <token postag='VMP00.+' postag_regexp="yes"/>
         <token min='0' max='1' postag='RM' postag_regexp="no"/>
         <marker>
           <and>


### PR DESCRIPTION
In the previous commit I tried to restrict the rule, but I was wrong, ChatGPT said that the results were all valid, so there is no reason to restrict it.


[_1_the_full_one.txt](https://github.com/user-attachments/files/17688531/_1_the_full_one.txt)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced disambiguation rules for Portuguese grammar, improving accuracy in handling parts of speech.
	- Added rules for common laughter onomatopoeia and their classifications.
	- Introduced new rules for better processing of numerical expressions, percentages, and time formats.
  
- **Bug Fixes**
	- Removed outdated rules that conflicted with common language usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->