### PR TITLE
[pt] Removed "temp_off" from rule ID:QUANTO_FOR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3710,7 +3710,7 @@ USA
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
 
-        <rule id='QUANTO_FOR' name="Quanto + intensidade + 'a' → 'for a'" type='style' tone_tags='formal' default='temp_off'>
+        <rule id='QUANTO_FOR' name="Quanto + intensidade + 'a' → 'for a'" type='style' tone_tags='formal'>
             <pattern>
                 <token skip='1'>quanto</token>
                 <token regexp='yes' inflected='yes'>maior|menor|melhor|pior|maioria|minoria|alto|baixo|denso|rápido|lento|forte|fraco|elevado|reduzido</token>


### PR DESCRIPTION
Removed temp_off from rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the "QUANTO_FOR" rule for Portuguese, making this style check active by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->