### PR TITLE
[pt-PT] Added exceptions to rule ID:VERBO_SER_ÚTIL_PARA_SERVIR_PARA

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -5072,11 +5072,12 @@ FIX THIS RULE WITH THE NEW DISAMBIGUATOR FIX 2025-09-30!!!!
         <pattern>
             <marker>
                 <token inflected='yes'>ser</token>
-                <token skip='1' regexp='yes'>út(il|eis)</token>
+                <token regexp='yes'>út(il|eis)</token>
             </marker>
+            <token min='0' max='1' postag='RM'/>
             <token>para</token>
-            <token postag='V.+' postag_regexp='yes'>
-                <exception regexp='yes' inflected='yes'>ser|estar|ficar|parecer|ter|haver|existir|sentir|gostar|odiar|amar|pensar|achar|crer|acreditar|lembrar|lembrar-se|recordar|imaginar|sonhar|ver|ouvir|perceber|notar|observar|reconhecer</exception></token> <!-- ChatGPT 5 said these exceptions make the rule ~99% accurate -->
+            <token postag='VMN0000'>
+                <exception regexp='yes' inflected='yes'>ser|estar|ficar|parecer|ter|haver|existir|sentir|gostar|odiar|amar|pensar|achar|crer|acreditar|lembrar|lembrar-se|recordar|imaginar|sonhar|ver|ouvir|perceber|notar|observar|reconhecer|servir</exception></token> <!-- ChatGPT 5 said these exceptions make the rule ~99% accurate -->
         </pattern>
         <message>Pode substituir &quot;ser útil&quot; por &quot;servir&quot; para uma formulação mais simples e natural.</message>
         <suggestion><match no='1' postag='V.+' postag_regexp='yes'>servir</match></suggestion>


### PR DESCRIPTION
Added exceptions to make rule ~99% accurate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese style checking for the phrase "ser útil para": clearer, more natural suggestion to use "servir"; better disambiguation to avoid false positives; explicit handling of exception cases for certain verb forms; overall more accurate and reliable suggestions for Portuguese text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->