### PR TITLE
[pt] Remove default=temp_off

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -2858,7 +2858,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
   </rulegroup>
 
-<rule id="CLITIC_AS_SUBJECT_TE_SER" name="[pt-PT] te → tu (sujeito)" default="temp_off">
+<rule id="CLITIC_AS_SUBJECT_TE_SER" name="[pt-PT] te → tu (sujeito)">
   <pattern>
     <token postag="SENT_START" postag_regexp="no"/>
     <marker>
@@ -2871,7 +2871,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   <example correction="Tu"> <marker>Te</marker> és muito inteligente.</example>
 </rule>
 
-<rule id="CLITIC_AS_SUBJECT_ME_SER" name="[pt-PT] me → eu (sujeito)" default="temp_off">
+<rule id="CLITIC_AS_SUBJECT_ME_SER" name="[pt-PT] me → eu (sujeito)">
   <pattern>
     <token postag="SENT_START" postag_regexp="no"/>
     <marker>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Activated two Portuguese (pt-PT) grammar checking rules now enabled by default: subject clitic pronoun corrections for te → tu and me → eu. These rules enhance grammar checking by detecting common subject pronoun errors in Portuguese text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->