### PR TITLE
[pt] Sorry, SPS00 is handled in the 2nd rule disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3987,7 +3987,7 @@ USA
           </and>
         </marker>
         <token min='0' max='1' postag='PP.C.+' postag_regexp='yes'/>
-        <token postag='VMN0000|V.+:PP3.+|SPS00' postag_regexp='yes'/>
+        <token postag='VMN0000|V.+:PP3.+' postag_regexp='yes'/>
       </pattern>
       <disambig action="replace" postag="RG"/>
       <!--


### PR DESCRIPTION
I forgot to remove "SPS00" from the rule when I created a second rule just for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Refined Portuguese language disambiguation rules for improved accuracy in verb pattern recognition and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->