### PR TITLE
[pt-PT] Made rule more flexible ID:SIMPLIFICAR_TAMBÉM_O_VERBO_PT_PT

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -4485,7 +4485,7 @@ USA
             <token min='1' max='2' postag='NC.+|AQ.+' postag_regexp='yes'/>
             <token min='1' max='3' postag='_PUNCT'/> <!-- max='3' for _TRESPONTOS -->
             <marker>
-                <token postag='DD.+|PP3.+' postag_regexp='yes'/>
+                <token postag='PD.+|DD.+|PP3.+' postag_regexp='yes'/>
                 <token regexp='yes'>até|igualmente|inclusive|também</token>
                 <token><match no='2'/></token>
                 <token><match no='3'/></token>


### PR DESCRIPTION
Made the rule more flexible, but it still has zero hits in 950 000 sentences.

It only works in very specific contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Broader, more flexible Portuguese style checks to catch redundant adjective+verb constructions more accurately.
  * Refined suggestion wording and detection thresholds to reduce false positives and offer clearer rewrite suggestions.
  * Updated examples and messaging for clearer guidance when simplifying redundant phrasing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->