### PR TITLE
[pt-PT] Added rule to rulegroup id:COLOQUIALISMOS_PT_PT

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -1251,7 +1251,7 @@ USA
 </rulegroup>
 
 
-    <rulegroup id='COLOQUIALISMOS_PT_PT' name="[Formal] Coloquialismos: evitar expressões orais" default="on" tone_tags="formal">
+    <rulegroup id='COLOQUIALISMOS_PT_PT' name="[pt-PT][Formal] Coloquialismos: evitar expressões orais" default="on" tone_tags="formal">
 
         <rule>
             <pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -2099,6 +2099,24 @@ USA
         <short>Coloquialismo</short>
         <example correction=''>Vai <marker>dar uma volta ao bilhar grande</marker>.</example>
     </rule>
+   <rule default='temp_off'> <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
+        <pattern>
+            <token>de</token>
+            <token>um</token>
+            <token>dia</token>
+            <token>para</token>
+            <token>o</token>
+            <token>outro</token>
+        </pattern>
+        <message>&colloquialism_msg;</message>
+        <suggestion>de forma súbita</suggestion>
+        <suggestion>subitamente</suggestion>
+        <suggestion>de maneira repentina</suggestion>
+        <suggestion>repentinamente</suggestion>
+        <suggestion>num curto intervalo de tempo</suggestion>
+        <short>Coloquialismo</short>
+        <example correction='de forma súbita|subitamente|de maneira repentina|repentinamente|num curto intervalo de tempo'>A Ana fê-lo <marker>de um dia para o outro</marker>.</example>
+    </rule>
     </rulegroup>
 
 


### PR DESCRIPTION
A colloquialism rule for pt-PT.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new style rule for Portuguese language to suggest more formal alternatives to the colloquial expression "de um dia para o outro"
- **Documentation**
	- Provided example corrections for the new style rule
<!-- end of auto-generated comment: release notes by coderabbit.ai -->