### PR TITLE
Mention JDK 17 instead of JDK 8 in the build instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Commands:
 
 ## Alternate way to build from source
 
-Before start: you will need to clone from GitHub and install Java 8 and Apache Maven.
+Before start: you will need to clone from GitHub and install Java 17 and Apache Maven.
 
 Warning: a complete clone requires downloading more than 500 MB and needs more than 1500 MB on disk.
 This can be reduced if you only need the last few revisions of the master branch


### PR DESCRIPTION
JDK 17 is now required to build LanguageTool instead of JDK 8.
See https://forum.languagetool.org/t/languagetool-now-requires-jdk-17/10586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Java version requirement from Java 8 to Java 17 in the build instructions for LanguageTool. This change is crucial for users building the software from source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->