### PR TITLE
[pt] Removed "temp_off" from yesterday rules (zero hits)

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -12848,7 +12848,7 @@ USA
         </rulegroup>
 
 
-        <rulegroup id='DOBRO_DUAS_VEZES_MAIS_V2' name="Simplificar: 'duas vezes mais' → 'o dobro'" default='temp_off'>
+        <rulegroup id='DOBRO_DUAS_VEZES_MAIS_V2' name="Simplificar: 'duas vezes mais' → 'o dobro'">
 
             <antipattern>
                 <token>duas</token>
@@ -12923,7 +12923,7 @@ USA
         </rulegroup>
 
 
-        <rulegroup id='TRIPLO_TRÊS_VEZES_MAIS_V2' name="Simplificar: 'três vezes mais' → 'o triplo'" default='temp_off'>
+        <rulegroup id='TRIPLO_TRÊS_VEZES_MAIS_V2' name="Simplificar: 'três vezes mais' → 'o triplo'">
 
             <antipattern>
                 <token>duas</token>


### PR DESCRIPTION
Zero hits in the nightly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled two Portuguese style checks that flag redundant multiplier constructions (e.g., “duas vezes mais”, “três vezes mais”). These rules are now active by default, improving detection of verbosity and clarity issues in Portuguese texts and providing suggestions to simplify phrasing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->