### PR TITLE
Fix incorrect sentence tokenization of .Net

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
@@ -6889,6 +6889,11 @@
 <beforebreak>[\.!?]</beforebreak>
 <afterbreak>\S*@</afterbreak>
 </rule>
+<!--Do not break on fullstop when Microsoft .Net platform is referenced.-->
+<rule break="no">
+<beforebreak>(^|[\s\u00A0])\.</beforebreak>
+<afterbreak>(NET|Net)\b</afterbreak>
+</rule>
 </languagerule>
 <languagerule languagerulename="Arabic">
 <rule break="no">

--- a/languagetool-standalone/src/test/java/org/languagetool/tokenizers/SRXSentenceTokenizerTest.java
+++ b/languagetool-standalone/src/test/java/org/languagetool/tokenizers/SRXSentenceTokenizerTest.java
@@ -21,6 +21,11 @@ package org.languagetool.tokenizers;
 import org.junit.Test;
 import org.languagetool.Language;
 import org.languagetool.Languages;
+import org.languagetool.language.AmericanEnglish;
+import org.languagetool.language.French;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -46,6 +51,26 @@ public class SRXSentenceTokenizerTest {
     }
     if (count == 0) {
       fail("No languages found for testing");
+    }
+  }
+
+  @Test
+  public void testDotNetSentence() {
+    // Test that .Net is recognized in multiple languages
+    List<Language> languages = Arrays.asList(AmericanEnglish.getInstance(), French.getInstance());
+    for (Language language : languages) {
+      String input = ".Net is a platform. .Net is a platform. The platform is .Net.";
+      SentenceTokenizer tokenizer = new SRXSentenceTokenizer(language);
+
+      // Note the srx file is configured to preserve whitespace
+      List<String> expectedSentences = Arrays.asList(
+              ".Net is a platform. ",
+              ".Net is a platform. ",
+              "The platform is .Net."
+      );
+
+      List<String> actualSentences = tokenizer.tokenize(input);
+      assertEquals("Tokenized sentences do not match for " + language, expectedSentences, actualSentences);
     }
   }
 


### PR DESCRIPTION
Rules were added in f4dee9c to recognize .Net as valid - as in the Microsoft .Net platform as valid. However, they didn't have any effect, because sentence tokenization split the sentences preventing the rules from seeing the tokens they needed.

See: 
https://github.com/languagetool-org/languagetool/pull/11322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved sentence segmentation to prevent incorrect splitting after ".Net" or ".NET", ensuring accurate handling of references to the Microsoft .Net platform.
- **Tests**
	- Added tests to confirm correct sentence splitting behavior for ".Net" in English and French.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->