### PR TITLE
[pt] APs to fix verbs/nouns in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -1693,7 +1693,7 @@ USA
     <antipattern> <!-- "sem falar de coisas sensíveis" -->
       <token postag='SPS00' postag_regexp='no'/>
       <token postag='VMN0000' postag_regexp='no'/>
-      <token postag='SPS00' postag_regexp='no'/>
+      <token postag='SPS.*' postag_regexp='yes'/>
     </antipattern>
     <rule>
       <pattern>
@@ -1998,7 +1998,7 @@ USA
       <antipattern> <!-- "sem falar de coisas sensíveis" -->
         <token postag='SPS00' postag_regexp='no'/>
         <token postag='VMN0000' postag_regexp='no'/>
-        <token postag='SPS00' postag_regexp='no'/>
+        <token postag='SPS.*' postag_regexp='yes'/>
       </antipattern>
       <pattern>
         <token postag="SPS00" postag_regexp="no">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -1690,6 +1690,11 @@ USA
       <token>de</token>
       <token regexp="yes">podere?s?</token>
     </antipattern>
+    <antipattern> <!-- "sem falar de coisas sensíveis" -->
+      <token postag='SPS00' postag_regexp='no'/>
+      <token postag='VMN0000' postag_regexp='no'/>
+      <token postag='SPS00' postag_regexp='no'/>
+    </antipattern>
     <rule>
       <pattern>
         <token postag="DA0MS0">o</token>
@@ -1989,6 +1994,11 @@ USA
         <token postag="V.*" postag_regexp="yes"/>
         <token spacebefore="no">-</token>
         <token spacebefore="no" postag="P.*" postag_regexp="yes"/>
+      </antipattern>
+      <antipattern> <!-- "sem falar de coisas sensíveis" -->
+        <token postag='SPS00' postag_regexp='no'/>
+        <token postag='VMN0000' postag_regexp='no'/>
+        <token postag='SPS00' postag_regexp='no'/>
       </antipattern>
       <pattern>
         <token postag="SPS00" postag_regexp="no">


### PR DESCRIPTION
Fixed issues in disambiguation regarding noun/verbs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese disambiguation by adding contextual safeguards so specific rules no longer trigger in particular POS-tag sequences.
  * Reduced false positives in determiner–verb/noun and verb–preposition cases, yielding more accurate suggestions.
  * Changes only affect targeted Portuguese contexts; behavior elsewhere unchanged.
  * No impact on other languages, public interfaces, or performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->