### PR TITLE
[pt] Removed "temp_off" and fixed FPs rule ID:SIMPLIFICAR_QUE_E_TEM_TÊM

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -18067,7 +18067,7 @@ USA
         </rule>
 
 
-        <rule id='SIMPLIFICAR_QUE_E_TEM_TÊM' name="Simplificar: Que/E tem/têm → com" tags="picky" default="temp_off">
+        <rule id='SIMPLIFICAR_QUE_E_TEM_TÊM' name="Simplificar: Que/E tem/têm → com" tags='picky'>
             <!--IDEA shorten_it-->
 
             <antipattern>
@@ -18175,22 +18175,19 @@ USA
             </antipattern>
 
             <pattern>
-                <token postag='NC.+|AQ.+|NP.+|VMP00.+' postag_regexp='yes'/>
-                <token min="0" max="1" postag='_PUNCT|_QUOT' postag_regexp='yes'/>
+                <token postag='N.+|AQ.+|VMP00.+' postag_regexp='yes'>
+                    <exception scope='previous' postag_regexp='yes' postag='SPS00|RG'/>
+                    <exception postag_regexp='yes' postag='VMIP3S0|VMM02S0'/></token>
+                <token min='0' max='1' postag='_PUNCT|_QUOT' postag_regexp='yes'/>
                 <marker>
                     <token regexp='yes'>que|e</token>
                     <token regexp='yes'>t[eê]m</token>
                 </marker>
-                <or>
-                    <token postag='NC.+|AQ.+|NP.+' postag_regexp='yes'>
-                        <exception postag_regexp='yes' postag='SPS00:DA.+|CS|RG'/>
-                    </token>
-                    <token regexp='yes'>[ao]s?</token>
-                </or>
+                <token postag='NC.+|AQ.+|DA.+' postag_regexp='yes'><exception postag_regexp='yes' postag='SPS00:DA.+|CS|RG|NP.+|DI.+|PP3.+'/></token>
                 <token>
-                    <exception postag_regexp='yes' postag='SPS00:DA.+'/>
-                    <exception regexp='no'>com</exception>
-                </token>
+                    <exception postag_regexp='yes' postag='SPS00:DA.+|RG'/>
+                    <exception regexp='yes'>com|porque</exception>
+                    <exception scope='previous' regexp='no'>sobre</exception></token>
             </pattern>
             <message>&simplify_msg;</message>
             <suggestion> com</suggestion>
@@ -18199,7 +18196,12 @@ USA
             <example>É um evento cognitivo que tem lugar na mente dos indivíduos.</example>
             <example>A preocupação e dedicação que têm um com o outro.</example>
             <example>No caso do Pasep, os servidores públicos que tem registro com número final dentre 0 e 4 também recebem este ano.</example>
-            <example>Amo viajar, então você vai ver algumas postagens de lugares por onde andei, usualmente lugares que tem relação com filmes ou livros ou os dois.</example>
+            <example>Você vai ver algumas postagens de lugares por onde andei, usualmente lugares que tem relação com filmes ou livros ou os dois.</example>
+            <example>"Está sabendo do Bill?" "Não, que tem ele?"</example>
+            <example>Há pessoas que têm filhos porque não podem manter um cachorro.</example>
+            <example>Antes de aplicar a atividade é preciso colher junto à criança as informações que tem sobre o assunto.</example>
+            <example>Como é formosa a humanidade! Ó admirável mundo novo, Que tem pessoas assim!</example>
+            <example>Meu marido está na legião, e tem chá pronto.</example>
         </rule>
 
 


### PR DESCRIPTION
False positives fixed and removed "temp_off".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced rule for simplifying the use of "que" and "tem/têm" in Portuguese, with expanded examples and improved specificity.
- **Bug Fixes**
	- Adjusted matching criteria for tokens to improve rule applicability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->