### PR TITLE
[pt-PT] Rewrote rule ID:FAZER_DESPORTO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -3520,7 +3520,7 @@ USA
           <!-- ChatGPT 5 and new disambiguator for 2026+ -->
           <pattern>
               <marker>
-                  <token skip='2' inflected='yes'>fazer</token> <!-- skip='3' gives false positives -->
+                  <token skip='2' inflected='yes'>fazer<exception scope='next' postag_regexp='yes' postag='V.+'/></token> <!-- skip='3' gives false positives -->
                   <token regexp='yes'>desportos?|sports?|esportes?</token>
               </marker>
           </pattern>
@@ -3528,6 +3528,7 @@ USA
           <suggestion><match no='1' include_skipped='all' postag='V.+' postag_regexp='yes'>praticar</match> <match no='2' postag='NC.+' postag_regexp='yes'>desporto</match></suggestion>
           <example correction="praticar muito desporto">Vou <marker>fazer muito desporto</marker>.</example>
           <example correction="praticar desportos">Vou <marker>fazer desportos</marker> de combate.</example>
+          <example>Foi o meu pai quem me fez interessar por esportes.</example>
       </rule>
 
 


### PR DESCRIPTION
Rewrote the rule to make it more powerful and fix possible false positives (it had skip=4, and only skip=2 fixes all false positives).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced Portuguese (European) style detection for sport-related phrases with broader pattern coverage to catch more variants.
  * Richer, more precise suggestions recommending "praticar desporto" (verb + noun) as the formal alternative and clearer explanatory messaging.
  * Default toggle option exposed for the rule so it can be enabled/disabled without code changes.
  * Updated example sentences to illustrate the broader matches and guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->