### PR TITLE
[pt-PT] Added two subrules to rulegroup ID:COLOQUIALISMOS_PT_PT

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -1240,7 +1240,7 @@ USA
 </rulegroup>
 
 
-    <rulegroup id='COLOQUIALISMOS_PT_PT' name="[pt-PT][Formal] Coloquialismos: evitar expressões orais" default="on" tone_tags="formal">
+    <rulegroup id='COLOQUIALISMOS_PT_PT' name="[pt-PT][Formal] Coloquialismos: evitar expressões orais" default='on' tone_tags='formal'>
 
         <rule>
             <pattern>
@@ -2088,7 +2088,7 @@ USA
         <short>Coloquialismo</short>
         <example correction=''>Vai <marker>dar uma volta ao bilhar grande</marker>.</example>
     </rule>
-   <rule> <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
+    <rule> <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
         <pattern>
             <token>de</token>
             <token>um</token>
@@ -2105,8 +2105,40 @@ USA
         <short>Coloquialismo</short>
         <example correction='rapidamente|subitamente|repentinamente|num curto intervalo de tempo'>A Ana fê-lo <marker>de um dia para o outro</marker>.</example>
     </rule>
+    <rule id='FAZER_CONTAS_À_VIDA' default='temp_off'>
+        <pattern>
+            <token inflected='yes'>fazer</token>
+            <token>contas</token>
+            <token>à</token>
+            <token>vida</token>
+        </pattern>
+        <message>&colloquialism_msg;</message>
+        <suggestion>saber com o que se pode contar</suggestion>
+        <suggestion>determinar com o que se pode contar</suggestion>
+        <suggestion>apurar os meios disponíveis</suggestion>
+        <suggestion>estabelecer as condições disponíveis</suggestion>
+        <short>Coloquialismo</short>
+        <example correction='saber com o que se pode contar|determinar com o que se pode contar|apurar os meios disponíveis|estabelecer as condições disponíveis'>Preciso de <marker>fazer contas à vida</marker>.</example>
+        <example>Ele pretende saber com o que se pode contar.</example>
+    </rule>
+    <rule id='ÀS_TRÊS_PANCADAS' default='temp_off'>
+        <pattern>
+            <token>às</token>
+            <token regexp='yes'>3|três</token>
+            <token>pancadas</token>
+        </pattern>
+        <message>&colloquialism_msg;</message>
+        <suggestion>mal feito</suggestion>
+        <suggestion>com incorreções</suggestion>
+        <suggestion>de modo inadequado</suggestion>
+        <suggestion>com deficiências</suggestion>
+        <suggestion>sem o devido rigor</suggestion>
+        <short>Coloquialismo</short>
+        <example correction='mal feito|com incorreções|de modo inadequado|com deficiências|sem o devido rigor'>Isso foi feito <marker>às três pancadas</marker>.</example>
+        <example>Aquilo foi tudo feito sem o devido rigor.</example>
+        <example>O trabalho foi todo mal feito.</example>
+    </rule>
     </rulegroup>
-
 
 
         <rulegroup id='GASTAR_DESPENDER_DESEMBOLSAR' name='[pt-PT][Formal] gastar → despender/desembolsar' tone_tags='formal' is_goal_specific='true'>


### PR DESCRIPTION
Two colloquialisms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new style rules for Portuguese (Portugal) to detect colloquial phrases: "fazer contas à vida" and "às três pancadas", each offering formal alternatives. These rules are currently disabled by default.
* **Style**
  * Improved attribute quoting and indentation for better consistency in style rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->