### PR TITLE
[pt] Fixed FPs in previous rule in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4254,7 +4254,7 @@ USA
     <pattern>
       <token postag='VMN0000|VMG0000|VMP00.+' postag_regexp='yes'/>
       <token min='0' max='1' postag='RM'/>
-      <token postag="(SPS00:)?(D[AI].+|PP.+)|Z0.+" postag_regexp="yes"/>
+      <token postag='(SPS00:)?(D[AI].+|PP.+)|Z0.+' postag_regexp='yes'><exception postag_regexp='no' postag='PP3CNO00'/></token> <!-- "se" -->
       <marker>
         <and>
           <token postag='V.+' postag_regexp="yes"/>


### PR DESCRIPTION
ChatGPT lied in the results.

It had false results using "se":
`Você está enganada se acha que isso vai ser fácil.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Portuguese language disambiguation rules in LanguageTool
  - Added multiple new rules for improving grammatical and linguistic accuracy
  - Introduced advanced handling of verb tagging, clitics, and word context

- **Improvements**
  - Refined rule set for better linguistic processing
  - Improved handling of complex Portuguese language constructs
  - Enhanced detection and classification of words in various contexts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->