### PR TITLE
Fix omission of the pattern(From|To)Pos params

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/RuleMatch.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/RuleMatch.java
@@ -143,7 +143,7 @@ public class RuleMatch implements Comparable<RuleMatch> {
 
   public RuleMatch(Rule rule, AnalyzedSentence sentence, int fromPos, int toPos, int patternFromPos, int patternToPos,
                    String message, String shortMessage, boolean startWithUppercase, String suggestionsOutMsg) {
-    this(rule, sentence, fromPos, toPos, fromPos, toPos, message, shortMessage, startWithUppercase, false, suggestionsOutMsg, false);
+    this(rule, sentence, fromPos, toPos, patternFromPos, patternToPos, message, shortMessage, startWithUppercase, false, suggestionsOutMsg, false);
   }
 
   /**


### PR DESCRIPTION
Fix intermediate constructor params in RuleMatch. patternFromPos and patternToPos are ommitted

This is where support for patternPosition was introduced
Commit:  6ff1c89ad7e
PR: https://github.com/languagetool-org/languagetool/pull/2699

An intermediate constructor was added, but it did not forward the patternFromPos and patternToPos
Line: https://github.com/languagetool-org/languagetool/commit/3a7fe05a64776737713ba75d8d318d378930090a#diff-e0a07efacfdb4c51986cb5d043497b05cdcc0e687176242558b5f5c19ffd45deR149
Commit: 3a7fe05a647
PR: https://github.com/languagetool-org/languagetool/pull/8928

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an issue where specific position information was not properly set, ensuring more accurate highlighting and feedback for detected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->