### PR TITLE
[pt] Major fix in VMIP1S0 disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4145,7 +4145,7 @@ USA
           <token postag='NC.+|AQ.+' postag_regexp='yes'/>
         </and>
       </marker>
-      <token postag='VMP00.+' postag_regexp='yes'/>
+      <token postag='VMP00.+' postag_regexp='yes'><exception scope='previous' regexp='yes' inflected='yes'>ser|estar|ter|haver|ficar|continuar|permanecer|manter|deixar|considerar|julgar|achar</exception></token>
     </pattern>
     <disambig action="remove" postag="VMIP1S0"/>
       <!--


### PR DESCRIPTION
Major fix in disambiguator regarding VMIP1S0 followed by past participle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese disambiguation to better distinguish verbs from nouns in constructions involving past participles, reducing incorrect verb/noun tagging in ambiguous sequences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->