### PR TITLE
[pt] Removed "temp_off" from rule ID:TOTALIZAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -12340,7 +12340,7 @@ USA
     <category id='SHORTEN_IT' name="Linguagem concisa" type="style">
 
 
-        <rule id='TOTALIZAR' name="Simplificar: 'perfazer um total de' → totalizar" default='temp_off'>
+        <rule id='TOTALIZAR' name="Simplificar: 'perfazer um total de' → totalizar">
             <pattern>
                 <marker>
                     <token inflected='yes' regexp='yes'>alcançar|contabilizar|perfazer|somar|totalizar</token>


### PR DESCRIPTION
Removed "temp_off" from rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - The language style rule for simplifying "perfazer um total de" to "totalizar" is now enabled by default. This update ensures that the correction is automatically applied during language processing, enhancing consistency in text suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->