### PR TITLE
[pt] Added formal rule ID:COMO_SEGUNDO_CONFORME

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3697,7 +3697,7 @@ USA
                 <marker>
                     <token regexp='yes'>como|segundo</token>
                 </marker>
-                <token min='0' max='2' regexp='yes' inflected='yes'>ser|ter|haver</token>
+                <token min='0' max='2' regexp='yes' inflected='yes'>ser|ter|haver|o</token>
                 <token postag='AQ.+' postag_regexp='yes' regexp='yes' inflected='yes'>acordado|alinhado|combinado</token>
             </pattern>
             <message>Use &quot;conforme&quot; para maior formalidade.</message>
@@ -3705,6 +3705,7 @@ USA
             <example correction="conforme">Aqui está o relatório <marker>segundo</marker> combinado.</example>
             <example>Redigi o documento conforme fora acordado por ambas as partes.</example>
             <example>Conforme havia sido combinado, aqui está o relatório.</example>
+            <example>Conforme o combinado, aqui está o livro.</example>
         </rule>
 
 


### PR DESCRIPTION
A formal rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Portuguese style rule that detects informal constructions like "como/segundo" followed by auxiliary verbs and certain adjectives, and suggests the more formal "conforme" with contextual examples to improve formality and consistency in writing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->