### PR TITLE
[pt] Fix for hyphenated "porta-NC" in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4541,8 +4541,8 @@ USA
             <token postag='N.+' postag_regexp='yes'/>
         </and>
       </marker>
-      <token regexp='yes'>[-]</token>
-      <token postag_regexp='yes' postag='NC.P.+'/>
+      <token spacebefore='no' regexp='yes'>[-]</token>
+      <token spacebefore='no' postag_regexp='yes' postag='NC.P.+'/>
     </pattern>
     <disambig action="remove" postag="V.*"/>
     <!--

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4533,6 +4533,27 @@ USA
     -->
   </rule>
 
+  <rule id="PORTA_HIFEN_SUBSTANTIVOPLURAL" name="Remove verbs in porta-Substantivo_Plural">
+    <pattern>
+      <marker>
+        <and>
+            <token>porta</token>
+            <token postag='N.+' postag_regexp='yes'/>
+        </and>
+      </marker>
+      <token regexp='yes'>[-]</token>
+      <token postag_regexp='yes' postag='NC.P.+'/>
+    </pattern>
+    <disambig action="remove" postag="V.*"/>
+    <!--
+    Examples:
+             O porta-carros.
+             Os porta-carros.
+             O porta-paletes.
+             Os porta-paletes.
+    -->
+  </rule>
+
   <rulegroup id="NATIONAL_PREFIXES" name="Ignore spelling in tagged words with national prefixes">
       <rule>
           <pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -40662,7 +40662,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
         <rule id="PORTA_SUBSTANTIVO_PLURAL" name="Composição de porta-substantivo_plural" default='temp_off'>
             <pattern>
-                <token>porta</token>
+                <token>porta<exception postag_regexp='yes' postag='NP.+'/></token>
                 <token postag_regexp='yes' postag='NC.P.+'/>
             </pattern>
             <message>A palavra <suggestion>\1-\2</suggestion> é hifenizada.</message>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -40659,6 +40659,21 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
     <category id='COMPOUNDING' name="Palavras Compostas" type="misspelling">
+
+        <rule id="PORTA_SUBSTANTIVO_PLURAL" name="Composição de porta-substantivo_plural" default='temp_off'>
+            <pattern>
+                <token>porta</token>
+                <token postag_regexp='yes' postag='NC.P.+'/>
+            </pattern>
+            <message>A palavra <suggestion>\1-\2</suggestion> é hifenizada.</message>
+            <example correction="porta-carros">Os <marker>porta carros</marker> são úteis.</example>
+            <example correction="porta-carros">O <marker>porta carros</marker> é útil.</example>
+            <example>Quero um porta-chaves.</example>
+            <example>Quero uns porta-chaves.</example>
+            <example>Quero um porta-paletes.</example>
+            <example>Quero uns porta-paletes.</example>
+        </rule>
+
         <rule id="SEM_ABRIGO" name="Composição de sem-abrigo">
             <pattern>
                 <token postag_regexp="yes" postag="[DP].+M[SP].+|Z.+|SENT_START|SP.+"></token>


### PR DESCRIPTION
Fix for "porta-paletes", "porta-carros", etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portuguese: added detection for porta‑NOUN_plural compounds, with suggestions to hyphenate (e.g., "porta carros" → "porta-carros"). The hyphenation rule is available but disabled by default.
* **Bug Fixes**
  * Portuguese: reduced false positives by preventing these porta‑ compounds from being misclassified as verbs, improving grammar and style suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->