### PR TITLE
[pt] Fix FPs in VERB_COMMA_CONJUNCTION

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -19145,6 +19145,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>Tenho 3 <marker>livros,</marker> um para cada vencedor.</example>
                 <example>Quero 20 <marker>cromos,</marker> uns para mim e outros para dar.</example>
                 <example>Quero vários <marker>cromos,</marker> uns para mim e outros para dar.</example>
+                <example>Não há uma resposta certa para isto.</example>
             </rule>
 
             <!-- ALÉM DA PONTE FORAM Além da ponte, foram -->
@@ -19256,6 +19257,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <!--
       Posso vê-la no espaço dela, quando acabar a pandemia.
       -->
+
             <rule>
                 <antipattern>
                     <token postag='NC.+' postag_regexp='yes'/>
@@ -19275,18 +19277,23 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                         <or>
                             <token regexp='yes'>daquel[ae]s?|del[ae]s?|dest[ae]s?</token>
                             <token postag='NC.+' postag_regexp='yes'>
-                                <exception postag_regexp='yes' postag='V.+|AQ.+|RN|RG'/>
+                                <exception postag_regexp='yes' postag='V.+|AQ.+|RN|RG|SP.+'/>
                             </token>
                         </or>
                     </marker>
                     <token postag='CS'>
                         <exception postag_regexp='yes' postag='P.+|I'/>
+                        <!-- much more frequently an adjective than a conjunction -->
+                        <exception>dado</exception>
                     </token>
                 </pattern>
                 <message>Esta locução deve ser separada por vírgulas.</message>
                 <suggestion>\2,</suggestion>
                 <example correction="dela,">Posso vê-la no espaço <marker>dela</marker> quando acabar a pandemia.</example>
                 <example>Posso vê-la no espaço <marker>dela,</marker> quando acabar a pandemia.</example>
+                <!-- disambiguation issue: 'sobre' tagged as noun -->
+                <example>Yanni escreveu um livro sobre como se converteu ao islã.</example>
+                <example>Nos últimos meses de vida, destacou-se pelo apoio dado à eleição de Dilma Rousseff.</example>
             </rule>
 
             <!-- Fizeram hacking à tua conta Rui. > Fizeram hacking à tua conta, Rui. -->


### PR DESCRIPTION
@marcoagpinto these are a couple of fixes to FPs that I *think* are related to side effects of the improvements you've made to the disambiguator. (Using the [diffs](https://regression.languagetoolplus.com/via-http/2024-11-30/pt-BR/index.html) from 30 Nov; specifically here asking for a comma to be added between the words in `sobre como`.) Looks healthy, to be honest, since 'sobre' in those cases is definitely not a verb, but we still need to be aware of the possibility of new FPs.

Some of the agreement issues seem to have been sorted already, but they're just not reflected in the diffs. Just a handful, nothing too serious, but I'd appreciate it if you had a look. I see you've added a fix for 'solo', but there are other instances (e.g. 'atacante estrela', 'final surpresa', etc.) that need to be looked at.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced grammar checking with new examples added to existing rules.
	- Expanded exception conditions for improved accuracy in rule application.
- **Bug Fixes**
	- Updated exception handling to cover a broader range of postag patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->