### PR TITLE
[pt] Added words to spelling.txt

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
@@ -342,6 +342,8 @@ carrapitos
 caudalímetro
 caudalímetros
 caulinar
+chefão
+chefões
 chinchada
 chifrudo
 chifrudos


### PR DESCRIPTION
Added missing words.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded the Portuguese spellchecker dictionary by adding “chefão” and “chefões.”
  - Text containing these words will no longer be flagged as misspelled, improving accuracy for Brazilian Portuguese usage.
  - Enhances writing and proofreading experiences by recognizing both singular and plural forms.
  - No behavioral changes elsewhere; this update solely broadens accepted vocabulary for Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->