### PR TITLE
[pt] Added formal rule:FAZER_PROCEDER

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3792,9 +3792,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
 
             <pattern>
-                <token postag='RG|V.+' postag_regexp='yes'>
+                <token postag='RG|V.+|SENT_START|_PUNCT' postag_regexp='yes'>
                     <exception inflected='yes'>ter</exception>
-                    <exception regexp='yes'>foi|foram|eram?</exception></token>
+                    <exception regexp='yes'>foi|foram|era|eram|sido</exception></token>
                 <token min='0' max='1' postag='PP.+' postag_regexp='yes'/> <!-- "eu", "tu", "ele", "você", etc. -->
                 <marker>
                     <token inflected='yes'>fazer</token>


### PR DESCRIPTION
Added a formal rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Portuguese style rule that suggests more formal alternatives—e.g., replacing casual "fazer" constructions (like "fazer o") with "proceder a"/"proceder à" in administrative/formal contexts. The rule is conservative and inactive by default; examples and suggestions are included to reduce false positives.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->