### PR TITLE
[pt-PT] Added AP to rule ID:VERBO_HIFENIZADOR_VERBOS_2

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -1822,6 +1822,15 @@ USA
         <example>Um inteiro n é par se é da forma n = 2k, onde k é um inteiro.</example>
     </antipattern>
 
+    <antipattern> <!-- #5: se + singular second person informal verb -->
+        <token>se</token>
+        <token postag='VMSF2S0' postag_regexp='no'/>
+        <token postag='SPS.+|[DP].+|N.+|AQ.+|RG|RM|CS|V.+|Z0.+|_PUNCT|SENT_END' postag_regexp='yes'/>
+        <example>Verifica o texto e, se tiveres de alterar alguma coisa, diz.</example>
+        <example>Se quiseres te levo.</example>
+        <example>"E se encontrares apenas quarenta?", insistiu Abraão.</example>
+    </antipattern>
+
     <antipattern>
         <token postag='N.+|AQ.+|V.+|PP.+' postag_regexp='yes'/>
         <token>a</token>


### PR DESCRIPTION
An antipattern for false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new grammar rule for Portuguese (Portugal) to better detect specific uses of the conjunction "se" followed by informal singular second person verb forms, improving grammar checking accuracy for these patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->