### PR TITLE
[pt] More verbs fixes in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -892,7 +892,7 @@ USA
         <token postag='R.+' postag_regexp="yes" min='0' max='4'>
           <exception negate_pos='yes' postag='R.+' postag_regexp="yes"/></token>
         <marker>
-          <token postag="V.P.+" postag_regexp="yes"><exception>junto</exception></token>
+          <token postag="V.P.+" postag_regexp="yes"><exception>junto</exception><exception postag='VMP00PM'/></token>
         </marker>
       </pattern>
       <disambig action="filter" postag="V.P.+"/>
@@ -968,6 +968,11 @@ USA
   </rulegroup>
   <rulegroup id="SER_NOUN" name="'ser' como substantivo">
     <!-- Localized from Catalan by Tiago F. Santos, 2017-05-16  -->
+    <antipattern> <!-- "Preciso mesmo ser muito cuidadoso." -->
+      <token postag='V.+' postag_regexp='yes'/>
+      <token regexp='yes' inflected='yes'>&adverbios_de_intensidade;</token>
+      <token>ser</token>
+    </antipattern>
     <rule>
       <pattern>
         <marker>


### PR DESCRIPTION
More disambiguator fixes in issues with verbs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese grammar checking to correctly distinguish between verb phrases and noun phrases in specific contexts, reducing false positives.
  * Enhanced recognition of verb forms in participle-related patterns for more accurate grammar rule application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->