### PR TITLE
[pt] New formal rule ID:FAZER_ELABORAR_TRAÇAR_DELINEAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3707,7 +3707,30 @@ USA
             <example>Os dados não <marker>confirmam</marker> essa afirmação…</example>
         </rule>
     </category>
+
+
+
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
+
+
+        <rule id='FAZER_ELABORAR_TRAÇAR_DELINEAR' name="Fazer/elaborar/traçar → delinear" type='style' tone_tags='formal' tags='picky' default='temp_off'>
+            <!-- This rule gave too many FPs, so I made it stricter -->
+            <pattern>                
+                <marker>
+                    <token regexp='yes' inflected='yes'>fazer|elaborar|traçar</token>
+                </marker>
+                <token min='0' max='1' regexp='yes'>qual|como|quando|onde|porquê|quanto|quem|se|que</token>
+                <token skip='1' regexp='yes'>[ao]s?|u(m|ns)|umas?</token>
+                <token regexp='yes' inflected='yes'>abordagem|ac?ção|agenda|arranjo|configuração|cronograma|designação|diretriz|esquema|estratégia|estrutura|formulação|intenção|meta|método|modelo|objec?tivo|organização|planej?amento|plano|política|procedimento|processo|projec?to|protocolo|roteiro|solução|tác?tica</token>
+            </pattern>
+            <message>Num contexto formal, empregue o verbo &quot;delinear&quot;.</message>
+            <suggestion><match no='1' postag='V.+' postag_regexp='yes'>delinear</match></suggestion>
+            <example correction="delinear">Vamos <marker>fazer</marker> um plano.</example>
+            <example correction="delinear">Vamos <marker>elaborar</marker> uma tática.</example>
+            <example correction="delinear">Vamos <marker>traçar</marker> o objetivo a alcançar.</example>
+            <example>Vamos delinear a estratégia a seguir.</example>
+            <example>Temos de delinear qual o melhor plano.</example>
+        </rule>
 
 
         <rule id='QUANTO_FOR' name="Quanto + intensidade + 'a' → 'for a'" type='style' tone_tags='formal'>


### PR DESCRIPTION
A formal rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new style rule for formal Portuguese language, suggesting the use of "delinear" instead of "fazer," "elaborar," or "traçar" in specific contexts related to plans, strategies, or procedures. This helps users improve formality in their writing with clearer suggestions and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->