### PR TITLE
[pt] Fixed verbs/nouns confusions in disambiguator

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4372,6 +4372,28 @@ USA
     -->
   </rule>
 
+  <rule id="REMOVE_VERBS_À_IN_NC_VERBS_RARE" name="Remove verbs in nouns">
+    <!-- Moved the rule down to assure it works correctly. -->
+    <pattern>
+      <token postag='N.+|AQ.+' postag_regexp='yes'/>
+      <token regexp='yes'>às?</token>
+      <marker>
+        <and>
+          <token postag='V.+' postag_regexp='yes'/>
+          <token postag='N.+' postag_regexp='yes'/>
+        </and>
+      </marker>
+    </pattern>
+    <disambig action="remove" postag="V.*"/>
+    <!--
+    Examples:
+             Alerta sobre risco à saúde.
+             Império à Deriva.
+             do Declínio Europeu à Era Global.
+             Todos os valores incluem IVA à taxa legal em vigor e podem ser alterados sem aviso prévio.
+    -->
+  </rule>
+
   <rulegroup id="NATIONAL_PREFIXES" name="Ignore spelling in tagged words with national prefixes">
       <rule>
           <pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -13592,23 +13592,6 @@ USA
         </rule>
 
 
-        <!-- ESTAR À ESPERA esperar -->
-        <rule id='ESTAR_A_ESPERA' name="[Simplificar] Estar à espera → Esperar" type="style">
-            <!--IDEA shorten_it-->
-            <!--      Created by Marco A.G.Pinto, Portuguese rule 2020-10-13 (2-JUL-2020+)     -->
-            <pattern>
-                <token inflected='yes'>estar</token>
-                <token regexp="yes">nas?|nos?|em</token>
-                <token postag='NC[CFM][SP]000|AQ0[CFM][SP]0' postag_regexp='yes'/>
-                <token>à</token>
-                <token inflected='yes'>esperar</token>
-            </pattern>
-            <message>&simplify_msg;</message>
-            <suggestion><match no='1' postag='V.+' postag_regexp='yes'>esperar</match> \2 \3</suggestion>
-            <example correction="esperar na fila">O Rui optou por <marker>estar na fila à espera</marker>.</example>
-        </rule>
-
-
         <!-- ESTAR A VERB_INFINITIVE verb (verb1 person)-->
         <rulegroup id='ESTAR_A_VERB-INFINITIVE' name="[Simplificar] Estar a + V.Inf. → V.1.ªPessoa" type="style">
             <!--IDEA shorten_it-->


### PR DESCRIPTION
More tons of fixes in verbs/nouns handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new rule to enhance disambiguation by removing verbs that appear with nouns in specific contexts.
  
- **Refactor**
  - Adjusted the Portuguese style checker by removing the automatic suggestion to simplify the phrase "estar à espera" to "esperar."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->