### PR TITLE
[pt] Another fix in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -1950,9 +1950,9 @@ USA
       <disambig action="remove" postag="V.[SI].*"></disambig>
     </rule>
     <rule>
-      <antipattern> <!-- Fix para tod[ao]s nós/elas/eles, that were being converted to nouns -->
+      <antipattern> <!-- Fix para tod[ao]s nós/elas/eles/particípio_passado (convidados, etc.), that were being converted to nouns -->
         <token regexp='yes'>tod[ao]s</token>
-        <token postag='PP[13].PN.+' postag_regexp='yes'/>
+        <token postag='PP[13].PN.+|VMP00P.+' postag_regexp='yes'/>
       </antipattern>
       <pattern>
         <token postag="SP.*|SENT_START" postag_regexp="yes"/>


### PR DESCRIPTION
More fixes for todos/todas. Past Participle verbs in the plural after it should not have the verb form removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese grammar detection for participle verb forms and noun constructions to enhance language checking accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->