### PR TITLE
[pt] Removed "temp_off" from rule ID:COLOCACAO_PRONOMINAL_EM_O_SENDO and ID:COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -12890,7 +12890,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="o entendi">Sei que <marker>entendi-o</marker></example>
         </rule>
 
-        <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO" default="temp_off">
+        <rule id="COLOCACAO_PRONOMINAL_COM_ATRATOR_COMPLEXO">
             <pattern>
                 <token>de</token>
                 <token regexp='yes'>forma|maneira|jeito|modo</token>
@@ -12921,7 +12921,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-        <rulegroup id="COLOCACAO_PRONOMINAL_EM_O_SENDO" name="Preferir a próclise em construções do tipo 'em o sendo'" default="temp_off">
+        <rulegroup id="COLOCACAO_PRONOMINAL_EM_O_SENDO" name="Preferir a próclise em construções do tipo 'em o sendo'">
             <rule>
                 <pattern>
                     <token>em</token>


### PR DESCRIPTION
Removed "temp_off" from rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated grammar rules for Portuguese, enhancing the accuracy of grammar checks.
	- Adjusted the default activation status of specific rules to improve user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->