### PR TITLE
[pt] Added APs to rule ID:GENERAL_NUMBER_AGREEMENT_ERRORS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -4330,6 +4330,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <!--
            MARCOAGPINTO inserted global antipatterns for all subrules on top using the logic (2-MAR-2023+)
       -->
+
+            <antipattern>
+                <token postag='AQ.+|N.+' postag_regexp='yes'/>
+                <token regexp='no'>tais</token>
+                <token postag='AQ..[PN].+|N..[PN].+|Z0.[PN].+' postag_regexp='yes'/>
+                <example>Navegue por várias categorias de modelos Webcam tais Casais, Transsexuais, Mulheres e Homens que realizam shows.</example>
+            </antipattern>
+
             <antipattern> <!-- These are idiomatic expressions in Portuguese: ChatGPT 4o -->
                 <token postag='V....S.+' postag_regexp='yes' inflected='yes'>ser</token>
                 <token regexp='yes'>tod[oa]</token>
@@ -4350,13 +4358,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>"Quer saber como o fez?" "Sou toda ouvidos."</example>
             </antipattern>
             <antipattern> <!-- Use of "nós" -->
-                <token postag='RM|RG|CS|CC|SPS00|(SPS00:)?[DP]...[SN].+|VM...S.+' postag_regexp='yes'/>
+                <token postag='RM|RG|CS|CC|SPS00|(SPS00:)?[DP]...[SN].+|VM...S.+|_PUNCT' postag_regexp='yes'/>
                 <token>nós</token>
-                <token postag="AQ..S.+|N..S.+" postag_regexp="yes"/>
+                <token postag="AQ..S.+|N..S.+|VMP00S.+" postag_regexp="yes"/>
                 <token postag='RM|RG|CS|CC|SPS00|(SPS00:)?[DP]...[SN].+|VM...S.+' postag_regexp='yes'/>
                 <example>Assim que partimos, juntou-se a nós Jesus com pequeno grupo de seguidores.</example>
                 <example>A nós Jesus disse estar cansado de pregar.</example>
                 <example>Sl 95:7-9 - Porque ele é o nosso Deus, e nós povo do seu pasto e ovelhas da sua mão.</example>
+                <example>notas: Nós medido manualmente, por favor permitido 1-4 cm desvio tamanho.</example>
             </antipattern>
             <antipattern> <!-- "álbuns solo" -->
                 <token postag='AQ..[PN].+|N..[PN].+|Z0.[PN].+|(SPS00:)?[DP]...[PN].+|VM...P.+' postag_regexp='yes'/>


### PR DESCRIPTION
Just added/improved antipatterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new antipattern for the word "tais" in Portuguese grammar rules.
- **Enhancements**
	- Expanded postag patterns for the antipattern concerning "nós" to include punctuation and a new verb postag.
	- Added an example sentence to illustrate the usage of the antipattern for "nós".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->