### PR TITLE
[pt] Added AP to rule ID:CRASE_CONFUSION

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -13553,10 +13553,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </antipattern>
 
             <antipattern>
-                <token postag='AQ.+|NC.+' postag_regexp="yes"/>
+                <token postag='AQ.+|NC.+|VMP00.+|RM|RG|SP000' postag_regexp="yes"/>
                 <token regexp='yes'>às?</token>
-                <token postag='VMP00.+' postag_regexp="yes"/>
+                <token postag='VMP00.+' postag_regexp="yes"><exception postag_regexp='yes' postag='RG|NC.+|AQ.+|SPS.+'/></token>
                 <example>Segundo ela, no ano passado a demanda por compósitos foi praticamente igual à registrada em 2018.</example>
+                <example>O conflito tem uma tendência crescente devido às aumentadas assimetrias entre os povos.</example>
+                <example>As práticas religiosas atuais do dodecateísmo não são iguais às praticadas na Grécia Antiga.</example>
             </antipattern>
 
             <antipattern>


### PR DESCRIPTION
An antipattern to fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced grammar checking capabilities for the Portuguese language module by broadening the scope of recognized patterns.
	- Added two new examples to illustrate the usage of updated grammar rules, providing clearer context for users.

- **Bug Fixes**
	- Improved exception handling for specific token patterns, refining grammar rule accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->