### PR TITLE
[pt] Made AP broader since there were FPs disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -5606,7 +5606,6 @@ USA
     </rule>
     <rule>
       <antipattern>
-        <token regexp='yes' inflected='yes'>ser|estar</token>
         <token postag='(SPS00:)?D[AI].+' postag_regexp='yes'/>
         <token min='1' max='2' postag='NC.+|AQ.+' postag_regexp='yes'><exception postag_regexp='yes' postag='V.+'/></token>
         <token min='0' max='1' postag='_PUNCT'/>


### PR DESCRIPTION
Made AP broader because there were still a couple of false positives.

Better to have fewer hits than to lose good sentences.

Still, it continues to have a high number of hits (success):
```
Portuguese (Portugal): 4702 total matches
Portuguese (Portugal): 949999 total sentences considered
Portuguese (Portugal): ø0.00 rule matches per sentence
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Refined Portuguese language grammar detection rules for more flexible verb form matching, enhancing accuracy in language analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->