### PR TITLE
[pt-PT] Removed "temp_off" from rule ID:AVOID_GERUND

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -134,7 +134,7 @@ USA
     </rule>
 
 
-    <rule id='AVOID_GERUND' name='[pt-PT] Evitar o Gerúndio (perifrásico)' default='temp_off' type='style' tone_tags="objective">
+    <rule id='AVOID_GERUND' name='[pt-PT] Evitar o Gerúndio (perifrásico)' type='style' tone_tags="objective">
         <!-- Created by Tiago F. Santos , Portuguese rule, 2016-11-24 -->
         <!-- Later revise the whole "&gerundio_verbos;", "&gerundio_excecoes;" and "&gerundio_excecoes_do_verbo_estar_auxiliares_chatgpt;" -->
 


### PR DESCRIPTION
Removed the "temp_off".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style Rules**
	- Activated the Portuguese language rule for avoiding gerunds
	- Enhanced rule guidance for more precise language usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->