### PR TITLE
[pt] Removed "temp_off" from rule ID:APENAS_SOMENTE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3697,7 +3697,7 @@ USA
         </rule>
 
 
-        <rule id='APENAS_SOMENTE' name="Apenas → Somente" tone_tags='formal' tags='picky' default='temp_off'>
+        <rule id='APENAS_SOMENTE' name="Apenas → Somente" tone_tags='formal' tags='picky'>
             <!-- Used DeepSeek-V3 -->
             <pattern>
                 <token regexp='no'>apenas</token>


### PR DESCRIPTION
Removed "temp_off" from rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Portuguese language style suggestions are now actively enabled, offering more consistent recommendations for word usage improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->