### PR TITLE
[es] Modified agreement rules to cover medical terminology

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -18769,6 +18769,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <antipattern>
                 <token regexp="yes">a|al|de|del|en|con|sin|por</token>
                 <token regexp="yes">valgo|varo|valgos|varos</token>
+                <example>Este mecánico izquierdo conservado, el derecho muestra desviación en valgo.</example>
             </antipattern>
             <antipattern>
                 <token>por</token>
@@ -23804,12 +23805,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <antipattern>
                <token postag="AQ.M.*" postag_regexp="yes"/>
                <token regexp="yes">litos?</token>
+               <example>Estudio tomográfico que muestra pequeño lito en el polo inferior del riñón derecho.</example>
             </antipattern>
             <antipattern>
                <token postag="AQ.*|NC.*" postag_regexp="yes"/>
                <token regexp="yes">areola|mama|vena</token>
                <token spacebefore="no">-</token>
                <token spacebefore="no" regexp="yes">pezón|ganglio|arteria</token>
+               <example>Complejo areola-pezón de adecuada morfología.</example>
             </antipattern>
             <antipattern>
                 <token regexp="yes">\d+″</token>
@@ -27115,10 +27118,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         <rulegroup id="MAMA" name="mama/mamá">
             <url>https://www.rae.es/dpd/mam%C3%A1</url>
             <antipattern>
-                <token regexp="yes">de|en|sobre|por|para|con|sin</token>
+                <token regexp="yes" skip="-1">cuadrante|cuadrantes|quiste|quistes|tumor|tumores|cáncer|glándula|tejido|nódulo|nódulos|pezón|areola|lóbulo|conducto|mastectomía|mamografía|ecografía|biopsia|calcificación|calcificaciones|lesión|lesiones|carcinoma|neoplasia|parénquima|estroma|ultrasonido|resonancia|radio</token>
+                <token regexp="yes">de|en|sobre|por|para|con|sin|a</token>
                 <token regexp="yes">la|las|el|los|su|sus|una|unas</token>
                 <token regexp="yes">mama|mamas</token>
-            </antipattern>
+                <example>Ella tiene un quiste en la mama.</example>
+            </antipattern>>
             <antipattern>
                 <token>mama</token>
                 <token regexp="yes">izquierda|derecha</token>


### PR DESCRIPTION
ESPACIO_DESPUES_DE_PUNTO: Ellipsis should be followed by a lowercase letter in most cases – added antipattern for that.
AGREEMENT_ADJ_NOUN: Added antipatterns for cases: "lito" (medical term for calculus/stone) is masculine, so "pequeño lito" is correct; medical compound term (complejo areola-pezón) where "complejo" modifies the entire hyphenated compound, not just "areola".
MAMA: Added antipattern to cover medical uses of "mama" (breast)
PREP_VERB: Added antipattern to cover phrases with words "valgo" and "varo" (nouns referring to anatomical deviations 
AGREEMENT_NUMERAL_PLURAL: Added antipattern to cover complex noun-adjective agreement ("moderada" correctly agrees with "condromalacia" (feminine singular), not with the number "3")









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false positives for Spanish preposition+verb sequences by adding targeted exclusion patterns.
  * Improved numeral–agreement and adjective–noun concordance checks to prevent spurious grammar alerts.
  * Refined ellipsis/tokenization handling to avoid incorrect flags after truncated or dotted text.

* **New Features**
  * Added targeted checks for mama-related medical phrasing to provide more precise suggestions and avoid misleading warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->