### PR TITLE
[pt] Added verb to "termos" in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3813,6 +3813,23 @@ USA
       </rule>
   </rulegroup>
 
+  <rule id="PARA_POR_TODOS_TERMOS_SUBSTANTIVO_PARA_VERBO" name="Adicionar tag de verbo ao substantivo">
+    <pattern>
+      <token regexp='yes'>para|por</token>
+      <token regexp='yes'>tod[ao]s</token>
+      <marker>
+        <token>termos</token>
+      </marker>
+      <token postag='N.+|AQ.+' postag_regexp='yes'/>
+    </pattern>
+    <disambig action="add"><wd pos='VMN01P0'/></disambig>
+    <!--
+    Examples:
+             Estou contente para todos termos mentes científicas.
+             Estou contente por todos termos mentes científicas.
+    -->
+  </rule>
+
   <rule id="VERB_NOUNVERB_SPS00_VERBS_RARE" name="Remove rare verbs from appearing as verbs"> <!-- Used ChatGPT 4o to verify the results -->
     <!-- Moved the rule down to assure it works correctly. -->
     <pattern>


### PR DESCRIPTION
It adds the verb tag to "termos" in special conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new disambiguation rule for the Portuguese language module in LanguageTool to enhance grammatical tagging.
	- The rule adds a verb tag to specific noun phrases involving "para" or "por" followed by "todos" and "termos".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->