### PR TITLE
[es] Agreement/accentuation in sentences with medical contexts

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -22910,15 +22910,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <!-- colon sigmoides: nombre anatómico compuesto, no revisar concordancia -->
             <antipattern>
                 <token inflected="yes">colon</token>
-                <token>sigmoides</token>
+                <token regexp="yes">sigmoide|sigmoides</token>
                 <example>A nivel del colon sigmoides con presencia de formaciones saculares de pared delgada.</example>
-            </antipattern>
-            <antipattern>
-                <token inflected="yes">método</token>
-                <token>de</token>
-                <token inflected="yes">imagen</token>
-                <token inflected="yes" postag="AQ.*|V.P.*" postag_regexp="yes">conservar</token>
-                <example>Los tejidos blandos que se pueden valorar por este método de imagen conservados.</example>
             </antipattern>
             <antipattern>
                 <token inflected="yes" skip="3">ser</token>


### PR DESCRIPTION
UNUSUAL_WITHOUT_ACCENT: pedio – is an adjective used in medical context
AGREEMENT_ADJ_NOUN: antipattern for complex agreement with ordinal numbers
AGREEMENT_DET_ADJ, AGREEMENT_POSTPONED_ADJ: antipattern for medical term – colon sigmoide/s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Spanish grammar detection with improved accent and tilde handling for medical and technical terminology
  * Strengthened recognition of proper nouns, abbreviations, and formal writing conventions
  * Added specialized correction rules for anatomical terms, Latin-origin words, and scholarly document formatting standards

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->