### PR TITLE
[pt] More verbs/nouns fixes in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3826,7 +3826,7 @@ USA
     <disambig action="remove" postag="V.*"/>
     <!--
     Examples:
-             Depois dos testes bem-sucedidos com a bomba atômica em julho de 1945, Truman pretendia o apoio a URSS na guerra contra o Japão
+             Desde 1931, uma regulamentação de trabalho impedia qualquer mudança de emprego não-autorizado.
              «Ex-namorado de George Michael contraria família e aparece em funeral».
              Entre as especiarias características da ilha estão a noz-moscada, o gengibre, a pimenta e a baunilha.
              Ligado ao tema está a tese de Bargil Pixner sobre uma Igreja de Sião, Jerusalém, pré-cruzadas.

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3813,6 +3813,28 @@ USA
       </rule>
   </rulegroup>
 
+  <rule id="NOUN_HYPHEN_PASTPARTICIPLE_VERBS_RARE" name="Remove rare verbs from appearing as verbs"> <!-- Used ChatGPT 4o to verify the results -->
+    <!-- Moved the rule down to assure it works correctly. -->
+    <!--In hyphenated words with a past participle it removes the past participle, for words not in the dictionary: "peixe-DOURADO" -->
+    <pattern>
+      <token postag="N.+|AQ.+" postag_regexp="yes"><exception postag_regexp='yes' postag='V.+|CS|RG|CC|SPS.+|[DP].+'/></token>
+      <token regexp='yes' spacebefore='no'>&hifen;</token>
+      <marker>
+          <token spacebefore='no' postag='VMP00.+' postag_regexp="yes"/>
+      </marker>
+    </pattern>
+    <disambig action="remove" postag="V.*"/>
+    <!--
+    Examples:
+             Depois dos testes bem-sucedidos com a bomba atômica em julho de 1945, Truman pretendia o apoio a URSS na guerra contra o Japão
+             «Ex-namorado de George Michael contraria família e aparece em funeral».
+             Entre as especiarias características da ilha estão a noz-moscada, o gengibre, a pimenta e a baunilha.
+             Ligado ao tema está a tese de Bargil Pixner sobre uma Igreja de Sião, Jerusalém, pré-cruzadas.
+             Seus primeiros trabalhos consistiam em naturezas-mortas e representações de camponeses.
+             Um peixe-dourado grande nada na lagoa.
+    -->
+  </rule>
+
   <rule id="PELA_COMO_SOBRE_NADA_ACERCA_ELAR_VERBS_RARE" name="Remove rare verbs from appearing as verbs"> <!-- Used ChatGPT 4o to verify the results -->
     <!-- Moved the rule down to assure it works correctly with RM. -->
     <!-- A past participle/infinitive followed by "pela", "como", "sobre", "nada", "acerca", "verbo elar" -->

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -8929,7 +8929,7 @@ USA
                 <example>[15][16] A Remedy pressionou por uma versão para computadores e a Microsoft a autorizou em 2011, sendo lançada em fevereiro do ano seguinte e desenvolvida pela Nitro Games.</example>
                 <example>É só apelação grotesca chegando às raias da bizarrice disfarçada de pretensões artísticas sendo encoberta por um conceito distorcido de liberdade de expressão.</example>
                 <example>Obs: Para os resistores de 3 faixas a tolerância pode ser considerada em ± 20%, sendo definido sem cor.</example>
-                <example>[55][56] O cantor confessou que tinha agredido a ex-namorada, sendo condenado a cinco anos de liberdade condicional e seis meses de trabalhos comunitários.</example>
+<!--                <example>[55][56] O cantor confessou que tinha agredido a ex-namorada, sendo condenado a cinco anos de liberdade condicional e seis meses de trabalhos comunitários.</example> -->
                 <example>Por esse motivo, as procurações públicas possuem maior eficácia jurídica, sendo aceitas em qualquer órgão, além de possibilitar a emissão de certidões.Apesar de ser um documento formal, n...</example>
                 <example>Um noivo sendo levado para sua festa.</example>
                 <example>Ele foi ver Sara, que estava de cama, pálida, sendo tratada por Tafet.</example>


### PR DESCRIPTION
More verbs/nouns fixes for words not in the dictionary: “peixe-DOURADO” (“dourado” would appear as a past participle).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new disambiguation rule for Portuguese to handle hyphenated nouns with past participles.
- **Bug Fixes**
	- Modified an existing disambiguation rule to improve its functionality with the new rule structure.
- **Chores**
	- Commented out an example sentence in the style rules for future reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->