### PR TITLE
[pt] Removed "temp_off" rule ID:TAO_TÃO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -34591,7 +34591,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='TAO_TÃO' name="[Confusão] tao/tão" default='temp_off'>
+        <rule id='TAO_TÃO' name="[Confusão] tao/tão">
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <pattern>
                 <token postag='V.+' postag_regexp='yes'/>


### PR DESCRIPTION
Removed "temp_off"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Portuguese grammar checker now enables detection of "tao" vs "tão" usage errors by default, improving grammar validation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->