### PR TITLE
[pt] Added tone_tags='scientific' to Rule ID:LINHA_RETA_RETA

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -11540,7 +11540,7 @@ USA
     <category id="SCIENTIFIC" name="Linguagem científica" type="style" tone_tags="scientific">
 
 
-        <rule id='LINHA_RETA_RETA' name="Traçar 'linha reta' → reta" type='style' is_goal_specific='true'>
+        <rule id='LINHA_RETA_RETA' name="Traçar 'linha reta' → reta" type='style' tone_tags='scientific' is_goal_specific='true'>
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <pattern>
                 <token skip='3' regexp='yes' inflected='yes'>traçar|desenhar|riscar</token>


### PR DESCRIPTION
Added "tone_tags='scientific'", "just in case"…

😛 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Portuguese language scientific writing rules with enhanced metadata organization. Updated rule definitions now ensure more consistent application of scientific tone and style recommendations, providing better accuracy in detecting verbose phrasing and suggesting more concise alternatives in scientific contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->