### PR TITLE
[pt-PT] Added AP to rule ID:CHUMBAR_REPROVAR_PT_PT

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -2231,6 +2231,11 @@ USA
 
         <rule id='CHUMBAR_REPROVAR_PT_PT' name="[pt-PT][Formal] Chumbar → reprovar" type='style' tone_tags='formal' tags='picky'>
             <antipattern>
+                <token skip='2' regexp='yes'>chumbos?</token>
+                <token regexp='yes' case_sensitive='yes'>Pb|pb|PB</token>
+                <example>Os símbolos de elementos químicos, como ouro (Au), chumbo (Pb) e potássio (K), derivam de seus nomes em latim.</example>
+            </antipattern>
+            <antipattern>
                 <token skip='2' inflected='yes'>chumbar</token>
                 <token regexp='yes' inflected='yes'>buraco|cano|carro|cimento|concreto|dente|estrutura|legislação|lei|obra|orçamento|parede|proposta|tinta</token>
                 <example>O toquinho de madeira chumbado na parede.</example>


### PR DESCRIPTION
An antipattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese (Portugal) style checks to prevent false positives when "chumbo" refers to the chemical element (Pb), ensuring accurate suggestions in scientific contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->