### PR TITLE
[pt] Enabled rule ID:FALAR_DE_ABORDAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3711,7 +3711,7 @@ USA
         </rule>
 
 
-        <rulegroup id='FALAR_DE_ABORDAR' name="Falar de → abordar" type='style' tone_tags='formal' default='temp_off'>
+        <rulegroup id='FALAR_DE_ABORDAR' name="Falar de → abordar" type='style' tone_tags='formal'>
             <!-- ChatGPT 5 -->
 
             <rule> <!-- #1: da(s)/do(s) -->


### PR DESCRIPTION
Enabled rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activated a new Portuguese style suggestion: “Falar de → abordar” for formal tone. Users will now receive guidance to prefer “abordar” over “falar de” in formal contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->