### PR TITLE
[pt] Added words to spelling.txt + APs

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
@@ -361,6 +361,8 @@ inumadas
 inumado
 inumados
 Jumarie
+lapalissada
+lapalissadas
 lascarim
 legos
 longeva

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
@@ -324,6 +324,7 @@ bridão
 bridões
 carrapito
 carrapitos
+caulinar
 chinchada
 coloquialismo
 coloquialismos
@@ -366,6 +367,8 @@ longeva
 longevas
 longevo
 longevos
+lumbago
+lumbagos
 mg
 Milda
 Nabeiro

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -3439,6 +3439,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <rulegroup default='on' id='A_WORD' name="Concordância: A + palavra">
             <!-- Created by Tiago F. Santos, Portuguese rule, 2016-10-28 -->
 
+            <antipattern> <!-- "batatas a murro" (Portuguese food) -->
+                <token>a</token>
+                <token>murro</token>
+                <example>Quero batatas que sejam a murro.</example>
+            </antipattern>
+
             <antipattern> <!-- Fix disambiguator changes: Verbs to Nouns 1/4 -->
                 <token skip='4' inflected='yes' regexp='no'>estar</token>
                 <token>a</token>


### PR DESCRIPTION
A few improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded Portuguese spelling dictionary with 106 new words and phrases, enhancing vocabulary recognition and validation.
	- Notable additions include terms like "caulinar," "lumbago," "palavra-passe," and "videogravação."
	- Added a new antipattern for the phrase "batatas a murro," improving grammar recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->