### PR TITLE
[pt] Changed rule ID to try to fix the temp_off issue

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3790,7 +3790,7 @@ USA
         </rulegroup>
 
 
-        <rule id='FAZER_TRAÇAR_DELINEAR_ELABORAR_V2' name="Fazer/traçar → delinear/elaborar" type='style' tone_tags='formal'>
+        <rule id='FAZER_TRAÇAR_DELINEAR_ELABORAR_V3' name="Fazer/traçar → delinear/elaborar" type='style' tone_tags='formal'>
             <pattern>
                 <marker>
                     <token regexp='yes' inflected='yes'>fazer|traçar</token>


### PR DESCRIPTION
My attempt to fix the "temp_off" persistent issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the versioning of a style rule for word replacement in Portuguese, reflecting the latest revision. No changes to rule behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->