### PR TITLE
[core] fix memory leak in Hunspell dictionary loading

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/Hunspell.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/Hunspell.java
@@ -1,80 +1,81 @@
 package org.languagetool.rules.spelling.hunspell;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.languagetool.JLanguageTool;
 import org.languagetool.broker.ResourceDataBroker;
 
-import java.io.*;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.*;
-import java.util.*;
-import java.util.function.BiFunction;
-
+@Slf4j
 public final class Hunspell {
-  static class LanguageAndPath {
-    private final Path dictionary;
-    private final Path affix;
-    LanguageAndPath(Path dictionary, Path affix) {
-      this.dictionary = Objects.requireNonNull(dictionary);
-      this.affix = Objects.requireNonNull(affix);
-    }
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      LanguageAndPath that = (LanguageAndPath) o;
-      return Objects.equals(dictionary, that.dictionary) &&
-          Objects.equals(affix, that.affix);
-    }
-    @Override
-    public int hashCode() {
-      return Objects.hash(dictionary, affix);
-    }
+  private record PathPair(Path dictionary, Path affix) {
+      private PathPair(Path dictionary, Path affix) {
+        this.dictionary = Objects.requireNonNull(dictionary);
+        this.affix = Objects.requireNonNull(affix);
+      }
   }
 
-  static final boolean FORCE_TEMP_FILES = "true".equals(System.getenv("HUNSPELL_FORCE_TEMP_FILES"));
-
-  private static final Map<LanguageAndPath, HunspellDictionary> map = new HashMap<>();
-  private static BiFunction<Path, Path, HunspellDictionary> hunspellDictionaryFactory = DumontsHunspellDictionary::new;
-  private static Factory hunspellDictionaryStreamFactory = viaTempFiles(DumontsHunspellDictionary::new);
+  private record ResourcePair(String dictionaryPath, String affixPath) {
+      private ResourcePair(String dictionaryPath, String affixPath) {
+        this.dictionaryPath = Objects.requireNonNull(dictionaryPath);
+        this.affixPath = Objects.requireNonNull(affixPath);
+      }
+  }
 
   /**
-   * @deprecated Use {@link #setHunspellStreamFactory}
+   * Cache for {@link HunspellDictionary Hunspell dictionaries} loaded from file paths (real files on disk)
    */
-  @Deprecated
-  public static void setHunspellDictionaryFactory(BiFunction<Path, Path, HunspellDictionary> factory) {
-    if (FORCE_TEMP_FILES) {
-      hunspellDictionaryFactory = factory;
-    } else {
-      hunspellDictionaryStreamFactory = viaTempFiles(factory);
-    }
-  }
+  private static final Map<PathPair, HunspellDictionary> pathCache = new HashMap<>();
 
-  private static Factory viaTempFiles(BiFunction<Path, Path, HunspellDictionary> factory) {
+  /**
+   * Cache for {@link HunspellDictionary Hunspell dictionaries} loaded from resources (may involve temp files)
+   */
+  private static final Map<ResourcePair, HunspellDictionary> resourceCache = new HashMap<>();
+
+  private static Factory hunspellDictionaryStreamFactory = viaTempFiles();
+
+  private static Factory viaTempFiles() {
     return new Factory() {
       @Override
       public HunspellDictionary createFromLocalFiles(String languageCode, Path dictionary, Path affix) {
-        return factory.apply(dictionary, affix);
+        // Local files on disk - no temp files, no cleanup needed
+        return new DumontsHunspellDictionary(dictionary, affix, false);
       }
 
       @Override
       public HunspellDictionary createFromStreams(String language, InputStream dictionaryStream, InputStream affixStream) throws IOException {
-        Path dictionary = Files.createTempFile(language, ".dic");
-        Path affix = Files.createTempFile(language, ".aff");
-        Files.copy(dictionaryStream, dictionary, StandardCopyOption.REPLACE_EXISTING);
-        Files.copy(affixStream, affix, StandardCopyOption.REPLACE_EXISTING);
-        try {
-          return factory.apply(dictionary, affix);
-        } finally {
-          Files.deleteIfExists(dictionary);
-          Files.deleteIfExists(affix);
-        }
+        // Create temp files from streams - must clean up when dictionary is closed
+        var tempFiles = createTempFilesFromStreams(language, dictionaryStream, affixStream);
+        log.trace("Created temp files for language {}: {} and {}", language, tempFiles.dictionary, tempFiles.affix);
+        return new DumontsHunspellDictionary(tempFiles.dictionary, tempFiles.affix, true);
       }
     };
   }
 
+  private static PathPair createTempFilesFromStreams(String language, InputStream dictionaryStream, InputStream affixStream) throws IOException {
+    Path dictionary = Files.createTempFile(language, ".dic");
+    Path affix = Files.createTempFile(language, ".aff");
+    Files.copy(dictionaryStream, dictionary, StandardCopyOption.REPLACE_EXISTING);
+    Files.copy(affixStream, affix, StandardCopyOption.REPLACE_EXISTING);
+
+    // Mark for deletion on JVM exit (for cached dictionaries that live for JVM lifetime)
+    dictionary.toFile().deleteOnExit();
+    affix.toFile().deleteOnExit();
+
+    return new PathPair(dictionary, affix);
+  }
+
   /**
-   * Set a custom way to create Hunspell dictionaries,
+   * Set a custom way to create {@link HunspellDictionary Hunspell dictionaries},
    * e.g., more efficient or portable than the default, possibly via Apache Lucene.
    * The default one is to use a native wrapper over the real Hunspell binary,
    * creating temporary files from the streams.
@@ -83,83 +84,118 @@ public final class Hunspell {
     hunspellDictionaryStreamFactory = factory;
   }
 
+  /**
+   * Get a {@link HunspellDictionary} for files that already exist on disk.
+   * The dictionary is cached and reused for subsequent requests with the same {@link Path paths}.
+   * The files are NOT deleted when the dictionary is closed (caller owns the files).
+   *
+   * @param dictionary {@link Path} to dictionary file (.dic) on disk
+   * @param affix {@link Path} to affix file (.aff) on disk
+   * @return {@link HunspellDictionary} that is either cached or newly created
+   */
+  @NotNull
   public static synchronized HunspellDictionary getDictionary(Path dictionary, Path affix) {
-    LanguageAndPath key = new LanguageAndPath(dictionary, affix);
-    HunspellDictionary hunspell = map.get(key);
+    PathPair key = new PathPair(dictionary, affix);
+    HunspellDictionary hunspell = pathCache.get(key);
     if (hunspell != null && !hunspell.isClosed()) {
+      log.trace("Returning cached dictionary for {} and {}", dictionary, affix);
       return hunspell;
-    }
-
-    if (FORCE_TEMP_FILES) {
-      HunspellDictionary newHunspell = hunspellDictionaryFactory.apply(dictionary, affix);
-      map.put(key, newHunspell);
-      return newHunspell;
     }
 
     try {
       HunspellDictionary newHunspell = hunspellDictionaryStreamFactory
         .createFromLocalFiles(dictionary.getFileName().toString(), dictionary, affix);
-      map.put(key, newHunspell);
+      pathCache.put(key, newHunspell);
+      log.trace("Created and cached new dictionary for {} and {}", dictionary, affix);
       return newHunspell;
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }
 
+  @NotNull
   public static HunspellDictionary forDictionaryInResources(String language, String resourcePath) {
     return forDictionaryInResources(language, resourcePath + language + ".dic", resourcePath + language + ".aff");
   }
 
-  public static HunspellDictionary forDictionaryInResources(String language, String dicPath, String affPath) {
-    if (FORCE_TEMP_FILES) {
-      try {
-        ResourceDataBroker broker = JLanguageTool.getDataBroker();
-        InputStream dictionaryStream = broker.getAsStream(dicPath);
-        InputStream affixStream = broker.getAsStream(affPath);
-        if (dictionaryStream == null || affixStream == null) {
-          throw new RuntimeException("Could not find dictionary for language \"" + language + "\" in classpath");
-        }
-        Path dictionary = Files.createTempFile(language, ".dic");
-        Path affix = Files.createTempFile(language, ".aff");
-        Files.copy(dictionaryStream, dictionary, StandardCopyOption.REPLACE_EXISTING);
-        Files.copy(affixStream, affix, StandardCopyOption.REPLACE_EXISTING);
-        return hunspellDictionaryFactory.apply(dictionary, affix);
-      } catch (IOException e) {
-        throw new RuntimeException("Could not create temporary dictionaries for language \"" + language + "\"", e);
-      }
+  /**
+   * Get a {@link HunspellDictionary} from classpath resources.
+   * The dictionary is cached by resource path and reused for subsequent requests.
+   * If the resource is a {@code file://} URL, uses the file directly.
+   * If the resource is in a JAR, creates temp files that live for the JVM lifetime.
+   *
+   * @param language Language code (for error messages and temp file naming)
+   * @param dicPath Classpath resource path to dictionary file (.dic)
+   * @param affPath Classpath resource path to affix file (.aff)
+   * @return {@link HunspellDictionary} that is either cached or newly created
+   */
+  @NotNull
+  public static synchronized HunspellDictionary forDictionaryInResources(String language, String dicPath, String affPath) {
+    // Check cache first using resource paths as key (before creating any temp files)
+    var key = new ResourcePair(dicPath, affPath);
+    var cached = resourceCache.get(key);
+    if (cached != null && !cached.isClosed()) {
+      log.trace("Returning cached dictionary for resource language {}", language);
+      return cached;
     }
 
     ResourceDataBroker broker = JLanguageTool.getDataBroker();
+
+    // Try to get file:// URLs - if available, use files directly (no temp files needed)
     URL dicUrl = broker.getFromResourceDirAsUrl(dicPath);
     URL affUrl = broker.getFromResourceDirAsUrl(affPath);
     if (dicUrl != null && affUrl != null &&
       dicUrl.getProtocol().equals("file") && affUrl.getProtocol().equals("file")) {
       try {
-        return hunspellDictionaryStreamFactory.createFromLocalFiles(language, Path.of(dicUrl.toURI()), Path.of(affUrl.toURI()));
-      } catch (IOException | URISyntaxException e) {
-        throw new RuntimeException(e);
+        // Resources are real files on disk - use getDictionary which caches by path
+        var dict = getDictionary(Path.of(dicUrl.toURI()), Path.of(affUrl.toURI()));
+        // Also cache in resource cache for faster lookup next time
+        resourceCache.put(key, dict);
+        log.trace("Cached dictionary from file:// resource for language {}", language);
+        return dict;
+      } catch (URISyntaxException e) {
+        throw new RuntimeException("Failed to convert resource URL to file path", e);
       }
     }
 
-    try (var dic = broker.getFromResourceDirAsStream(dicPath); var aff = broker.getFromResourceDirAsStream(affPath)) {
-      if (dic == null || aff == null) {
+    // Resources are in JARs or other non-file sources - must create temp files
+    // These temp files live for the JVM lifetime (deleteOnClose=false)
+    try (var dictionaryStream = broker.getFromResourceDirAsStream(dicPath);
+         var affixStream = broker.getFromResourceDirAsStream(affPath)) {
+      if (dictionaryStream == null || affixStream == null) {
         throw new RuntimeException("Could not find the dictionary for language \"" + language + "\" in the classpath");
       }
-      return hunspellDictionaryStreamFactory.createFromStreams(language, dic, aff);
+
+      var tempFiles = createTempFilesFromStreams(language, dictionaryStream, affixStream);
+      var dict = new DumontsHunspellDictionary(tempFiles.dictionary, tempFiles.affix, false);
+
+      // Cache by resource path for future lookups (fixes #11380)
+      resourceCache.put(key, dict);
+      log.trace("Created and cached dictionary from JAR resource for language {}: {} and {}",
+                language, tempFiles.dictionary, tempFiles.affix);
+
+      return dict;
     } catch (IOException e) {
       throw new RuntimeException("Could not create temporary dictionaries for language \"" + language + "\"", e);
     }
   }
 
+  @NotNull
   public static HunspellDictionary forDictionaryInResources(String language) {
     return forDictionaryInResources(language, "");
   }
 
   public interface Factory {
     /**
-     * An equivalent of {@link #createFromStreams(String, InputStream, InputStream)} that can be used
-     * if the caller is sure that the Hunspell dictionaries are located in the files in the local file system.
-     * This allows for more efficient implementation.
+     * Create a {@link HunspellDictionary} from files that already exist on the local filesystem.
+     * These files are owned by the caller and should NOT be deleted when the dictionary is closed.
+     * The returned dictionary should have {@code deleteOnClose=false}.
+     *
+     * @param languageCode Language code for the dictionary
+     * @param dictionary {@link Path} to dictionary file (.dic) on disk
+     * @param affix {@link Path} to affix file (.aff) on disk
+     * @return {@link HunspellDictionary} that will not delete the files on close
+     * @throws IOException if an I/O error occurs while reading the files
      */
     default HunspellDictionary createFromLocalFiles(String languageCode, Path dictionary, Path affix) throws IOException {
       try (InputStream dic = Files.newInputStream(dictionary); InputStream aff = Files.newInputStream(affix)) {
@@ -168,9 +204,20 @@ public final class Hunspell {
     }
 
     /**
-     * Create a Hunspell dictionary from the given streams.
-     * All necessary information should be extracted from both streams by the time this method returns.
-     * Closing the streams is not necessary in the implementation of this method, as the caller will close them itself.
+     * Create a {@link HunspellDictionary} from {@link InputStream InputStreams}.
+     * Implementations must extract all necessary data from the streams before returning.
+     * <p>
+     * <strong>Important:</strong> The caller will close the streams, so implementations should not close them.
+     * <p>
+     * Implementations typically create temporary files and should use {@code deleteOnClose=true}
+     * to clean them up when the dictionary is closed (unless the dictionary will be cached
+     * for the lifetime of the JVM).
+     *
+     * @param languageCode Language code for the dictionary
+     * @param dictionary {@link InputStream} for dictionary data (.dic)
+     * @param affix {@link InputStream} for affix data (.aff)
+     * @return {@link HunspellDictionary} (usually with {@code deleteOnClose=true} for temp file cleanup)
+     * @throws IOException if an I/O error occurs while reading the streams
      */
     HunspellDictionary createFromStreams(String languageCode, InputStream dictionary, InputStream affix) throws IOException;
   }

--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/HunspellRule.java
@@ -513,23 +513,11 @@ public class HunspellRule extends SpellingCheckRule {
     if(!Tools.isExternSpeller()) {    //  use of external speller for OO extension (32-bit)
                                       //  hunspell doesn't support 32-bit java
       if (JLanguageTool.getDataBroker().resourceExists(shortDicPath)) {
-        if (Hunspell.FORCE_TEMP_FILES) {
-          String path = getDictionaryPath(langCountry, shortDicPath);
-          if ("".equals(path)) {
-            hunspell = null;
-          } else {
-            Path affPath = Paths.get(path + ".aff");
-            hunspell = Hunspell.getDictionary(Paths.get(path + ".dic"), affPath);
-            addIgnoreWords();
-            nonWordPattern = nonWordPatternFromPath(affPath);
-          }
-        } else {
-          String aff = shortDicPath.substring(0, shortDicPath.length() - 3) + "aff";
-          hunspell = Hunspell.forDictionaryInResources(langCountry, shortDicPath, aff);
-          addIgnoreWords();
-          nonWordPattern = nonWordPatterns.computeIfAbsent("resource:" + shortDicPath, __ ->
-            computeNonWordPattern(JLanguageTool.getDataBroker().getFromResourceDirAsStream(aff)));
-        }
+        String aff = shortDicPath.substring(0, shortDicPath.length() - 3) + "aff";
+        hunspell = Hunspell.forDictionaryInResources(langCountry, shortDicPath, aff);
+        addIgnoreWords();
+        nonWordPattern = nonWordPatterns.computeIfAbsent("resource:" + shortDicPath, __ ->
+          computeNonWordPattern(JLanguageTool.getDataBroker().getFromResourceDirAsStream(aff)));
       } else if (new File(shortDicPath + ".dic").exists()) {
         // for dynamic languages
         Path affPath = Paths.get(shortDicPath + ".aff");


### PR DESCRIPTION
### Root Cause
---
The memory leak was introduced in commit 1b86363a561 (PR #11359) which added the `FORCE_TEMP_FILES` flag and modified temp file handling. The leak occurred because `forDictionaryInResources()` created new `HunspellDictionary` objects on **every call** without caching.

For each request, the code would:
1. Extract Hunspell dictionary files (.dic/.aff) from the JAR to temp files
2. Load them into the native Hunspell library (allocating native memory)
3. Create a new `HunspellDictionary` Java object (allocating heap memory)
4. Repeat for every request to the same language

This caused three types of memory growth:
1. Java heap: new `HunspellDictionary` objects created repeatedly
2. Native memory: Hunspell library allocated new dictionary structures each time
3. Disk space: accumulating temp files (new files created on every request)

### Solution
---
This commit refactors Hunspell dictionary management:

1. Dual-cache architecture
    - `pathCache`: Caches dictionaries from real files on disk (keyed by `Path`)
    - `resourceCache`: Caches dictionaries from classpath resources (keyed by resource path `String`)
    - Created `PathPair` and `ResourcePair` record classes for cache keys
    - Cache lookups happen **before** creating temp files, eliminating the wasteful temp-file-then-check-cache pattern.

2. Clear lifecycle management
    - `createFromLocalFiles()`: Real files on disk → `deleteOnClose=false` (caller owns the files)
    - `createFromStreams()`: Temp files from streams → `deleteOnClose=true` (cleanup when dictionary closes)
    - `forDictionaryInResources()`:
      - If resource is a `file://` URL → uses file directly, `deleteOnClose=false` (no temp files)
      - If resource is in a JAR → creates temp files **once**, caches them, `deleteOnClose=false`, marked with `deleteOnExit()` for cleanup on JVM shutdown

3. Removed `FORCE_TEMP_FILES`
    - Removed the `FORCE_TEMP_FILES` environment variable. The new design handles both `file://` URLs and JAR resources without needing this flag.

4. Code cleanup
    - Added comprehensive Javadoc with `@link` annotations
    - Removed deprecated `setHunspellDictionaryFactory()` method
    - Added `@Slf4j` trace logging for cache hits, temp file creation, and deletion

### Testing

Download [`logback-trace.xml`](https://github.com/user-attachments/files/23997480/logback-trace.xml)

1. Terminal 1: Build and start server with [`run.sh`](https://github.com/user-attachments/files/23997482/run.sh). Select from buggy or fixed version as well as standalone or fat JAR.
2. Terminal 2: Monitor metrics with [`monitor.sh`](https://github.com/user-attachments/files/23997481/monitor.sh)
3. Terminal 3: Run leak test with [`test.sh`](https://github.com/user-attachments/files/23997483/test.sh)

#### Expected results (Fixed, Fat JAR)

Monitor output:
```shell
TIME                 RSS(MB)    TEMP_FILES
2025-12-06 10:50:21  468        0           ← Idle
2025-12-06 10:51:21  3217       8           ← Loaded (fat JAR: 4 languages × 2 files)
2025-12-06 10:52:21  3252       8           ← Stable!
2025-12-06 10:53:21  3255       8           ← Stable!
```

- `RSS` stabilizes ~3000-4000 MB
- `TEMP_FILES` stays constant (fat JAR: ~8-14 files, standalone: 0)
- Logs show "Returning cached dictionary" after first load

### Impact
---
Dictionaries are now cached and reused. Temp files are created once per resource and managed properly for their lifetime. The JVM garbage collector periodically compacts the heap and frees unused objects. Dictionaries remain cached in static maps, but temporary objects are reclaimed.

### Fixes
---
- Primary: #11380
- Related: 1b86363a (via PR #11359 which introduced the leak)
- Related (earlier temp file work): 0e706140 (dcc18585 which reverts 0e706140)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent caching of loaded dictionaries for improved performance.
  * Enhanced support for dictionary resources in JAR files with automatic temporary file management.

* **Bug Fixes**
  * Improved resource cleanup with automatic deletion of temporary files and better error handling.
  * Strengthened runtime safety with validation checks for dictionary operations.

* **Refactor**
  * Simplified dictionary initialization flow and enhanced thread-safety mechanisms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->