### PR TITLE
[pt] Added formal rule ID:CARRO_AUTOMOVEL_VEICULO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3714,6 +3714,20 @@ USA
         </rule>
 
 
+        <rule id='CARRO_AUTOMOVEL_VEICULO' name="Carro → automóvel/veículo" tone_tags='formal' tags='picky' default='temp_off'>
+            <pattern>
+                <marker>
+                    <token regexp='yes'>carros?</token>
+                </marker>
+            </pattern>
+            <message>Use &quot;carro&quot; no cotidiano, &quot;automóvel&quot; em contextos técnicos e &quot;veículo&quot; para designar qualquer meio de transporte.</message>
+            <suggestion><match no='1' postag='N.+' postag_regexp='yes'>automóvel</match></suggestion>
+            <suggestion><match no='1' postag='N.+' postag_regexp='yes'>veículo</match></suggestion>
+            <example correction="automóveis|veículos">A rua tem imensos <marker>carros</marker>.</example>
+            <example>Tantos veículos na estrada, mal se consegue andar.</example>
+        </rule>
+
+
         <rule id='COISAS_FUNCIONALIDADES' name="Coisas → funcionalidades" tone_tags='formal'>
             <pattern>
                 <token skip='4' inflected='yes' regexp='no'>implementar</token>


### PR DESCRIPTION
A formal rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a language rule for Portuguese that clarifies the proper usage of the term "carro," suggesting "automóvel" for technical contexts and "veículo" for general references, with practical examples for guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->