### PR TITLE
[pt] Placed exceptions to fix FPs in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3960,7 +3960,7 @@ USA
     -->
   </rule>
 
-  <rulegroup id="VPARTPASS_TO_THIRDPERSONSINGULAR_20251008" name="Make past participle verbs and others appear as 3rd person singular">
+  <rulegroup id="VPARTPASS_TO_THIRDPERSONSINGULAR_20251009" name="Make past participle verbs and others appear as 3rd person singular">
     <!-- ChatGPT 5 -->
     <rule>
       <pattern>
@@ -4068,8 +4068,8 @@ USA
       <pattern>
         <marker>
           <and>
-            <token postag='VMIP3S0'/>
-            <token postag='VMM02S0'/>
+            <token postag='VMIP3S0'><exception scope='previous' regexp='no'>a</exception></token>
+            <token postag='VMM02S0'><exception scope='previous' regexp='no'>a</exception></token>
           </and>
         </marker>
         <token postag='VMN0000'/>
@@ -4729,10 +4729,11 @@ USA
     -->
   </rule>
 
-  <rule id="VERB_VERBINFINITIVE_20251008_RARE" name="Remove infinitive verbs from appearing as nouns">
+  <rule id="VERB_VERBINFINITIVE_20251009_RARE" name="Remove infinitive verbs from appearing as nouns">
     <!-- ChatGPT 5 -->
     <pattern>
       <token postag='V.+' postag_regexp='yes'>
+        <exception postag='VMN0000'/>
         <exception regexp='yes' inflected='yes'>ter|haver</exception>
         <exception scope='next' postag_regexp='yes' postag='AQ.+'/></token>
       <marker>


### PR DESCRIPTION
Just two exceptions added to fix false positives in the nightly Diffs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Portuguese: Reduced false positives when distinguishing passive participles from third‑person singular verb forms, especially in contexts preceded by “a”.
  - Portuguese: Improved detection of infinitive verbs to avoid misclassification as nouns.
  - Portuguese: More accurate verb-form disambiguation leading to clearer suggestions and fewer incorrect alerts in common sentence patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->