### PR TITLE
[pt-PT] Added formal rule:TER_REUNIDAS_CONDIÇÕES_PARA

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -2301,6 +2301,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
       <rulegroup id='TER_REUNIDAS_CONDIÇÕES_PARA' name="[pt-PT][Formal] não 'ter' condições para → 'ver reunidas'" tone_tags='formal' default='temp_off'>
+          <!-- ChatGPT 5 and new disambiguator for 2026+ -->
           <rule>
               <pattern>
                   <token>não</token>
@@ -2322,7 +2323,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                   <token>não</token>
                   <marker>
                       <token inflected='yes'>ter</token>
-                      <token postag='RG' postag_regexp='no'/>
+                      <token regexp='yes'>mais|já|nunca</token>
                   </marker>
                   <token min='0' max='1'>as</token>
                   <token>condições</token>


### PR DESCRIPTION
Added a formal rule for European Portuguese.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Portuguese (Portugal) style rule that detects the phrase pattern "não ter condições para ..." and suggests the more formal alternative "não vejo reunidas as condições para ...".
  * Includes two detection variants to improve coverage of common inflected verbs and phrasing, providing tailored messages, suggested replacements, and examples to guide formal writing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->