### PR TITLE
[pt] Fixed FPs in rule:CONFUSÃO_TEM_TÊM

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -35187,7 +35187,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <!-- Later expand also to "(SPS00:)?" -->
             <antipattern>
                 <token postag='[DP]...[NS].+' postag_regexp='yes'><exception postag='CS|CC|RG|PD0NN000' postag_regexp='yes'/></token>
-                <token min='0' max='1' postag='SPS00' postag_regexp='no'/>
+                <token min='0' max='1' postag='SPS0.+' postag_regexp='yes'/>
                 <token postag='[DP]...P.+' postag_regexp='yes'/>
                 <token min='0' max='1' postag='RN|RG|RM' postag_regexp='yes'/>
                 <token>tem</token>
@@ -35197,6 +35197,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>Nenhum de nós tem razão.</example>
                 <example>Você os tem visto?</example>
                 <example>Algum de vocês tem um lápis?</example>
+                <example>Ninguém dentre nós tem o direito de estar envaidecido, porque a nossa força não é o mérito de qualquer de nós.</example>
+                <example>É um ponto cruzado oblíquo composto por duas meias cruzes, uma das quais tem o dobro do comprimento da outra.</example>
             </antipattern>
 
             <antipattern>


### PR DESCRIPTION
Fixed false positives in rule by improving antipattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive rules for Portuguese punctuation spacing and quotation formatting.
  * Extended support for abbreviations, proper nouns, and technical terminology handling.
  * Added rules for date formatting and mathematical notation.

* **Bug Fixes**
  * Refined spacing rules around punctuation, hyphens, and ellipses.
  * Improved pattern matching for complex typographical expressions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->