### PR TITLE
[pt] Removed "temp_off" from rule ID:RECURSO_À_FORÇA_COERCIVAMENTE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3684,7 +3684,7 @@ USA
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
 
-        <rulegroup id='RECURSO_À_FORÇA_COERCIVAMENTE' name="Recurso à força → coercivamente" type='style' tone_tags='formal' default='temp_off'>
+        <rulegroup id='RECURSO_À_FORÇA_COERCIVAMENTE' name="Recurso à força → coercivamente" type='style' tone_tags='formal'>
             <rule> <!-- com recurso à força -->
                 <pattern>
                     <marker>


### PR DESCRIPTION
Removed "temp_off".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled a previously inactive Portuguese language style rule, making it active by default for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->