### PR TITLE
[pt-PT] Rewrote rule ID:PRECISAR_DE_PT_PT_V2

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -2914,7 +2914,7 @@ USA
                 <token regexp='yes' inflected='yes'>&adverbios_de_intensidade;</token>
                 <token postag='NC.+|AQ.+' postag_regexp='yes'><exception postag_regexp='yes' postag='V.+|RG'/></token>
             </pattern>
-            <message>No português europeu, use &quot;de&quot; após precisar quando o complemento for um substantivo, mesmo com advérbio de intensidade.</message>
+            <message>No português europeu, use &quot;de&quot; após &quot;precisar&quot; quando o complemento for um substantivo, mesmo com advérbio de intensidade.</message>
             <suggestion>\1 de</suggestion>
             <example correction="precisamos de">Hoje <marker>precisamos</marker> muita paciência.</example>
             <example>Preciso de muita diversão.</example>
@@ -2927,7 +2927,7 @@ USA
                 </marker>
                 <token postag='NC.+|AQ.+' postag_regexp='yes'><exception postag_regexp='yes' postag='V.+|RG'/></token>
             </pattern>
-            <message>No português europeu, use &quot;de&quot; após precisar quando for seguido de um substantivo.</message>
+            <message>No português europeu, use &quot;de&quot; após &quot;precisar&quot; quando for seguido de um substantivo.</message>
             <suggestion>\1 de</suggestion>
             <example correction="precisamos de">Hoje <marker>precisamos</marker> paciência.</example>
             <example>Preciso de diversão.</example>
@@ -2941,7 +2941,7 @@ USA
                 </marker>
                 <token postag='VMN000.+' postag_regexp='yes'/>
             </pattern>
-            <message>No português europeu, use &quot;de&quot; após precisar quando o complemento for um verbo no infinitivo, mesmo com advérbio de intensidade.</message>
+            <message>No português europeu, use &quot;de&quot; após &quot;precisar&quot; quando o complemento for um verbo no infinitivo, mesmo com advérbio de intensidade.</message>
             <suggestion>\1 \2 de</suggestion>
             <example correction="Precisamos muito de"><marker>Precisamos muito</marker> estudar.</example>
             <example>Preciso muito de saber o resultado do exame.</example>
@@ -2954,7 +2954,7 @@ USA
                 </marker>
                 <token postag='VMN000.+' postag_regexp='yes'/>
             </pattern>
-            <message>No português europeu, use &quot;de&quot; após precisar quando for seguido de um verbo no infinitivo.</message>
+            <message>No português europeu, use &quot;de&quot; após &quot;precisar&quot; quando for seguido de um verbo no infinitivo.</message>
             <suggestion>\1 de</suggestion>
             <example correction="Precisamos de"><marker>Precisamos</marker> estudar muito.</example>
             <example>Preciso de saber o resultado do exame.</example>


### PR DESCRIPTION
Rewrote the rule to make it suggest “DE” BEFORE verbs in the infinitive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Portuguese grammar checks for the "precisar de" construction with a reorganized rule set covering noun and infinitive complements.
  * Improved handling of intensity adverbs by splitting rules into more precise cases and refining guidance and examples for European Portuguese.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->