### PR TITLE
fix(de): stabilize Aho–Corasick build order in SpellingData (HashMap→…

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/SpellingData.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/SpellingData.java
@@ -24,7 +24,7 @@ import org.languagetool.JLanguageTool;
 import org.languagetool.synthesis.GermanSynthesizer;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -47,7 +47,7 @@ class SpellingData {
   @NotNull
   private static Map<String, String> getCoherencyMap(String filePath, boolean sentStartMode) {
     List<String> lines = JLanguageTool.getDataBroker().getFromResourceDirAsLines(filePath);
-    Map<String,String> coherencyMap = new HashMap<>();
+    Map<String, String> coherencyMap = new LinkedHashMap<>();
     for (String line : lines) {
       if (line.startsWith("#")) {
         continue;


### PR DESCRIPTION
Summary

NonDeterminism detected by NonDex: OldSpellingRuleTest#testGermanAT fails with seed 933178 ( Not only this seed).

Cause: SpellingData#getCoherencyMap used HashMap; HanLP’s AhoCorasickDoubleArrayTrie.build(..) iterates map.keySet() → iteration order is undefined.

Fix: switch to LinkedHashMap to preserve insertion order and stabilize trie construction.

Reproduction

mvn -pl languagetool-language-modules/de -am \
  edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -Dtest=org.languagetool.rules.de.OldSpellingRuleTest#testGermanAT \
  -DnondexRuns=1 -DnondexSeed=933178 -DnondexMode=FULL


Observed: Expected: <0> but: was <1>.

Root Cause
NonDex debug stack:

HashMap$KeySet.iterator → AhoCorasickDoubleArrayTrie$Builder.addAllKeyword/build
→ org.languagetool.rules.de.SpellingData.<init>(:43)
→ OldSpellingRule.lambda$static$0(:60)


Different map iteration order altered trie contents → match/no-match flips.

Fix

Replace new HashMap<>() with new LinkedHashMap<>() in SpellingData#getCoherencyMap.

(Alternatives considered, not chosen): wrap with new TreeMap<>(map) or pre-sort keys and add explicitly.

Verification

Baseline mvn test: pass.

NonDex single-seed repro (above): now passes.

Multiple NonDex runs: no recurrence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * German spelling and coherence suggestions now appear in a consistent, predictable order, eliminating occasional variations between runs or environments.
* **Refactor**
  * Improved stability of German language rule processing to ensure deterministic ordering of results, enhancing reliability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->