### PR TITLE
hunspell: don't fail when .dic exists in the temp dir and .aff doesn't; add a way to avoid temp file creation completely (with Lucene)

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
@@ -37,9 +37,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -79,7 +79,7 @@ public class HunspellRule extends SpellingCheckRule {
   private final Pattern MINUS_PLUS = Pattern.compile("-+");
 
   private static final ConcurrentMap<URL, List<String>> ignoreFileContents = new ConcurrentHashMap<>();
-  private static final ConcurrentMap<Path, Pattern> nonWordPatterns = new ConcurrentHashMap<>();
+  private static final ConcurrentMap<String, Pattern> nonWordPatterns = new ConcurrentHashMap<>();
 
   public static Queue<String> getActiveChecks() {
     return activeChecks;
@@ -507,47 +507,44 @@ public class HunspellRule extends SpellingCheckRule {
     }
     String shortDicPath = getDictFilenameInResources(langCountry);
     // set dictionary only if there are dictionary files:
-    Path affPath = null;
     if(!Tools.isExternSpeller()) {    //  use of external speller for OO extension (32-bit)
-                                      //  hunspell doesn't support 32 bit java
+                                      //  hunspell doesn't support 32-bit java
       if (JLanguageTool.getDataBroker().resourceExists(shortDicPath)) {
-        String path = getDictionaryPath(langCountry, shortDicPath);
-        if ("".equals(path)) {
-          hunspell = null;
-        } else {
-          affPath = Paths.get(path + ".aff");
-          hunspell = Hunspell.getDictionary(Paths.get(path + ".dic"), affPath);
-          addIgnoreWords();
-        }
+        String aff = shortDicPath.substring(0, shortDicPath.length() - 3) + "aff";
+        hunspell = Hunspell.forDictionaryInResources(langCountry, shortDicPath, aff);
+        addIgnoreWords();
+        nonWordPattern = nonWordPatterns.computeIfAbsent(shortDicPath, __ ->
+          computNonWordPattern(JLanguageTool.getDataBroker().getFromResourceDirAsStream(aff)));
+
       } else if (new File(shortDicPath + ".dic").exists()) {
         // for dynamic languages
-        affPath = Paths.get(shortDicPath + ".aff");
+        Path affPath = Paths.get(shortDicPath + ".aff");
         hunspell = Hunspell.getDictionary(Paths.get(shortDicPath + ".dic"), affPath);
-      }
-    }
-    if (affPath != null) {
-      nonWordPattern = nonWordPatterns.computeIfAbsent(affPath, (path) -> {
-        String wordChars = "";
-        if (path != null) {
-          try (Scanner sc = new Scanner(path)) {
-            while (sc.hasNextLine()) {
-              String line = sc.nextLine();
-              if (line.startsWith("WORDCHARS ")) {
-                String wordCharsFromAff = line.substring("WORDCHARS ".length());
-                //System.out.println("#" + wordCharsFromAff+ "#");
-                wordChars = "(?![" + wordCharsFromAff.replace("-", "\\-") + "])";
-                break;
-              }
-            }
+        nonWordPattern = nonWordPatterns.computeIfAbsent(shortDicPath, __ -> {
+          try (InputStream stream = Files.newInputStream(affPath)) {
+            return computNonWordPattern(stream);
           } catch (IOException e) {
-            logger.error("Could not read aff file: " + path, e);
+            logger.error("Could not read aff file: " + affPath, e);
           }
-        }
-        return Pattern.compile(wordChars + NON_ALPHABETIC);
-      });
+          return NON_ALPHABETIC_PATTERN;
+        });
+      }
     } else {
       nonWordPattern = NON_ALPHABETIC_PATTERN;
     }
+  }
+
+  private static Pattern computNonWordPattern(InputStream stream) {
+    Scanner sc = new Scanner(stream);
+    while (sc.hasNextLine()) {
+      String line = sc.nextLine();
+      if (line.startsWith("WORDCHARS ")) {
+        String wordCharsFromAff = line.substring("WORDCHARS ".length());
+        //System.out.println("#" + wordCharsFromAff+ "#");
+        return Pattern.compile("(?![" + wordCharsFromAff.replace("-", "\\-") + "])" + NON_ALPHABETIC);
+      }
+    }
+    return NON_ALPHABETIC_PATTERN;
   }
 
   @NotNull
@@ -577,53 +574,4 @@ public class HunspellRule extends SpellingCheckRule {
            // A better way might be nice.
            SpellingCheckRule.LANGUAGETOOL.equals(word) || SpellingCheckRule.LANGUAGETOOLER.equals(word);
   }
-
-  private static synchronized String getDictionaryPath(String dicName,
-                                                       String originalPath) throws IOException {
-
-    URL dictURL = JLanguageTool.getDataBroker().getFromResourceDirAsUrl(originalPath);
-    String dictionaryPath;
-    //in the webstart, java EE or OSGi bundle version, we need to copy the files outside the jar
-    //to the local temporary directory
-    if (StringUtils.equalsAny(dictURL.getProtocol(), "jar", "vfs", "bundle", "bundleresource")) {
-      File tempDir = new File(System.getProperty("java.io.tmpdir"));
-      File tempDicFile = new File(tempDir, dicName + FILE_EXTENSION);
-      if (!tempDicFile.exists()) {
-        JLanguageTool.addTemporaryFile(tempDicFile);
-        try (InputStream dicStream = JLanguageTool.getDataBroker().getFromResourceDirAsStream(originalPath)) {
-          fileCopy(dicStream, tempDicFile);
-        }
-        File tempAffFile = new File(tempDir, dicName + ".aff");
-        JLanguageTool.addTemporaryFile(tempAffFile);
-        if (originalPath.endsWith(FILE_EXTENSION)) {
-          originalPath = originalPath.substring(0, originalPath.length() - FILE_EXTENSION.length()) + ".aff";
-        }
-        try (InputStream affStream = JLanguageTool.getDataBroker().getFromResourceDirAsStream(originalPath)) {
-          fileCopy(affStream, tempAffFile);
-        }
-      }
-      dictionaryPath = tempDir.getAbsolutePath() + "/" + dicName;
-    } else {
-      int suffixLength = FILE_EXTENSION.length();
-      try {
-        dictionaryPath = new File(dictURL.toURI()).getAbsolutePath();
-        dictionaryPath = dictionaryPath.substring(0, dictionaryPath.length() - suffixLength);
-      } catch (URISyntaxException e) {
-        return "";
-      }
-    }
-    return dictionaryPath;
-  }
-
-  private static void fileCopy(InputStream in, File targetFile) throws IOException {
-    try (OutputStream out = new FileOutputStream(targetFile)) {
-      byte[] buf = new byte[1024];
-      int len;
-      while ((len = in.read(buf)) > 0) {
-        out.write(buf, 0, len);
-      }
-      in.close();
-    }
-  }
-
 }

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
@@ -535,13 +535,14 @@ public class HunspellRule extends SpellingCheckRule {
   }
 
   private static Pattern computNonWordPattern(InputStream stream) {
-    Scanner sc = new Scanner(stream);
-    while (sc.hasNextLine()) {
-      String line = sc.nextLine();
-      if (line.startsWith("WORDCHARS ")) {
-        String wordCharsFromAff = line.substring("WORDCHARS ".length());
-        //System.out.println("#" + wordCharsFromAff+ "#");
-        return Pattern.compile("(?![" + wordCharsFromAff.replace("-", "\\-") + "])" + NON_ALPHABETIC);
+    try (Scanner sc = new Scanner(stream)) {
+      while (sc.hasNextLine()) {
+        String line = sc.nextLine();
+        if (line.startsWith("WORDCHARS ")) {
+          String wordCharsFromAff = line.substring("WORDCHARS ".length());
+          //System.out.println("#" + wordCharsFromAff+ "#");
+          return Pattern.compile("(?![" + wordCharsFromAff.replace("-", "\\-") + "])" + NON_ALPHABETIC);
+        }
       }
     }
     return NON_ALPHABETIC_PATTERN;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a flexible approach for configuring spelling dictionaries using stream-based inputs for improved customization.

- **Refactor**
  - Streamlined dictionary initialization and resource handling, resulting in clearer error reporting and enhanced reliability of the spelling feature. 
  - Simplified the handling of non-word patterns, improving clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->