### PR TITLE
[pt] Replaced the two previous rules with fixed logic

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -12848,31 +12848,17 @@ USA
         </rulegroup>
 
 
-        <rulegroup id='DOBRO_DUAS_VEZES_MAIS' name="Simplificar: 'duas vezes mais' → 'o dobro'" default='temp_off'>
-
-            <antipattern> <!-- "do que" was too complex to handle, so it is better to remove problematic cases -->
-                <token>duas</token>
-                <token>vezes</token>
-                <token>mais</token>
-                <token min='0' max='2' postag='N.+|AQ.+' postag_regexp='yes'/>
-                <token min='0' max='1'>do</token>
-                <token>que</token>
-                <token postag='[DP].+|N.+|AQ.+' postag_regexp='yes'/>
-                <example>O computador consome duas vezes mais energia do que o outro.</example>
-                <example>Tom tem duas vezes mais livros do que eu.</example>
-                <example>Quando Tom se casou com Mary, ela era duas vezes mais jovem do que ele.</example>
-                <example>Tom bebe duas vezes mais do que Mary.</example>
-                <example>Meu amigo Tom tem duas vezes mais selos que eu.</example>
-            </antipattern>
+        <rulegroup id='DOBRO_DUAS_VEZES_MAIS_V2' name="Simplificar: 'duas vezes mais' → 'o dobro'" default='temp_off'>
 
             <antipattern>
                 <token>duas</token>
                 <token>vezes</token>
                 <token>mais</token>
-                <token min='1' max='2' postag='N.+|AQ.+' postag_regexp='yes'/>
-                <token>em</token>
+                <token skip='-1' postag='N.+|AQ.+' postag_regexp='yes'/>
+                <token regexp='yes'>em|que|do</token>
+                <token min='0' max='1'>que</token> <!-- do que -->
                 <token postag='[DP].+|N.+|AQ.+' postag_regexp='yes'/>
-                <example>É duas vezes mais comuns em homens.</example>
+                <example>Destacando que há cerca de duas vezes mais topônimos com Grim na Inglaterra do que topônimos com Odim.</example>
             </antipattern>
 
             <rule> <!-- #1: Without noun/adjective -->
@@ -12880,13 +12866,16 @@ USA
                     <marker>
                         <token>duas</token>
                         <token>vezes</token>
-                        <token>mais<exception scope='next' postag_regexp='yes' postag='N.+|AQ.+'/></token>
+                        <token>mais</token>
                     </marker>
+                    <token postag='_PUNCT|SENT_END|RG' postag_regexp='yes'>
+                        <exception postag_regexp='yes' postag='N.+|AQ.+'/>
+                        <exception regexp='yes'>abaixo|acima|acolá|adiante|aí|além|algures|amanhã|aquém|aqui|atrás|cedo|dentro|embaixo|fora|lá|longe|nenhures|off-?line|on-?line|ontem|perto|tarde</exception></token>
                 </pattern>
                 <message>&simplify_msg;</message>
                 <suggestion>o dobro</suggestion>
-                <example correction="o dobro">Quero <marker>duas vezes mais</marker> do que propõe.</example>
-                <example>Quero o dobro do oferecido.</example>
+                <example correction="o dobro">Quero <marker>duas vezes mais</marker>.</example>
+                <example>Ele produz o dobro agora.</example>
             </rule>
 
             <rule> <!-- #2: Noun male/C -->
@@ -12896,7 +12885,9 @@ USA
                         <token>vezes</token>
                         <token>mais</token>
                     </marker>
-                    <token postag='NC[CM].+' postag_regexp='yes'><exception postag_regexp='no' postag='RG'/></token>
+                    <token postag='NC[CM].+' postag_regexp='yes'>
+                        <exception postag_regexp='no' postag='RG'/>
+                        <exception scope='next' regexp='yes'>em|que|do</exception></token>
                 </pattern>
                 <message>&simplify_msg;</message>
                 <suggestion>o dobro <match no='4' postag='NC(.)(.)000' postag_replace='SPS00:DA0M$20'>de:o</match></suggestion>
@@ -12915,7 +12906,9 @@ USA
                         <token>vezes</token>
                         <token>mais</token>
                     </marker>
-                    <token postag='NCF.+' postag_regexp='yes'><exception postag_regexp='no' postag='RG'/></token>
+                    <token postag='NCF.+' postag_regexp='yes'>
+                        <exception postag_regexp='no' postag='RG'/>
+                        <exception scope='next' regexp='yes'>em|que|do</exception></token>
                 </pattern>
                 <message>&simplify_msg;</message>
                 <suggestion>o dobro <match no='4' postag='NC(.)(.)000' postag_replace='SPS00:DA0F$20'>de:o</match></suggestion>
@@ -12930,32 +12923,7 @@ USA
         </rulegroup>
 
 
