### PR TITLE
[pt] Added AP to rule ID:FRAGMENT_TWO_PREPOSITIONS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -15359,8 +15359,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
         <rulegroup id='FRAGMENT_TWO_PREPOSITIONS' name="Fragmento: duas preposições seguidas">
+
+            <antipattern>
+                <token postag='AQ..S.+|NC.S.+|V.+' postag_regexp='yes'/>
+                <token regexp='yes' case_sensitive='yes'>A|E</token>
+                <token>em</token>
+                <example>Eu tirei A em francês.</example>
+                <example>Tom tirou A em francês.</example>
+                <example>A equação A em matemática.</example>
+                <example>A curva E em matemática.</example>
+            </antipattern>
+
             <rule>
-                <!-- Created by Tiago F. Santos, Portuguese rule, 2017-07-15	-->
+                <!-- Created by Tiago F. Santos, Portuguese rule, 2017-07-15 -->
                 <antipattern><!-- XXX Better handled by CONFUSION_POR rule -->
                     <token>de</token>
                     <token>por</token>


### PR DESCRIPTION
An antipattern to fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Portuguese grammar rule to detect consecutive prepositions "a" or "e" immediately followed by "em"—a common grammatical error. This enhancement helps users identify and correct such mistakes to improve their Portuguese writing quality and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->