### PR TITLE
[pt] Added AP to rule ID:GENERAL_NUMBER_AGREEMENT_ERRORS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -4331,6 +4331,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
            MARCOAGPINTO inserted global antipatterns for all subrules on top using the logic (2-MAR-2023+)
       -->
 
+            <antipattern> <!-- "álbuns solo" -->
+                <token postag='AQ..[PN].+|N..[PN].+|Z0.[PN].+|(SPS00:)?[DP]...[PN].+|VM...P.+' postag_regexp='yes'/>
+                <token postag="AQ..[PN].+|N..[PN].+|Z0.[PN].+|(SPS00:)?[DP]...[PN].+|VM...P.+" postag_regexp="yes"/>
+                <token regexp='no'>solo</token>
+                <example>Quero dois álbuns solo.</example>
+                <example>Quorthon também produziu dois álbuns solo.</example>
+            </antipattern>
+
             <antipattern> <!-- This is an idiomatic expression in Portuguese -->
                 <token inflected='yes'>fazer</token>
                 <token>das</token>


### PR DESCRIPTION
Just an antipattern to fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new antipattern for the phrase "álbuns solo" in the Portuguese language module to enhance grammar checking.
	- Added example sentences to illustrate the usage of the new antipattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->