### PR TITLE
[pt-PT] Made rule stricter ID:DEPOIS_É_QUE_VERBO_DEPOIS_VERBO_PT_PT

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -4296,22 +4296,23 @@ USA
     </rulegroup>
 
 
-<rule id='DEPOIS_É_QUE_VERBO_DEPOIS_VERBO_PT_PT' name="[pt-PT][Simplificar] Depois é que + Verbo → Depois + Verbo" type='style' tone_tags="objective">
-    <pattern>
-        <token postag='RM|RG' postag_regexp='yes'/>
-        <marker>
-            <token>depois</token>
-            <token>é</token>
-            <token skip='4'>que</token>
-        </marker>
-        <token postag='V.+' postag_regexp='yes'/>
-    </pattern>
-    <message>&simplify_msg;</message>
-    <suggestion>\2</suggestion>
-    <example correction="depois">Estava a fazer exercício e só <marker>depois é que</marker> li o texto dela.</example>
-    <example correction="depois">Estava a fazer exercício e apenas <marker>depois é que</marker> eu li o texto dela.</example>
-    <example correction="depois">Estava a fazer exercício e somente <marker>depois é que</marker> o Rui leu o texto dela.</example>
-</rule>
+      <rule id='DEPOIS_É_QUE_VERBO_DEPOIS_VERBO_PT_PT' name="[pt-PT][Simplificar] Depois é que → depois" type='style' tone_tags='objective'>
+          <!-- ChatGPT 5 and new disambiguator for 2026+ -->
+          <pattern>
+              <token regexp='yes'>só|apenas|somente</token>
+              <marker>
+                  <token>depois</token>
+                  <token>é</token>
+                  <token skip='3'>que</token>
+              </marker>
+              <token postag='V.+' postag_regexp='yes'/>
+          </pattern>
+          <message>&simplify_msg;</message>
+          <suggestion>\2</suggestion>
+          <example correction="depois">Estava a fazer exercício e só <marker>depois é que</marker> li o texto dela.</example>
+          <example correction="depois">Estava a fazer exercício e apenas <marker>depois é que</marker> eu li o texto dela.</example>
+          <example correction="depois">Estava a fazer exercício e somente <marker>depois é que</marker> o Rui leu o texto dela.</example>
+      </rule>
 
 
     <rulegroup id='SIMPLIFICAR_E_ESTAS_ESTES_QUE_PT_PT' name="[pt-PT][Simplificar] E est(a/e)(s) → que" type='style'>


### PR DESCRIPTION
Made the rule stricter, with only the three possible words before the “depois” word that allow the suggestion without removing the emphasis.

Also skip is now =3 which makes the rule stricter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Portuguese language style rule to better detect phrase patterns eligible for simplification, including additional variants with intensity qualifiers. Now provides consistent and improved grammar suggestions for Portuguese speakers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->