### PR TITLE
[pt] Quick fixes about "outros/outras" in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4940,7 +4940,7 @@ USA
     <disambig action="remove" postag="[NAV].*"/>
     <!--
     Examples:
-             
+              
       -->
   </rule>
 


### PR DESCRIPTION
Just some hardcoded quick fixes for “todos/todas” in a rule I was working on.

Must expand it and then test with a large dataset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved Portuguese disambiguation with two new rules to better classify ambiguous forms of "todos"/"todas" as pronoun or verb in context.
* **Bug Fixes**
  * Refined an existing disambiguation pattern to reduce incorrect determiner/pronoun/verb assignments in complex contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->