### PR TITLE
[pt] Added names of major AI companies to spelling.txt

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
@@ -587,3 +587,16 @@ Bash
 Elixir
 Lisp
 Clojure
+Alphabet
+NVIDIA
+Anthropic
+DeepL
+Cohere
+Anduril
+ElevenLabs
+Zhipu
+Mistral
+Perplexity
+Scale
+Stability
+AI


### PR DESCRIPTION
Added names of major AI companies, also added “AI” for the companies that have it in front: “Meta AI”, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded Portuguese language dictionary with new spelling entries for technology companies and AI-related terms to enhance spell-checking capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->