### PR TITLE
[pt] More verbs/nouns fixes in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3960,7 +3960,7 @@ USA
     -->
   </rule>
 
-  <rulegroup id="VPARTPASS_TO_THIRDPERSONSINGULAR_20251004" name="Make past participle verbs appear as 3rd person singular">
+  <rulegroup id="VPARTPASS_TO_THIRDPERSONSINGULAR_20251005" name="Make past participle verbs appear as 3rd person singular">
     <rule>
       <pattern>
         <token>a</token>
@@ -3990,8 +3990,8 @@ USA
     <rule>
       <pattern>
         <token postag='D[AIP].+' postag_regexp='yes'/>
-        <token postag='NCM.+|AQ0M.+|NP.+' postag_regexp='yes'/>
-        <token min='0' max='1' postag_regexp='yes' postag='RM|RN|RG|CS'/>
+        <token postag='NCM.+|AQ0M.+|NP.+' postag_regexp='yes'><exception scope='next' regexp='yes'>surpresa|assente</exception></token>
+        <token min='0' max='1' postag_regexp='yes' postag='RM|RN|RG|CS'><exception scope='next' regexp='yes'>surpresa|assente</exception></token>
         <marker>
           <and>
             <token postag='VMIP3S0'/>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3965,14 +3965,16 @@ USA
       <pattern>
         <token>a</token>
         <token postag='NCF.+|AQ0F.+|NP.+' postag_regexp='yes'/>
-        <token min='0' max='1' postag_regexp='yes' postag='RM|RN'/>
+        <token min='0' max='1' postag_regexp='yes' postag='RM|RN|RG|CS'/>
         <marker>
           <and>
             <token postag='VMIP3S0'/>
             <token postag='VMP00SF'/>
           </and>
         </marker>
-        <token postag='D[AIP].+' postag_regexp='yes'><exception regexp='yes'>ao?|às?</exception></token> <!-- It will remove valid verbs, but better this way -->
+        <token postag='D[AIP].+' postag_regexp='yes'>
+          <exception scope='previous' regexp='yes'>surpresa|assente</exception>
+          <exception regexp='yes'>ao?|às?</exception></token> <!-- It will remove valid verbs, but better this way -->
       </pattern>
       <disambig action="replace"><wd pos="VMIP3S0"/></disambig>
       <!--
@@ -3990,15 +3992,15 @@ USA
     <rule>
       <pattern>
         <token postag='D[AIP].+' postag_regexp='yes'/>
-        <token postag='NCM.+|AQ0M.+|NP.+' postag_regexp='yes'><exception scope='next' regexp='yes'>surpresa|assente</exception></token>
-        <token min='0' max='1' postag_regexp='yes' postag='RM|RN|RG|CS'><exception scope='next' regexp='yes'>surpresa|assente</exception></token>
+        <token postag='NCM.+|AQ0M.+|NP.+' postag_regexp='yes'/>
+        <token min='0' max='1' postag_regexp='yes' postag='RM|RN|RG|CS'/>
         <marker>
           <and>
             <token postag='VMIP3S0'/>
             <token postag='VMP00SF'/>
           </and>
         </marker>
-        <token postag='D[AIP].+|RG|CS' postag_regexp='yes'/>
+        <token postag='D[AIP].+|RG|CS' postag_regexp='yes'><exception scope='previous' regexp='yes'>surpresa|assente</exception></token>
       </pattern>
       <disambig action="replace"><wd pos="VMIP3S0"/></disambig>
       <!--

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3991,14 +3991,14 @@ USA
       <pattern>
         <token postag='D[AIP].+' postag_regexp='yes'/>
         <token postag='NCM.+|AQ0M.+|NP.+' postag_regexp='yes'/>
-        <token min='0' max='1' postag_regexp='yes' postag='RM|RN|RG'/>
+        <token min='0' max='1' postag_regexp='yes' postag='RM|RN|RG|CS'/>
         <marker>
           <and>
             <token postag='VMIP3S0'/>
             <token postag='VMP00SF'/>
           </and>
         </marker>
-        <token postag='D[AIP].+|RG' postag_regexp='yes'/>
+        <token postag='D[AIP].+|RG|CS' postag_regexp='yes'/>
       </pattern>
       <disambig action="replace"><wd pos="VMIP3S0"/></disambig>
       <!--


### PR DESCRIPTION
More fixes in disambiguator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Portuguese disambiguation improved by treating an additional part-of-speech category like the existing tag, reducing misclassifications.
  * Pattern matching and boundary exceptions refined to better handle clause-linking tokens and specific lemmas, yielding fewer false positives/negatives.
  * Internal rule identifiers updated; users will see more precise suggestions and checks in Portuguese text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->