### PR TITLE
[pt-PT] Added rule ID:BRASILEIRISMO_MACHUCAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -3100,6 +3100,18 @@ USA
       </rule>
 
 
+     <rule id='BRASILEIRISMO_MACHUCAR' name="[pt-PT][Brasileirismo] machucar → magoar/aleijar/ferir" default='temp_off'>
+          <pattern>
+              <token inflected='yes' regexp='no'>machucar</token>
+          </pattern>
+          <message>Grafia do Brasil. Substitua por:</message>
+          <suggestion><match no='1' postag='V.+' postag_regexp='yes'>magoar</match></suggestion>
+          <suggestion><match no='1' postag='V.+' postag_regexp='yes'>aleijar</match></suggestion>
+          <suggestion><match no='1' postag='V.+' postag_regexp='yes'>ferir</match></suggestion>
+          <example correction='magoar|aleijar|ferir'>Vais <marker>machucar</marker> o Rui.</example>
+      </rule>
+
+
       <rule id='BRASILEIRISMO_PRIVADA' name="[pt-PT][Brasileirismo] 'privada sanitária', 'vaso sanitário' → retrete">
           <!-- Created by Tiago F. Santos , Portuguese rule, 2017-04-12 -->
           <pattern>


### PR DESCRIPTION
Added a pt-PT rule, converting Brazilian to European Portuguese.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a grammar rule for Portuguese language to suggest alternative terms for the word "machucar" in European Portuguese.
	- Provides language refinement suggestions for regional language variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->