### PR TITLE
[pt] Removed "temp_off" from two rules

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -4115,7 +4115,7 @@ USA
         </rule>
 
 
-        <rulegroup id='GASTAR_DESPENDER_DESEMBOLSAR' name='gastar → despender/desembolsar' default='temp_off' tone_tags='formal' is_goal_specific='true'>
+        <rulegroup id='GASTAR_DESPENDER_DESEMBOLSAR' name='gastar → despender/desembolsar' tone_tags='formal' is_goal_specific='true'>
         <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
 
             <rule> <!-- #1: No past participle of "gastar" -->
@@ -4284,7 +4284,7 @@ USA
         </rule>
 
 
-        <rule id='QUE_VEM_PROXIMA' name="[Simplificar] Substantivo + que vem → próxim(ao)(s) + substantivo" type='style' tone_tags='formal' default='temp_off'>
+        <rule id='QUE_VEM_PROXIMA' name="[Simplificar] Substantivo + que vem → próxim(ao)(s) + substantivo" type='style' tone_tags='formal'>
             <!--IDEA shorten_it-->
 
             <pattern>


### PR DESCRIPTION
Removed "temp_off".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Removed `default='temp_off'` attribute from two language rule configurations in Portuguese language module
	- Potentially activates previously disabled style rules for language processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->