### PR TITLE
[pt] Removed "temp_off" from rule ID:TEMOS_TERMOS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -22697,7 +22697,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <category id='CONFUSED_WORDS' name="Confusão de Palavras">
 
 
-        <rule id='TEMOS_TERMOS' name="Temos → termos" default='temp_off'>
+        <rule id='TEMOS_TERMOS' name="Temos → termos">
             <pattern>
                 <token regexp='yes'>para|por</token>
                 <marker>


### PR DESCRIPTION
Removed "temp_off".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled the "TEMOS_TERMOS" grammar rule for Portuguese by default, improving grammar checking coverage for Portuguese users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->