### PR TITLE
[es] Modified date, accent and voseo rules

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -5422,7 +5422,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token postag="_QM_OPEN|R.*|LOC_ADV" postag_regexp="yes" min="0" max="4"><exception postag="C.*" postag_regexp="yes"/></token>
                     <marker>
                         <and>
-                            <token postag="VMIP1S0" regexp="yes">.+o<exception postag="V...3.*|C.*|SP.*|V.G.*|[ANCR].*|_possible_NP" postag_regexp="yes"/></token>
+                            <token postag="VMIP1S0" regexp="yes">.+o<exception postag="V...3.*|C.*|SP.*|V.G.*|[ANCR].*|_possible_NP" postag_regexp="yes"/><exception>objeto</exception></token>
                             <token inflected="yes" regexp="yes">.+ar<exception inflected="yes" regexp="yes">.+ir</exception></token>
                         </and>
                     </marker>
@@ -5459,6 +5459,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 <example>Total envío:</example>
                 <example>Silencio mientras termino.</example>
                 <example>Justo acabo de ver que en el otro equipo tiene el mismo problema.</example>
+                <example>La consulta objeto de análisis por la DGT analiza lo que ocurre cuando se adquieren a título lucrativo una serie de inmuebles.</example>
             </rule>
             <rule>
                 <antipattern>
@@ -34152,6 +34153,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 where users will prefer to turn it off.
                 The least bad solution (without language variants) is to leave it on.-->
             <antipattern>
+                <token>filum</token>
+                <token>terminale</token>
+                <example>condicionando efecto de masa con compresión de las raíces del filum terminale desplazándolas hacia la derecha.</example>
+            </antipattern>
+            <antipattern>
                 <token skip="-1">vos</token>
                 <token postag="V...2V0.*" postag_regexp="yes"/>
                 <example>Vos hacés siempre lo mismo.</example>
@@ -35340,6 +35346,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             </rule>
             <rule>
                 <!--NUMBER_DAYS_MONTH[11]-->
+                <antipattern>
+                    <token regexp="yes">31[\.,]\d+</token>
+                    <token regexp="yes">x|×</token>
+                    <token regexp="yes">\d+[\.,]?\d*</token>
+                    <example>Se realizan mediciones de las amígdalas observando dimensiones de 31.6 x 18.4 x 18.9 mm.</example>
+                </antipattern>
                 <antipattern>
                     <token postag="SENT_START"/>
                     <token regexp="yes">31\.(11|0?[469])</token>


### PR DESCRIPTION
NUMBER_DAYS_MONTH – added antipattern to cover medical measurements like  "**31.6** x 18.4 x 18.9 mm".
VOSEO – added an exception **filum terminale** – Latin anatomical term.
SE_CREO2 – added an exception  **objeto** (as a noun) to cover legal contexts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spanish grammar rules for proper spacing in multi-word and technical terms.
  * Enhanced hyphenation detection and correction for compound words.
  * Improved ellipsis and punctuation spacing validation.
  * Added typographically correct quotation mark usage recommendations based on context and position.
  * Expanded detection for common misspellings and formatting errors in proper nouns and technical terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->