### PR TITLE
[pt] Added exceptions to rule ID:OS_DOIS_AS_DUAS_AMBOS_AMBAS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3691,7 +3691,7 @@ USA
                 <pattern>
                     <token postag='V.+|RG|CS' postag_regexp='yes'>
                         <exception postag_regexp='yes' postag='SPS.+'/>
-                        <exception regexp='yes' inflected='yes'>formar|precisar|só</exception></token> <!-- "ser" removed in rule #1 -->
+                        <exception regexp='yes' inflected='yes'>enviar|formar|precisar|só</exception></token> <!-- "ser" removed in rule #1 -->
                     <marker>
                         <token regexp='yes'>[ao]s</token>
                         <token regexp='yes'>duas|dois
@@ -3720,7 +3720,7 @@ USA
                 <pattern>
                     <token postag='V.+|RG|CS' postag_regexp='yes'>
                         <exception postag_regexp='yes' postag='SPS.+'/>
-                        <exception regexp='yes' inflected='yes'>formar|precisar|ser|só</exception></token>
+                        <exception regexp='yes' inflected='yes'>enviar|formar|precisar|ser|só</exception></token>
                     <marker>
                         <token regexp='yes'>[ao]s</token>
                         <token regexp='yes'>duas|dois</token>
@@ -3751,6 +3751,7 @@ USA
                 <example>Os filhos eram os dois únicos homens a quem ela se dedicava.</example>
                 <example>Estas são as duas únicas palavras que não compreendemos.</example>
                 <example>Já em 1904 seriam as duas maiores ferrovias da República, da central e nacional através da cidade.</example>
+                <example>Peço que enviem os dois e-mails dos rascunhos.</example>
             </rule>
 
         </rulegroup>


### PR DESCRIPTION
To fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated Portuguese language rules to improve verb exception handling
	- Added more comprehensive verb exceptions for specific language patterns
- **Documentation**
	- Included a new example illustrating verb usage in context of sending emails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->