### PR TITLE
hunspell: don't fail when .dic exists in the temp dir and .aff doesn't; add a way to avoid temp file creation completely (with Lucene)

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/Hunspell.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/Hunspell.java
@@ -4,6 +4,7 @@ import org.languagetool.JLanguageTool;
 import org.languagetool.broker.ResourceDataBroker;
 
 import java.io.*;
+import java.net.URL;
 import java.nio.file.*;
 import java.util.*;
 import java.util.function.BiFunction;
@@ -30,11 +31,55 @@ public final class Hunspell {
     }
   }
 
+  static final boolean FORCE_TEMP_FILES = "true".equals(System.getenv("HUNSPELL_FORCE_TEMP_FILES"));
+
   private static final Map<LanguageAndPath, HunspellDictionary> map = new HashMap<>();
   private static BiFunction<Path, Path, HunspellDictionary> hunspellDictionaryFactory = DumontsHunspellDictionary::new;
+  private static Factory hunspellDictionaryStreamFactory = viaTempFiles(DumontsHunspellDictionary::new);
 
+  /**
+   * @deprecated Use {@link #setHunspellStreamFactory}
+   */
+  @Deprecated
   public static void setHunspellDictionaryFactory(BiFunction<Path, Path, HunspellDictionary> factory) {
-    hunspellDictionaryFactory = factory;
+    if (FORCE_TEMP_FILES) {
+      hunspellDictionaryFactory = factory;
+    } else {
+      hunspellDictionaryStreamFactory = viaTempFiles(factory);
+    }
+  }
+
+  private static Factory viaTempFiles(BiFunction<Path, Path, HunspellDictionary> factory) {
+    return new Factory() {
+      @Override
+      public HunspellDictionary createFromLocalFiles(String languageCode, Path dictionary, Path affix) {
+        return factory.apply(dictionary, affix);
+      }
+
+      @Override
+      public HunspellDictionary createFromStreams(String language, InputStream dictionaryStream, InputStream affixStream) throws IOException {
+        Path dictionary = Files.createTempFile(language, ".dic");
+        Path affix = Files.createTempFile(language, ".aff");
+        Files.copy(dictionaryStream, dictionary, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(affixStream, affix, StandardCopyOption.REPLACE_EXISTING);
+        try {
+          return factory.apply(dictionary, affix);
+        } finally {
+          Files.deleteIfExists(dictionary);
+          Files.deleteIfExists(affix);
+        }
+      }
+    };
+  }
+
+  /**
+   * Set a custom way to create Hunspell dictionaries,
+   * e.g., more efficient or portable than the default, possibly via Apache Lucene.
+   * The default one is to use a native wrapper over the real Hunspell binary,
+   * creating temporary files from the streams.
+   */
+  public static void setHunspellStreamFactory(Factory factory) {
+    hunspellDictionaryStreamFactory = factory;
   }
 
   public static synchronized HunspellDictionary getDictionary(Path dictionary, Path affix) {
@@ -43,24 +88,63 @@ public final class Hunspell {
     if (hunspell != null && !hunspell.isClosed()) {
       return hunspell;
     }
-    HunspellDictionary newHunspell = hunspellDictionaryFactory.apply(dictionary, affix);
-    map.put(key, newHunspell);
-    return newHunspell;
+
+    if (FORCE_TEMP_FILES) {
+      HunspellDictionary newHunspell = hunspellDictionaryFactory.apply(dictionary, affix);
+      map.put(key, newHunspell);
+      return newHunspell;
+    }
+
+    try {
+      HunspellDictionary newHunspell = hunspellDictionaryStreamFactory
+        .createFromLocalFiles(dictionary.getFileName().toString(), dictionary, affix);
+      map.put(key, newHunspell);
+      return newHunspell;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public static HunspellDictionary forDictionaryInResources(String language, String resourcePath) {
-    try {
-      ResourceDataBroker broker = JLanguageTool.getDataBroker();
-      InputStream dictionaryStream = broker.getAsStream(resourcePath + language + ".dic");
-      InputStream affixStream = broker.getAsStream(resourcePath + language + ".aff");
-      if (dictionaryStream == null || affixStream == null) {
-        throw new RuntimeException("Could not find dictionary for language \"" + language + "\" in classpath");
+    return forDictionaryInResources(language, resourcePath + language + ".dic", resourcePath + language + ".aff");
+  }
+
+  public static HunspellDictionary forDictionaryInResources(String language, String dicPath, String affPath) {
+    if (FORCE_TEMP_FILES) {
+      try {
+        ResourceDataBroker broker = JLanguageTool.getDataBroker();
+        InputStream dictionaryStream = broker.getAsStream(dicPath);
+        InputStream affixStream = broker.getAsStream(affPath);
+        if (dictionaryStream == null || affixStream == null) {
+          throw new RuntimeException("Could not find dictionary for language \"" + language + "\" in classpath");
+        }
+        Path dictionary = Files.createTempFile(language, ".dic");
+        Path affix = Files.createTempFile(language, ".aff");
+        Files.copy(dictionaryStream, dictionary, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(affixStream, affix, StandardCopyOption.REPLACE_EXISTING);
+        return hunspellDictionaryFactory.apply(dictionary, affix);
+      } catch (IOException e) {
+        throw new RuntimeException("Could not create temporary dictionaries for language \"" + language + "\"", e);
       }
-      Path dictionary = Files.createTempFile(language, ".dic");
-      Path affix = Files.createTempFile(language, ".aff");
-      Files.copy(dictionaryStream, dictionary, StandardCopyOption.REPLACE_EXISTING);
-      Files.copy(affixStream, affix, StandardCopyOption.REPLACE_EXISTING);
-      return hunspellDictionaryFactory.apply(dictionary, affix);
+    }
+
+    ResourceDataBroker broker = JLanguageTool.getDataBroker();
+    URL dicUrl = broker.getFromResourceDirAsUrl(dicPath);
+    URL affUrl = broker.getFromResourceDirAsUrl(affPath);
+    if (dicUrl != null && affUrl != null &&
+      dicUrl.getProtocol().equals("file") && affUrl.getProtocol().equals("file")) {
+      try {
+        return hunspellDictionaryStreamFactory.createFromLocalFiles(language, Path.of(dicUrl.getPath()), Path.of(affUrl.getPath()));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    try (var dic = broker.getFromResourceDirAsStream(dicPath); var aff = broker.getFromResourceDirAsStream(affPath)) {
+      if (dic == null || aff == null) {
+        throw new RuntimeException("Could not find the dictionary for language \"" + language + "\" in the classpath");
+      }
+      return hunspellDictionaryStreamFactory.createFromStreams(language, dic, aff);
     } catch (IOException e) {
       throw new RuntimeException("Could not create temporary dictionaries for language \"" + language + "\"", e);
     }
@@ -68,5 +152,25 @@ public final class Hunspell {
 
   public static HunspellDictionary forDictionaryInResources(String language) {
     return forDictionaryInResources(language, "");
+  }
+
+  public interface Factory {
+    /**
+     * An equivalent of {@link #createFromStreams(String, InputStream, InputStream)} that can be used
+     * if the caller is sure that the Hunspell dictionaries are located in the files in the local file system.
+     * This allows for more efficient implementation.
+     */
+    default HunspellDictionary createFromLocalFiles(String languageCode, Path dictionary, Path affix) throws IOException {
+      try (InputStream dic = Files.newInputStream(dictionary); InputStream aff = Files.newInputStream(affix)) {
+        return createFromStreams(languageCode, dic, aff);
+      }
+    }
+
+    /**
+     * Create a Hunspell dictionary from the given streams.
+     * All necessary information should be extracted from both streams by the time this method returns.
+     * Closing the streams is not necessary in the implementation of this method, as the caller will close them itself.
+     */
+    HunspellDictionary createFromStreams(String languageCode, InputStream dictionary, InputStream affix) throws IOException;
   }
 }

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
@@ -40,6 +40,7 @@ import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -79,7 +80,7 @@ public class HunspellRule extends SpellingCheckRule {
   private final Pattern MINUS_PLUS = Pattern.compile("-+");
 
   private static final ConcurrentMap<URL, List<String>> ignoreFileContents = new ConcurrentHashMap<>();
-  private static final ConcurrentMap<Path, Pattern> nonWordPatterns = new ConcurrentHashMap<>();
+  private static final ConcurrentMap<String, Pattern> nonWordPatterns = new ConcurrentHashMap<>();
 
   public static Queue<String> getActiveChecks() {
     return activeChecks;
@@ -507,47 +508,63 @@ public class HunspellRule extends SpellingCheckRule {
     }
     String shortDicPath = getDictFilenameInResources(langCountry);
     // set dictionary only if there are dictionary files:
-    Path affPath = null;
     if(!Tools.isExternSpeller()) {    //  use of external speller for OO extension (32-bit)
-                                      //  hunspell doesn't support 32 bit java
+                                      //  hunspell doesn't support 32-bit java
       if (JLanguageTool.getDataBroker().resourceExists(shortDicPath)) {
-        String path = getDictionaryPath(langCountry, shortDicPath);
-        if ("".equals(path)) {
-          hunspell = null;
+        if (Hunspell.FORCE_TEMP_FILES) {
+          String path = getDictionaryPath(langCountry, shortDicPath);
+          if ("".equals(path)) {
+            hunspell = null;
+          } else {
+            Path affPath = Paths.get(path + ".aff");
+            hunspell = Hunspell.getDictionary(Paths.get(path + ".dic"), affPath);
+            addIgnoreWords();
+            nonWordPattern = nonWordPatternFromPath(affPath);
+          }
         } else {
-          affPath = Paths.get(path + ".aff");
-          hunspell = Hunspell.getDictionary(Paths.get(path + ".dic"), affPath);
+          String aff = shortDicPath.substring(0, shortDicPath.length() - 3) + "aff";
+          hunspell = Hunspell.forDictionaryInResources(langCountry, shortDicPath, aff);
           addIgnoreWords();
+          nonWordPattern = nonWordPatterns.computeIfAbsent("resource:" + shortDicPath, __ ->
+            computeNonWordPattern(JLanguageTool.getDataBroker().getFromResourceDirAsStream(aff)));
         }
       } else if (new File(shortDicPath + ".dic").exists()) {
         // for dynamic languages
-        affPath = Paths.get(shortDicPath + ".aff");
+        Path affPath = Paths.get(shortDicPath + ".aff");
         hunspell = Hunspell.getDictionary(Paths.get(shortDicPath + ".dic"), affPath);
+        nonWordPattern = nonWordPatternFromPath(affPath);
       }
     }
-    if (affPath != null) {
-      nonWordPattern = nonWordPatterns.computeIfAbsent(affPath, (path) -> {
-        String wordChars = "";
-        if (path != null) {
-          try (Scanner sc = new Scanner(path)) {
-            while (sc.hasNextLine()) {
-              String line = sc.nextLine();
-              if (line.startsWith("WORDCHARS ")) {
-                String wordCharsFromAff = line.substring("WORDCHARS ".length());
-                //System.out.println("#" + wordCharsFromAff+ "#");
-                wordChars = "(?![" + wordCharsFromAff.replace("-", "\\-") + "])";
-                break;
-              }
-            }
-          } catch (IOException e) {
-            logger.error("Could not read aff file: " + path, e);
-          }
-        }
-        return Pattern.compile(wordChars + NON_ALPHABETIC);
-      });
-    } else {
+
+    if (nonWordPattern == null) {
       nonWordPattern = NON_ALPHABETIC_PATTERN;
     }
+  }
+
+  private static Pattern nonWordPatternFromPath(Path affPath) {
+    return nonWordPatterns.computeIfAbsent(affPath.toString(), (path) -> {
+      String wordChars = "";
+      try (var stream = Files.newInputStream(Paths.get(path))) {
+        return computeNonWordPattern(stream);
+      } catch (IOException e) {
+        logger.error("Could not read aff file: " + path, e);
+      }
+      return Pattern.compile(wordChars + NON_ALPHABETIC);
+    });
+  }
+
+  private static Pattern computeNonWordPattern(InputStream stream) {
+    try (Scanner sc = new Scanner(stream)) {
+      while (sc.hasNextLine()) {
+        String line = sc.nextLine();
+        if (line.startsWith("WORDCHARS ")) {
+          String wordCharsFromAff = line.substring("WORDCHARS ".length());
+          //System.out.println("#" + wordCharsFromAff+ "#");
+          return Pattern.compile("(?![" + wordCharsFromAff.replace("-", "\\-") + "])" + NON_ALPHABETIC);
+        }
+      }
+    }
+    return NON_ALPHABETIC_PATTERN;
   }
 
   @NotNull


### PR DESCRIPTION
With a fix for #11321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced dictionary loading with a flexible Factory interface supporting both file and stream inputs.
  - Streamlined initialization and pattern computation for dictionary resources, improving maintainability.
- **New Features**
  - Added support for creating Hunspell dictionaries directly from input streams for better resource compatibility.
- **Deprecation**
  - Deprecated the old factory setter method in favor of a new stream-based factory setter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->