### PR TITLE
[pt] Replaced more topographical symbols

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -698,7 +698,7 @@ USA
             <example>Vou honrar os meus compromissos.</example>
         </rule>
 
-        <rule id='IMAGEM_DE_SATELITE' name="Imagem satélite -> Imagem de satélite" tags="picky">
+        <rule id='IMAGEM_DE_SATELITE' name="Imagem satélite → Imagem de satélite" tags="picky">
             <!--      Created by Tiago F. Santos, 2019-09-07      -->
             <pattern>
                 <token regexp="yes">image(?:m|ns)</token>
@@ -11048,7 +11048,7 @@ USA
     </category>
 
     <category id="SCIENTIFIC" name="Linguagem científica" type="style" tone_tags="scientific">
-        <rulegroup id="NUMERO_DE_MOLS" name="Número de mols -> massa molecular" tags="picky" is_goal_specific="true">
+        <rulegroup id="NUMERO_DE_MOLS" name="Número de mols → massa molecular" tags="picky" is_goal_specific="true">
             <rule>
                 <pattern>
                     <token postag_regexp="yes" postag="(SP.+:)?D.+MS.*" min="0"/>
@@ -11076,7 +11076,7 @@ USA
             </rule>
         </rulegroup>
 
-        <rulegroup id="PESO_MOLECULAR" name="Peso molecular -> massa molecular" tags="picky" is_goal_specific="true">
+        <rulegroup id="PESO_MOLECULAR" name="Peso molecular → massa molecular" tags="picky" is_goal_specific="true">
             <rule>
                 <pattern>
                     <token postag_regexp="yes" postag="(SP.+:)?D.+MS.*" min="0"/>
@@ -11103,7 +11103,7 @@ USA
             </rule>
         </rulegroup>
 
-        <rule id="NUMERO_DE_AVOGADRO" name="Número de Avogadro -> constante" tags="picky" is_goal_specific="true">
+        <rule id="NUMERO_DE_AVOGADRO" name="Número de Avogadro → constante" tags="picky" is_goal_specific="true">
             <pattern>
                 <token postag_regexp="yes" postag="(SP.+:)?D.+MS.*" min="0"/>
                 <token>número</token>
@@ -11730,7 +11730,7 @@ USA
                     <token regexp='yes'>e|ou|nem</token>
                     <token postag="RM" regexp="yes">.+mente</token>
                 </pattern>
-                <!-- FIXME: create correct form: diariamente -> diária -->
+                <!-- FIXME: create correct form: diariamente → diária -->
                 <!--<filter class="org.languagetool.rules.pt.PortugueseSuppressMisspelledSuggestionsFilter" args="suppressMatch:true"/>-->
                 <message>Quando os advérbio de modo aparecem em sequência, só o último deve ser afixado com -mente.</message>
                 <suggestion ><match no='1' regexp_match="(.+)mente" regexp_replace="$1"/></suggestion>
@@ -13763,7 +13763,7 @@ USA
 
             Subrule 1.3:
              -mento → ir
-            Vimos O SURGIMENTO DE uma fórmula. -> Vimos SURGIR uma fórmula.
+            Vimos O SURGIMENTO DE uma fórmula. → Vimos SURGIR uma fórmula.
 
             Subrule 2.1:
              -ação → ar
@@ -16805,7 +16805,7 @@ USA
                 <example correction='ser'>Afirmei a minha inocência alegando <marker>que era</marker> canhoto.</example>
             </rule>
 
-            <!-- TU -> QUE ERAS -->
+            <!-- TU → QUE ERAS -->
             <rule>
                 <antipattern>
                     <token>que</token>
@@ -16831,7 +16831,7 @@ USA
                 <example correction='seres'>Afirmaste a tua inocência alegando <marker>que eras</marker> canhoto.</example>
             </rule>
 
-            <!-- NÓS -> QUE ÉRAMOS -->
+            <!-- NÓS → QUE ÉRAMOS -->
             <rule>
                 <antipattern>
                     <token>que</token>
@@ -16857,7 +16857,7 @@ USA
                 <example correction='sermos'>Afirmámos a nossa inocência alegando <marker>que éramos</marker> canhotos.</example>
             </rule>
 
-            <!-- VÓS/VOCÊS/ELES -> QUE ERAM -->
+            <!-- VÓS/VOCÊS/ELES → QUE ERAM -->
             <rule>
                 <antipattern>
                     <token>que</token>


### PR DESCRIPTION
More topographical symbols replaced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated textual content in Portuguese language style rules to use the Unicode right arrow (→) instead of the ASCII arrow (->) in rule names, comments, and examples. No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->