### PR TITLE
fix `RussianSRXSentenceTokenizerTest` on JDK 21

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
@@ -4432,38 +4432,38 @@
 <languagerule languagerulename="Russian">
 <rule break="no">
 <beforebreak>\b\d+\.\s</beforebreak>
-<afterbreak>\p{Ll}|\p{Lu}{2,}</afterbreak>
+<afterbreak>(?U)\p{Ll}|\p{Lu}{2,}</afterbreak>
 </rule>
 <!-- capital char abbreviations А. Б. В. -->
 <rule break="no">
-<beforebreak>\b[А-ЯЁ]\.\s</beforebreak>
+<beforebreak>(?U)\b[А-ЯЁ]\.\s</beforebreak>
 <afterbreak></afterbreak>
 </rule>
 <rule break="no">
-<beforebreak>\b[A-Z]\.\s</beforebreak>
+<beforebreak>(?U)\b[A-Z]\.\s</beforebreak>
 <afterbreak></afterbreak>
 </rule>
 <!-- N(ame).Family -->
 <rule break="no">
-<beforebreak>\b[А-ЯЁ]\.</beforebreak>
-<afterbreak>[А-ЯЁ][а-яё]+</afterbreak>
+<beforebreak>(?U)\b[А-ЯЁ]\.</beforebreak>
+<afterbreak>(?U)[А-ЯЁ][а-яё]+</afterbreak>
 </rule>
 <!-- N(ame).S(urname).Family -->
 <rule break="no">
-<beforebreak>\b[А-ЯЁ]\.[А-ЯЁ]\.</beforebreak>
-<afterbreak>[А-ЯЁ][а-яё]+</afterbreak>
+<beforebreak>(?U)\b[А-ЯЁ]\.[А-ЯЁ]\.</beforebreak>
+<afterbreak>(?U)[А-ЯЁ][а-яё]+</afterbreak>
 </rule>
 <rule break="no">
-<beforebreak>\b\p{L}\.</beforebreak>
-<afterbreak>\p{L}\.</afterbreak>
+<beforebreak>(?U)\b\p{L}\.</beforebreak>
+<afterbreak>(?U)\p{L}\.</afterbreak>
 </rule>
 <!-- date/time -->
 <rule break="no">
-<beforebreak>\b[0-9]+(гг|г)\.\s</beforebreak>
+<beforebreak>(?U)\b[0-9]+(гг|г)\.\s</beforebreak>
 <afterbreak></afterbreak>
 </rule>
 <rule break="no">
-<beforebreak>\b[XVILMC]+(в|вв)\.\s</beforebreak>
+<beforebreak>(?U)\b[XVILMC]+(в|вв)\.\s</beforebreak>
 <afterbreak></afterbreak>
 </rule>
 <rule break="no">
@@ -4476,49 +4476,49 @@
 </rule>
 <!--Measures  -->
 <rule break="no">
-<beforebreak>\b[0-9]+(м|мм|см|дм|л|км|га|кг|т|г|мг)\.\s</beforebreak>
-<afterbreak>\p{Ll}</afterbreak>
+<beforebreak>(?U)\b[0-9]+(м|мм|см|дм|л|км|га|кг|т|г|мг)\.\s</beforebreak>
+<afterbreak>(?U)\p{Ll}</afterbreak>
 </rule>
 <rule break="no">
-<beforebreak>\b[0-9]+(руб|Руб|тыс|Тыс|трлн|млн|млрд)\.\s</beforebreak>
+<beforebreak>(?U)\b[0-9]+(руб|Руб|тыс|Тыс|трлн|млн|млрд)\.\s</beforebreak>
 <afterbreak>\b[0-9]+</afterbreak>
 </rule>
 <!-- other abbreviations  -->
 <rule break="no">
-<beforebreak>\b(бульв|г|д|доп|др|е|зам|Зам|и|им|инд|исп|Исп)\.\s</beforebreak>
+<beforebreak>(?U)\b(бульв|г|д|доп|др|е|зам|Зам|и|им|инд|исп|Исп)\.\s</beforebreak>
 <afterbreak></afterbreak>
 </rule>
 <rule break="no">
-<beforebreak>\b(англ|в|вв|га|гг|гл|гос|грн|дм|долл|е|ед)\.\s</beforebreak>
-<afterbreak>\p{Ll}</afterbreak>
+<beforebreak>(?U)\b(англ|в|вв|га|гг|гл|гос|грн|дм|долл|е|ед)\.\s</beforebreak>
+<afterbreak>(?U)\p{Ll}</afterbreak>
 </rule>
 <rule break="no">
-<beforebreak>\b(к|кап|кав|кв|кл|кол|комн|куб|л|лиц|лл|м|макс)\.\s</beforebreak>
+<beforebreak>(?U)\b(к|кап|кав|кв|кл|кол|комн|куб|л|лиц|лл|м|макс)\.\s</beforebreak>
 <afterbreak></afterbreak>
 </rule>
 <rule break="no">
-<beforebreak>\b(кг|км|коп|л|лл|м|мг|мин|мл|млн|Млн|млрд|Млрд|мм)\.\s</beforebreak>
-<afterbreak>\p{Ll}</afterbreak>
+<beforebreak>(?U)\b(кг|км|коп|л|лл|м|мг|мин|мл|млн|Млн|млрд|Млрд|мм)\.\s</beforebreak>
+<afterbreak>(?U)\p{Ll}</afterbreak>
 </rule>
 <rule break="no">
