### PR TITLE
[pt] Enabled rule:AO_PONTO_DE_INF

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -4237,7 +4237,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- "ao ponto de" + infinitivo -> quase sempre deveria ser "a ponto de" -->
-        <rule id="AO_PONTO_DE_INF" name="Ao ponto de + infinitivo" default='temp_off'>
+        <rule id="AO_PONTO_DE_INF" name="Ao ponto de + infinitivo">
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <pattern>
                 <token regexp='yes' inflected='yes'>estar|ficar|andar|ser|tornar|encontrar|permanecer</token>


### PR DESCRIPTION
Enabled the rule after checking the nightly diffs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Activated Portuguese grammar rule for "Ao ponto de + infinitivo" phrase checking. This rule will now actively identify potentially ambiguous or incorrect usage of this common Portuguese expression and recommend the grammatically correct form, helping catch subtle grammar mistakes in Portuguese writing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->