### PR TITLE
[pt] More major fixes in verbs/nouns in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3960,7 +3960,8 @@ USA
     -->
   </rule>
 
-  <rulegroup id="VPARTPASS_TO_THIRDPERSONSINGULAR_20251007" name="Make past participle verbs appear as 3rd person singular">
+  <rulegroup id="VPARTPASS_TO_THIRDPERSONSINGULAR_20251008" name="Make past participle verbs and others appear as 3rd person singular">
+    <!-- ChatGPT 5 -->
     <rule>
       <pattern>
         <token>a</token>
@@ -4061,6 +4062,29 @@ USA
                Ela expressa o ponto de vista dela e cabe ao governo, secular, ignora-la.
                Ele ganha três vezes mais que eu.
                Ele ganha a vida ensinando.
+      -->
+    </rule>
+    <rule>
+      <pattern>
+        <marker>
+          <and>
+            <token postag='VMIP3S0'/>
+            <token postag='VMM02S0'/>
+          </and>
+        </marker>
+        <token postag='VMN0000'/>
+        <token postag='VMP00S.+' postag_regexp='yes'><exception postag_regexp='yes' postag='AQ.+'/></token>
+      </pattern>
+      <disambig action="replace"><wd pos="VMIP3S0"/></disambig>
+      <!--
+      Examples:
+               Esta tradição pode ser revivida no núcleo das charqueadas, por meio de visitas orientadas.
+               Isso nos permite detectar o que não pode ser removido ou alterado sem remover ou alterar o fenômeno em questão.
+               Necessita ser reciclada de acordo com o livro de estilo.
+               Parece estar escrita em formato publicitário.
+               No entanto, ele pode ser achado na internet.
+               Wile E. Coyote Um coiote rival do Papa Léguas, que costuma ser derrotado de formas inusitadas.
+               Jones passa a explicar que o seu maior objetivo é assumir o controle da OCP, e admite ter sido ele a encomendar o assassinato de Morton.
       -->
     </rule>
   </rulegroup>
@@ -4705,9 +4729,11 @@ USA
     -->
   </rule>
 
-  <rule id="VERB_VERBINFINITIVE_20251007_RARE" name="Remove infinitive verbs from appearing as nouns">
+  <rule id="VERB_VERBINFINITIVE_20251008_RARE" name="Remove infinitive verbs from appearing as nouns">
+    <!-- ChatGPT 5 -->
     <pattern>
       <token postag='V.+' postag_regexp='yes'>
+        <exception regexp='yes' inflected='yes'>ter|haver</exception>
         <exception scope='next' postag_regexp='yes' postag='AQ.+'/></token>
       <marker>
         <and>
@@ -4724,6 +4750,30 @@ USA
              Páginas nesta categoria devem ser adicionadas pelo Módulo:Citação/CS1.
              Mas superou tudo, e bastou cantar três músicas para que ela conquistasse o público revoltado.
              Não deve haver nó distinto ou nós que assumam papéis especiais ou conjunto extra de responsabilidades.
+    -->
+  </rule>
+
+  <rule id="VERB_VERBINFINITIVE_REMOVEVERB_20251008_RARE" name="Convert infinitive verbs to nouns/adjectives">
+    <!-- ChatGPT 5 -->
+    <pattern>
+      <token inflected='yes' regexp='yes'>ter|haver</token>
+      <marker>
+        <and>
+          <token postag='VMN0000'/>
+          <token postag='NC.+' postag_regexp='yes'/>
+        </and>
+      </marker>
+    </pattern>
+    <disambig action="remove" postag="V.*"/>
+    <!--
+    Examples:
+             Aquele que tem poder total sobre as tarefas e usuários do computador.
+             Quando o homem se sente respeitado pela esposa, ele naturalmente tem prazer em agradá-la.
+             Eu terei prazer em ajudá-la.
+             Você teve azar, eu voltei cinco minutos depois que você foi embora.
+             Dê a um homem um peixe e ele terá jantar por uma noite; ensine-o a pescar e ele terá jantar pela vida toda.
+             Eu tenho dever de casa.
+             Não há colher.
     -->
   </rule>
 


### PR DESCRIPTION
More major fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved Portuguese verb handling: past participles now better recognized as 3rd‑person singular where appropriate.
  - Added support for interpreting infinitives as nouns/adjectives in relevant contexts for more natural analysis.

- Bug Fixes
  - Reduced false positives in verb–infinitive patterns by refining matching and adding exceptions for common verbs.

- Language Quality
  - More accurate disambiguation and suggestions in ambiguous verb–noun contexts, improving overall Portuguese grammar checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->