-<beforebreak>\b(н|наб|нач|неуд|нем|ном|о|обл|обр|общ|ок|ост|отл|п|пер|Пер|перераб|пл|пос|пр|пром|просп|Просп|проф|Проф)\.\s</beforebreak>
+<beforebreak>(?U)\b(н|наб|нач|неуд|нем|ном|о|обл|обр|общ|ок|ост|отл|п|пер|Пер|перераб|пл|пос|пр|пром|просп|Просп|проф|Проф)\.\s</beforebreak>
 <afterbreak></afterbreak>
 </rule>
 <rule break="no">
-<beforebreak>\b(р|ред|Рис|рус|с|сб|св|См|см|сов|соч|соц|спец|ср|ст|стр|т|тел|Тел|тех|тов|тт|туп)\.\s</beforebreak>
-<afterbreak>\p{Ll}</afterbreak>
+<beforebreak>(?U)\b(р|ред|Рис|рус|с|сб|св|См|см|сов|соч|соц|спец|ср|ст|стр|т|тел|Тел|тех|тов|тт|туп)\.\s</beforebreak>
+<afterbreak>(?U)\p{Ll}</afterbreak>
 </rule>
 <rule break="no">
-<beforebreak>\b(руб|Руб|тыс|Тыс|трлн)\.\s</beforebreak>
-<afterbreak>\p{Ll}</afterbreak>
+<beforebreak>(?U)\b(руб|Руб|тыс|Тыс|трлн)\.\s</beforebreak>
+<afterbreak>(?U)\p{Ll}</afterbreak>
 </rule>
 <rule break="no">
-<beforebreak>\b(уд|ул|уч|физ|х|хор|э|Эл|эл)\.\s</beforebreak>
+<beforebreak>(?U)\b(уд|ул|уч|физ|х|хор|э|Эл|эл)\.\s</beforebreak>
 <afterbreak></afterbreak>
 </rule>
 <rule break="no">
-<beforebreak>\b(ч|чел|шт|экз)\.\s</beforebreak>
-<afterbreak>\p{Ll}</afterbreak>
+<beforebreak>(?U)\b(ч|чел|шт|экз)\.\s</beforebreak>
+<afterbreak>(?U)\p{Ll}</afterbreak>
 </rule>
 <rule break="no">
 <beforebreak>['"„“][\.!?…]['"”]\s</beforebreak>
@@ -4530,15 +4530,15 @@
 </rule>
 <rule break="no">
 <beforebreak>[\[\(]*\.\.\.[\]\)]* </beforebreak>
-<afterbreak>\p{Ll}</afterbreak>
+<afterbreak>(?U)\p{Ll}</afterbreak>
 </rule>
 <rule break="no">
 <beforebreak>[\[\(]*…[\]\)]* </beforebreak>
-<afterbreak>\p{Ll}</afterbreak>
+<afterbreak>(?U)\p{Ll}</afterbreak>
 </rule>
 <rule break="no">
 <beforebreak>["”'\u00BB]\s*</beforebreak>
-<afterbreak>\s*\p{Ll}</afterbreak>
+<afterbreak>(?U)\s*\p{Ll}</afterbreak>
 </rule>
 <!-- break  -->
 <rule break="yes">
@@ -4554,8 +4554,8 @@
 <afterbreak>\p{Lu}[^\p{Lu}]</afterbreak>
 </rule>
 <rule break="yes">
-<beforebreak>\s\p{L}[\.!?…]\s</beforebreak>
-<afterbreak>\p{Lu}\p{Ll}</afterbreak>
+<beforebreak>(?U)\s\p{L}[\.!?…]\s</beforebreak>
+<afterbreak>(?U)\p{Lu}\p{Ll}</afterbreak>
 </rule>
 </languagerule>
 <languagerule languagerulename="Default">
@@ -6040,12 +6040,12 @@
 </rule>
 <!--Measures  -->
 <rule break="no">
-<beforebreak>\b[0-9]+(г|гг|грн|млн|млрд|руб|тыс)\.\s</beforebreak>
+<beforebreak>(?U)\b[0-9]+(г|гг|грн|млн|млрд|руб|тыс)\.\s</beforebreak>
 <afterbreak></afterbreak>
 </rule>
 <!-- other abbreviations  -->
 <rule break="no">
-<beforebreak>\b(в|вв|г|гг|грн|млн|млрд|руб|ст|р|тыс)\.\s</beforebreak>
+<beforebreak>(?U)\b(в|вв|г|гг|грн|млн|млрд|руб|ст|р|тыс)\.\s</beforebreak>
 <afterbreak></afterbreak>
 </rule>
 <rule break="no">

--- a/languagetool-language-modules/ru/src/test/java/org/languagetool/tokenizers/ru/RussianSRXSentenceTokenizerTest.java
+++ b/languagetool-language-modules/ru/src/test/java/org/languagetool/tokenizers/ru/RussianSRXSentenceTokenizerTest.java
@@ -42,6 +42,7 @@ public class RussianSRXSentenceTokenizerTest {
     testSplit("Более 300 тыс. документов и справочников.");
     testSplit("Скидки до 50000 руб. на автомобили.");
     testSplit("Изготовление визиток любыми тиражами (от 20 шт. до 10 тысяч) в минимальные сроки (от 20 минут).");
+    testSplit("Временно не работает, т.к. не поддерживается.");
   }
 
   private void testSplit(final String... sentences) {


### PR DESCRIPTION
The pull request aims to address the [issue](https://github.com/languagetool-org/languagetool/issues/11703)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sentence boundary detection across multiple languages including Russian, Ukrainian, Belarusian, Polish, Spanish, Dutch, German, Danish, Icelandic, Romanian, Slovak, Slovenian, Bulgarian, and Greek for more accurate text segmentation.

* **Tests**
  * Added test coverage for Russian sentence tokenization to validate proper segmentation handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->