### PR TITLE
[pt] More fixes regarding verbs/nouns in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -672,7 +672,7 @@ USA
     <antipattern> <!-- It can be both a verb and a non-verb -->
       <token postag='RG'/>
       <token postag='VMIP2S0'/>
-      <token postag='NC.+|AQ.+' postag_regexp='yes'><exception postag_regexp='no' postag='RG'/></token>
+      <token postag='NC.+|AQ.+' postag_regexp='yes'><exception postag_regexp='yes' postag='RG|NP.+'/></token>
       <!-- "inclusive certas organizações" -->
       <!-- "Quanto vales Bruno Fernandes?" -->
       <!-- "Agora sabes porquê." -->

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -672,8 +672,10 @@ USA
     <antipattern> <!-- It can be both a verb and a non-verb -->
       <token postag='RG'/>
       <token postag='VMIP2S0'/>
-      <token postag='N.+|AQ.+' postag_regexp='yes'/>
+      <token postag='NC.+|AQ.+' postag_regexp='yes'><exception postag_regexp='no' postag='RG'/></token>
       <!-- "inclusive certas organizações" -->
+      <!-- "Quanto vales Bruno Fernandes?" -->
+      <!-- "Agora sabes porquê." -->
     </antipattern>
     <rule>
       <pattern>


### PR DESCRIPTION
Fixed more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved Portuguese disambiguation for adverb–verb–noun patterns, reducing false positives in common phrases.
  - Refined detection of ambiguous noun/verb tokens to avoid misclassifying certain noun forms (e.g., articles/pronouns), yielding fewer incorrect flags.
  - Excludes specific edge cases that previously triggered misclassifications, improving overall Portuguese grammar-check accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->