### PR TITLE
[pt] Removed "temp_off" from rule ID:ESTAR_CONSTAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3772,7 +3772,7 @@ USA
         </rule>
 
 
-        <rule id='ESTAR_CONSTAR' name="Estar → constar" tone_tags='formal' tags='picky' default='temp_off'>
+        <rule id='ESTAR_CONSTAR' name="Estar → constar" tone_tags='formal' tags='picky'>
             <!-- Used DeepSeek-V3 -->
             <pattern>
                 <marker>


### PR DESCRIPTION
Heya, @susanaboatto 

All results seem valid for: ESTAR_CONSTAR

However, I am not very happy about: DAR_ATRIBUIR_CONFERIR and I will rewrite it during the weekend.

https://internal1.languagetool.org/regression-tests/via-http/2025-02-20/pt-BR/

❤️ ❤️ ❤️ 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Activated a language style suggestion for Portuguese, ensuring real-time guidance for distinguishing between common verb usages. This enhancement improves language accuracy by enabling the rule by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->