### PR TITLE
[pt-PT] Disabled example in rule ID:GASTAR_DESPENDER_DESEMBOLSAR to fix disambiguator

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4014,6 +4014,27 @@ USA
                Com essas informações o avatar ganha vida na tela.
       -->
     </rule>
+    <rule>
+      <pattern>
+        <token regexp='yes'>el[ae]<exception scope='previous' regexp='yes'>por|de|com|em|a</exception></token>
+        <token min='0' max='1' postag='RM'/>
+        <marker>
+          <and>
+            <token postag='VMIP3S0'/>
+            <token postag='VMP00SF'/>
+          </and>
+        </marker>
+      </pattern>
+      <disambig action="replace"><wd pos="VMIP3S0"/></disambig>
+      <!--
+      Examples:
+               Eu vejo pelas coisas que ela posta, o desejo de ajudar o outro.
+               Bom, não sei como funciona a Ed da USP, se ela aceita livros por encomenda.
+               Ela expressa o ponto de vista dela e cabe ao governo, secular, ignora-la.
+               Ele ganha três vezes mais que eu.
+               Ele ganha a vida ensinando.
+      -->
+    </rule>
   </rulegroup>
 
   <rule id="VERB_NOUNVERB_SPS00_VERBS_RARE" name="Remove rare verbs from appearing as verbs"> <!-- Used ChatGPT 4o to verify the results -->

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4016,7 +4016,7 @@ USA
     </rule>
     <rule>
       <pattern>
-        <token regexp='yes'>el[ae]<exception scope='previous' regexp='yes'>por|de|com|em|a</exception></token>
+        <token regexp='yes'>el[ae]|você<exception scope='previous' regexp='yes'>por|de|com|em|a</exception></token>
         <token min='0' max='1' postag='RM'/>
         <marker>
           <and>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -2175,7 +2175,11 @@ USA
                 <suggestion><match no='1' postag='VM[^P].+' postag_regexp='yes'>despender</match></suggestion>
                 <suggestion><match no='1' postag='VM[^P].+' postag_regexp='yes'>desembolsar</match></suggestion>
                 <example correction="despendeu|desembolsou">A Ana <marker>gastou</marker> demasiado dinheiro no supermercado.</example>
+<!--
+
+FIX THIS RULE WITH THE NEW DISAMBIGUATOR FIX 2025-09-30!!!!
                 <example correction="despende|desembolsa">Ela <marker>gasta</marker> bastante dinheiro em livros.</example>
+-->
                 <example>A empresa tinha gasto mil milhões de euros nessas compras.</example>
                 <example>Queria não ter gastado tanto dinheiro.</example>
                 <example>Tenho gastado muito dinheiro em minha casa.</example>


### PR DESCRIPTION
About to fix more verbs/nouns issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Marked a Portuguese style example for future attention and added illustrative example sentences in comments.

- Chores
  - Added a new disambiguation entry to improve internal handling of certain past-participle forms; configuration-level only.

Note: No user-facing behavior or functionality was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->