### PR TITLE
[pt] More verbs/nouns fixes in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3993,7 +3993,7 @@ USA
       <pattern>
         <token postag='D[AI]0MS0' postag_regexp='yes'/>
         <token postag='N.[CM].+|AQ0[CM].+' postag_regexp='yes'><exception scope='next' regexp='yes'>surpresa|assente</exception></token>
-        <token min='0' max='1' postag='RM'/>
+        <token min='0' max='1' postag_regexp='yes' postag='RM|RN'><exception scope='next' regexp='yes'>surpresa|assente</exception></token>
         <marker>
           <and>
             <token postag='VMIP3S0'/>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4016,7 +4016,7 @@ USA
     <rule>
       <pattern>
         <token regexp='yes'>el[ae]|você<exception scope='previous' regexp='yes'>por|de|com|em|a</exception></token>
-        <token min='0' max='1' postag='RM'/>
+        <token min='0' max='1' postag_regexp='yes' postag='RM|RN'/>
         <marker>
           <and>
             <token postag='VMIP3S0'/>


### PR DESCRIPTION
More fixes in disambiguator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese disambiguation to recognize additional part-of-speech variants (RM and RN), reducing misclassifications.
  * Fewer false positives and missed issues in Portuguese grammar/style checks.
  * Better handling of ambiguous word forms, yielding more accurate, context-aware suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->