### PR TITLE
[pt] Added formal rule ID:MAIORES_PRINCIPAIS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3691,6 +3691,26 @@ USA
     <category id='FORMAL' name='Linguagem formal' type='style' tone_tags="formal">
 
 
+        <rule id='MAIORES_PRINCIPAIS' name="Maiores → principais (plural apenas)" type='style' tone_tags='formal' tags='picky' default='temp_off'>
+            <!-- ChatGPT 5 -->
+            <!-- Atenção: esta regra aplica-se apenas a "maiores" (plural).
+                          Não utilizar com "maior" (singular), pois o sentido muda
+                          e a substituição por "principal" nem sempre é válida. -->
+            <pattern>
+                <token postag='(SPS00:)?D[AI].+' postag_regexp='yes'/>
+                <marker>
+                    <token>maiores</token>
+                </marker>
+                <token postag='N.+|AQ.+' postag_regexp='yes'/>
+            </pattern>
+            <message>Use &quot;principais&quot; para importância/relevância, e &quot;maiores&quot; apenas para tamanho, quantidade ou idade.</message>
+            <suggestion>principais</suggestion>
+            <example correction="principais">O Marco é um dos <marker>maiores</marker> contribuidores lexicográficos.</example>
+            <example>Conheci alguns dos principais escritores da atualidade.</example>
+            <example>Ele é um dos principais responsáveis pela decisão.</example>
+        </rule>
+
+
         <rulegroup id='PERTO_PRÓXIMO' name="Perto → próximo" type='style' tone_tags='formal'>
 
             <antipattern>


### PR DESCRIPTION
A formal rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Portuguese style check that flags misuse of “maiores” when the intended meaning is importance/relevance, suggesting “principais”.
  - Applies in plural contexts (typically after determiners and before nouns) and offers an automatic suggestion.
  - Includes examples to illustrate correct usage and improve clarity and tone in formal Portuguese.
  - Optional rule, off by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->