### PR TITLE
[pt-PT] Removed AP (fixed the verbs) in rule ID:FORMAL_T-V_DISTINCTION_ALL

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -3148,17 +3148,6 @@ FIX THIS RULE WITH THE NEW DISAMBIGUATOR FIX 2025-09-30!!!!
 
     <!-- MARCOAGPINTO 2022-10-21 (Checked/Enhanced) (25-JUL-2022+) *START* -->
     <antipattern>
-        <token postag='VMIP3S0:PP3CNO00' postag_regexp="no"/>
-        <example>Em amarelo representa-se o conhecimento como um conjunto de crenças verdadeiras, que foram provadas e justificadas.</example>
-        <example>Estende-se por uma área de 45,89 km².</example>
-        <example>Pode-se chegar lá depressa?</example>
-        <example>Diz-se isso.</example>
-        <example>Fala-se grego.</example>
-    </antipattern>
-    <!-- MARCOAGPINTO 2022-10-21 (Checked/Enhanced) (25-JUL-2022+) *END* -->
-
-    <!-- MARCOAGPINTO 2022-10-21 (Checked/Enhanced) (25-JUL-2022+) *START* -->
-    <antipattern>
         <token postag='NC.+|AQ.+|NP.+|[DP][ADIPR].[FM].+|SPS00:[DP][ADIPR].[FM].+' postag_regexp="yes"/>
         <token postag='VMIP3S0' postag_regexp="no"/>
         <token postag='SPS00|CC|CS|RG|I|RM|RN|[DP][ADIPR].+|SPS00:[DP][ADIPR].+' postag_regexp="yes"/>


### PR DESCRIPTION
AP no longer needed since I fixed the affected verbs in the disambiguator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an overly restrictive style rule for Portuguese that was incorrectly flagging valid passive voice constructions with reflexive pronouns, allowing these common sentence patterns to pass without style warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->