### PR TITLE
[pt] Enabled rule ID:LINHA_RETA_RETA

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -11540,7 +11540,7 @@ USA
     <category id="SCIENTIFIC" name="Linguagem científica" type="style" tone_tags="scientific">
 
 
-        <rule id='LINHA_RETA_RETA' name="Traçar 'linha reta' → reta" type='style' is_goal_specific='true' default='temp_off'>
+        <rule id='LINHA_RETA_RETA' name="Traçar 'linha reta' → reta" type='style' is_goal_specific='true'>
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <pattern>
                 <token skip='3' regexp='yes' inflected='yes'>traçar|desenhar|riscar</token>


### PR DESCRIPTION
Enabled the rule after checking the nightly Diffs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portuguese language style checking now includes automatic detection and suggestions for simplifying "linha reta" to "reta," enabled by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->