### PR TITLE
[pt] Added rule ID:OUTRA_ALTERNATIVA

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -12859,6 +12859,62 @@ USA
     <category id='SHORTEN_IT' name="Linguagem concisa" type="style">
 
 
+        <rulegroup id='OUTRA_ALTERNATIVA' name="Simplificar: Outra opção/hipótese/possibilidade/solução/via/saída → alternativa" default='temp_off'>
+            <!-- ChatGPT 5 and new disambiguator for 2026+ -->
+
+            <rule> <!-- #1: Negative (triggered first): "alternativa" -->
+                <pattern>
+                    <token skip='2' regexp='yes'>sempre|quando|caso|se|enquanto</token> <!-- GPT 5 said these work 100% accurately -->
+                    <token>não</token>
+                    <token regexp='yes' inflected='yes'>haver|existir</token>
+                    <token min='0' max='1'>sem</token>
+                    <marker>
+                        <token regexp='yes'>outras?</token>
+                        <token regexp='yes' inflected='yes'>opção|hipótese|possibilidade|solução|via|saída</token> <!-- GPT 5 said it is 100% safe -->
+                    </marker>
+                </pattern>
+                <message>Prefira &quot;alternativa&quot; para maior concisão/consistência.</message>
+                <suggestion><match no='5' postag='DI0F(.)0' postag_replace='NCF$1000'>alternativa</match></suggestion>
+                <example correction="alternativa">Faz isso só quando não houver <marker>outra hipótese</marker>.</example>
+                <example correction="alternativa">Faz o cálculo sempre que não houver <marker>outra opção</marker>.</example>
+                <example>É sempre pior quando não há alternativas.</example>
+            </rule>
+
+            <rule> <!-- #2: Positive (triggered only if #1 fails) "uma alternativa" (singular) -->
+                <pattern>
+                    <token regexp='yes' inflected='yes'>haver|existir<exception scope='previous'>não</exception></token>
+                    <marker>
+                        <token>outra</token>
+                        <token regexp='yes' inflected='yes'>opção|hipótese|possibilidade|solução|via|saída</token> <!-- GPT 5 said it is 100% safe -->
+                    </marker>
+                </pattern>
+                <message>Prefira &quot;alternativa&quot; para maior concisão/consistência.</message>
+                <suggestion>uma alternativa</suggestion>
+                <example correction="uma alternativa">Faz isso se houver <marker>outra hipótese</marker>.</example>
+                <example correction="uma alternativa">Evita o cálculo se houver <marker>outra opção</marker>.</example>
+                <example>É sempre melhor quando há uma alternativa.</example>
+            </rule>
+
+            <rule> <!-- #3: Positive (triggered only if #1 and #2 fail) "alternativas"/"outras alternativas" (plural) -->
+                <pattern>
+                    <token regexp='yes' inflected='yes'>haver|existir<exception scope='previous'>não</exception></token>
+                    <marker>
+                        <token>outras</token>
+                        <token regexp='yes' inflected='yes'>opção|hipótese|possibilidade|solução|via|saída</token> <!-- GPT 5 said it is 100% safe -->
+                    </marker>
+                    <token><exception regexp='yes' inflected='yes'>formular|propor|postular|sugerir|testar|avaliar|analisar|investigar|verificar|confirmar|refutar|considerar|discutir|explorar|apresentar|mencionar|descrever|explicar|defender|sustentar|comprovar|validar|apoiar|corroborar|rejeitar|comparar|contrastar|relacionar|interpretar|demonstrar|abordar|examinar|estudar|enunciar</exception></token> <!-- Exception verbs (scientific/technical) -->
+                </pattern>
+                <message>Prefira &quot;alternativa&quot; para maior concisão/consistência.</message>
+                <suggestion>alternativas</suggestion>
+                <suggestion>outras alternativas</suggestion>
+                <example correction="alternativas|outras alternativas">Faz isso se houver <marker>outras hipóteses</marker>.</example>
+                <example>É sempre melhor quando há alternativas.</example>
+                <example>É sempre melhor quando há outras alternativas.</example>
+            </rule>
+
+        </rulegroup>
+
+
         <rule id='DEPOIS_DE_APÓS' name="Simplificar: Depois de → após">
             <antipattern>
                 <token>depois</token>


### PR DESCRIPTION
A simplification rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portuguese style checker now flags verbose expressions of alternatives (e.g., “outra hipótese/possibilidades”) and suggests concise forms like “alternativa/alternativas.”
  * Detects patterns with negation plus “haver/existir” and multiple-option phrasing, offering streamlined replacements.
  * Provides contextual messages and examples to guide clearer, more concise rewrites in Portuguese texts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->