### PR TITLE
[pt] More fixes in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3975,7 +3975,7 @@ USA
     -->
   </rule>
 
-  <rulegroup id="VERB_MESMO_TANTO_20251104_RARE" name="mesmo/tanto is an RG, not a noun, nor PI.+">
+  <rulegroup id="VERB_MESMO_TANTO_20251105_RARE" name="mesmo/tanto is an RG, not a noun, nor PI.+">
     <!-- ChatGPT 5 -->
     <rule>
       <pattern>
@@ -4009,7 +4009,7 @@ USA
             <token postag_regexp='yes' postag='NC.+'/>
           </and>
         </marker>
-        <token regexp='yes' inflected='yes'>de|este|esse|aquele|isto|isso|aquilo|ele|algum|outro|onde|aqui|aí|ali<exception postag_regexp='yes' postag='DA.+'/></token>
+        <token regexp='yes' inflected='yes'>de|de:o|este|de:este|esse|de:esse|aquele|de:aquele|isto|de:isto|isso|de:isso|aquilo|de:aquilo|ele|de:ele|algum|de:algum|outro|de:outro|onde|de:onde|aqui|de:aqui|aí|de:aí|ali|de:ali<exception postag_regexp='yes' postag='DA.+'/></token>
       </pattern>
       <disambig action="replace" postag="RG"/>
       <!--
@@ -4020,6 +4020,10 @@ USA
                Por favor, certifique-se de que é mesmo isto que pretende.
                Como se chama mesmo aquela tartaruga do Mario Bros? Ah, Koopa Bros!
                Tom não consegue acreditar que Mary disse mesmo aquilo.
+               Mas gosto tanto destas árvores nesta altura.
+               Será que descendo mesmo dos judeus?
+               Ai, eu sou absurdamente fã do Charles Dickens, por isso gostei tanto do seu vídeo e do seu texto.
+               Lopo diz-lhe que se o cabelo for mesmo dela, Clarice terá de cumprir a promessa e beijá –lo.
       -->
     </rule>
   </rulegroup>
@@ -4862,21 +4866,22 @@ USA
     -->
   </rule>
 
-  <rule id="VERB_VERBINFINITIVE_20251009_RARE" name="Remove infinitive verbs from appearing as nouns">
+  <rule id="VERB_VERBINFINITIVE_20251105_RARE" name="Remove infinitive verbs from appearing as nouns">
     <!-- ChatGPT 5 -->
     <pattern>
       <token postag='V.+' postag_regexp='yes'>
         <exception postag='VMN0000'/>
         <exception regexp='yes' inflected='yes'>ter|haver</exception>
         <exception scope='next' postag_regexp='yes' postag='AQ.+'/></token>
+      <token min='0' max='1' postag='RG|RM|RN' postag_regexp='yes'/>
       <marker>
         <and>
-          <token postag='VMN0000'/>
-          <token postag='NC.+' postag_regexp='yes'/>
+          <token postag='VMN0000'><exception postag_regexp='yes' postag='AQ.+'/></token>
+          <token postag='NC.+|VMN01S0|VMN03S0|VMSF1S0|VMSF3S0' postag_regexp='yes'><exception postag_regexp='yes' postag='AQ.+'/></token>
         </and>
       </marker>
     </pattern>
-    <disambig action="remove" postag="N.*"/>
+    <disambig action="filter" postag="VMN0000"/>
     <!--
     Examples:
              Ele precisa saber o que fazer com essas ferramentas.
@@ -4887,14 +4892,15 @@ USA
     -->
   </rule>
 
-  <rule id="VERB_VERBINFINITIVE_PASTPART_NC_AQ_DA_DI_20251102_RARE" name="Remove infinitive verbs from appearing as nouns">
+  <rule id="VERB_VERBINFINITIVE_PASTPART_NC_AQ_DA_DI_20251105_RARE" name="Remove infinitive verbs from appearing as nouns">
     <!-- ChatGPT 5 -->
     <pattern>
       <token postag_regexp='yes' postag='V.+'><exception postag_regexp='yes' postag='NC.+|AQ.+'/></token>
+      <token min='0' max='1' postag='RG|RM|RN' postag_regexp='yes'/>
       <marker>
         <and>
           <token postag='VMN0000'/>
-          <token postag='NC.+' postag_regexp='yes'/>
+          <token postag='NC.+|VMN01S0|VMN03S0|VMSF1S0|VMSF3S0' postag_regexp='yes'/>
         </and>
         <token postag='VMP00.+|D[AI].+' postag_regexp='yes'/>
       </marker>


### PR DESCRIPTION
More fixes in the disambiguator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Portuguese grammar checking for verb disambiguation, improving accuracy in constructions with "mesmo" (same) and "tanto" (so much)
  * Refined infinitive verb detection and past participle handling with broader pattern recognition
  * Optimized disambiguation logic for more precise language rule application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->