### PR TITLE
[pt] Major verb/noun fix in disambiguation.xml (must see nightly diff)

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4708,8 +4708,7 @@ USA
   <rule id="VERB_VERBINFINITIVE_20251007_RARE" name="Remove infinitive verbs from appearing as nouns">
     <pattern>
       <token postag='V.+' postag_regexp='yes'>
-        <exception scope='next' postag_regexp='yes' postag='AQ.+'/>
-        <exception postag_regexp='yes' postag='NC.+|AQ.+'/></token>
+        <exception scope='next' postag_regexp='yes' postag='AQ.+'/></token>
       <marker>
         <and>
           <token postag='VMN0000'/>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4705,6 +4705,29 @@ USA
     -->
   </rule>
 
+  <rule id="VERB_VERBINFINITIVE_20251007_RARE" name="Remove infinitive verbs from appearing as nouns">
+    <pattern>
+      <token postag='V.+' postag_regexp='yes'>
+        <exception scope='next' postag_regexp='yes' postag='AQ.+'/>
+        <exception postag_regexp='yes' postag='NC.+|AQ.+'/></token>
+      <marker>
+        <and>
+          <token postag='VMN0000'/>
+          <token postag='NC.+' postag_regexp='yes'/>
+        </and>
+      </marker>
+    </pattern>
+    <disambig action="remove" postag="N.*"/>
+    <!--
+    Examples:
+             Ele precisa saber o que fazer com essas ferramentas.
+             No seu período de operação, provou ser altamente confiável e produtivo.
+             Páginas nesta categoria devem ser adicionadas pelo Módulo:Citação/CS1.
+             Mas superou tudo, e bastou cantar três músicas para que ela conquistasse o público revoltado.
+             Não deve haver nó distinto ou nós que assumam papéis especiais ou conjunto extra de responsabilidades.
+    -->
+  </rule>
+
   <rule id="PORTA_HIFEN_SUBSTANTIVOPLURAL" name="Remove verbs in porta-Substantivo_Plural">
     <pattern>
       <marker>


### PR DESCRIPTION
Very high-impact fix!

I must pay close attention to the diffs tonight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improves Portuguese analysis by adding a disambiguation rule to prevent infinitive verbs from being mis-tagged as nouns (including plural cases). This reduces false positives and increases accuracy of grammar checks, agreement detection, and suggestions in complex sentences, so users will see more reliable results where infinitives and nouns might be confused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->