### PR TITLE
Made Russian language a singleton

### DIFF
--- a/languagetool-language-modules/ru/src/main/java/org/languagetool/rules/ru/RussianPartialPosTagFilter.java
+++ b/languagetool-language-modules/ru/src/main/java/org/languagetool/rules/ru/RussianPartialPosTagFilter.java
@@ -22,8 +22,6 @@ import org.languagetool.AnalyzedSentence;
 import org.languagetool.AnalyzedTokenReadings;
 import org.languagetool.language.Russian;
 import org.languagetool.rules.PartialPosTagFilter;
-import org.languagetool.tagging.Tagger;
-import org.languagetool.tagging.disambiguation.Disambiguator;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -39,15 +37,13 @@ import java.util.List;
  */
 public class RussianPartialPosTagFilter extends PartialPosTagFilter {
 
-  private final Tagger tagger = new Russian().getTagger();
-  private final Disambiguator disambiguator = new Russian().getDisambiguator();
-
   @Override
   protected List<AnalyzedTokenReadings> tag(String token) {
     try {
-      List<AnalyzedTokenReadings> tags = tagger.tag(Collections.singletonList(token));
+      var russianLanguage = Russian.getInstance();
+      List<AnalyzedTokenReadings> tags = russianLanguage.getTagger().tag(Collections.singletonList(token));
       AnalyzedTokenReadings[] atr = tags.toArray(new AnalyzedTokenReadings[tags.size()]);
-      AnalyzedSentence disambiguated = disambiguator.disambiguate(new AnalyzedSentence(atr));
+      AnalyzedSentence disambiguated = russianLanguage.getDisambiguator().disambiguate(new AnalyzedSentence(atr));
       return Arrays.asList(disambiguated.getTokens());
     } catch (IOException e) {
       throw new RuntimeException("Could not tag and disambiguate '" + token + "'", e);

--- a/languagetool-language-modules/ru/src/main/java/org/languagetool/rules/ru/RussianSimpleReplaceRule.java
+++ b/languagetool-language-modules/ru/src/main/java/org/languagetool/rules/ru/RussianSimpleReplaceRule.java
@@ -18,19 +18,14 @@
  */
 package org.languagetool.rules.ru;
 
-import org.languagetool.rules.AbstractSimpleReplaceRule2;
-import org.languagetool.rules.Example;
+import org.languagetool.language.Russian;
+import org.languagetool.rules.*;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
-
-import org.languagetool.language.Russian;
-import org.languagetool.rules.ITSIssueType;
-import org.languagetool.rules.Category;
-import org.languagetool.rules.CategoryId;
 
 /**
  * A rule that matches words or phrases which should not be used and suggests
@@ -50,7 +45,7 @@ public class RussianSimpleReplaceRule extends AbstractSimpleReplaceRule2 {
   private static final Locale RU_LOCALE = new Locale("ru");
 
   public RussianSimpleReplaceRule(ResourceBundle messages) throws IOException {
-    super(messages, new Russian());
+    super(messages, Russian.getInstance());
     setLocQualityIssueType(ITSIssueType.Misspelling);
     setCategory(new Category(new CategoryId("MISC"), "Общие правила"));
     addExamplePair(Example.wrong("<marker>Экспрессо</marker> – крепкий кофе, приготовленный из хорошо обжаренных и тонко помолотых кофейных зёрен."),

--- a/languagetool-language-modules/ru/src/main/java/org/languagetool/tagging/disambiguation/ru/RussianHybridDisambiguator.java
+++ b/languagetool-language-modules/ru/src/main/java/org/languagetool/tagging/disambiguation/ru/RussianHybridDisambiguator.java
@@ -19,6 +19,7 @@
 
 package org.languagetool.tagging.disambiguation.ru;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.languagetool.AnalyzedSentence;
 import org.languagetool.JLanguageTool;
@@ -37,10 +38,13 @@ import java.io.IOException;
  */
 
 public class RussianHybridDisambiguator extends AbstractDisambiguator {
-  public static final RussianHybridDisambiguator INSTANCE = new RussianHybridDisambiguator();
+  private static volatile RussianHybridDisambiguator INSTANCE = null;
 
   private final Disambiguator chunker = new MultiWordChunker("/ru/multiwords.txt");
-  private final Disambiguator disambiguator = new XmlRuleDisambiguator(new Russian());
+  private final Disambiguator disambiguator = new XmlRuleDisambiguator(Russian.getInstance());
+
+  private RussianHybridDisambiguator() {
+  }
 
   @Override
   public final AnalyzedSentence disambiguate(AnalyzedSentence input) throws IOException {
@@ -53,5 +57,16 @@ public class RussianHybridDisambiguator extends AbstractDisambiguator {
   @Override
   public AnalyzedSentence disambiguate(AnalyzedSentence input, @Nullable JLanguageTool.CheckCancelledCallback checkCanceled) throws IOException {
     return disambiguator.disambiguate(chunker.disambiguate(input, checkCanceled), checkCanceled);
+  }
+
+  public static @NotNull RussianHybridDisambiguator getInstance() {
+    if (INSTANCE == null) {
+      synchronized (RussianHybridDisambiguator.class) {
+        if (INSTANCE == null) {
+          INSTANCE = new RussianHybridDisambiguator();
+        }
+      }
+    }
+    return INSTANCE;
   }
 }

--- a/languagetool-language-modules/ru/src/test/java/org/languagetool/RussianConcurrencyTest.java
+++ b/languagetool-language-modules/ru/src/test/java/org/languagetool/RussianConcurrencyTest.java
@@ -24,7 +24,7 @@ import org.languagetool.language.Russian;
 public class RussianConcurrencyTest extends AbstractLanguageConcurrencyTest {
   @Override
   protected Language createLanguage() {
-    return new Russian();
+    return Russian.getInstance();
   }
 
   @Override

--- a/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/MorfologikRussianSpellerRuleTest.java
+++ b/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/MorfologikRussianSpellerRuleTest.java
@@ -33,9 +33,9 @@ public class MorfologikRussianSpellerRuleTest {
   @Test
   public void testMorfologikSpeller() throws IOException {
     MorfologikRussianSpellerRule rule =
-      new MorfologikRussianSpellerRule(TestTools.getMessages("ru"), new Russian(), null, Collections.emptyList());
+      new MorfologikRussianSpellerRule(TestTools.getMessages("ru"), Russian.getInstance(), null, Collections.emptyList());
 
-    JLanguageTool lt = new JLanguageTool(new Russian());
+    JLanguageTool lt = new JLanguageTool(Russian.getInstance());
 
     // correct word
     assertEquals(0, rule.match(lt.getAnalyzedSentence("русский")).length);

--- a/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/MorfologikRussianYOSpellerRuleTest.java
+++ b/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/MorfologikRussianYOSpellerRuleTest.java
@@ -33,9 +33,9 @@ public class MorfologikRussianYOSpellerRuleTest {
   @Test
   public void testMorfologikSpeller() throws IOException {
     MorfologikRussianYOSpellerRule rule =
-      new MorfologikRussianYOSpellerRule(TestTools.getMessages("ru"), new Russian(), null, Collections.emptyList());
+      new MorfologikRussianYOSpellerRule(TestTools.getMessages("ru"), Russian.getInstance(), null, Collections.emptyList());
 
-    JLanguageTool lt = new JLanguageTool(new Russian());
+    JLanguageTool lt = new JLanguageTool(Russian.getInstance());
 
     // correct word
     assertEquals(0, rule.match(lt.getAnalyzedSentence("русский")).length);

--- a/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/RussianCompoundRuleTest.java
+++ b/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/RussianCompoundRuleTest.java
@@ -37,8 +37,8 @@ public class RussianCompoundRuleTest extends AbstractCompoundRuleTest {
 
   @Before
   public void setUp() throws Exception {
-    lt = new JLanguageTool(new Russian());
-    rule = new RussianCompoundRule(TestTools.getEnglishMessages(), new Russian(), null);
+    lt = new JLanguageTool(Russian.getInstance());
+    rule = new RussianCompoundRule(TestTools.getEnglishMessages(), Russian.getInstance(), null);
   }
 
   @Test

--- a/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/RussianSimpleReplaceRuleTest.java
+++ b/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/RussianSimpleReplaceRuleTest.java
@@ -36,7 +36,7 @@ public class RussianSimpleReplaceRuleTest {
     RussianSimpleReplaceRule rule = new RussianSimpleReplaceRule(TestTools.getMessages("ru"));
 
     RuleMatch[] matches;
-    JLanguageTool lt = new JLanguageTool(new Russian());
+    JLanguageTool lt = new JLanguageTool(Russian.getInstance());
 
     // correct sentences:
     matches = rule.match(lt.getAnalyzedSentence("Рост кораллов тут самый быстрый,"));

--- a/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/RussianTest.java
+++ b/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/RussianTest.java
@@ -31,7 +31,7 @@ public class RussianTest extends LanguageSpecificTest {
   public void testLanguage() throws IOException {
     // NOTE: this text needs to be kept in sync with config.ts -> DEMO_TEXTS:
     String s = "Вставьте ваш текст сюда .. или проверьте этот текстт. Релиз LanguageTool 4.7 состоялся в четверг 28 сентября 2019 года.";
-    Russian lang = new Russian();
+    Russian lang = Russian.getInstance();
     testDemoText(lang, s,
       Arrays.asList( "DOUBLE_PUNCTUATION", "UPPERCASE_SENTENCE_START", "MORFOLOGIK_RULE_RU_RU", "DATE_WEEKDAY1")
     );

--- a/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/RussianUnpairedBracketsRuleTest.java
+++ b/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/RussianUnpairedBracketsRuleTest.java
@@ -35,9 +35,9 @@ public class RussianUnpairedBracketsRuleTest {
   @Test
   public void testRuleRussian() throws IOException {
     RussianUnpairedBracketsRule rule = new RussianUnpairedBracketsRule(TestTools
-        .getEnglishMessages(), new Russian());
+      .getEnglishMessages(), Russian.getInstance());
     RuleMatch[] matches;
-    JLanguageTool lt = new JLanguageTool(new Russian());
+    JLanguageTool lt = new JLanguageTool(Russian.getInstance());
     // correct sentences:
     matches = rule.match(Collections.singletonList(lt
         .getAnalyzedSentence("(О жене и детях не беспокойся, я беру их на свои руки).")));

--- a/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/RussianVerbConjugationRuleTest.java
+++ b/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/RussianVerbConjugationRuleTest.java
@@ -28,16 +28,16 @@ import org.languagetool.language.Russian;
 import java.io.IOException;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class RussianVerbConjugationRuleTest {
 
-    private Set<String> rightSentences = ImmutableSet.of("Я иду", "Она сидит", "Оно думает",
+    private final Set<String> rightSentences = ImmutableSet.of("Я иду", "Она сидит", "Оно думает",
             "Они пишут", "Мы думаем", "Ты читаешь", "Он творит", "Вы идёте",
             "Я ходил", "Они ходили", "Мы ходили", "Она ходила", "Оно ходило", "Я ходила",
             "Я пойду", "Она пойдёт", "Оно пойдёт", "Мы пойдём", "Ты пойдёшь", "Я согласился на предложение.", "Джек и я согласились", "Ты может быть не помнишь." );
 
-    private Set<String> wrongSentences = ImmutableSet.of("Я идёт", "Она сидят",
+    private final Set<String> wrongSentences = ImmutableSet.of("Я идёт", "Она сидят",
             "Оно думаешь","Они идёте","Мы думаю","Ты читает", "Он творю",
             "Я ходили", "Они ходил", "Мы ходила", "Она ходил", "Оно ходила", "Я ходило",
             "Я пойдёт", "Она пойдут", "Оно пойдёте", "Мы пойдёшь", "Ты пойду", "Мы может поговорить здесь.");
@@ -45,7 +45,7 @@ public class RussianVerbConjugationRuleTest {
     @Test
     public void testRussianVerbConjugationRule() throws IOException {
         RussianVerbConjugationRule rule = new RussianVerbConjugationRule(TestTools.getEnglishMessages());
-        JLanguageTool lt = new JLanguageTool(new Russian());
+      JLanguageTool lt = new JLanguageTool(Russian.getInstance());
 
         for (String sentence : wrongSentences) {
             AnalyzedSentence analyzedSentence = lt.getAnalyzedSentence(sentence);

--- a/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/RussianWordCoherencyRuleTest.java
+++ b/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/RussianWordCoherencyRuleTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 
 public class RussianWordCoherencyRuleTest {
 
-  private final JLanguageTool lt = new JLanguageTool(new Russian());
+  private final JLanguageTool lt = new JLanguageTool(Russian.getInstance());
 
   @Test
   public void testRule() throws IOException {

--- a/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/RussianWordRepeatRuleTest.java
+++ b/languagetool-language-modules/ru/src/test/java/org/languagetool/rules/ru/RussianWordRepeatRuleTest.java
@@ -35,7 +35,7 @@ public class RussianWordRepeatRuleTest {
   public void testRule() throws IOException {
     final RussianWordRepeatRule rule = new RussianWordRepeatRule(TestTools.getEnglishMessages());
     RuleMatch[] matches;
-    JLanguageTool lt = new JLanguageTool(new Russian());
+    JLanguageTool lt = new JLanguageTool(Russian.getInstance());
     //correct
     matches = rule.match(lt.getAnalyzedSentence("Повтор слов в предложении."));
     assertEquals(0, matches.length);

--- a/languagetool-language-modules/ru/src/test/java/org/languagetool/tagging/ru/RussianTaggerTest.java
+++ b/languagetool-language-modules/ru/src/test/java/org/languagetool/tagging/ru/RussianTaggerTest.java
@@ -29,7 +29,7 @@ public class RussianTaggerTest {
 
   @Test
   public void testDictionary() throws IOException {
-    TestTools.testDictionary(RussianTagger.INSTANCE, new Russian());
+    TestTools.testDictionary(RussianTagger.INSTANCE, Russian.getInstance());
   }
 
   @Test

--- a/languagetool-language-modules/ru/src/test/java/org/languagetool/tokenizers/ru/RussianSRXSentenceTokenizerTest.java
+++ b/languagetool-language-modules/ru/src/test/java/org/languagetool/tokenizers/ru/RussianSRXSentenceTokenizerTest.java
@@ -27,7 +27,7 @@ import org.languagetool.tokenizers.SentenceTokenizer;
 
 public class RussianSRXSentenceTokenizerTest {
 
-  private final SentenceTokenizer stokenizer = new SRXSentenceTokenizer(new Russian());
+  private final SentenceTokenizer stokenizer = new SRXSentenceTokenizer(Russian.getInstance());
 
   @Test
   public final void testTokenize() {

--- a/languagetool-standalone/src/test/java/org/languagetool/JLanguageToolTest.java
+++ b/languagetool-standalone/src/test/java/org/languagetool/JLanguageToolTest.java
@@ -425,7 +425,7 @@ public class JLanguageToolTest {
   public void testRuleMessagesForSpellingErrors() throws Exception {
     JLanguageTool lt = new JLanguageTool(english);
     //JLanguageTool lt = new JLanguageTool(GermanyGerman.getInstance());
-    //JLanguageTool lt = new JLanguageTool(new Russian());
+    //JLanguageTool lt = new JLanguageTool(Russian.getInstance());
     String[] rulesDisabled = {
             // en:
             "EN_QUOTES", "UPPERCASE_SENTENCE_START", "WHITESPACE_RULE",


### PR DESCRIPTION
Removed some static initializations of the language instance and nested objects

This fix the flaky test: https://github.com/languagetool-org/languagetool/commit/1951f9f1b3a73983fb1b5ab9bcabbbfd2ae61828#commitcomment-150409918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a singleton pattern for the `Russian` language instance across various components, enhancing instance management.
  
- **Bug Fixes**
	- Improved error handling and instance retrieval for the `Russian` language class to prevent multiple instantiations.

- **Tests**
	- Updated test classes to utilize the singleton instance of `Russian`, ensuring consistent usage across tests. 

- **Documentation**
	- Enhanced clarity in the structure and functionality of the `Russian` language components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->