### PR TITLE
[pt] Removed "temp_off" from rule

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -2105,7 +2105,7 @@ USA
         <short>Coloquialismo</short>
         <example correction='rapidamente|subitamente|repentinamente|num curto intervalo de tempo'>A Ana fê-lo <marker>de um dia para o outro</marker>.</example>
     </rule>
-    <rule id='FAZER_CONTAS_À_VIDA' default='temp_off'>
+    <rule id='FAZER_CONTAS_À_VIDA'>
         <pattern>
             <token inflected='yes'>fazer</token>
             <token>contas</token>
@@ -2121,22 +2121,20 @@ USA
         <example correction='saber com o que se pode contar|determinar com o que se pode contar|apurar os meios disponíveis|estabelecer as condições disponíveis'>Preciso de <marker>fazer contas à vida</marker>.</example>
         <example>Ele pretende saber com o que se pode contar.</example>
     </rule>
-    <rule id='ÀS_TRÊS_PANCADAS' default='temp_off'>
+    <rule id='ÀS_TRÊS_PANCADAS'>
         <pattern>
             <token>às</token>
             <token regexp='yes'>3|três</token>
             <token>pancadas</token>
         </pattern>
         <message>&colloquialism_msg;</message>
-        <suggestion>mal feito</suggestion>
         <suggestion>com incorreções</suggestion>
         <suggestion>de modo inadequado</suggestion>
         <suggestion>com deficiências</suggestion>
         <suggestion>sem o devido rigor</suggestion>
         <short>Coloquialismo</short>
-        <example correction='mal feito|com incorreções|de modo inadequado|com deficiências|sem o devido rigor'>Isso foi feito <marker>às três pancadas</marker>.</example>
+        <example correction='com incorreções|de modo inadequado|com deficiências|sem o devido rigor'>Isso foi feito <marker>às três pancadas</marker>.</example>
         <example>Aquilo foi tudo feito sem o devido rigor.</example>
-        <example>O trabalho foi todo mal feito.</example>
     </rule>
     </rulegroup>
 

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3713,7 +3713,7 @@ USA
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
 
-        <rule id='FAZER_ELABORAR_TRAÇAR_DELINEAR' name="Fazer/elaborar/traçar → delinear" type='style' tone_tags='formal' tags='picky' default='temp_off'>
+        <rule id='FAZER_ELABORAR_TRAÇAR_DELINEAR' name="Fazer/elaborar/traçar → delinear" type='style' tone_tags='formal' tags='picky'>
             <!-- This rule gave too many FPs, so I made it stricter -->
             <pattern>                
                 <marker>
@@ -3721,7 +3721,7 @@ USA
                 </marker>
                 <token min='0' max='1' regexp='yes'>qual|como|quando|onde|porquê|quanto|quem|se|que</token>
                 <token skip='1' regexp='yes'>[ao]s?|u(m|ns)|umas?</token>
-                <token regexp='yes' inflected='yes'>abordagem|ac?ção|agenda|arranjo|configuração|cronograma|designação|diretriz|esquema|estratégia|estrutura|formulação|intenção|meta|método|modelo|objec?tivo|organização|planej?amento|plano|política|procedimento|processo|projec?to|protocolo|roteiro|solução|tác?tica</token>
+                <token regexp='yes' inflected='yes'>abordagem|ac?ção|agenda|arranjo|configuração|cronograma|designação|diretriz|esquema|estratégia|estrutura|formulação|intenção|meta|método|modelo|objec?tivo|organização|planej?amento|plano|política|procedimento|protocolo|roteiro|solução|tác?tica</token>
             </pattern>
             <message>Num contexto formal, empregue o verbo &quot;delinear&quot;.</message>
             <suggestion><match no='1' postag='V.+' postag_regexp='yes'>delinear</match></suggestion>


### PR DESCRIPTION
Removed "temp_off" from rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled additional Portuguese style rules by default, improving automatic detection of certain language patterns.
* **Improvements**
  * Refined rule suggestions and examples for Portuguese (Portugal), offering more accurate guidance and corrections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->