### PR TITLE
[pt-PT] Added APs to rule ID:PHRASAL_VERB_RESIDIR_EM

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -867,14 +867,38 @@ USA
           <token regexp='yes'>residentes?|morad(?:as?|or(?:es)?)</token>
           <token postag_regexp='yes' postag='A.+'/>
       </antipattern>
-      <!-- MARCOAGPINTO 2020-10-06 + 2020-10-27 (21-OCT-2020+) *START* -->
-      <!-- "No núcleo reside a força imprescindível dos modelos." -->
       <antipattern>
-          <token regexp="yes">residem?</token>
-          <token regexp="yes">as?|os?|um|uns|umas?</token>
-          <token postag='NC[CFM][SP]000|AQ0[CFM][SP]0' postag_regexp='yes'/>
+          <token regexp='yes'>moram?|residem?</token>
+          <token postag='(SPS00:)?[DP].+' postag_regexp='yes'/>
+          <token postag='N.+|AQ.+' postag_regexp='yes'/>
+          <example>No núcleo reside a força imprescindível dos modelos.</example>
+          <example>Em que tipo de casa mora o Tom?</example>
+          <example>É aqui que mora o senhor Pedro?</example>
+          <example>Onde mora seu sogro? - Na casa que está situada junto da casa do meu cunhado.</example>
+          <example>Ele mora um andar acima do meu.</example>
+          <example>Vocês devem ter errado de endereço. Aqui não mora nenhum Wagner.</example>
+          <example>Onde mora teu avô?</example>
+          <example>Dentro de todos os adultos mora o desejo secreto de voltar à infância.</example>
+          <example>Onde moram tuas filhas?</example>
       </antipattern>
-      <!-- MARCOAGPINTO 2020-10-06 + 2020-10-27 (21-OCT-2020+) *END* -->
+      <antipattern>
+          <token regexp='yes'>residentes?|moradora?|morador[ae]s</token>
+          <token regexp='yes'>loca(l|is)</token>
+          <example>Circulam histórias entre os moradores locais sobre a faculdade.</example>
+          <example>Alguns moradores locais não quiseram comentar.</example>
+          <example>As taxas de admissão são reduzidas para os residentes locais durante o inverno.</example>
+      </antipattern>
+      <antipattern>
+          <token regexp='yes'>residentes?|moradora?|morador[ae]s</token>
+          <token postag='SPS.+|NP..[^G].+' postag_regexp='yes'/>
+          <example>Hoje, para evitar reação hostil de moradores contra os guardas, a Polícia Civil contou com o apoio da PM.</example>
+          <example>O prefeito Rafael Greca (PMN) relatou uma série de reclamações de moradores contra o mau comportamento dos invasores.</example>
+          <example>Eles viajam para Burkittsville, Maryland (anteriormente Blair) e entrevistam os moradores sobre a lenda da Bruxa de Blair.</example>
+          <example>O prefeito Rafael Greca (PMN) relatou uma série de reclamações de moradores contra o mau comportamento dos invasores.</example>
+          <example>O morador Henrique Gonçalves, 35, destacou que a maior preocupação, é que diante do período chuvoso esses locais estão...</example>
+          <example>Já para o morador Fábio Santos, que também esteve acompanhando a manifestação, é lamentável a situação ao qual se enco...</example>
+          <example>“É a melhor notícia que eu poderia ter recebido”, comemora a moradora Madalena, que vive no Camanducaia há 8 anos.</example>
+      </antipattern>
       <pattern>
           <token inflected='yes' regexp='yes'>residir|morar|residente|morador</token>
           <token postag_regexp='yes' postag='[DN].+'>


### PR DESCRIPTION
Added antipatterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false positives in pt-PT for residency-related expressions (e.g., morar/residir, moradores/residentes) across varied contexts.
  * Improved handling of nominal and prepositional constructions, leading to more natural sentences passing without incorrect flags.
  * Broadened recognition of locale-related phrases and determiner patterns to better reflect real-world usage.
  * Added comprehensive examples to enhance rule reliability and coverage, improving overall grammar checking accuracy for Portuguese (Portugal).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->