### PR TITLE
[pt] Added AP to rule ID:CONFUSÃO_ESTA_ESTÁ

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -32712,7 +32712,21 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="entraste">Então <marker>entras te</marker> bem o ano.</example>
         </rule>
 
+
         <rulegroup id='CONFUSÃO_ESTA_ESTÁ' name="[Confusão] Esta/Está">
+
+            <antipattern>
+                <token postag='RG'><exception regexp='no'>agora</exception></token> <!-- Add more RG exceptions as found -->
+                <token regexp='yes'>estas?</token>
+                <token postag='Z0.+|NC.+|AQ.+' postag_regexp='yes'>
+                    <exception postag_regexp='yes' postag='DI.+|VMP00.+'/>
+                    <exception scope='next' postag_regexp='yes' postag='VMP00.+'/></token>
+                <example>Apenas estas 10 páginas.</example>
+                <example>Então estas séries são para você.</example>
+                <example>Mesmo estas palavras desaparecerão um dia.</example>
+                <example>Espero que Lafe idade não se apaga conosco por ele stashing aqui esta árvore.</example>
+            </antipattern>
+
             <antipattern>
                 <token postag='CC'/>
                 <token regexp="yes">estas?</token>


### PR DESCRIPTION
An antipattern to fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese grammar checking to better detect and correct confusion between "esta" and "está" forms with enhanced contextual recognition.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->