### PR TITLE
[pt-PT] Enabled rule:TER_QUE_DE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -2383,7 +2383,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-      <rule id='TER_QUE_DE' name="[pt-PT][Formal] Ter 'que' infinitivo → 'de'" tone_tags='formal' default='temp_off'>
+      <rule id='TER_QUE_DE' name="[pt-PT][Formal] Ter 'que' infinitivo → 'de'" tone_tags='formal'>
           <!-- ChatGPT 5 and new disambiguator for 2026+ -->
           <pattern>
               <token inflected='yes'>ter</token>


### PR DESCRIPTION
Enabled the rule after checking the nightly diffs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Portuguese (PT-PT) formal grammar rule for "Ter 'que' infinitivo → 'de'" pattern is now enabled by default. Users will automatically receive style-checking feedback and suggestions to help maintain consistent formal writing conventions, improve document quality, enhance communication clarity, and ensure professional presentation in formal writing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->