### PR TITLE
[pt] Removed "temp_off" from rule ID:QUE_SER_ESTAR_PARTPASSADO_V2

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -16963,7 +16963,7 @@ USA
         </rule>
 
 
-        <rule id='QUE_SER_ESTAR_PARTPASSADO_V2' name="Simplificar: Que + ser/estar + part. passado → Particípio passado" type='style' tags='picky' default="temp_off">
+        <rule id='QUE_SER_ESTAR_PARTPASSADO_V2' name="Simplificar: Que + ser/estar + part. passado → Particípio passado" type='style' tags='picky'>
             <!-- The rule has been completely rewritten.
                  In my first rewrite, I used postag='VMI[IPS]3.+' for the verb "ser" and "estar".
                  In my second rewrite, I removed the 'I' ("estava(m)") postag='VMI[PS]3.+' to avoid too many false positives.


### PR DESCRIPTION
"temp_off" removed!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated language rule for Portuguese to improve accuracy and reduce false positives related to verb usage.
  
- **Bug Fixes**
  - Removed the default attribute from a specific rule to enhance its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->