### PR TITLE
[pt] Fixed more rare verbs in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3935,6 +3935,32 @@ USA
 
   </rulegroup>
 
+  <rule id="DP_VPARTPASS_NCAQ_20250925" name="Remove rare verbs from appearing as verbs">
+    <!-- Moved the rule down to assure it works correctly. -->
+    <pattern>
+      <token postag='[DP].+' postag_regexp='yes'/>
+      <marker>
+        <and>
+          <token postag='VMP00PM' postag_regexp='no'/>
+          <token postag='NC.+' postag_regexp='yes'/>
+        </and>
+      </marker>
+    </pattern>
+    <disambig action="remove" postag="V.*"/>
+    <!--
+    Examples:
+             Em Roma dividiam-se os partidos mas a maioria estava contra os intentos da rainha.
+             Muito conhecidos são os mercados e socos cairotas.
+             Sendo assim, Bênlio assumiu os teclados, mais continuou a tocar guitarra em algumas ocasiões.
+             Normalmente são alaranjados, alguns esverdeados, quando em boas condições.
+             «Reforma trabalhista: como votaram os deputados».
+             Mas juntos somos fortes e conseguiremos chegar onde queremos e merecemos.
+             Esses resultados definiram os classificados ao quadrangular semifinal da competição.
+             Às vezes, os opostos não estão preparados para se atrair.
+             Tal música fere os ouvidos.
+    -->
+  </rule>
+
   <rule id="VERB_NOUNVERB_SPS00_VERBS_RARE" name="Remove rare verbs from appearing as verbs"> <!-- Used ChatGPT 4o to verify the results -->
     <!-- Moved the rule down to assure it works correctly. -->
     <pattern>


### PR DESCRIPTION
Fixed some more rare verbs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Portuguese disambiguation to prevent rare participles and similar forms from being misidentified as verbs after determiners/pronouns.
  - Reduces false positives and enhances accuracy of grammar and style suggestions in Portuguese, especially in noun phrase contexts.
  - Overall, users should see more reliable analyses and fewer incorrect verb-related flags in Portuguese text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->