### PR TITLE
[pt] Added AP to rule ID:GENERAL_NUMBER_AGREEMENT_ERRORS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -4377,6 +4377,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       -->
 
             <antipattern>
+                <token postag='AQ..[PN].+|N..[PN].+|Z0.[PN].+' postag_regexp='yes'/>
+                <token regexp='yes'>coup[éê]|cup[éê]</token>
+                <example>Isso permitiu com que esse carro competisse contra carros Cupê importados como, o Toyota Celica japonês.</example>
+            </antipattern>
+
+            <antipattern>
                 <token postag='AQ.+|N.+' postag_regexp='yes'/>
                 <token regexp='no'>tais</token>
                 <token postag='AQ..[PN].+|N..[PN].+|Z0.[PN].+' postag_regexp='yes'/>


### PR DESCRIPTION
Just an antipattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Portuguese grammar rules with a new antipattern to improve language detection and validation
	- Added specific token matching for linguistic patterns involving adjectives, nouns, and variations of the word "coupé"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->