### PR TITLE
[pt-PT] Removed "temp_off" from rule ID:BRASILEIRISMO_MACHUCAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -3100,7 +3100,7 @@ USA
       </rule>
 
 
-     <rule id='BRASILEIRISMO_MACHUCAR' name="[pt-PT][Brasileirismo] machucar → magoar/aleijar/ferir" default='temp_off'>
+     <rule id='BRASILEIRISMO_MACHUCAR' name="[pt-PT][Brasileirismo] machucar → magoar/aleijar/ferir">
           <pattern>
               <token inflected='yes' regexp='no'>machucar</token>
           </pattern>


### PR DESCRIPTION
Removed the "temp_off".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Reactivated a grammar rule for the term "machucar" in Portuguese language rules
	- Corrected rule status to improve language detection and suggestions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->