### PR TITLE
[pt] Moved rule verbs/nouns down and improved it disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -254,19 +254,7 @@ USA
       </pattern>
       <disambig action="remove" postag="V.*"/>
     </rule>
-    <rule> <!-- Used ChatGPT 4o to verify the results -->
-      <pattern>
-        <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>
-        <token regexp='yes' inflected='yes'>um|muito|pouco|vários|diversos|tal</token> <!-- Special PI.* that don't break rules -->
-        <marker>
-          <and>
-            <token postag="VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0|VMIP1S0" postag_regexp="yes"/> <!-- Removed "VMP00SM" not to break Premium -->
-            <token postag="NC.+" postag_regexp="yes"/>
-          </and>
-        </marker>
-      </pattern>
-      <disambig action="remove" postag="V.*"/>
-    </rule>
+    <!-- Rule regarding PI.+ moved to bottom -->
     <rule>
       <pattern> <!-- Used ChatGPT 4o to verify the results -->
         <token postag="Z0.[PN].+" postag_regexp="yes"/>
@@ -3850,6 +3838,21 @@ USA
       <token postag='NC.+|AQ.+' postag_regexp='yes'/>
     </pattern>
     <disambig action="remove" postag="V.*"/>
+  </rule>
+
+  <rule id="PI_VERBS" name="Remove PI.+ followed by noun from appearing as verb"> <!-- Used ChatGPT 4o to verify the results -->
+      <!-- Had to move the rule down for it to work with all the PI.+ here -->
+      <pattern>
+        <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>
+        <token regexp='yes' inflected='yes'>um|muito|pouco|vários|diversos|tal|de:esse|em:esse</token> <!-- Special PI.+ that don't break rules -->
+        <marker>
+          <and>
+            <token postag="VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0|VMIP1S0" postag_regexp="yes"/> <!-- Removed "VMP00SM" not to break Premium -->
+            <token postag="NC.+" postag_regexp="yes"/>
+          </and>
+        </marker>
+      </pattern>
+      <disambig action="remove" postag="V.*"/>
   </rule>
 
   <rulegroup id="NATIONAL_PREFIXES" name="Ignore spelling in tagged words with national prefixes">


### PR DESCRIPTION
I noticed that the verb/noun rules, some of them, need to be moved down to fully work.

So, I have moved it down and improved it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new grammar rule for Portuguese to improve verb disambiguation, specifically targeting infinitive forms followed by nouns.
- **Documentation**
	- Added comments to clarify the functionality of specific grammar rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->