### PR TITLE
[pt] Added formal rule ID:ESTAR_CONSTAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3742,19 +3742,31 @@ USA
 
         <rule id='DAR_ATRIBUIR_CONFERIR' name="Dar → atribuir/conferir" tone_tags='formal' tags='picky' default='temp_off'>
             <!-- Used ChatGPT with Reason and DeepSeek-V3 -->
+            <!-- Later expand into two subrules to accept directly the list of words after the "DAR" verb -->
+
             <pattern>
                 <marker>
-                    <token inflected='yes' regexp='no'>dar</token>
+                    <token inflected='yes' regexp='no'>dar
+                        <exception postag_regexp='yes' postag='N.+'/>
+                        <exception regexp='no'>dados</exception></token>
                 </marker>
-                <token skip='2' regexp='yes'>[ao]s?|um|uns|umas?</token>
-                <token inflected='yes' regexp='yes'>acesso|atenção|autoridade|autorização|benefício|cargo|certificação|certificado|chance|competência|condecoração|designação|destaque|diploma|direito|distinção|distintivo|dom|emblema|ênfase|enfoque|forma|função|garantia|graduação|grau|habilitação|honra|honraria|importância|investidura|liberdade|licença|lugar|mandato|medalha|mérito|oportunidade|ordem|outorga|patente|permissão|poder|posição|possibilidade|pr[éê]mio|prerrogativa|prioridade|privilégio|propósito|reconhecimento|responsabilidade|sentido|status|título|troféu|valor|vantagem</token>
+                <token skip='1' regexp='yes'>[ao]s?|um|uns|umas?|&adverbios_de_intensidade;</token>
+                <token inflected='yes' regexp='yes'>acesso|atenção|autoridade|autorização|benefício|cargo|certificação|certificado|clareza|chance|competência|condecoração|credibilidade|designação|destaque|diploma|direito|distinção|distintivo|dom|emblema|ênfase|enfoque|forma|função|garantia|graduação|grau|habilitação|honra|honraria|importância|investidura|liberdade|licença|licitude|lugar|mandato|medalha|mérito|oportunidade|ordem|outorga|patente|permissão|poder|posição|possibilidade|pr[éê]mio|prerrogativa|prioridade|privilégio|propósito|realismo|reconhecimento|responsabilidade|sentido|seriedade|status|título|troféu|valor|vantagem</token>
             </pattern>
             <message>Use &quot;dar&quot; para casos gerais, &quot;conferir&quot; para concessões formais e &quot;atribuir&quot; para designações.</message>
             <suggestion><match no='1' postag='V.+' postag_regexp='yes'>atribuir</match></suggestion>
             <suggestion><match no='1' postag='V.+' postag_regexp='yes'>conferir</match></suggestion>
             <example correction="atribuiu|conferiu">O tribunal <marker>deu</marker> a responsabilidade da criança à mãe.</example>
             <example>A comissão atribuiu a distinção ao melhor candidato.</example>
+            <example>Além disso, os dados fortemente tipados podem ser armazenados no registro.</example>
+            <example>Mas fomos dados uma segunda chance.</example>
+            <example>Dê o lugar, Milton.</example>
+            <example>Corte-o na linha reta, ou seja, dê uma forma quadrada.</example>
+            <example>Dada a oportunidade, você deve negociar ambas as direções</example>
+            <example>Nos dê uma chance.</example>
+            <example>- Todos teriamos dado as mesmas ordens.</example>
         </rule>
+
 
         <rule id='ESTAR_CONSTAR' name="Estar → constar" tone_tags='formal' tags='picky' default='temp_off'>
             <!-- Used DeepSeek-V3 -->
@@ -3763,7 +3775,7 @@ USA
                     <token inflected='yes' regexp='no'>estar</token>
                 </marker>
                 <token regexp='yes'>n[ao]s?</token>
-                <token inflected='yes' regexp='yes'>anexo|artigo|autos|bibliografia|biografia|carta|contrato|cr[óô]nica|currículo|CV|dissertação|documento|edital|ensaio|escritos|Europass|guia|licença|livro|manual|memorial|memórias|monografia|parecer|pesquisa|plano|projeto|publicação|referências|relatório|revista|sentença|tese|texto|tratado</token>
+                <token inflected='yes' regexp='yes'>anais|anexo|artigo|autos|bibliografia|biografia|carta|contrato|cr[óô]nica|currículo|CV|dissertação|documento|edital|ensaio|escritos|Europass|guia|licença|livro|manual|memorial|memórias|monografia|parecer|pesquisa|plano|projeto|publicação|referências|registo|relatório|revista|sentença|tese|texto|tratado</token>
             </pattern>
             <message>Substitua &quot;está&quot; por &quot;consta&quot; para indicar registo oficial ou dar um tom mais formal.</message>
             <suggestion><match no='1' postag='V.+' postag_regexp='yes'>constar</match></suggestion>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3740,7 +3740,7 @@ USA
         </rule>
 
 
-        <rule id='DAR_ATRIBUIR' name="Dar → atribuir/conferir" tone_tags='formal' tags='picky' default='temp_off'>
+        <rule id='DAR_ATRIBUIR_CONFERIR' name="Dar → atribuir/conferir" tone_tags='formal' tags='picky' default='temp_off'>
             <!-- Used ChatGPT with Reason and DeepSeek-V3 -->
             <pattern>
                 <marker>
@@ -3754,6 +3754,21 @@ USA
             <suggestion><match no='1' postag='V.+' postag_regexp='yes'>conferir</match></suggestion>
             <example correction="atribuiu|conferiu">O tribunal <marker>deu</marker> a responsabilidade da criança à mãe.</example>
             <example>A comissão atribuiu a distinção ao melhor candidato.</example>
+        </rule>
+
+        <rule id='ESTAR_CONSTAR' name="Estar → constar" tone_tags='formal' tags='picky' default='temp_off'>
+            <!-- Used DeepSeek-V3 -->
+            <pattern>
+                <marker>
+                    <token inflected='yes' regexp='no'>estar</token>
+                </marker>
+                <token regexp='yes'>n[ao]s?</token>
+                <token inflected='yes' regexp='yes'>anexo|artigo|autos|bibliografia|biografia|carta|contrato|cr[óô]nica|currículo|CV|dissertação|documento|edital|ensaio|escritos|Europass|guia|licença|livro|manual|memorial|memórias|monografia|parecer|pesquisa|plano|projeto|publicação|referências|relatório|revista|sentença|tese|texto|tratado</token>
+            </pattern>
+            <message>Substitua &quot;está&quot; por &quot;consta&quot; para indicar registo oficial ou dar um tom mais formal.</message>
+            <suggestion><match no='1' postag='V.+' postag_regexp='yes'>constar</match></suggestion>
+            <example correction="consta">O conteúdo que <marker>está</marker> na tese é relevante.</example>
+            <example>O que consta nos autos deve ser bastante levado em conta.</example>
         </rule>
 
 


### PR DESCRIPTION
Another formal rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new rule for suggesting the use of "consta" instead of "está" in formal contexts, aiding users in adopting a refined tone in their Portuguese texts.
  
- **Refactor**
  - Renamed an existing rule to improve clarity while enhancing its specificity without changing its original intent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->