### PR TITLE
[pt] Improved last rule in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3991,8 +3991,8 @@ USA
     </rule>
     <rule>
       <pattern>
-        <token regexp='yes'>o|um</token>
-        <token postag='N.+|AQ.+' postag_regexp='yes'/>
+        <token postag='D[AI]0MS0' postag_regexp='yes'/>
+        <token postag='N.[CM].+|AQ0[CM].+' postag_regexp='yes'/>
         <token min='0' max='1' postag='RM'/>
         <marker>
           <and>
@@ -4000,6 +4000,7 @@ USA
             <token postag='VMP00SF'/>
           </and>
         </marker>
+        <token><exception scope='previous' regexp='no'>surpresa</exception></token>
       </pattern>
       <disambig action="replace"><wd pos="VMIP3S0"/></disambig>
       <!--


### PR DESCRIPTION
Additional refinements/fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese disambiguation to reduce false positives by using more specific part‑of‑speech patterns.
  * Enhanced accuracy for noun/adjective sequences, leading to more precise grammar checks.
  * Added a targeted exception for contexts involving “surpresa,” preventing incorrect flags.
  * Overall, users should see fewer mistaken alerts and more reliable suggestions in Portuguese text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->