### PR TITLE
[pt-PT] Removed "temp_off" from rule ID:CHUMBAR_REPROVAR_PT_PT

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -2229,7 +2229,7 @@ USA
         </rule>
 
 
-        <rule id='CHUMBAR_REPROVAR_PT_PT' name="[pt-PT][Formal] Chumbar → reprovar" type='style' tone_tags='formal' tags='picky' default='temp_off'>
+        <rule id='CHUMBAR_REPROVAR_PT_PT' name="[pt-PT][Formal] Chumbar → reprovar" type='style' tone_tags='formal' tags='picky'>
             <antipattern>
                 <token skip='2' inflected='yes'>chumbar</token>
                 <token regexp='yes' inflected='yes'>buraco|cano|carro|cimento|concreto|dente|estrutura|legislação|lei|obra|orçamento|parede|proposta|tinta</token>


### PR DESCRIPTION
Removed “temp_off”.

There are two false positives that can't be fixed because one has a typo before the token and the other needs a disambiguator fix to convert “chumbo” to noun.

And there is a third false positive which would require a specific antipattern for it 😋 (the chemical symbol of “chumbo”).

In the coming days I will improve the disambiguator and code this antipattern which will only remove one false positive, too much work for one hit, but I will try to do it.