### PR TITLE
[pt] Removed "temp_off" from rule ID:PARA_DENTRO_INTERIOR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3666,7 +3666,7 @@ USA
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
 
-        <rule id='PARA_DENTRO_INTERIOR' name="Para 'dentro' → Para 'o interior'" tone_tags='formal' tags='picky' default='temp_off'>
+        <rule id='PARA_DENTRO_INTERIOR' name="Para 'dentro' → Para 'o interior'" tone_tags='formal' tags='picky'>
             <antipattern>
                 <token>para</token>
                 <token>dentro</token>


### PR DESCRIPTION
Removed "temp_off".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the behavior of a Portuguese language style rule so that it now follows the default setting rather than being temporarily disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->