### PR TITLE
[pt] Convert nouns to verbs in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3848,21 +3848,41 @@ USA
     -->
   </rule>
 
-  <rule id="OUTRA_SUBSTANTIVO_PARA_VERBO" name="Adicionar tag de verbo ao substantivo">
-    <pattern>
-      <token>outra</token>
-      <marker>
-        <token regexp='yes'>choco|esbarro</token> <!-- Add verbs as found -->
-      </marker>
-      <token postag='SPS.+' postag_regexp='yes'/>
-    </pattern>
-    <disambig action="add"><wd pos='VMIP1S0'/></disambig>
-    <!--
-    Examples:
-             De alguma forma, vez ou outra esbarro em algumas dessas coisas.
-             De alguma forma, vez ou outra choco em algumas dessas coisas.
-    -->
-  </rule>
+
+
+  <rulegroup id="OUTRA_SUBSTANTIVO_PARA_VERBO" name="Adicionar tag de verbo ao substantivo">
+
+    <rule> <!-- #1 -->
+      <pattern>
+        <token>outra</token>
+        <marker>
+          <token regexp='yes'>choco|esbarro</token> <!-- Add verbs as found -->
+        </marker>
+        <token postag='SPS.+|RG' postag_regexp='yes'/>
+      </pattern>
+      <disambig action="add"><wd pos='VMIP1S0'/></disambig>
+      <!--
+      Examples:
+               De alguma forma, vez ou outra esbarro em algumas dessas coisas.
+               De alguma forma, vez ou outra choco em algumas dessas coisas.
+      -->
+    </rule>
+    <rule> <!-- #2 -->
+      <pattern>
+        <token>outra</token>
+        <marker>
+          <token regexp='no'>vale</token> <!-- Add verbs as found -->
+        </marker>
+        <token postag='SPS.+|RG' postag_regexp='yes'/>
+      </pattern>
+      <disambig action="add"><wd pos='VMIP3S0|VMM02S0'/></disambig>
+      <!--
+      Examples:
+               Um pouco de bondade de uma pessoa para outra vale mais que todo o amor pela humanidade.
+      -->
+    </rule>
+
+  </rulegroup>
 
   <rule id="VERB_NOUNVERB_SPS00_VERBS_RARE" name="Remove rare verbs from appearing as verbs"> <!-- Used ChatGPT 4o to verify the results -->
     <!-- Moved the rule down to assure it works correctly. -->


### PR DESCRIPTION
Fixed more issues with verbs after “outra” appearing as nouns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced Portuguese language disambiguation rules
  - Updated verb and noun tagging for specific grammatical contexts
  - Refined rule handling for rare verb identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->