### PR TITLE
[pt] More verbs/nouns fix in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3864,6 +3864,7 @@ USA
     <rule> <!-- Used ChatGPT 4o to verify the results -->
       <pattern>
         <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>
+        <token min='0' max='1' postag='RM'/>
         <token postag="(SPS00:)?D[AI].+|Z0.+" postag_regexp="yes"><exception postag_regexp='yes' postag='PI.+'/></token> <!-- Removed PP.+: "morrer nos custa muito" -->
         <marker>
           <and>
@@ -3880,12 +3881,14 @@ USA
                Soma-se, então, este total com o da saída, anotando o valor para calcular o acumulado da partida.
                Se este for o caso, os pilares da criação vão sofrer uma erosão mais gradual.
                Apesar de ter limitado os poderes do rei, este tinha ainda o direito de designar seus ministros.
-               Vamos precisar deles cedo ou tarde.Eu preciso dele vivo e ileso.
+               Stalin apoiou à direita e [4] e reprimiu severamente a esquerda.
+               O Palmeiras virou novamente o jogo e definiu o placar em 3 a 2, com gols de Alex e Galeano
       -->
     </rule>
     <rule>
       <pattern>
         <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>
+        <token min='0' max='1' postag='RM'/>
         <token postag='(SPS00:)?PI.+' postag_regexp="yes"/>
         <marker>
           <and>
@@ -3902,7 +3905,8 @@ USA
                É único, há muito espaço para você ficar sozinho.
                Giger (que também já fez várias capas para bandas de rock).
                Não me foi consentido qualquer voto na matéria.
-               Você não me ofendeu em nada, está tudo certo.
+               Tem visto relativamente pouco uso devido ao pequeno número de tipos de mídia até aqui que usa o TCP.
+               Por exemplo, meu salário é de R$ 1.500,00 e será depositado mensalmente nessa conta.
       -->
     </rule>
   </rulegroup>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3892,7 +3892,7 @@ USA
         <token postag='(SPS00:)?PI.+' postag_regexp="yes"/>
         <marker>
           <and>
-            <token postag="VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0|VMIP1S0" postag_regexp="yes"/> <!-- Removed "VMP00SM" not to break Premium -->
+            <token postag="VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0" postag_regexp="yes"/> <!-- Removed "VMIP1S0|VMP00SM" not to break Premium -->
             <token postag="NC.+" postag_regexp="yes"/>
           </and>
         </marker>
@@ -3910,7 +3910,7 @@ USA
       -->
     </rule>
   </rulegroup>
-
+ 
   <rulegroup id="NATIONAL_PREFIXES" name="Ignore spelling in tagged words with national prefixes">
       <rule>
           <pattern>


### PR DESCRIPTION
Also considering adverbs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced multiple new rule groups for improved disambiguation in Portuguese, including handling of compound conjunctions, rare part-of-speech tags, and punctuation.
	- Enhanced disambiguation logic for the verb "poder" and other verb forms.
	- Added numerous examples to clarify the application of new rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->