### PR TITLE
[pt] Enabled rule:PRESO_RETIDO_V2

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -4077,7 +4077,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='PRESO_RETIDO_V2' name="Preso → retido" tone_tags='formal' default='temp_off'>
+        <rule id='PRESO_RETIDO_V2' name="Preso → retido" tone_tags='formal'>
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <pattern>
                 <token postag='SENT_START|_PUNCT|V.+' postag_regexp='yes'><exception regexp='no' inflected='yes'>ser</exception></token> <!-- Só dispara com verbos típicos de estado (não com "ser" na passiva: foram presos...) -->


### PR DESCRIPTION
Enabled rule after checking nightly diffs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled a Portuguese grammar rule that now actively checks and suggests more formal word choices to improve document style in Portuguese text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->