### PR TITLE
[pt] Added scientific rule ID:LINHA_RETA_RETA

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -11538,6 +11538,25 @@ USA
     </category>
 
     <category id="SCIENTIFIC" name="Linguagem científica" type="style" tone_tags="scientific">
+
+
+        <rule id='LINHA_RETA_RETA' name="Traçar 'linha reta' → reta" type='style' is_goal_specific='true' default='temp_off'>
+            <!-- ChatGPT 5 and new disambiguator for 2026+ -->
+            <pattern>
+                <token skip='3' regexp='yes' inflected='yes'>traçar|desenhar|riscar</token>
+                <marker>
+                    <token regexp='yes'>linhas?</token>
+                    <token regexp='yes'>rec?tas?</token>
+                </marker>
+            </pattern>
+            <message>Em contexto técnico, &quot;reta&quot; é suficiente.</message>
+            <suggestion>\3</suggestion>
+            <example correction="reta">Vou traçar uma <marker>linha reta</marker> entre os pontos.</example>
+            <example correction="retas">Vou traçar várias <marker>linhas retas</marker> no quadro.</example>
+            <example>O Rui vai traçar mais duas retas para todos analisarem.</example>
+        </rule>
+
+
         <rulegroup id="NUMERO_DE_MOLS" name="Número de mols → massa molecular" tags="picky" is_goal_specific="true">
             <rule>
                 <pattern>
@@ -11605,7 +11624,7 @@ USA
             <example correction="a constante de Avogadro">Calculamos com <marker>o número de Avogadro</marker>.</example>
         </rule>
 
-        <rule id="GRAU_CENTIGRADO" name="Preferir 'grau Celius' a 'grau centígrado'.">
+        <rule id="GRAU_CENTIGRADO" name="Preferir 'grau Celsius' a 'grau centígrado'.">
             <pattern>
                 <token regexp="yes">graus?</token>
                 <marker>


### PR DESCRIPTION
Added a scientific rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new scientific language style rule for Portuguese that identifies and simplifies verbose geometric expressions in technical writing. The rule detects phrases like "Traçar uma linha reta" and "Desenhar linhas retas" and suggests replacing them with the more concise term "reta," helping users communicate more clearly and efficiently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->