### PR TITLE
Hunspell: fix Windows path handling

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/Hunspell.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/Hunspell.java
@@ -4,6 +4,7 @@ import org.languagetool.JLanguageTool;
 import org.languagetool.broker.ResourceDataBroker;
 
 import java.io.*;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.*;
 import java.util.*;
@@ -134,8 +135,8 @@ public final class Hunspell {
     if (dicUrl != null && affUrl != null &&
       dicUrl.getProtocol().equals("file") && affUrl.getProtocol().equals("file")) {
       try {
-        return hunspellDictionaryStreamFactory.createFromLocalFiles(language, Path.of(dicUrl.getPath()), Path.of(affUrl.getPath()));
-      } catch (IOException e) {
+        return hunspellDictionaryStreamFactory.createFromLocalFiles(language, Path.of(dicUrl.toURI()), Path.of(affUrl.toURI()));
+      } catch (IOException | URISyntaxException e) {
         throw new RuntimeException(e);
       }
     }


### PR DESCRIPTION
## Problem
The code introduced in PR #11359 uses `Path.of(url.getPath())` which fails on Windows with:  
`InvalidPathException: Illegal char <:> at index 2: /C:/git/languagetool/...`

## Root Cause
On Windows, `URL.getPath()` returns `/C:/path/to/file` (with leading slash), 
but `Path.of()` cannot handle this format.

## Solution
- Replace `Path.of(url.getPath())` with `Paths.get(url.toURI())`
- Add proper `URISyntaxException` handling
- `toURI()` properly converts URLs to platform-specific paths

## Testing
- ✅ `CustomSpellingTest` now passes on Windows

## Related
- Resolves regression from PR #11359


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading locally stored dictionaries and affix files, reducing failures with file paths that include spaces or special characters across platforms.

* **Refactor**
  * Streamlined path resolution and exception handling during resource loading to increase robustness without changing existing behavior for non-file resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->