### PR TITLE
[pt] Removed "temp_off" from rule ID:TORNAR_MAIS_DIFICIL_FACIL

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -11447,7 +11447,7 @@ USA
         </rule>
 
 
-        <rulegroup id='TORNAR_MAIS_DIFICIL_FACIL' name='Tornar mais difícil/fácil → dificultar/facilitar' tone_tags='objective' default='temp_off'>
+        <rulegroup id='TORNAR_MAIS_DIFICIL_FACIL' name='Tornar mais difícil/fácil → dificultar/facilitar' tone_tags='objective'>
             <!--IDEA shorten_it-->
             <antipattern>
                 <token postag='V.+:.+|VMP00.+' postag_regexp='yes' inflected='yes'>tornar</token>


### PR DESCRIPTION
Removed "temp_off".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - A previously inactive Portuguese style rule group is now enabled by default, potentially improving detection of certain style issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->