### PR TITLE
[pt] A few Susana reports fixed in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3814,7 +3814,7 @@ USA
   </rulegroup>
 
   <rule id="PELA_COMO_VERBS_RARE" name="Remove pela/como from appearing as verbs"> <!-- Used ChatGPT 4o to verify the results -->
-    <!-- Had to move the rule down for it to work with RM: "As espécies viáveis foram sendo incorporadas gradativamente pela natureza." -->
+    <!-- Moved the rule down for it to work with RM: "As espécies viáveis foram sendo incorporadas gradativamente pela natureza." -->
     <pattern>
       <token postag='VMP00.+' postag_regexp="yes"/>
       <token min='0' max='1' postag='RM'/>
@@ -3860,12 +3860,12 @@ USA
   </rule>
 
   <rulegroup id="PI_RELATED_VERBS_RARE" name="Remove PI.+ related followed by noun appearing as verb"> <!-- Used ChatGPT 4o to verify the results -->
-    <!-- Had to move the rules down for them to work with all the conditions included -->
+    <!-- Moved the rules down for them to work with all the conditions included. -->
     <rule> <!-- Used ChatGPT 4o to verify the results -->
       <pattern>
         <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>
         <token min='0' max='1' postag='RM'/>
-        <token postag="(SPS00:)?D[AI].+|Z0.+" postag_regexp="yes"><exception postag_regexp='yes' postag='PI.+'/></token> <!-- Removed PP.+: "morrer nos custa muito" -->
+        <token postag="(SPS00:)?D[AI].+|Z0.+" postag_regexp="yes"><exception postag_regexp='yes' postag='P[IP].+'/></token> <!-- Removed PP.+: "morrer nos custa muito" -->
         <marker>
           <and>
             <token postag="VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0|VMIP1S0|VMP00SM" postag_regexp="yes"/>
@@ -3889,7 +3889,7 @@ USA
       <pattern>
         <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>
         <token min='0' max='1' postag='RM'/>
-        <token postag='(SPS00:)?PI.+' postag_regexp="yes"/>
+        <token postag='(SPS00:)?PI.+' postag_regexp="yes"><exception postag_regexp='yes' postag='PP.+'/></token>
         <marker>
           <and>
             <token postag="VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0" postag_regexp="yes"/> <!-- Removed "VMIP1S0|VMP00SM" not to break Premium -->
@@ -3910,7 +3910,7 @@ USA
       -->
     </rule>
   </rulegroup>
- 
+
   <rulegroup id="NATIONAL_PREFIXES" name="Ignore spelling in tagged words with national prefixes">
       <rule>
           <pattern>


### PR DESCRIPTION
@susanaboatto 

I will merge it after the checks.

Like I wrote in the other pull request, I have been slowly resolving all the issues and some of them were already fixed.

With this pull request, we get the right verbs postags in the sentences:
https://internal1.languagetool.org/regression-tests/via-http/2024-11-05/pt-BR/result_grammar_GENERAL_NUMBER_AGREEMENT_ERRORS%5B2%5D.html

```
A habilidade de comunicar-se nos ajuda bastante.
Parar nos ajuda a ver.
Muito obrigado por ter nos convidado para jantar.
De acordo com relatos da mídia, os membros moveram um processo contra a Stardom no Tribunal Central de Seoul, "Durante o contrato exclusivo, foi nos prometido que além de oferecer treinamentos e facilidades, estaríamos recebendo o pagamento do mês todo dia 25..
```

Thanks for your understanding.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced disambiguation rules for Portuguese verbs, improving accuracy in complex phrase identification.
	- Introduced new rules for handling specific verb forms and their interactions with nouns and modifiers.

- **Bug Fixes**
	- Adjusted existing rules to prevent incorrect tagging of verbs in various contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->