### PR TITLE
[pt] Fixed false positives in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -2303,7 +2303,7 @@ USA
       </antipattern>
       <pattern>
         <token postag='NP.+' postag_regexp='yes'>
-          <exception inflected='yes' regexp='yes'>ser|estar</exception> <!-- Fixes at least "São" which is a Proper Name -->
+          <exception postag_regexp='yes' postag='V.+'/> <!-- Fixes at least "São" which is a Proper Name and verb "ser" -->
           <exception scope='next' postag_regexp='yes' postag='NP.+'/></token> <!-- reinforce NC.+ below -->
         <marker>
           <and>


### PR DESCRIPTION
Fixed false positives in yesterday's change.

“São” is a verb and a proper name.

To play safe, I excluded the verb “ser” and “estar”.

“São”, “Sãos”, and to play safe added exception as those verbs just in case I miss other proper names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese disambiguation rules to better recognize proper-name-like tokens (e.g., "São") when followed by noun phrases and to correctly account for adjacent inflected verbs, improving parsing accuracy in ambiguous contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->