### PR TITLE
Added proper names to spelling_global.txt

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/resource/spelling_global.txt
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/spelling_global.txt
@@ -29473,9 +29473,7 @@ Poole
 Washburn
 Springer
 Hillier
-Aurélio
 Universidade Europeia
-Academia Militar
 Bergström
 Eddie
 Anderson


### PR DESCRIPTION
Proper names plus two universities/schools:
Universidade Europeia=international university
Academia Militar=military school or whatever, which should be written the same way in other Latin countries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the global spell-check dictionary with many additional proper nouns, brand and place names, and person names to reduce false positives and improve recognition across languages—resulting in fewer incorrect suggestions and more accurate validation for names and specialized terms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->