### PR TITLE
[pt] Added confusion rule ID:TEMOS_TERMOS + minor enhancements

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -399,7 +399,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <!-- </rule> -->
         <!-- </rulegroup> -->
 
-        <rulegroup id="MELHOR_EDUCADO" name="Melhor educado -> mais bem-educado">
+        <rulegroup id="MELHOR_EDUCADO" name="Melhor educado → mais bem-educado">
             <rule>
                 <pattern>
                     <token regexp="yes">melhor(es)?</token>
@@ -437,7 +437,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <rulegroup id="MAIS_BEM_MELHORES" name="Melhores colocados -> melhor/mais bem colocados">
+        <rulegroup id="MAIS_BEM_MELHORES" name="Melhores colocados → melhor/mais bem colocados">
             <antipattern> <!-- TODO: list of adjectives that cannot be compared (or don't make sense in the comparative) -->
                 <token regexp="yes">(pior|melhor)es</token>
                 <token>causados</token>
@@ -514,7 +514,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <rulegroup id="PARA_MIM_FAZER" name="Para mim fazer -> para eu fazer">
+        <rulegroup id="PARA_MIM_FAZER" name="Para mim fazer → para eu fazer">
             <rule id="PARA_MIM_FAZER_SENT_START">
                 <pattern>
                     <token postag_regexp="yes" postag="SENT_START|_PUNCT"/>
@@ -13653,7 +13653,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <rule id="MEIO_DIA_E_MEIO" name="Meio-dia e meio -> meia">
+        <rule id="MEIO_DIA_E_MEIO" name="Meio-dia e meio → meia">
             <pattern>
                 <token>meio</token>
                 <token regexp="yes" min="0" spacebefore="no">&hifen;</token>
@@ -13667,7 +13667,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="meia">Chegamos meio-dia e <marker>meio</marker>.</example>
         </rule>
 
-        <rulegroup id="SAIR_AS_RUAS" name="Erro de crase em 'sair as ruas' -> 'às'">
+        <rulegroup id="SAIR_AS_RUAS" name="Erro de crase em 'sair as ruas' → 'às'">
             <rule>
                 <pattern>
                     <token postag_regexp="yes" postag="V.+" inflected="yes">sair</token>
@@ -16202,7 +16202,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
         </rulegroup>
 
-        <rulegroup id="ABREVIATIONS" name="Abreviaturas: p.ex. sr. -> Sr.">
+        <rulegroup id="ABREVIATIONS" name="Abreviaturas: p.ex. sr. → Sr.">
             <!--  Based on German gramar.xml rule, by Tiago F. Santos, 2018-07-13      -->
             <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/sobre-o-uso-de-maiusculas-e-de-minusculas/30160</url>
             <rule>
@@ -16225,7 +16225,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <url>https://www.uc.pt/sibuc/Pdfs/ISBD3</url>
                 <example correction="Sra.">Exma <marker>sra.</marker> Costa,</example>
             </rule>
-            <rule id="ABREVIATIONS_DR" name="Abreviaturas: dr. -> Dr.">
+            <rule id="ABREVIATIONS_DR" name="Abreviaturas: dr. → Dr.">
                 <pattern>
                     <token case_sensitive='yes' regexp='yes'>dra?</token>
                     <token spacebefore='no'>.</token>
@@ -16353,7 +16353,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </category>
 
     <category id='MISC' name="Sem Categoria Definida" type="uncategorized">
-        <rulegroup id="EM_MEADO" name="Em meado -> meados">
+        <rulegroup id="EM_MEADO" name="Em meado → meados">
             <rule>
                 <pattern>
                     <token>em</token>
@@ -17653,7 +17653,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
         <!-- SE CASO caso -->
         <!--      Created by Marco A.G.Pinto, Portuguese rule 2020-10-20 (2-JUL-2020+)     -->
-        <rule id='SE_CASO-CASO' name="Se caso -> caso">
+        <rule id='SE_CASO-CASO' name="Se caso → caso">
             <pattern>
                 <marker>
                     <token>se</token>
@@ -17784,7 +17784,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='VISANDO_A_EM_CONSEGUIR' name="Visando a/em conseguir -> Visando conseguir">
+        <rule id='VISANDO_A_EM_CONSEGUIR' name="Visando a/em conseguir → Visando conseguir">
             <!-- Created by Marco A.G.Pinto, Portuguese rule 2023-01-18 (Checked/Enhanced) (25-JUL-2022+) -->
             <!--
       Ele assinou um documento visando a conseguir dividendos. → Ele assinou um documento visando conseguir dividendos.
@@ -17802,7 +17802,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <!-- RULES TU/TI -> EU/MIM *START* -->
+        <!-- RULES TU/TI → EU/MIM *START* -->
         <!-- ***************************** -->
         <rulegroup id='TU_TI_EU_MIM' name='Uso de pronomes oblíquos (eu, mim; tu, ti)'>
             <url>https://duvidas.dicio.com.br/entre-mim-e-ti-ou-entre-tu-e-eu/</url>
@@ -17940,7 +17940,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
         </rulegroup>
         <!-- *************************** -->
-        <!-- RULES TU/TI -> EU/MIM *END* -->
+        <!-- RULES TU/TI → EU/MIM *END* -->
 
 
         <rule id='VOTOS_BRANCOS' name="Votos em branco">
@@ -22633,7 +22633,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
         <!-- My assumption here is that these are mostly typos since they're pretty obviously ungrammatical,
              from the descriptive point of view. So it doesn't seem to be worthwhile to account for non-3SG
-             inflections. I mean, 'dever' -> 'deve' is pretty straightforward, but 'dever' -> 'devo' less so.  -->
+             inflections. I mean, 'dever' → 'deve' is pretty straightforward, but 'dever' → 'devo' less so.  -->
         <rulegroup id="DOUBLE_INFINITIVE" name="Infinitivo duplo">
             <short>Possível erro de digitação.</short>
             <!-- This contains the original structure as described in premium issue 5538
@@ -22695,7 +22695,22 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
     <category id='CONFUSED_WORDS' name="Confusão de Palavras">
-        <rule id="NOTAS_FICAIS" name="Notas ficais -> fiscais">
+
+
+        <rule id='TEMOS_TERMOS' name="Temos → termos" default='temp_off'>
+            <pattern>
+                <token regexp='yes'>para|por</token>
+                <marker>
+                    <token>temos</token>
+                </marker>
+            </pattern>
+            <message>Possível erro de digitação. Provavelmente você quis escrever <suggestion>termos</suggestion>.</message>
+            <example correction="termos">Isso é ótimo por <marker>temos</marker> informação adicional.</example>
+            <example>O estudo foi elaborado para termos informação sobre a população do país.</example>
+        </rule>
+
+
+        <rule id='NOTAS_FICAIS' name="Notas ficais → fiscais">
             <pattern>
                 <token>notas</token>
                 <token>ficais</token>
@@ -22704,7 +22719,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="notas fiscais">E as <marker>notas ficais</marker> de 2020?</example>
         </rule>
 
-        <rule id="PER_CAPTA" name="Per capta -> per capita">
+        <rule id='PER_CAPTA' name="Per capta → per capita">
             <pattern>
                 <token>per</token>
                 <token>capta</token>
@@ -37107,7 +37122,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>Você nos incomoda com sua música.</example>
             </rule>
 
-            <!-- Fix for "matricula" -> "matrícula" - https://github.com/languagetool-org/languagetool/issues/6492 - 2022-05-11 -->
+            <!-- Fix for "matricula" → "matrícula" - https://github.com/languagetool-org/languagetool/issues/6492 - 2022-05-11 -->
             <rule>
 
                 <!--
@@ -37581,7 +37596,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
         <rule id='OLD_SPELLING_U' name="Acordo Ortográfico de 45: ü (uso de trema)" type="misspelling" default="off">
-            <!-- Disabled on 16 Nov 2023: the new Morfologik speller takes care of this. This rule introduces loops like Gmünd -> Gmund. -->
+            <!-- Disabled on 16 Nov 2023: the new Morfologik speller takes care of this. This rule introduces loops like Gmünd → Gmund. -->
             <pattern>
                 <token regexp="yes">.*ü.*
                     <exception regexp="yes">Atatürk|Hübner|hübneriano|Müller|mülleriano|ü|über.*|Württemberg|Zürich|Führer.*|Düsseldorf|München|Für</exception>
@@ -41179,7 +41194,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example>2.a. Sistemas</example>
         </rule>
 
-        <rulegroup id="ORDINAL_ABBREVIATION" name="Abreviatura de ordinais: 1o -> 1º">
+        <rulegroup id="ORDINAL_ABBREVIATION" name="Abreviatura de ordinais: 1o → 1º">
             <antipattern> <!-- enumeration as 2a. -->
                 <token postag="SENT_START"/>
                 <token regexp="yes">\d+a</token>
@@ -43334,7 +43349,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="…">Tenha um bom dia, Srta. <marker>...</marker>ele foi a caminho de se rebaixar numa…</example>
         </rule>
 
-        <rulegroup id='TIME_FORMAT' name="Tipografia de horas: 22.30 h -> 22:30h">
+        <rulegroup id='TIME_FORMAT' name="Tipografia de horas: 22.30 h → 22:30h">
             <!-- Localized from Catalan, by Tiago F. Santos, 2017-05-15 -->
             <url>https://ciberduvidas.iscte-iul.pt/artigos/rubricas/idioma/sobre-a-escrita-dos-numeros-das-horas-e-de-outras-representacoes/3267</url>
             <short>Preferência tipográfica</short>


### PR DESCRIPTION
A confusion rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved readability by replacing all instances of the ASCII arrow "->" with the Unicode arrow "→" in Portuguese grammar rule descriptions and comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->