### PR TITLE
[it] Add antipatterns to ER_01 rules

### DIFF
--- a/languagetool-language-modules/it/src/main/resources/org/languagetool/rules/it/grammar.xml
+++ b/languagetool-language-modules/it/src/main/resources/org/languagetool/rules/it/grammar.xml
@@ -1752,7 +1752,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         </rulegroup>
         <rulegroup name="scambio di 'ai' ed 'hai'" id="ER_01_002">
           <antipattern> <!-- verbi con "ai"  -->
-            <token inflected="yes" regexp="yes">andare|portare|rispetto|ricorrere|associare|contribuire|procedere|indirizzare|incentivare|abilitare|tendere|indurre|scendere</token>
+            <token inflected="yes" regexp="yes">andare|portare|ricorrere|associare|contribuire|procedere|indirizzare|incentivare|abilitare|tendere|indurre|scendere</token>
             <token>ai</token>
           </antipattern>
           <antipattern>


### PR DESCRIPTION
I added antipatterns to 2 rules: ER_01_001 and ER_01_002.
Some of them were needed for the rule not to be triggered on phrases:

- [l'arco a volta](https://www.studiarapido.it/arco-a-volta-inventato-dagli-etruschi/)
- mettere a punto
- a seguito di
- a cascata

Additionally, I added antipatterns for verbs that can be used with prepositions a/ai.
I used [lo Zingarelli 2026](https://www.zanichelli.it/ricerca/prodotti/lo-zingarelli-2026) to verify the usage of verbs and prepositions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Italian grammar checks to catch wrong uses of "a" vs "ha" across more phrase patterns (including "a" + nouns, verbs and reflexive constructions).
* **Bug Fixes**
  * Expanded detection and corrections for ai/hai and anno/hanno confusions, improving suggestion accuracy and reducing false positives.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->