### PR TITLE
Issue 11165 -- turn off space rule for fr-CA

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
+++ b/languagetool-core/src/main/java/org/languagetool/JLanguageTool.java
@@ -475,6 +475,9 @@ public class JLanguageTool {
   private List<Rule> getAllBuiltinRules(Language language, ResourceBundle messages, UserConfig userConfig, GlobalConfig globalConfig) {
     try {
       List<Rule> rules = new ArrayList<>(language.getRelevantRules(messages, userConfig, motherTongue, altLanguages));
+      if (!language.getDefaultDisabledRulesForVariant().isEmpty()) {
+        rules = rules.stream().filter(k -> !language.getDefaultDisabledRulesForVariant().contains(k.getId())).collect(Collectors.toList());
+      }
       rules.addAll(language.getRelevantRulesGlobalConfig(messages, globalConfig, userConfig, motherTongue, altLanguages));
       return rules;
     } catch (IOException e) {

--- a/languagetool-core/src/test/java/org/languagetool/rules/DemoRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/DemoRuleTest.java
@@ -1,0 +1,84 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2025 Daniel Naber (http://www.danielnaber.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules;
+
+import org.junit.Test;
+import org.languagetool.AnalyzedSentence;
+import org.languagetool.JLanguageTool;
+import org.languagetool.Language;
+import org.languagetool.UserConfig;
+import org.languagetool.language.Demo;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.ResourceBundle;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public class DemoRuleTest {
+
+  @Test
+  public void testDemoRule() throws IOException {
+    JLanguageTool lt1 = new JLanguageTool(new DemoLang1());
+    assertThat(lt1.check("This is a sentence").size(), is(0));
+    assertThat(lt1.check("This is a foobar sentence").size(), is(1));
+    JLanguageTool lt2 = new JLanguageTool(new DemoLang2());
+    assertThat(lt2.check("This is a sentence").size(), is(0));
+    assertThat(lt2.check("This is a foobar sentence").size(), is(0));  // DEMO_RULE_FOR_TESTS turned off in DemoLang2
+  }
+
+  public static class DemoRule extends Rule {
+    @Override
+    public String getId() {
+      return "DEMO_RULE_FOR_TESTS";
+    }
+    @Override
+    public String getDescription() {
+      return "A demo rule for tests";
+    }
+    @Override
+    public RuleMatch[] match(AnalyzedSentence sentence) throws IOException {
+      if (sentence.getText().contains("foobar")) {
+        return new RuleMatch[] { new RuleMatch(this, sentence, 0, 1, "A demo rule match somewhere in the input") };
+      }
+      return RuleMatch.EMPTY_ARRAY;
+    }
+  }
+
+  public static class DemoLang1 extends Demo {
+    @Override
+    public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig, Language motherTongue, List<Language> altLanguages) {
+      return Collections.singletonList(new DemoRule());
+    }
+    @Override
+    public List<String> getDefaultDisabledRulesForVariant() {
+      return Arrays.asList("test_unification_with_negation");
+    }
+  }
+
+  public static class DemoLang2 extends DemoLang1 {
+    @Override
+    public List<String> getDefaultDisabledRulesForVariant() {
+      return Arrays.asList("DEMO_RULE_FOR_TESTS", "test_unification_with_negation");
+    }
+  }
+}

--- a/languagetool-language-modules/ca/src/main/java/org/languagetool/language/BalearicCatalan.java
+++ b/languagetool-language-modules/ca/src/main/java/org/languagetool/language/BalearicCatalan.java
@@ -83,7 +83,6 @@ public class BalearicCatalan extends Catalan {
 
   @Override
   public List<String> getDefaultDisabledRulesForVariant() {
-    // Important: Java rules are not disabled here
     List<String> rules = Arrays.asList("EXIGEIX_VERBS_CENTRAL","CA_SIMPLE_REPLACE_BALEARIC");
     return Collections.unmodifiableList(rules);
   }

--- a/languagetool-language-modules/ca/src/main/java/org/languagetool/language/ValencianCatalan.java
+++ b/languagetool-language-modules/ca/src/main/java/org/languagetool/language/ValencianCatalan.java
@@ -99,7 +99,6 @@ public class ValencianCatalan extends Catalan {
 
   @Override
   public List<String> getDefaultDisabledRulesForVariant() {
-    // Important: Java rules are not disabled here
     List<String> rules = Arrays.asList("EXIGEIX_VERBS_CENTRAL", "EXIGEIX_ACCENTUACIO_GENERAL", "EXIGEIX_POSSESSIUS_V",
         "EVITA_PRONOMS_VALENCIANS", "EVITA_DEMOSTRATIUS_EIXE", "VOCABULARI_VALENCIA", "EXIGEIX_US", "FINS_EL_GENERAL", 
         "EVITA_INFINITIUS_INDRE", "EVITA_DEMOSTRATIUS_ESTE");

--- a/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
+++ b/languagetool-language-modules/de/src/main/resources/org/languagetool/resource/de/hunspell/spelling.txt
@@ -65834,6 +65834,11 @@ Durchbruchzeit
 Durchbruchzeiten
 Überfliegung
 Überfliegungen
+Vorjahreszubau/S
+Solarzubau/S
+Repowering/S  #eng
+Inbetriebnahmezahl
+Inbetriebnahmezahlen
 Sauropodenspur
 Sauropodenspuren
 Sauropodenfußabdruck/S

--- a/languagetool-language-modules/es/src/main/java/org/languagetool/language/SpanishVoseo.java
+++ b/languagetool-language-modules/es/src/main/java/org/languagetool/language/SpanishVoseo.java
@@ -1,10 +1,10 @@
 package org.languagetool.language;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public class SpanishVoseo extends Spanish {
+
   public SpanishVoseo() {
     super(true);
   }
@@ -16,14 +16,13 @@ public class SpanishVoseo extends Spanish {
 
   @Override
   public String[] getCountries() {
-    return new String[] { "AR" //, "PA" , "UY", "CR"
-    };
+    return new String[] { "AR" }; //, "PA" , "UY", "CR"
   }
 
   @Override
   public List<String> getDefaultDisabledRulesForVariant() {
     List<String> rules = Collections.singletonList("VOSEO");
-    return Collections.unmodifiableList(rules);
+    return rules;
   }
 
 }

--- a/languagetool-language-modules/fr/src/main/java/org/languagetool/language/CanadianFrench.java
+++ b/languagetool-language-modules/fr/src/main/java/org/languagetool/language/CanadianFrench.java
@@ -18,7 +18,7 @@
  */
 package org.languagetool.language;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 public class CanadianFrench extends French {
@@ -46,7 +46,7 @@ public class CanadianFrench extends French {
 
   @Override
   public List<String> getDefaultDisabledRulesForVariant() {
-    List<String> rules = Collections.singletonList("DOUBLER_UNE_CLASSE");
+    List<String> rules = Arrays.asList("DOUBLER_UNE_CLASSE", "FRENCH_WHITESPACE");
     return rules;
   }
 }


### PR DESCRIPTION
See https://github.com/languagetool-org/languagetool/issues/11165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced language-specific rule filtering for more precise language tool configurations
	- Added support for demo language testing scenarios

- **Improvements**
	- Updated rule handling for Balearic and Valencian Catalan language variants
	- Expanded Spanish Voseo language configuration
	- Modified Canadian French language rule settings

- **Dictionary Updates**
	- Added new German language terms related to construction and energy sectors

- **Testing**
	- Introduced comprehensive demo rule testing framework

<!-- end of auto-generated comment: release notes by coderabbit.ai -->