### PR TITLE
[pt] More verbs/nouns fixes in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3814,14 +3814,14 @@ USA
   </rulegroup>
 
   <rule id="PELA_COMO_SOBRE_VERBS_RARE" name="Remove pela/como/sobre from appearing as verbs"> <!-- Used ChatGPT 4o to verify the results -->
-    <!-- Moved the rule down for it to work with RM: "As espécies viáveis foram sendo incorporadas gradativamente pela natureza." -->
+    <!-- Moved the rule down to assure it works correctly with RM. -->
+    <!-- ChatGPT stated that a past participle followed by "pela", "como", "sobre" doesn't depend on the next token to be removed as a verb. -->
     <pattern>
       <token postag='VMP00.+' postag_regexp="yes"/>
       <token min='0' max='1' postag='RM'/>
       <marker>
           <token regexp="yes">pel[ao]s?|como|sobre</token>
       </marker>
-      <token postag='NC.+|AQ.+|DP.+' postag_regexp='yes'/>
     </pattern>
     <disambig action="remove" postag="V.*"/>
     <!--
@@ -3834,6 +3834,7 @@ USA
              A segunda, que era conhecida como sua esposa no Olimpo, era a ciumenta Hera.
              Ele escreveu que ficou surpreso sobre como os resultados ficaram bons.
              Se ofendem por conta de suspeitas sobre artistas.
+             Desde 1967, Ele tem derramado sobre a Igreja a graça do batismo no Espírito Santo.
     -->
   </rule>
 


### PR DESCRIPTION
ChatGPT stated that a past participle followed by "pela", "como", "sobre" doesn't depend on the next token to be removed as a verb.

![Screenshot 2024-11-17 at 09-29-02 Como é usado como](https://github.com/user-attachments/assets/087e1923-d17f-4607-89b2-2427633a6066)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced verb disambiguation rules for Portuguese, improving accuracy in distinguishing between verbs and nouns.
	- Introduced new examples to clarify the functionality of updated rules.

- **Bug Fixes**
	- Adjusted handling of specific phrases to ensure correct verb form functionality.
	- Refined logic for removing inappropriate tags from verbs identified as nouns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->