### PR TITLE
[pt] Fixed "prazer" appearing as a verb in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -3910,6 +3910,20 @@ USA
     <disambig action="filter" postag="SPS00"/>
   </rule>
 
+  <rule id="PRAZER_VERB_20251116" name="In this case PRAZER is NCMS000">
+    <!-- ChatGPT 5 -->
+    <pattern>
+      <token postag='V.+|NC.+|AQ.+' postag_regexp='yes'/>
+      <marker>
+        <and>
+          <token>prazer</token>
+          <token postag='NCMS000'/>
+        </and>
+      </marker>
+    </pattern>
+    <disambig action="filter" postag="NCMS000"/>
+  </rule>
+
   <rulegroup id="SIM_NOUN" name="Remover substantivo da palavra 'sim'">
     <!-- ChatGPT 5 -->
     <rule> <!-- #1: "sim" at start of sentence, after a verb, or after punctuation -->


### PR DESCRIPTION
Fixed the “prazer” word from appearing as a verb (obsolete) in the most common usage. It should be used as a noun nowadays in most cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Portuguese language processing with improved disambiguation rules for more accurate text analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->