### PR TITLE
[pt] Had to move rule down for it to work with adverbs (RM)

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -230,17 +230,6 @@ USA
   <rulegroup id="RARE_POS" name="rare POS tags">
     <rule> <!-- Used ChatGPT 4o to verify the results -->
       <pattern>
-        <token postag='VMP00.+' postag_regexp="yes"/>
-        <token min='0' max='1' postag='RM'/>
-        <marker>
-            <token regexp="yes">pel[ao]s?|como</token>
-        </marker>
-        <token postag='NC.+|AQ.+' postag_regexp='yes'/>
-      </pattern>
-      <disambig action="remove" postag="V.*"/>
-    </rule>
-    <rule> <!-- Used ChatGPT 4o to verify the results -->
-      <pattern>
         <token>à</token>
         <marker>
           <and>
@@ -3849,6 +3838,19 @@ USA
           <disambig action="remove"><wd lemma="farar"/></disambig>
       </rule>
   </rulegroup>
+
+  <rule id="PELA_COMO" name="Remove pela/como from appearing as verbs"> <!-- Used ChatGPT 4o to verify the results -->
+    <!-- Had to move the rule down for it to work with RM: "As espécies viáveis foram sendo incorporadas gradativamente pela natureza." -->
+    <pattern>
+      <token postag='VMP00.+' postag_regexp="yes"/>
+      <token min='0' max='1' postag='RM'/>
+      <marker>
+          <token regexp="yes">pel[ao]s?|como</token>
+      </marker>
+      <token postag='NC.+|AQ.+' postag_regexp='yes'/>
+    </pattern>
+    <disambig action="remove" postag="V.*"/>
+  </rule>
 
   <rulegroup id="NATIONAL_PREFIXES" name="Ignore spelling in tagged words with national prefixes">
       <rule>


### PR DESCRIPTION
I had to move the rule down because it wasn't working with adverbs (RM):
`“As espécies viáveis foram sendo incorporadas gradativamente pela natureza.”`
RM="gradativamente”


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new disambiguation rule for Portuguese that removes specific tags for the words "pela" and "como" in certain contexts.
- **Documentation**
	- Added comments verifying the new rule's functionality and its integration within existing rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->