### PR TITLE
[pt] Removed FPs in rule ID:INIMIGO_ADVERSÁRIO_ALIADO_OPONENTE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -13219,6 +13219,7 @@ USA
                     </token>
                     <token postag='NC.[^N].+' postag_regexp='yes'>
                         <exception postag_regexp='yes' postag='RG|DI.+|Z0.+|VMIP3S0'/>
+                        <exception regexp="yes">amig[ao]s?</exception> <!-- "amigo dos inimigos" -->
                     </token>
                     <marker>
                         <token regexp='yes'>d[ao]s?</token>
@@ -13273,6 +13274,7 @@ USA
                     <token regexp='yes'>de|d[ao]s?</token>
                     <token postag='NC.+' postag_regexp='yes'>
                         <exception postag_regexp='yes' postag='RG|DI.+|Z0.+|VMIP3S0'/>
+                        <exception regexp="yes">amig[ao]s?</exception> <!-- "amigo dos inimigos" -->
                     </token>
                     <marker>
                         <token regexp='yes'>d[ao]s?</token>


### PR DESCRIPTION
Removed false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new exception rule for the Portuguese language module, allowing for more accurate grammar checks by recognizing variations of "amigo" and "amiga" in both singular and plural forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->