### PR TITLE
[pt] Added AP to rule ID:VERB_QUE_É_VERB_SER

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
@@ -257,3 +257,4 @@ videogravações	videogravação	NCFP000
 Whirlpool	Whirlpool	NPFS000
 Woodcock	Woodcock	NPMS000
 WritingTool	WritingTool	NPMN000
+X	X	NPMS000

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -15082,6 +15082,16 @@ USA
             <!--
       Eu acho que é perigoso subir aquela montanha sozinho. → Eu acho ser perigoso subir aquela montanha sozinho.
       -->
+
+            <antipattern>
+                <token postag='SPS00:DA.+' postag_regexp='yes'/>
+                <token skip='4' postag='DP.+' postag_regexp='yes'/>
+                <token>que</token>
+                <token regexp='yes'>é|são</token>
+                <token postag='DI.+' postag_regexp='yes'/>
+                <example>Ele alega no seu perfil no X, que é um alienígena viajante do tempo.</example>
+                <example>Eles alegam no seu perfil no X, que são uns alienígenas viajantes do tempo.</example>
+            </antipattern>
             <antipattern>
                 <token>que</token>
                 <token>é</token>


### PR DESCRIPTION
Just an antipattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Portuguese language rule configuration with a new grammatical antipattern to improve language detection and style checking.
	- Added more precise token matching for specific sentence structures involving determiners, "que", and verb forms.
	- Expanded the part-of-speech dictionary by adding the term "X" as a noun for better language processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->