### PR TITLE
[pt] Fix for verb "há" in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4030,6 +4030,31 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     -->
   </rule>
 
+  <rule id="HÁ_VERB_20260116" name="In this case HÁ is VMIP3S0">
+    <pattern>
+      <marker>
+        <and>
+          <token>há</token>
+          <token postag='VMIP3S0|VMM02S0' postag_regexp='yes'/>
+        </and>
+      </marker>
+      <token postag='Z0.+|NC.+|AQ.+' postag_regexp='yes'/>
+    </pattern>
+    <disambig action="filter" postag="VMIP3S0"/>
+    <!--
+    Examples:
+             Aos meus Pais e Irmão que me toleram há 52 anos.
+             Há dois obstáculos a se evitar : a rigidez e a moleza.
+             Há controvérsia relativa à grafia correta do termo, bem como de seu plural.
+             Há duas formas de bater para cada dupla.
+             Há uma variação considerável na magnitude dos riscos dependendo do local da mutação no gene.
+             Não há artigos.
+             A probabilidade de sobreviver é recalculada somente nos intervalos em que há morte.
+             «Há 25 anos, Steffi Graf tocava o céu com sua raquete».
+             Há uma lacuna nos registros quando ele viveu em Paris, já que os irmãos moravam juntos.
+    -->
+  </rule>
+
   <rule id="NP_UNKNOWN_VMIP3S0_VMM02S0_20251127" name="It is VMIP3S0">
     <!-- ChatGPT 5 -->
     <pattern>


### PR DESCRIPTION
Fix for postag of verb "há" in disambiguator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved Portuguese grammar detection for the verb "há" to enhance language checking accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->