### PR TITLE
[pt] Removed "temp_off" from rule ID:TER_PARTICIPIO-PASSADO_V2

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -11558,7 +11558,7 @@ USA
         </rule>
 
 
-        <rule id='TER_PARTICIPIO-PASSADO_V2' name='Ter + Particípio passado' tone_tags='objective' tags='picky' default='temp_off'>
+        <rule id='TER_PARTICIPIO-PASSADO_V2' name='Ter + Particípio passado' tone_tags='objective' tags='picky'>
             <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
 
             <antipattern>
@@ -11582,7 +11582,7 @@ USA
                 <token regexp='yes'>[ao]s?|que|em|com|desde|u(m|ns)|umas?|muit[ao]s|há</token>
             </pattern>
             <filter class='org.languagetool.rules.pt.AdvancedSynthesizerFilter' args='lemmaFrom:2 lemmaSelect:V.* postagFrom:1 postagSelect:V.*'/>
-            <message>Use o presente perfeito para ações contínuas até o presente (ex: &quot;tenho estudado muito&quot;) e o indicativo para ações habituais (ex: &quot;estudo muito&quot;).</message>
+            <message>Use o presente perfeito para ações contínuas até o presente (ex: &quot;tenho lido muito&quot;) e o indicativo para ações habituais (ex: &quot;leio muito&quot;).</message>
             <suggestion>{suggestion}</suggestion>
             <example correction='pesquiso'>Eu <marker>tenho pesquisado</marker> o assunto há décadas.</example>
             <example correction='pesquisas'>Tu <marker>tens pesquisado</marker> o assunto há décadas.</example>


### PR DESCRIPTION
Just removed "temp_off" and made the suggestion shorter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Portuguese language rule for improved clarity in examples.
	- Removed the default setting for the rule related to "Ter + Particípio passado."
	- Enhanced guidance for using present perfect and indicative tenses in examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->