### PR TITLE
Incorrect Handling of Spaces Before .NET

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/CommaWhitespaceRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/CommaWhitespaceRule.java
@@ -191,7 +191,7 @@ public class CommaWhitespaceRule extends Rule {
   }
 
   private boolean isDomain(AnalyzedTokenReadings[] tokens, int i) {
-    return i < tokens.length && tokens[i].getToken().matches("(com|org|net|int|edu|gov|mil|[a-z]{2})");
+    return i < tokens.length && tokens[i].getToken().matches("(?i)(com|org|net|int|edu|gov|mil|[a-z]{2})");
   }
 
   private boolean isFileExtension(AnalyzedTokenReadings[] tokens, int i) {

--- a/languagetool-core/src/test/java/org/languagetool/rules/CommaWhitespaceRuleTest.java
+++ b/languagetool-core/src/test/java/org/languagetool/rules/CommaWhitespaceRuleTest.java
@@ -43,6 +43,8 @@ public class CommaWhitespaceRuleTest {
   @Test
   public void testRule() throws IOException {
     assertMatches("This is a test sentence.", 0);
+    assertMatches("I work with the technology .Net and Azure.", 0);
+    assertMatches("I work with the technology .NET and Azure.", 0);
     assertMatches("I use .MP3 or .WAV file suffix", 0);
     assertMatches("This, is, a test sentence.", 0);
     assertMatches("This (foo bar) is a test!.", 0);


### PR DESCRIPTION
### Bug

https://github.com/languagetool-org/languagetool/issues/11295 

### Description
`CommaWhitespaceRule` allows file extensions and website domains after a full stop. `.net` is allow listed as part of existing website domains. Making regular expression case **insensitive** fixes the issues. 

**Note** : Although **.NET** in this context isn't really a domain,  instead of introducing a new category of allow listing, opted to re-purpose the existing rule for `.net`