### PR TITLE
[pt] Fixed disambiguation.xml rule ID:PELA_COMO_SOBRE_NADA_ACERCA_ELAR_NEXTVERB_VERBS_RARE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4057,7 +4057,7 @@ USA
   <rule id="PELA_COMO_SOBRE_NADA_ACERCA_ELAR_NEXTVERB_VERBS_RARE" name="Remove rare verbs from appearing as verbs"> <!-- Used ChatGPT 4o to verify the results -->
     <!-- False verbs after "pela", "como", "sobre", "nada", "acerca", "verbo elar" -->
     <pattern>
-      <token postag='V.+' postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+'/></token>
+      <token postag='V.+' postag_regexp="yes"><exception postag_regexp='yes' postag='CS|RG|NC.+|AQ.+|CC|SPS.+|[DP].+|VMG0000'/></token>
       <token regexp="yes">pel[ao]s?|como|sobre|nada|acerca|el[ae]s?|logo</token>
       <marker>
         <token postag='V.+' postag_regexp='yes'/>


### PR DESCRIPTION
Fixed the rule by adding an exception.

"mostrando como extrair informação de dados"

"extrair" was appearing as null.
