### PR TITLE
[pt] More rare verbs/nouns fixes in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4652,14 +4652,14 @@ USA
     -->
   </rule>
 
-  <rule id="VERB_NCAQ_VERBINFORMAL_TO_NOUN_20251001" name="Remove rare verbs from appearing as verbs">
+  <rule id="VERB_NCAQ_VERBINFORMAL_TO_NOUN_20251001_RARE" name="Remove rare verbs from appearing as verbs">
     <pattern>
       <token postag='V.+' postag_regexp='yes'><exception postag_regexp='yes' postag='NC.+|AQ.+'/></token>
       <token postag='AQ0P.+|NC.P.+' postag_regexp='yes'/>
       <marker>
         <and>
           <token postag='VMN02S0' postag_regexp='no'/>
-          <token postag='NC.+' postag_regexp='yes'/>
+          <token postag='NC.+|AQ.+' postag_regexp='yes'/>
         </and>
       </marker>
     </pattern>


### PR DESCRIPTION
More verbs/nouns fixes in disambiguator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved Portuguese text analysis to correctly interpret certain rare word forms as nouns instead of verbs, reducing false positives in verb-related checks.
  - Enhanced part-of-speech disambiguation for Portuguese with a new rule to further reduce ambiguous verb/noun misclassifications, improving grammar and agreement suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->