### PR TITLE
[pt] Rewrote rule ID:FAZER_TRAÇAR_DELINEAR_ELABORAR_V2

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3713,23 +3713,23 @@ USA
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
 
-        <rule id='FAZER_ELABORAR_TRAÇAR_DELINEAR' name="Fazer/elaborar/traçar → delinear" type='style' tone_tags='formal' tags='picky'>
-            <!-- This rule gave too many FPs, so I made it stricter -->
-            <pattern>                
+        <rule id='FAZER_TRAÇAR_DELINEAR_ELABORAR_V2' name="Fazer/traçar → delinear/elaborar" type='style' tone_tags='formal' default='temp_off'>
+            <pattern>
                 <marker>
-                    <token regexp='yes' inflected='yes'>fazer|elaborar|traçar</token>
+                    <token regexp='yes' inflected='yes'>fazer|traçar</token>
                 </marker>
                 <token min='0' max='1' regexp='yes'>qual|como|quando|onde|porquê|quanto|quem|se|que</token>
                 <token skip='1' regexp='yes'>[ao]s?|u(m|ns)|umas?</token>
-                <token regexp='yes' inflected='yes'>abordagem|ac?ção|agenda|arranjo|configuração|cronograma|designação|diretriz|esquema|estratégia|estrutura|formulação|intenção|meta|método|modelo|objec?tivo|organização|planej?amento|plano|política|procedimento|protocolo|roteiro|solução|tác?tica</token>
+                <token regexp='yes' inflected='yes'>abordagem|ac?ção|agenda|arranjo|configuração|cronograma|designação|diretriz|esquema|estratégia|estrutura|formulação|intenção|meta|método|modelo|objec?tivo|organização|planej?amento|plano|política|procedimento|processo|projec?to|protocolo|roteiro|solução|tác?tica</token>
             </pattern>
-            <message>Num contexto formal, empregue o verbo &quot;delinear&quot;.</message>
+            <message>Num contexto formal, empregue o verbo &quot;delinear&quot; ou &quot;elaborar&quot;.</message>
             <suggestion><match no='1' postag='V.+' postag_regexp='yes'>delinear</match></suggestion>
-            <example correction="delinear">Vamos <marker>fazer</marker> um plano.</example>
-            <example correction="delinear">Vamos <marker>elaborar</marker> uma tática.</example>
-            <example correction="delinear">Vamos <marker>traçar</marker> o objetivo a alcançar.</example>
+            <suggestion><match no='1' postag='V.+' postag_regexp='yes'>elaborar</match></suggestion>
+            <example correction="delinear|elaborar">Vamos <marker>fazer</marker> um plano.</example>
+            <example correction="delinear|elaborar">Vamos <marker>traçar</marker> o objetivo a alcançar.</example>
             <example>Vamos delinear a estratégia a seguir.</example>
             <example>Temos de delinear qual o melhor plano.</example>
+            <example>Vou elaborar um cronograma com toda a informação pertinente.</example>
         </rule>
 
 


### PR DESCRIPTION
Rewrote part of it.

No longer needs to use "picky" because the results decreased.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated language suggestions to recommend using "delinear" or "elaborar" instead of "fazer" or "traçar" in formal contexts.
  * Expanded detection to include additional nouns such as "processo" and "projeto".
  * Improved example sentences to clarify correct usage and suggestions.

* **Style**
  * Refined rule patterns and suggestions to reduce false positives and provide clearer recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->