### PR TITLE
[pt-PT] Improved and no more FPs in rule:CICLO_VICIOSO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -119,7 +119,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id='CICLO_VICIOSO' name="[pt-PT] Calinada: 'cíclo' vicioso → 'círculo'" tone_tags='objective'>
+    <rule id='CICLO_VICIOSO' name="[pt-PT] Calinada: 'ciclo' vicioso → 'círculo'" tone_tags='objective'>
        <!-- ChatGPT 5 and new disambiguator for 2026+ -->
        <pattern>
             <marker>


### PR DESCRIPTION
Made the rule more flexible, and now it gives no false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved Portuguese guidance for "círculo vicioso" with clearer, more objective wording and a revised rule name for clarity.
  * Enhanced detection of word variations and surrounding context to reduce false positives.
  * Updated examples (including a new example) and suggestions to better reflect preferred phrasing.
  * Adjusted suggestion behavior to ensure corrections consider skipped or intervening words.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->