### PR TITLE
[pt] Removed "temp_off" from rule ID:MEDO_RECEIO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3710,7 +3710,7 @@ USA
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
 
-        <rule id='MEDO_RECEIO' name="Medo → receio" type='style' tone_tags='formal' tags='picky' default='temp_off'>
+        <rule id='MEDO_RECEIO' name="Medo → receio" type='style' tone_tags='formal' tags='picky'>
             <pattern>
                 <token skip='2' regexp='yes' inflected='yes'>estar|ficar|ter
                     <exception scope='next' postag_regexp='yes' postag='VMP00.+|V.+:.+'/></token>


### PR DESCRIPTION
Removed "temp_off".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "MEDO_RECEIO" style rule for Portuguese is now enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->