### PR TITLE
[pt] Removed "temp_off" and rule that does the same as this one

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -12793,8 +12793,8 @@ USA
         </rule>
 
 
-        <rulegroup id='QUE_SE_V_PRESENTE' name="Simplificar: 'que se + V. presente' → V. part. passado" default='temp_off'>
-
+        <rulegroup id='QUE_SE_V_PRESENTE' name="Simplificar: 'que se + V. presente' → V. part. passado">
+<!-- TO DO: support also plural of present -->
             <antipattern>
                 <token regexp='yes'>[ao]|uma?</token>
                 <token min='1' max='2' postag='N.+|AQ.+' postag_regexp='yes'/>
@@ -15130,49 +15130,6 @@ USA
             <example>No local, funciona um consulado móvel para atender os colombianos que estão no Rio para as competições.</example>
             <example>Só se abre a porta que está nos corações com amor.</example>
             <example>Tom tem um amigo que está na prisão.</example>
-        </rule>
-
-
-        <!-- AMBIENTE QUE SE VIVE ambiente vivido -->
-        <rule id='QUE_SE_VERBO_TIPO_VIVE_PART_PASSADO' name="[Simplificar] 'Que se V.Tipo.Vive(m)' → 'V.Part.Pass.'" type="style" tags="picky">
-            <!--IDEA shorten_it-->
-            <!-- Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2023-05-03/14 (2-MAR-2023+) -->
-            <!--
-      O ambiente que se vive na escola é péssimo. → O ambiente vivido na escola é péssimo.
-      Os ambientes que se vivem na escola são péssimos. → Os ambientes vividos na escola são péssimos.
-      -->
-
-            <antipattern>
-                <token>que</token>
-                <token>se</token>
-                <token postag='VMIP3.+' postag_regexp='yes'/>
-                <token regexp='yes'>às?</token>
-                <token min="0" max="1" postag='_QUOT' postag_regexp='no'/>
-                <token postag='V.+' postag_regexp='yes'/>
-<!--                <example>Temos as leoas que se movem à procura de alimento.</example> -->
-            </antipattern>
-
-            <pattern>
-                <token postag='DA.+|DI.+|CC' postag_regexp='yes'>
-                    <exception postag_regexp='no' postag='SPS00'/>
-                </token>
-                <token postag='NC[FM][SP].+' postag_regexp='yes'/>
-                <marker>
-                    <token>que</token>
-                    <token>se</token>
-                    <token postag='VMIP3.+' postag_regexp='yes'/>
-                </marker>
-                <token postag='SPS00:DA.+' postag_regexp='yes'>
-                    <exception postag_regexp='yes' postag='V.+'/>
-                </token>
-                <token min="0" max="1" postag='_QUOT' postag_regexp='no'/>
-                <token postag='NC.+|AQ.+|NP.+|DI.+' postag_regexp='yes'/>
-            </pattern>
-            <filter class="org.languagetool.rules.pt.AdvancedSynthesizerFilter" args="lemmaFrom:5 lemmaSelect:V.* postagFrom:2 postagSelect:NC(.)(.).* postagReplace:VMP00[\b2N][\b1C]" />
-            <message>&simplify_msg;</message>
-            <suggestion>{suggestion}</suggestion>
-            <example correction="vivido">O ambiente <marker>que se vive</marker> na escola é péssimo.</example>
-            <example correction="vividos">Os ambientes <marker>que se vivem</marker> na escola são péssimos.</example>
         </rule>
 
 


### PR DESCRIPTION
Removed "temp_off".

Also removed rule ID:QUE_SE_VERBO_TIPO_VIVE_PART_PASSADO because it did the same as this one but with tons of false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activated a Portuguese style suggestion that recommends simplifying “que se + verbo no presente” to the past participle form, providing clearer, more concise phrasing.

* **Chores**
  * Removed a specific Portuguese simplification rule, which may slightly change or reduce suggestions for certain “que se …” constructions to streamline outputs and avoid overlapping guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->