### PR TITLE
[pt] Fix for "X" ("rede social X") in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
@@ -257,5 +257,3 @@ videogravações	videogravação	NCFP000
 Whirlpool	Whirlpool	NPFS000
 Woodcock	Woodcock	NPMS000
 WritingTool	WritingTool	NPMN000
-X	X	NPMS000
-X	X	ZRCN0

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
@@ -258,3 +258,4 @@ Whirlpool	Whirlpool	NPFS000
 Woodcock	Woodcock	NPMS000
 WritingTool	WritingTool	NPMN000
 X	X	NPMS000
+X	X	ZRCN0

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
@@ -246,6 +246,10 @@ sistémico	sistémico	AQ0MS0
 sistêmico	sistêmico	AQ0MS0
 sistémicos	sistémico	AQ0MP0
 sistêmicos	sistêmico	AQ0MP0
+sossegadinha	sossegadinho	NCFS00D
+sossegadinhas	sossegadinho	NCFP00D
+sossegadinho	sossegadinho	NCMS00D
+sossegadinhos	sossegadinho	NCMP00D
 tênue	tênue	AQ0CS0
 ténue	ténue	AQ0CS0
 tênues	tênue	AQ0CP0

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -2756,10 +2756,21 @@ USA
 
   <rulegroup id="ROMAN_NUMBER" name="Roman number">
     <rule>
+      <antipattern>
+        <token>rede</token>
+        <token>social</token>
+        <token case_sensitive='yes'>X</token>
+      </antipattern>
       <pattern>
         <token regexp="yes" case_sensitive="yes">(?=[MDCLXVI])M*(C[MD]|D?C*)(X[CL]|L?X*)(I[XV]|V?I*)</token>
       </pattern>
       <disambig postag="ZRCN0"/>
+    </rule>
+    <rule> <!-- "rede social X" -->
+      <pattern>
+        <token case_sensitive='yes'>X</token>
+      </pattern>
+      <disambig postag='NPMS000_'/>
     </rule>
     <rule>
       <pattern case_sensitive="yes">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -2770,7 +2770,7 @@ USA
       <pattern>
         <token case_sensitive='yes'>X</token>
       </pattern>
-      <disambig postag='NPMS000_'/>
+      <disambig action="add"><wd pos="NPMS000_"/></disambig>
     </rule>
     <rule>
       <pattern case_sensitive="yes">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3842,6 +3842,16 @@ USA
       </rule>
   </rulegroup>
 
+  <rule id="NÓS_PROFESSORES_NCMP000" name="professores aparecia como verbo">
+    <pattern>
+      <token>nós</token>
+      <marker>
+        <token>professores</token>
+      </marker>
+    </pattern>
+    <disambig postag="NCMP000"/>
+  </rule>
+
   <rule id="PARA_POR_TODOS_TERMOS_SUBSTANTIVO_PARA_VERBO" name="Adicionar tag de verbo ao substantivo">
     <pattern>
       <token regexp='yes'>para|por</token>
@@ -3858,8 +3868,6 @@ USA
              Estou contente por todos termos mentes científicas.
     -->
   </rule>
-
-
 
   <rulegroup id="OUTRA_SUBSTANTIVO_PARA_VERBO" name="Adicionar tag de verbo ao substantivo">
 

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
@@ -418,3 +418,7 @@ Whirlpool
 Woodcock
 WritingTool
 X
+sossegadinha
+sossegadinhas
+sossegadinho
+sossegadinhos

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -12780,7 +12780,7 @@ USA
                     </token>
                     <token postag='NC.[^N].+' postag_regexp='yes'>
                         <exception postag_regexp='yes' postag='RG|DI.+|Z0.+|VMIP3S0'/>
-                        <exception regexp="yes">amig[ao]s?</exception> <!-- "amigo dos inimigos" -->
+                        <exception regexp='yes' inflected='yes'>amigo|inimigo|adversário|aliado|oponente</exception> <!-- "amigo dos inimigos", etc. -->
                     </token>
                     <marker>
                         <token regexp='yes'>d[ao]s?</token>
@@ -12805,6 +12805,8 @@ USA
                 <example>Enquanto isso, os representantes dos Aliados em Viena, sem o apoio de seus respectivos governos, tentaram derrubar o governo de Kun e substituí-...</example>
                 <example>Para ceifarem as vidas dos inimigos deles e do seu mestre.</example>
                 <example>Para ceifarem as vidas dos inimigos destes e do seu mestre.</example>
+                <example>Ele é amigo dos inimigos.</example>
+                <example>Ele é inimigo dos inimigos.</example>
             </rule>
 
             <!-- #2: Number/gender agreement depends on using "de|d[ao]s?" -->


### PR DESCRIPTION
Ahhhh... finally I managed to fix it. It had to be done in the disambiguator, since it appeared as a Roman number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced disambiguation rules for Portuguese language processing.
  - Improved handling of Roman numerals and specific phrase contexts.
  - Added specialized rule for "rede social X" phrase detection.
  - Expanded vocabulary with new entries for "sossegadinha" and related terms.
  - Added 118 new questionable foreign words to the spelling resource.
  
- **Bug Fixes**
  - Removed entry for the term "X" from the part-of-speech dictionary, refining vocabulary recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->