### PR TITLE
[pt] More verbs/nouns fixes in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4151,11 +4151,13 @@ USA
       <token postag="V.+" postag_regexp="yes"/>
       <marker>
         <and>
-          <token postag='VMSP3S0|VMIP3S0|VMM02S0|VMSP2S0|VMIP2S0|VMN02S0|VMSF2S0|VMIP1S0|VMP00SM' postag_regexp="yes"/>
+          <token postag='V.+' postag_regexp="yes"/>
           <token postag='NC.+' postag_regexp='yes'/>
         </and>
       </marker>
-      <token><exception scope="previous" regexp="no">tá</exception></token>
+      <token>
+        <exception scope="previous" postag_regexp='yes' postag='VMN0000|VMIP3P0'/>
+        <exception scope="previous" regexp="no">tá</exception></token>
     </pattern>
     <disambig action="remove" postag="V.*"/>
     <!--
@@ -4171,6 +4173,10 @@ USA
              Alguém sabe me explicar sobre isso?
              Pare de se anular, aja com humildade mas seja firme em suas decisões.
              Que a terra lhe seja leve.
+             Eles iniciaram a revolta ao exigir a convocação dos Estados Gerais para votar o projeto de reformas.
+             Um aluno de Stewart, James Mackintosh, escreveu em resposta uma apaixonada defesa da causa francesa.
+             Outras leis proibiram a venda de cargos públicos e a isenção tributária das camadas privilegiadas.
+             De salientar que as carruagens se encontram ordenadas de sul para norte (1 -> 6).
     -->
   </rule>
 

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4156,7 +4156,7 @@ USA
         </and>
       </marker>
       <token>
-        <exception scope="previous" postag_regexp='yes' postag='VMN0000|VMIP3P0|VMP00.+'/>
+        <exception scope="previous" postag_regexp='yes' postag='VMN0000|VMIP3P0'/>
         <exception scope="previous" regexp="no">tá</exception></token>
     </pattern>
     <disambig action="remove" postag="V.*"/>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4148,7 +4148,7 @@ USA
       <token postag="V.+|NC.+|AQ.+" postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|CC|SPS.+|[DP].+'/></token>
       <token min='0' max='1' postag='RM'/>
       <token postag="(SPS00:)?(D[AI].+|PP.+)|Z0.+" postag_regexp="yes"/>
-      <token postag="V.+" postag_regexp="yes"/>
+      <token postag="V.+" postag_regexp="yes"><exception postag_regexp='no' postag='VMN0000'/></token>
       <marker>
         <and>
           <token postag='V.+' postag_regexp="yes"/>
@@ -4156,7 +4156,7 @@ USA
         </and>
       </marker>
       <token>
-        <exception scope="previous" postag_regexp='yes' postag='VMN0000|VMIP3P0'/>
+        <exception scope="previous" postag_regexp='yes' postag='VMN0000|VMIP3P0|VMP00.+'/>
         <exception scope="previous" regexp="no">tá</exception></token>
     </pattern>
     <disambig action="remove" postag="V.*"/>


### PR DESCRIPTION
More verbs/nouns fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced Portuguese language disambiguation rules in LanguageTool.
	- Refined verb pattern matching to improve grammatical accuracy.
	- Updated rule conditions for more precise identification of verb forms in complex sentences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->