### PR TITLE
[pt] Added AP to fix two FPs in verbs/nouns removals in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4444,6 +4444,17 @@ USA
 
   <rule id="PPPLURAL_SUBSTANTIVE_SUBSTANTIVEADJECTIVE_RARE" name="Remove verbs in substantives">
     <!-- Moved the rule down to assure it works correctly. -->
+    <antipattern>
+      <token postag='SPS00'/>
+      <token postag='(V.+:)?PP..P.+' postag_regexp='yes'/>
+      <token postag='NCMP000'/>
+      <token postag='VMP00.+' postag_regexp='yes'/>
+      <!--
+      Examples:
+               Até tentava achar que mamãe estava feliz por nos termos casado.
+               Depois de nós termos trabalhado tanto para capturá-los.
+      -->
+    </antipattern>
     <pattern>
       <token postag='(V.+:)?PP..P.+' postag_regexp='yes'>
         <exception scope='previous' regexp='yes' inflected='yes'>estar|ter|ser</exception></token>


### PR DESCRIPTION
It only fixed two false positives in 950 000 sentences, but better than nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Portuguese grammar checking by refining a rule to prevent false positives in sentences with certain pronoun and verb combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->