### PR TITLE
[pt] More verbs/nouns fixes in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -5693,6 +5693,34 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
   </rulegroup>
 
+  <rule id="SPS00_DP_NC_VMN0000_20260105_RARE" name="This word is NOT A NOUN, but an INFINITIVE">
+    <pattern>
+      <token postag='SPS00'/>
+      <token postag='[DP].+' postag_regexp='yes'/>
+      <token min='0' max='1' postag='N.+|AQ.+' postag_regexp='yes'><exception postag_regexp='yes' postag='V.+'/></token>
+      <token postag='N.+|AQ.+' postag_regexp='yes'>
+        <exception postag_regexp='yes' postag='V.+'/>
+        <exception scope='next' postag_regexp='yes' postag='AQ.+'/></token>
+      <marker>
+        <and>
+          <token postag='VMN0000'><exception scope='next' postag='CS'/></token>
+          <token postag='NC.+' postag_regexp='yes'><exception scope='next' postag='CS'/></token>
+        </and>
+      </marker>
+    </pattern>
+    <disambig action="remove" postag="N.*"/>
+    <!--
+    Examples:
+             Para uma experiência ser considerada rigorosa nas ciências humanas, leva-se muito em conta o fator da aleatoriedade.
+             O fato de o transporte coletivo ser um dos principais problemas estruturais do país reforça tudo isso.
+             Está na hora de o Congresso olhar e falar: “olha, adia (as eleições)”.
+             (Não há nada de errado em uma mulher querer ser mãe nessa idade e em um relacionamento estável.)
+             Se durante o negócio sentir demoras agradeço que me contacte e aguarde antes de dar feedbacks disparatados.
+             Após o incenso ser queimado, coloque as cinzas em um vaso pequeno com com terra.
+             É difícil para os estudantes estrangeiros falar bem o inglês.
+      -->
+  </rule>
+
   <rule id="PORTA_HIFEN_SUBSTANTIVOPLURAL" name="Remove verbs in porta-Substantivo_Plural">
     <pattern>
       <marker>


### PR DESCRIPTION
More verbs/nouns fixes in disambiguator.

In this case, it removes the noun tag from infinitive verbs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Portuguese language disambiguation to better distinguish infinitive verbs from nouns in specific grammatical contexts, improving accuracy of language analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->