### PR TITLE
[pt] Made rule very strict reducing FPs disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -2308,6 +2308,7 @@ USA
             <token postag='V.+' postag_regexp='yes'/>
           </and>
         </marker>
+        <token min='0' max='1' postag='SPS00|D[AI].+' postag_regexp='yes'/> <!-- Ana era A filha do padeiro -->
         <token postag='NC.+|AQ.+' postag_regexp='yes'/> <!-- Makes the rule very strict reducing FPs -->
       </pattern>
       <disambig action="filter" postag="V.+"/>


### PR DESCRIPTION
Made the disambiguator rule very strict to avoid the maximum false positives possible.

I made this rule specifically for: “Ana era filha do padeiro.” and it works with structures like this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese proper-name disambiguation: matching tightened to better identify proper names, plural forms explicitly handled, and contextual token handling refined—reducing false positives and improving accuracy. Removed an older constraint that interfered with correct matches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->