### PR TITLE
[es] Fix false positives in sentences with medical contexts

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -4090,11 +4090,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <url>https://languagetool.org/insights/es/publicacion/cuando-lleva-tilde-que/</url>
             <!-- TODO: y si no que otros tratamientos deberia consultar. -->
             <antipattern>
-                <token>que</token>
-                <token postag="NC.*|AQ.*" postag_regexp="yes"/>
-                <token postag="DA.*|DI.*|DP.*|DD.*" postag_regexp="yes"/>
-            </antipattern>
-            <antipattern>
                 <token regexp="yes">salvo|siempre|desde|sino|tal|algo</token>
                 <token>que</token>
             </antipattern>
@@ -6647,13 +6642,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             </rule>
         </rulegroup>
         <rulegroup id="SUBJUNTIVO_INCORRECTO" name="verbo en modo subjuntivo incorrecto">
-            <antipattern>
-                <token postag="NC.*" postag_regexp="yes" skip="3"/>
-                <token>blandas</token>
-                <token>y</token>
-                <token postag="VMP.*" postag_regexp="yes"/>
-                <example>Placas de ateroma blandas y calcificadas en aorta abdominal e ilíacas.</example>
-            </antipattern>
             <antipattern>
                 <token postag="_english_ignore_"/>
                 <token postag="_english_ignore_"/>


### PR DESCRIPTION
PREP_VERB: added antipattern, since meso exists as maculine noun 
QUE_TILDE2: added antipattern when 'que' is relative pronoun
SE_CREO2: added antipattern, when radio is a noun
SUBJUNTIVO_INCORRECTO: added antipattern, since blanda – is medical adjective, NOT verb 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Spanish grammar checking: added targeted detection and correction suggestions for mistaken "se creó/creo" constructions, enhancing recognition of incorrect reflexive+past-participle forms and offering proper accentuation guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->