### PR TITLE
[pt] Added formal rule ID:QUANTO_FOR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3710,14 +3710,15 @@ USA
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
 
-        <rule id='QUANTO_FOR' name="Quanto + intensidade + 'a' → 'for a'" type='style' tone_tags='formal' tags='picky' default='temp_off'>
+        <rule id='QUANTO_FOR' name="Quanto + intensidade + 'a' → 'for a'" type='style' tone_tags='formal' default='temp_off'>
             <pattern>
-                <token skip='1' regexp='no'>quanto</token>
-                <token regexp='yes' inflected='yes'>maior|menor|melhor|pior|maioria|minoria|alto|baixo|denso|forte|fraco|reduzido</token>
+                <token skip='1'>quanto</token>
+                <token regexp='yes' inflected='yes'>maior|menor|melhor|pior|maioria|minoria|alto|baixo|denso|rápido|lento|forte|fraco|elevado|reduzido</token>
                 <marker>
                     <token skip='1' regexp='yes'>[ao]s?</token>
                 </marker>
-                <token postag='N.+' postag_regexp='yes'/> <!-- AQ.+ would make it impossible to check for the plural of "for" -->
+                <token postag='N.+' postag_regexp='yes'/>
+                <token><exception postag_regexp='yes' postag='VMSF.+|VMIP.+|VMN0000'/></token>
             </pattern>
             <message>Num contexto formal, adicione &quot;for&quot;/&quot;forem&quot; para explicitar a condição.</message>
             <suggestion><match no='4' postag='NC(.)(.)000' postag_replace='VMSF3$20'>ser</match> \3</suggestion>
@@ -3726,6 +3727,7 @@ USA
             <example>Quanto maior for a informação, mais variáveis ficam disponíveis.</example>
             <example>Quanto maior for a sua informação, mais variáveis ficam disponíveis.</example>
             <example>Quanto mais denso for o vidro menor são as chances dele quebrar.</example>
+            <example>Quanto mais rápido a gente começar a fazer isso, mais rápido a gente termina.</example>
         </rule>
 
 

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3713,7 +3713,7 @@ USA
         <rule id='QUANTO_FOR' name="Quanto + intensidade + 'a' → 'for a'" type='style' tone_tags='formal' tags='picky' default='temp_off'>
             <pattern>
                 <token skip='1' regexp='no'>quanto</token>
-                <token regexp='yes' inflected='yes'>maior|menor|melhor|pior|maioria|minoria|alto|baixo|denso|rápido|lento|forte|fraco|reduzido</token>
+                <token regexp='yes' inflected='yes'>maior|menor|melhor|pior|maioria|minoria|alto|baixo|denso|forte|fraco|reduzido</token>
                 <marker>
                     <token skip='1' regexp='yes'>[ao]s?</token>
                 </marker>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3710,6 +3710,25 @@ USA
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
 
+        <rule id='QUANTO_FOR' name="Quanto + intensidade + 'a' → 'for a'" type='style' tone_tags='formal' tags='picky' default='temp_off'>
+            <pattern>
+                <token skip='1' regexp='no'>quanto</token>
+                <token regexp='yes' inflected='yes'>maior|menor|melhor|pior|maioria|minoria|alto|baixo|denso|rápido|lento|forte|fraco|reduzido</token>
+                <marker>
+                    <token skip='1' regexp='yes'>[ao]s?</token>
+                </marker>
+                <token postag='N.+' postag_regexp='yes'/> <!-- AQ.+ would make it impossible to check for the plural of "for" -->
+            </pattern>
+            <message>Num contexto formal, adicione &quot;for&quot;/&quot;forem&quot; para explicitar a condição.</message>
+            <suggestion><match no='4' postag='NC(.)(.)000' postag_replace='VMSF3$20'>ser</match> \3</suggestion>
+            <example correction="for a">Quanto maior <marker>a</marker> entropia, mais difícil é organizar o sistema.</example>
+            <example correction="forem as">Quanto maiores <marker>as</marker> entropias, mais difícil é organizar os sistemas.</example>
+            <example>Quanto maior for a informação, mais variáveis ficam disponíveis.</example>
+            <example>Quanto maior for a sua informação, mais variáveis ficam disponíveis.</example>
+            <example>Quanto mais denso for o vidro menor são as chances dele quebrar.</example>
+        </rule>
+
+
         <rule id='MEDO_RECEIO' name="Medo → receio" type='style' tone_tags='formal' tags='picky'>
             <pattern>
                 <token skip='2' regexp='yes' inflected='yes'>estar|ficar|ter


### PR DESCRIPTION
A formal rule. 😛 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new formal style rule for Portuguese that recommends adding the verb "for" or "forem" in "quanto + intensity adjective + article + noun" constructions, enhancing formal language accuracy with clear suggestions and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->