### PR TITLE
[pt] Added AP to rule ID:CONTRACOES_OBRIGATORIAS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -18026,6 +18026,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <url>https://pt.wiktionary.org/wiki/Ap%C3%AAndice:Combina%C3%A7%C3%B5es_e_contra%C3%A7%C3%B5es_do_portugu%C3%AAs</url>
 
             <antipattern>
+                <token regexp='yes'>[ao]s?|d[ao]s?|n[ao]s?</token>
+                <token postag='NC.+|AQ.+' postag_regexp='yes'/>
+                <token case_sensitive='yes' regexp='yes'>A|E|O</token>
+                <token case_sensitive='yes' regexp='yes'>[ao]s?</token>
+                <example>Na manobra A os Blue atacaram de quatro frentes.</example>
+                <example>No lado A as faixas de "Whales and Sharks" de 2007, e uma música inédita.</example>
+            </antipattern>
+
+            <antipattern>
                 <token postag='V.+' postag_regexp='yes'/>
                 <token regexp='no'>por</token>
                 <token postag='DA.+' postag_regexp='yes'/>


### PR DESCRIPTION
An antipattern to fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Reduced false positives in Portuguese (Portugal) grammar checks by refining patterns for determiner/article + noun constructions followed by uppercase letters (A/E/O).
  - Examples now handled correctly include: “Na manobra A os …” and “No lado A as faixas …”.
  - Improves accuracy without changing the interface or affecting other languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->