### PR TITLE
[pt-PT] Added AP rule:AO45_CARDINAL_POINTS_CASING

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -4360,6 +4360,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
 <rulegroup id='AO45_CARDINAL_POINTS_CASING' type='grammar' name='[pt-PT][AO45] Capitalização de Pontos Cardeais'>
+
+              <antipattern>
+                  <token>que</token>
+                  <token regexp='yes' case_sensitive='yes'>l?este|oriente</token>
+                  <token postag='RM|[DP].+' postag_regexp='yes'/>
+                  <example>Inexistência de um objetivo global que oriente coletivamente o movimento.</example>
+                  <example>Havia um livro que leste realmente.</example>
+                  <example>Tu o saberás; enquanto isso, roguemos a Deus que oriente nossos atos e decisões no sentido da glória de seu nome.</example>
+              </antipattern>
+
     <rule>
         <pattern case_sensitive='yes'>
             <marker>


### PR DESCRIPTION
An antipattern to fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved European Portuguese grammar checking for cardinal direction capitalization errors. The validation rule now accurately detects additional cases of incorrect capitalization with directional terms. This enhancement catches more instances where cardinal directions are improperly capitalized in specific grammatical structures and sentence contexts that were previously undetected by the grammar system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->