### PR TITLE
[pt] Commented out the change from yesterday in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3901,7 +3901,9 @@ USA
         <token postag="V.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>
         <token min='0' max='1' postag='RM'/>
         <token postag="(SPS00:)?D[AI].+|Z0.+" postag_regexp="yes"><exception postag_regexp='yes' postag='P[IP].+'/></token> <!-- Removed PP.+: "morrer nos custa muito" -->
+<!--
         <token min='0' max='1' postag="NC.+|AQ.+" postag_regexp="yes"><exception postag_regexp='yes' postag='V.+|CS|RG|CC|SPS.+|[DP].+'/></token>
+-->
         <marker>
           <and>
             <token postag="VMSP3S0|VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0|VMIP1S0|VMP00SM" postag_regexp="yes"/>


### PR DESCRIPTION
I need to create a rule separated from this one to deal with nouns, so I have commented it out.

EDIT: Commented out the nouns usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new disambiguation rules for Portuguese, enhancing grammar processing.
	- Added specific rule groups for handling laughter-related text and English-style decades.
	- Implemented new rules for proper names and foreign names to improve accuracy.

- **Improvements**
	- Refined existing rules to better capture nuances in Portuguese syntax.
	- Removed redundant rules to streamline grammar processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->