### PR TITLE
[pt] Added APs to rule ID:QUE_HÁ_QUE_NÃO_HÁ

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -16580,6 +16580,7 @@ USA
             <example>E assim <marker>impossibilitando</marker> falhar.</example>
         </rule>
 
+
         <!-- QUE [NÃO] HÁ [não] haver -->
         <rulegroup id='QUE_HÁ_QUE_NÃO_HÁ' name="Que [não] há → [Não] haver" type="style" tags="picky">
             <!--IDEA shorten_it-->
@@ -16588,16 +16589,28 @@ USA
             É assumido que há substituição de jogadores durante a partida. → É assumido haver substituição de jogadores durante a partida.
             É assumido que não há substituição de jogadores durante a partida. → É assumido não haver substituição de jogadores durante a partida.
             -->
+
+            <antipattern>
+                <token regexp='no' inflected='no'>é</token>
+                <token>que</token>
+                <token>há</token>
+                <example>O fato é que há títulos do governo sendo rejeitados às taxas de juros vigentes.</example>
+                <example>O que é que há de novo nesse projeto?</example>
+                <example>Tudo o que sei é que há algo mais acontecendo.</example>
+                <example>O que eu quero dizer é que há limites que precisam ser estabelecidos e respeitados.</example>
+            </antipattern>
+
+            <antipattern>
+                <token postag='V.+' postag_regexp='yes'/>
+                <token>que</token>
+                <token min='0' max='1'>não</token>
+                <token skip='4'>há</token>
+                <token postag='Z0.+' postag_regexp='yes'/>
+                <token regexp='yes'>&expressoes_de_tempo_simples;</token>
+                <example>Jamais esquecerei que há uns vinte anos me disseste isso.</example>
+            </antipattern>
+
             <rule>
-
-                <antipattern>
-                    <token postag='VMIF1S0' postag_regexp='no'/>
-                    <token>que</token>
-                    <token>há</token>
-                    <token postag='[DP][ADIPR].+|SPS00:[DP][ADIPR].+|SPS00|CC|CS|RG|I|RM|RN|NC.+|AQ.+|NP.+' postag_regexp='yes'/>
-                    <example>Jamais esquecerei que há uns vinte anos me disseste isso.</example>
-                </antipattern>
-
                 <antipattern>
                     <token postag='VMIP1S0' postag_regexp='no'/>
                     <token>que</token>


### PR DESCRIPTION
Antipatterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded Portuguese grammar rules now offer improved detection of specific stylistic constructions.
  - Enhanced example sentences provide clearer guidance for correct usage in written text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->