-        <rulegroup id='TRIPLO_TRÊS_VEZES_MAIS' name="Simplificar: 'três vezes mais' → 'o triplo'" default='temp_off'>
-
-            <antipattern> <!-- "do que" was too complex to handle, so it is better to remove problematic cases -->
-                <token>três</token>
-                <token>vezes</token>
-                <token>mais</token>
-                <token min='0' max='2' postag='N.+|AQ.+' postag_regexp='yes'/>
-                <token min='0' max='1'>do</token>
-                <token>que</token>
-                <token postag='[DP].+|N.+|AQ.+' postag_regexp='yes'/>
-                <example>O computador consome três vezes mais energia do que o outro.</example>
-                <example>Tom tem três vezes mais livros do que eu.</example>
-                <example>Quando Tom se casou com Mary, ela era três vezes mais jovem do que ele.</example>
-                <example>Tom bebe três vezes mais do que Mary.</example>
-                <example>Meu amigo Tom tem três vezes mais selos que eu.</example>
-            </antipattern>
-
-            <antipattern>
-                <token>três</token>
-                <token>vezes</token>
-                <token>mais</token>
-                <token min='1' max='2' postag='N.+|AQ.+' postag_regexp='yes'/>
-                <token>em</token>
-                <token postag='[DP].+|N.+|AQ.+' postag_regexp='yes'/>
-                <example>É três vezes mais comuns em homens.</example>
-            </antipattern>
+        <rulegroup id='TRIPLO_TRÊS_VEZES_MAIS_V2' name="Simplificar: 'três vezes mais' → 'o triplo'" default='temp_off'>
 
             <antipattern>
                 <token>duas</token>
@@ -12966,18 +12934,32 @@ USA
                 <example>Armas de implosão linear usam duas ou três vezes mais plutônio e são consideravelmente mais caras.</example>
             </antipattern>
 
+            <antipattern>
+                <token>três</token>
+                <token>vezes</token>
+                <token>mais</token>
+                <token skip='-1' postag='N.+|AQ.+' postag_regexp='yes'/>
+                <token regexp='yes'>em|que|do</token>
+                <token min='0' max='1'>que</token> <!-- do que -->
+                <token postag='[DP].+|N.+|AQ.+' postag_regexp='yes'/>
+                <example>Destacando que há cerca de três vezes mais topônimos com Grim na Inglaterra do que topônimos com Odim.</example>
+            </antipattern>
+
             <rule> <!-- #1: Without noun/adjective -->
                 <pattern>
                     <marker>
                         <token>três</token>
                         <token>vezes</token>
-                        <token>mais<exception scope='next' postag_regexp='yes' postag='N.+|AQ.+'/></token>
+                        <token>mais</token>
                     </marker>
+                    <token postag='_PUNCT|SENT_END|RG' postag_regexp='yes'>
+                        <exception postag_regexp='yes' postag='N.+|AQ.+'/>
+                        <exception regexp='yes'>abaixo|acima|acolá|adiante|aí|além|algures|amanhã|aquém|aqui|atrás|cedo|dentro|embaixo|fora|lá|longe|nenhures|off-?line|on-?line|ontem|perto|tarde</exception></token>
                 </pattern>
                 <message>&simplify_msg;</message>
                 <suggestion>o triplo</suggestion>
-                <example correction="o triplo">Quero <marker>três vezes mais</marker> do que propõe.</example>
-                <example>Quero o triplo do oferecido.</example>
+                <example correction="o triplo">Quero <marker>três vezes mais</marker>.</example>
+                <example>Ele produz o triplo agora.</example>
             </rule>
 
             <rule> <!-- #2: Noun male/C -->
@@ -12987,7 +12969,9 @@ USA
                         <token>vezes</token>
                         <token>mais</token>
                     </marker>
-                    <token postag='NC[CM].+' postag_regexp='yes'><exception postag_regexp='no' postag='RG'/></token>
+                    <token postag='NC[CM].+' postag_regexp='yes'>
+                        <exception postag_regexp='no' postag='RG'/>
+                        <exception scope='next' regexp='yes'>em|que|do</exception></token>
                 </pattern>
                 <message>&simplify_msg;</message>
                 <suggestion>o triplo <match no='4' postag='NC(.)(.)000' postag_replace='SPS00:DA0M$20'>de:o</match></suggestion>
@@ -13006,7 +12990,9 @@ USA
                         <token>vezes</token>
                         <token>mais</token>
                     </marker>
-                    <token postag='NCF.+' postag_regexp='yes'><exception postag_regexp='no' postag='RG'/></token>
+                    <token postag='NCF.+' postag_regexp='yes'>
+                        <exception postag_regexp='no' postag='RG'/>
+                        <exception scope='next' regexp='yes'>em|que|do</exception></token>
                 </pattern>
                 <message>&simplify_msg;</message>
                 <suggestion>o triplo <match no='4' postag='NC(.)(.)000' postag_replace='SPS00:DA0F$20'>de:o</match></suggestion>


### PR DESCRIPTION
The logic of the previous rules was wrong.

Now they work properly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Improved Portuguese style checks for “duas/três vezes mais” and variants, with better handling of “do que/em/que,” punctuation boundaries, and flexible sentence patterns to reduce false positives and improve suggestions.
* Documentation
  * Updated examples to reflect expanded detection and clearer corrective guidance.
* Refactor
  * Renamed related Portuguese style rules (V2), with no change to default activation or user-facing availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->