### PR TITLE
[pt] Fixed tons of FPs and removed "temp_off" from rule ID:TAMANHO_DIMENSÃO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3695,6 +3695,8 @@ USA
                     <exception regexp='yes' inflected='yes'>autocarro|carro|ônibus|caminhão|avião|barco|navio|trem|metr[oô]|bonde|triciclo|biciclo|trator|vagão|helicóptero|ferry|veículo|guincho|iate|canoa|caminhete|jet-ski|limusine|furgão|táxi|motociclo|patinete|patins|esqui</exception>
                     <!-- The exception list below includes tools/instruments -->
                     <exception regexp='yes' inflected='yes'>martelo|serrote|alicate|parafuso|prego|formão|compasso|alavanca|machado|escopro|furador|arco|tubo|cabo|grampo|torno|alfinete|trinco|filtro|estilete|cortador|ferro|nivelador|pincel|rolo|bastão|espátula|tijolo|fio|gancho|macho|morsa|raspador|medidor|saca-rolhas|clipe|carrinho</exception>
+                    <!-- The exception list below includes people and human beings -->
+                    <exception regexp='yes' inflected='yes'>filho|pai|mãe|irmão|avô|tio|sobrinho|neto|amigo|vizinho|colega|chefe|aluno|professor|médico|dentista|advogado|engenheiro|polícia|juiz|motorista|cantor|ac?tor|pintor|escritor|padre|pastor|diretor|empregado|gerente|cozinheiro|garçom|bombeiro|soldado|enfermeiro|cientista|estudante|artista|atleta|treinador|jogador</exception>
                     <!-- The exception list below is for proper names -->
                     <exception postag_regexp='yes' postag='NP.+'/>
                 </token>


### PR DESCRIPTION
This rule can't become much better than this, thus the "picky" tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy of language suggestions by updating the rule for preferring "dimensão" over "tamanho" in formal Portuguese.
  - Expanded and reorganized exception handling to better recognize common words, body parts, objects, animals, vehicles, tools, and proper names, reducing false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->