### PR TITLE
[pt] More fixes regarding verbs/nouns in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3960,34 +3960,60 @@ USA
     -->
   </rule>
 
-  <rule id="DA_DI_DP_NCM_NP_AQM_VPARTPASS_20250926" name="Make verb appear as 3rd person singular">
-    <pattern>
-      <token postag='D[AIP].+' postag_regexp='yes'/>
-      <token postag='NCM.+|AQ0M.+|NP.+' postag_regexp='yes'/>
-      <marker>
-        <and>
-          <token postag='VMIP3S0'/>
-          <token postag='VMP00SF'/>
-        </and>
-      </marker>
-      <token postag='D[AIP].+' postag_regexp='yes'/>
-    </pattern>
-    <disambig action="replace"><wd pos="VMIP3S0"/></disambig>
-    <!--
-    Examples:
-             O sujeito ganha uma medalha de ouro, critica a burocracia cuba..digo, brasileira, e leva uma bronca.
-             Já o Aécio oculta o patrimônio e não quer esclarecer.
-             Como o sal resseca o cabelo, é preciso fazer uma hidratação semanal.
-             O aplicativo pega cada trecho e monta aleatoriamente uma frase perfeita para incrementar sua reunião.
-             "Ou o Parlamento aceita as nossas condições, ou não aprovaremos qualquer pagamento", diz Cristas.
-             O cão desperta muito amor e é modelo de fidelidade.
-             Um Picasso estuda um objeto como um cirurgião disseca um cadáver.
-             Ao utilizar os nossos serviços aceita a sua utilização.
-             Meu pai pega o metrô às 7 da manhã para ir ao trabalho.
-             Teu sorriso desperta meu sorriso, e o duelo do amor já recomeça.
-             Fazendo isso, você ajudará o site a manter-se sempre ativo, pois a Amazon paga uma comissão por cada venda.
-    -->
-  </rule>
+  <rulegroup id="VPARTPASS_TO_THIRDPERSONSINGULAR_20250928" name="Make past participle verb appear as 3rd person singular">
+    <rule>
+      <pattern>
+        <token postag='D[AIP].+' postag_regexp='yes'/>
+        <token postag='NCM.+|AQ0M.+|NP.+' postag_regexp='yes'/>
+        <marker>
+          <and>
+            <token postag='VMIP3S0'/>
+            <token postag='VMP00SF'/>
+          </and>
+        </marker>
+        <token postag='D[AIP].+' postag_regexp='yes'/>
+      </pattern>
+      <disambig action="replace"><wd pos="VMIP3S0"/></disambig>
+      <!--
+      Examples:
+               O sujeito ganha uma medalha de ouro, critica a burocracia cuba..digo, brasileira, e leva uma bronca.
+               Já o Aécio oculta o patrimônio e não quer esclarecer.
+               Como o sal resseca o cabelo, é preciso fazer uma hidratação semanal.
+               O aplicativo pega cada trecho e monta aleatoriamente uma frase perfeita para incrementar sua reunião.
+               "Ou o Parlamento aceita as nossas condições, ou não aprovaremos qualquer pagamento", diz Cristas.
+               O cão desperta muito amor e é modelo de fidelidade.
+               Um Picasso estuda um objeto como um cirurgião disseca um cadáver.
+               Ao utilizar os nossos serviços aceita a sua utilização.
+               Meu pai pega o metrô às 7 da manhã para ir ao trabalho.
+               Teu sorriso desperta meu sorriso, e o duelo do amor já recomeça.
+               Fazendo isso, você ajudará o site a manter-se sempre ativo, pois a Amazon paga uma comissão por cada venda.
+      -->
+    </rule>
+    <rule>
+      <pattern>
+        <token>o</token>
+        <token postag='N.+|AQ.+' postag_regexp='yes'/>
+        <token min='0' max='1' postag='RM'/>
+        <marker>
+          <and>
+            <token postag='VMIP3S0'/>
+            <token postag='VMP00SF'/>
+          </and>
+        </marker>
+      </pattern>
+      <disambig action="replace"><wd pos="VMIP3S0"/></disambig>
+      <!--
+      Examples:
+               O David ganha muito pouco com os livros, mas dá aulas.
+               Muitas pessoas comparam a renda do brasileiro com do europeu e conclui que o europeu ganha mais.
+               O Brasil desperta interesse.
+               A terceira etapa, é quando o arqueiro solta a flecha.
+               De um modo geral o carro agrada e têm um ótimo custo benefício.
+               Assim, o prazo finda apenas no dia 2 de maio (segunda-feira).
+               Com essas informações o avatar ganha vida na tela.
+      -->
+    </rule>
+  </rulegroup>
 
   <rule id="VERB_NOUNVERB_SPS00_VERBS_RARE" name="Remove rare verbs from appearing as verbs"> <!-- Used ChatGPT 4o to verify the results -->
     <!-- Moved the rule down to assure it works correctly. -->

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3991,7 +3991,7 @@ USA
     </rule>
     <rule>
       <pattern>
-        <token>o</token>
+        <token regexp='yes'>o|um</token>
         <token postag='N.+|AQ.+' postag_regexp='yes'/>
         <token min='0' max='1' postag='RM'/>
         <marker>


### PR DESCRIPTION
More fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved Portuguese handling of past participles misread as third‑person singular verbs (e.g., after determiners like “o”), reducing false alerts and improving agreement suggestions.

- Refactor
  - Related rules were grouped and expanded to cover additional contextual patterns while preserving existing behavior for previously supported cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->