### PR TITLE
[pt] Added academic rule ID:EVIDENCIAR_COMPROVAR_DEMONSTRAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -10762,6 +10762,22 @@ USA
         </rule>
 
 
+        <rule id='EVIDENCIAR_COMPROVAR_DEMONSTRAR' name="[Universitário] Mostrar → evidenciar/comprovar/demonstrar" type='style' tags='picky' tone_tags='academic' default='temp_off'>
+            <pattern>
+                <token regexp='yes' inflected='yes' skip='1'>abordagem|achado|amostra|análise|artigo|avaliação|caso|cenário|coleta|comparação|conceito|consulta|contexto|critério|dado|diagnóstico|dissertação|documento|enquadramento|ensaio|entrevista|equação|estratégia|estudo|evidência|exemplo|experiência|experimento|fen[óô]meno|ferramenta|fórmula|framework|gráfico|hipótese|indicador|inquérito|instrumento|investigação|levantamento|mapa|mecanismo|método|métrica|modelo|monografia|observação|padrão|paradigma|parâmetro|pesquisa|prática|pressuposto|princípio|procedimento|processo|projeto|protocolo|relatório|resultado|revisão|simulação|sistema|sondagem|tabela|técnica|tecnologia|tendência|teoria|tese|teste|trabalho|variável</token>
+                <marker>
+                    <token regexp='no' inflected='yes'>mostrar</token>
+                </marker>
+            </pattern>
+            <message>Num contexto formal/universitário, é preferível escrever &quot;evidenciar&quot;, &quot;comprovar&quot; ou &quot;demonstrar&quot;.</message>
+            <suggestion><match no='2' postag='V.+' postag_regexp='yes'>evidenciar</match></suggestion>
+            <suggestion><match no='2' postag='V.+' postag_regexp='yes'>comprovar</match></suggestion>
+            <suggestion><match no='2' postag='V.+' postag_regexp='yes'>demonstrar</match></suggestion>
+            <example correction="evidencia|comprova|demonstra">A pesquisa <marker>mostra</marker> que os resultados são os esperados.</example>
+            <example>O estudo evidencia um enorme grau de sucesso.</example>
+        </rule>
+
+
         <rule id='PHD_TESE_FICOU_DEMONSTRADO_QUE_DEMONSTRÁMOS_QUE' name="[Universitário] Expressões do tipo 'ficou demonstrado que' → ‘demonstrámos que'" type='style' tags="picky" tone_tags="academic" is_goal_specific="true">
             <pattern>
                 <marker>


### PR DESCRIPTION
An academic rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new style guideline for Portuguese that recommends using formal alternatives (“evidenciar”, “comprovar”, “demonstrar”) instead of “mostrar” in academic and formal writing.
  - Provides suggestions and examples to help users produce clearer and more precise language in academic contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->