### PR TITLE
[pt] Added AP to rule:HOMONYM_VIAGEM_2

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -31411,6 +31411,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </rule>
             <rule id='HOMONYM_VIAGEM_2' name='Homófona: viagem - viajem'>
                 <antipattern>
+                    <token postag='CS' postag_regexp='no'/>
+                    <token>viagem</token>
+                    <token postag='V.+|NC.+|AQ.+' postag_regexp='yes'/>
+                    <example>Que viagem é essa?</example>
+                    <example>Que viagem agradável nós tivemos!</example>
+                </antipattern>
+                <antipattern>
                     <token postag='(?:A|D|SP|V).+|_PUNCT' postag_regexp='yes'/>
                     <token min="0" regexp="yes">["'“‘«]</token>
                     <token>viagem</token>


### PR DESCRIPTION
Added an antipattern to fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Portuguese homophone detection for "viagem" vs "viajem," with automated correction suggestions to help users identify and fix this common mistake in grammar checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->