### PR TITLE
[pt] Add antipattern and new rule for clictic pronouns

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -2847,7 +2847,7 @@ USA
       </rule>
   </rulegroup>
 
-<rule id="CLITIC_AS_SUBJECT_TE_SER" name="[pt-PT] te → tu (sujeito)">
+<rule id="CLITIC_AS_SUBJECT_TE_SER" name="[pt-PT] te → tu (sujeito)" default="temp_off">
   <pattern>
     <token postag="SENT_START" postag_regexp="no"/>
     <marker>
@@ -2860,7 +2860,7 @@ USA
   <example correction="Tu"> <marker>Te</marker> és muito inteligente.</example>
 </rule>
 
-<rule id="CLITIC_AS_SUBJECT_ME_SER" name="[pt-PT] me → eu (sujeito)">
+<rule id="CLITIC_AS_SUBJECT_ME_SER" name="[pt-PT] me → eu (sujeito)" default="temp_off">
   <pattern>
     <token postag="SENT_START" postag_regexp="no"/>
     <marker>


### PR DESCRIPTION
VERBO_HIFENIZADOR_VERBOS_2: added 2 antipatterns
VERBO_PRONOME_PESSOAL_VERB: added antipattern

CLITIC_AS_SUBJECT_ME_SER/CLITIC_AS_SUBJECT_TE_SER: added 2 rule patterns for correction of pronouns 'me/te' to 'eu/tu'



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two Portuguese (PT-PT) grammar checks to improve detection and correction of clitic-as-subject errors, enhancing grammar suggestions and examples:
    * Detects use of "te" as a subject and suggests replacing it with "tu".
    * Detects use of "me" as a subject and suggests replacing it with "eu".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->