### PR TITLE
[pt] Removed "temp_off" from rule ID:PHD_TESE_PROCURAR_PROVAR_PROVARA

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -10623,7 +10623,7 @@ USA
         </rule>
 
 
-        <rulegroup id='PHD_TESE_PROCURAR_PROVAR_PROVARA' name="[Universitário] Evitar expressões do tipo 'procura provar'" type='style' tags='picky' default='temp_off' tone_tags='academic'>
+        <rulegroup id='PHD_TESE_PROCURAR_PROVAR_PROVARA' name="[Universitário] Evitar expressões do tipo 'procura provar'" type='style' tags='picky' default='on' tone_tags='academic'>
 
             <antipattern> <!-- Remove interrogation sentences -->
                 <token regexp='yes' inflected='yes'>buscar|procurar|pretender|querer|tentar|ir</token>


### PR DESCRIPTION
Removed the “temp_off” but the rule must be entirely rewritten.

This is just a quick fix that removed 17 000? hits, so that people won't get annoying by seeing all the time their text underlined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The style checking rule for "PHD_TESE_PROCURAR_PROVAR_PROVARA" is now enabled by default, enhancing the language tool's functionality for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->