### PR TITLE
[pt] split rule into two because of exception in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4018,7 +4018,7 @@ USA
           <token postag='NC.+|AQ.+' postag_regexp='yes'/>
         </and>
       </marker>
-      <token postag='NC.+' postag_regexp='yes'><exception postag_regexp='yes' postag='V.+'/></token>
+      <token postag='NC.+' postag_regexp='yes'><exception postag_regexp='yes' postag='V.+|RG'/></token>
     </pattern>
     <disambig action="remove" postag="VMIP2S0"/>
       <!--
@@ -4028,6 +4028,9 @@ USA
                Este Metal Zipper é feito de latão e geralmente usado para calças jeans.
                Para compras exclusivas no e-commerce, parcelamento em 3 vezes sem juros ou em até 10 vezes com juros de 2,5% a.m.
                Nos anos 70 e 80, os filipinos vendiam seus “peixes” para editoras americanas (Warren, remember?).
+               A baixas temperaturas, a água transforma-se em gelo.
+               Para palavras loucas, orelhas moucas.
+               Riem dele pelas costas.
       -->
   </rule>
 


### PR DESCRIPTION
Added more fixes to the disambiguator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Portuguese disambiguation rule to better handle cases where a short functional word precedes verb–noun sequences, improving alignment and accuracy.
* **Refactor**
  * Split the existing past-participle/rare-verb disambiguation into two variants to handle alternate token sequences more precisely and reduce misclassification in ambiguous verb/noun contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->