### PR TITLE
[pt] Enabled rule:SOBRE_QUAL_QUAIS_INFLACIONADO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3831,9 +3831,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='SOBRE_QUAL_QUAIS_INFLACIONADO' name="Construção 'sobre qual/quais' inflacionada" type='style' tone_tags='formal' default='temp_off'>
+        <rulegroup id='SOBRE_QUAL_QUAIS_INFLACIONADO' name="Construção 'sobre qual/quais' inflacionada" type='style' tone_tags='formal'>
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
-
 
             <rule> <!-- #1: Comparativos/superlativos irregulares (adjetivos) -->
                 <pattern>


### PR DESCRIPTION
Enabled the rule!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled a Portuguese style rule for "sobre qual/quais" grammar constructions by default, ensuring this style check is now active in the Portuguese language module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->