### PR TITLE
[nl] Fixed decapitalization of months and religion names

### DIFF
--- a/languagetool-language-modules/nl/src/main/resources/org/languagetool/rules/nl/check_case.txt
+++ b/languagetool-language-modules/nl/src/main/resources/org/languagetool/rules/nl/check_case.txt
@@ -688,3 +688,11 @@ axolotls=Diersoorten schrijf je zonder hoofdletter, net als alle andere woorden 
 axolotl=Diersoorten schrijf je zonder hoofdletter, net als alle andere woorden die een soort aangeven.
 stabij=Diersoorten schrijf je zonder hoofdletter, net als alle andere woorden die een soort aangeven.
 yucca
+jodendom
+boeddhisme
+hindoeïsme
+sikhisme
+taoïsme
+confucianisme
+shintoïsme
+jaïnisme

--- a/languagetool-language-modules/nl/src/main/resources/org/languagetool/rules/nl/grammar.xml
+++ b/languagetool-language-modules/nl/src/main/resources/org/languagetool/rules/nl/grammar.xml
@@ -12513,7 +12513,7 @@ regexp case-insensitive maken: (?i)
 				<pattern>
 					<token><exception postag_regexp="yes" postag="SENT_START|START"/></token>
 					<marker>
-						<token regexp="yes" case_sensitive="yes">(Maan|Dins|Woens|Donder|Zater|Zon)dag|Januari|Februari|Maart|April|Mei|Juni|Juli|Augustus|September</token>
+						<token regexp="yes" case_sensitive="yes">(Maan|Dins|Woens|Donder|Zater|Zon)dag|Januari|Februari|Maart|April|Mei|Juni|Juli|Augustus|September|Oktober|November|December</token>
 					</marker>
 				</pattern>
 				<message>De dagen van de week en maanden horen (behalve aan het begin van de zin) met kleine letters: <suggestion><match no="2" case_conversion="alllower"/></suggestion>.</message>


### PR DESCRIPTION
WEEKDAGEN_MAANDEN: added missing months to the rule pattern
check_case.txt: added missing religion names, as they need to be corrected to lowercase letter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Dutch month recognition expanded to cover all 12 months, improving detection of month-related capitalization issues.
  * Added eight Dutch religious terms to case-checking rules for more accurate capitalization handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->