### PR TITLE
[pt] Moved down and improved verbs/nouns rule in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -241,20 +241,6 @@ USA
       </pattern>
       <disambig action="remove" postag="V.*"/>
     </rule>
-    <rule> <!-- Used ChatGPT 4o to verify the results -->
-      <pattern>
-        <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>
-        <token postag="(SPS00:)?D[AI].+|PP.+|Z0.+" postag_regexp="yes"><exception postag_regexp='yes' postag='PI.+'/></token>
-        <marker>
-          <and>
-            <token postag="VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0|VMIP1S0|VMP00SM" postag_regexp="yes"/>
-            <token postag="NC.+" postag_regexp="yes"/>
-          </and>
-        </marker>
-      </pattern>
-      <disambig action="remove" postag="V.*"/>
-    </rule>
-    <!-- Rule regarding PI.+ moved to bottom -->
     <rule>
       <pattern> <!-- Used ChatGPT 4o to verify the results -->
         <token postag="Z0.[PN].+" postag_regexp="yes"/>
@@ -3838,10 +3824,38 @@ USA
       <token postag='NC.+|AQ.+' postag_regexp='yes'/>
     </pattern>
     <disambig action="remove" postag="V.*"/>
+    <!--
+    Examples:
+             Elas eram conhecidas pelas cadelas.
+             Elas eram conhecidas como cadelas.
+             As espécies viáveis foram sendo incorporadas gradativamente pela natureza.
+    -->
   </rule>
 
   <rulegroup id="PI_RELATED_VERBS" name="Remove PI.+ related followed by noun appearing as verb"> <!-- Used ChatGPT 4o to verify the results -->
     <!-- Had to move the rules down for them to work with all the conditions included -->
+    <rule> <!-- Used ChatGPT 4o to verify the results -->
+      <pattern>
+        <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>
+        <token postag="(SPS00:)?D[AI].+|PP.+|Z0.+" postag_regexp="yes"><exception postag_regexp='yes' postag='PI.+'/></token>
+        <marker>
+          <and>
+            <token postag="VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0|VMIP1S0|VMP00SM" postag_regexp="yes"/>
+            <token postag="NC.+" postag_regexp="yes"/>
+          </and>
+        </marker>
+      </pattern>
+      <disambig action="remove" postag="V.*"/>
+      <!--
+      Examples:
+               As duas últimas equipes nesta fase são rebaixadas à Segunda Divisão.
+               Para bater da segunda vez, é preciso ter pego o morto e ter ao menos uma canastra limpa.
+               Soma-se, então, este total com o da saída, anotando o valor para calcular o acumulado da partida.
+               Se este for o caso, os pilares da criação vão sofrer uma erosão mais gradual.
+               Apesar de ter limitado os poderes do rei, este tinha ainda o direito de designar seus ministros.
+               Vamos precisar deles cedo ou tarde.Eu preciso dele vivo e ileso.
+      -->
+    </rule>
     <rule>
       <pattern>
         <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3837,7 +3837,7 @@ USA
     <rule> <!-- Used ChatGPT 4o to verify the results -->
       <pattern>
         <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>
-        <token postag="(SPS00:)?D[AI].+|PP.+|Z0.+" postag_regexp="yes"><exception postag_regexp='yes' postag='PI.+'/></token>
+        <token postag="(SPS00:)?(D[AI].+|PP.+)|Z0.+" postag_regexp="yes"><exception postag_regexp='yes' postag='PI.+'/></token>
         <marker>
           <and>
             <token postag="VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0|VMIP1S0|VMP00SM" postag_regexp="yes"/>


### PR DESCRIPTION
Had to more the rule down for it to fully work, and improved it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved disambiguation rules for Portuguese grammar, enhancing accuracy in handling verb interactions with nouns and pronouns.
	- Added new rules for handling "pelas" and "como" as conjunctions, and for specific verb patterns to refine language processing.

- **Bug Fixes**
	- Removed outdated rules to streamline the disambiguation process and improve contextual relevance.

- **Documentation**
	- Included comments and examples to clarify the application of new and modified rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->