### PR TITLE
[pt] Enabled rule

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -17152,7 +17152,7 @@ USA
         </rulegroup>
 
 
-        <rule id='EM_QUE_ONDE_NO_QUAL' name="Em que → onde/no qual" type='style' tags='picky' default='temp_off'>
+        <rule id='EM_QUE_ONDE_NO_QUAL' name="Em que → onde/no qual" type='style' tags='picky'>
             <!-- ChatGPT 5 -->
             <!-- Regra de simplificação no uso de pronomes relativos em texto formal. -->
             <pattern>


### PR DESCRIPTION
Enabled the new rule that replaces the old one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled a Portuguese style suggestion that recommends replacing “em que” with “onde”/“no qual” where appropriate. This rule is now active by default (previously off), enhancing style guidance for PT texts. It appears under picky suggestions and can be disabled in settings if desired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->