### PR TITLE
[pt-PT] Removed "temp_off" from rule ID:CHEGAR_AO_FIM_FINDAR_TERMINAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -3998,7 +3998,7 @@ USA
     </rule>
 
 
-    <rule id='CHEGAR_AO_FIM_FINDAR_TERMINAR' name="[pt-PT][Simplificar] Chegar ao fim → findar/terminar/acabar" type="style" tone_tags="objective" default="temp_off">
+    <rule id='CHEGAR_AO_FIM_FINDAR_TERMINAR' name="[pt-PT][Simplificar] Chegar ao fim → findar/terminar/acabar" type="style" tone_tags="objective">
         <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
         <antipattern>
             <token postag='V.+|N.+|AQ.+|UNKNOWN|RN|SPS00' postag_regexp='yes'/>


### PR DESCRIPTION
Removed "temp_off".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new language rules to enhance grammatical accuracy and formal language usage in Portuguese.
	- Added rules to replace informal expressions with formal alternatives and avoid redundancy.
	- Enhanced existing rules for clearer suggestions and improved specificity.

- **Bug Fixes**
	- Refined rules for better handling of pronouns and specific contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->