### PR TITLE
[pt] More verbs/nouns fixes in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4045,7 +4045,7 @@ USA
     <rule>
       <pattern>
         <token regexp='yes'>el[ae]|você<exception scope='previous' regexp='yes'>por|de|com|em|a</exception></token>
-        <token min='0' max='1' postag_regexp='yes' postag='RM|RN'/>
+        <token min='0' max='1' postag_regexp='yes' postag='RM|RN|RG|CS'/>
         <marker>
           <and>
             <token postag='VMIP3S0'/>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3960,7 +3960,7 @@ USA
     -->
   </rule>
 
-  <rulegroup id="VPARTPASS_TO_THIRDPERSONSINGULAR_20251005" name="Make past participle verbs appear as 3rd person singular">
+  <rulegroup id="VPARTPASS_TO_THIRDPERSONSINGULAR_20251006" name="Make past participle verbs appear as 3rd person singular">
     <rule>
       <pattern>
         <token>a</token>
@@ -4000,7 +4000,7 @@ USA
             <token postag='VMP00SF'/>
           </and>
         </marker>
-        <token postag='D[AIP].+|RG|CS' postag_regexp='yes'><exception scope='previous' regexp='yes'>surpresa|assente</exception></token>
+        <token postag='(SPS00:)?D[AIP].+|RG|CS' postag_regexp='yes'><exception scope='previous' regexp='yes'>surpresa|assente</exception></token>
       </pattern>
       <disambig action="replace"><wd pos="VMIP3S0"/></disambig>
       <!--
@@ -4020,13 +4020,13 @@ USA
     </rule>
     <rule>
       <pattern>
-        <token postag='D[AI]0MS0' postag_regexp='yes'/>
+        <token postag='D[AI]0MS0|CS' postag_regexp='yes'/>
         <token postag='N.[CM].+|AQ0[CM].+|CS' postag_regexp='yes'><exception scope='next' regexp='yes'>surpresa|assente</exception></token>
         <token min='0' max='1' postag_regexp='yes' postag='RM|RN|RG|CS'><exception scope='next' regexp='yes'>surpresa|assente</exception></token>
         <marker>
           <and>
-            <token postag='VMIP3S0'/>
-            <token postag='VMP00SF'/>
+            <token postag='VMIP3S0'><exception scope='next' postag_regexp='yes' postag='V.+|PP3..N.+'/></token>
+            <token postag='VMP00SF'><exception scope='next' postag_regexp='yes' postag='V.+|PP3..N.+'/></token>
           </and>
         </marker>
       </pattern>


### PR DESCRIPTION
More fixes in the disambiguator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese disambiguation to better identify past participle vs. 3rd person singular, reducing incorrect suggestions.
  * Broadened part-of-speech handling (additional POS contexts allowed) to cover more real-world constructions.
  * Added targeted exceptions to avoid false positives in specific verb forms, improving suggestion precision for Portuguese users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->