### PR TITLE
[pt] Major rare verbs/nouns fix in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4003,7 +4003,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
   <rule id="SÃO_VERB_20260115" name="In this case SÃO is VMIP3P0">
     <pattern>
-      <token postag='(SPS00:)?[DP].+' postag_regexp='yes'/>
+      <token postag='AQ..P.+|NC.P.+|(SPS00:)?[DP].+' postag_regexp='yes'/>
       <token postag='AQ..P.+|NC.P.+' postag_regexp='yes'/>
       <marker>
         <and>
@@ -4024,6 +4024,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
              Os rodízios são referidos coletivamente como rodízios móveis e rodízios fixos.
              Mas a ideia que tentam passar para fora é a de que as pessoas são mal-educadas.
              Quantos informáticos são precisos para mudar uma lâmpada?
+             Passeios de barco e atrações musicais são oferecidos à beira do rio.
+             As fundações públicas são denominadas pela doutrina brasileira especializada como fundações governamentais.
+             Murphy é rapidamente declarado morto e seus restos mortais são escolhidos para o programa RoboCop.
     -->
   </rule>
 


### PR DESCRIPTION
This commit fixes the verb “são” appearing as both verb and noun.

I used a postag instead of “são” just in case there is another similar verb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese grammar checking by adding disambiguation that better recognizes "são" as a verb in multi-token contexts, reducing misclassifications and false positives and providing clearer suggestions (includes inline examples).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->