### PR TITLE
[pt-PT] Replaced [pt-PT] with the Portuguese flag emoji in rules

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -111,8 +111,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- Unification rules retrieved from galician grammar.xml - END  -->
 
 
-    <category id="EUROPEAN_PORTUGUESE_PT_PT" name="[pt-PT] Português de Portugal">
-        <rule id='A_APRENDIZ' name="[pt-PT] Concordância: Variação (p.ex. juiz/juíza)">
+    <category id="EUROPEAN_PORTUGUESE_PT_PT" name="🇵🇹 Português de Portugal">
+        <rule id='A_APRENDIZ' name="🇵🇹 Concordância: Variação (p.ex. juiz/juíza)">
         <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
                 <token negate_pos="yes" postag="VMP.+|N.+|AQ.+" postag_regexp="yes"/>
@@ -132,7 +132,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
         <!-- DAR NA VISTA das nas vistas -->
         <!--      Created by Marco A.G.Pinto, Portuguese rule 2020-10-26 (21-OCT-2020+)     -->
-        <rule id='DAR_NA_VISTA' name="[pt-PT] Dar nas vistas">
+        <rule id='DAR_NA_VISTA' name="🇵🇹 Dar nas vistas">
             <pattern>
                 <token inflected='yes'>dar</token>
                 <marker>
@@ -145,7 +145,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id="ARTICLES_PRECEDING_LOCATIONS" name="[pt-PT] Nomes geográficos que requerem artigo">
+        <rulegroup id="ARTICLES_PRECEDING_LOCATIONS" name="🇵🇹 Nomes geográficos que requerem artigo">
             <!-- Based on Catalan grammar.xml by Tiago F. Santos,  2017-09-05      -->
             <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/toponimos-com-ou-sem-artigo/24569</url>
             <!--
@@ -397,7 +397,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
   <!-- ME DISSE Disse-me / ME DISSERAM Disseram-me / TE PODERIA Poder-te-ia / NOS PODERIAM Poder-nos-iam -->
-  <rulegroup id='PROCLISE_COMECO_FRASE' name="[pt-PT] Próclise começo frase">
+  <rulegroup id='PROCLISE_COMECO_FRASE' name="🇵🇹 Próclise começo frase">
       <!--      Created by Ricardo Joseh Lima and improved by Marco A.G.Pinto, Portuguese rule 2021-11-25 + 2021-12-02 (25-JUN-2021+)      -->
       <!--
           Me disse que ele veio. → Disse-me que ele veio.
@@ -567,7 +567,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
   </rulegroup>
 
-  <rule id="ACEITO_ACEITE" name="[pt-PT] aceito → aceite" >
+  <rule id="ACEITO_ACEITE" name="🇵🇹 aceito → aceite" >
       <pattern>
           <token regexp='yes' inflected='yes'>ser|estar|ficar|permanecer|parecer
           <exception>seres</exception></token>
@@ -583,7 +583,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   </rule>
 
 
-  <rule id="EFEITO_ESTUFA" name="[pt-PT] Hifenização: Efeito-estufa">
+  <rule id="EFEITO_ESTUFA" name="🇵🇹 Hifenização: Efeito-estufa">
       <!-- Created by Marco A.G.Pinto, Portuguese rule, 2017-01-25 -->
       <pattern>
           <token regexp='yes'>efeitos?</token>
@@ -597,7 +597,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <example correction="efeito de estufa|efeito estufa">O calor deve-se ao <marker>efeito-estufa</marker>.</example><!-- TODO Confirm if this is a case of AO changes. VOP (AO90) has 'efeito de estufa'. Verify per-AO. -->
   </rule>
 
-  <rulegroup id='INVARIABLE_NOUNS' name="[pt-PT] Substantivos invariáveis">
+  <rulegroup id='INVARIABLE_NOUNS' name="🇵🇹 Substantivos invariáveis">
       <!-- Created by Tiago F. Santos, Portuguese rule, 2017-06-18 -->
       <short>Expressão invariável</short>
       <rule>
@@ -800,7 +800,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-      <rule id='INVARIABLE_NOUNS_ÀS_CUSTAS_DA_DAS_DO_DOS' name="[pt-PT][Confusão] 'às custas'/'à custa'">
+      <rule id='INVARIABLE_NOUNS_ÀS_CUSTAS_DA_DAS_DO_DOS' name="🇵🇹[Confusão] 'às custas'/'à custa'">
       <!-- Created by Marco A.G.Pinto, Portuguese rule 2022-09-20 (Checked/Enhanced) (25-JUL-2022+) -->
           <pattern>
               <marker>
@@ -817,7 +817,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-      <rule id='INVARIABLE_NOUNS_POR_MOMENTO_POR_MOMENTOS' name="[pt-PT] 'por momento'/'por momentos'">
+      <rule id='INVARIABLE_NOUNS_POR_MOMENTO_POR_MOMENTOS' name="🇵🇹 'por momento'/'por momentos'">
           <pattern>
               <marker>
                   <token>por</token>
@@ -835,7 +835,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
   <!-- MEIO CHEIA meio-cheia -->
-  <rule id='MEIO_ADJETIVO_HÍFEN_PT_PT' name="[pt-PT] Hifenizar 'meio' + adjetivo">
+  <rule id='MEIO_ADJETIVO_HÍFEN_PT_PT' name="🇵🇹 Hifenizar 'meio' + adjetivo">
       <!-- Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2022-11-11 (25-JUL-2022+) -->
       <!--
           A garrafa está meio cheia. → A garrafa está meio-cheia.
@@ -857,7 +857,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   </rule>
 
 
-  <rule id='PHRASAL_VERB_RESIDIR_EM' name='[pt-PT] Regência verbal: Residir em'>
+  <rule id='PHRASAL_VERB_RESIDIR_EM' name='🇵🇹 Regência verbal: Residir em'>
       <!--      Created by Tiago F. Santos, 2018-09-19      -->
       <!--antipattern>
           <token regexp='yes'>residentes?|morador(?:es)?</token>
@@ -922,7 +922,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   </rule>
 
 
-  <rulegroup id="POSSESSIVE_WITHOUT_ARTICLE" name="[pt-PT] Determinante possessivo sem artigo">
+  <rulegroup id="POSSESSIVE_WITHOUT_ARTICLE" name="🇵🇹 Determinante possessivo sem artigo">
       <!-- Improved by Tiago F. Santos, Portuguese rule, 2016-10-18 -->
       <!--     Base rule id="A_SUA" name="a sua" by Marco Pinto -->
       <!--
@@ -1701,7 +1701,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   </rulegroup>
 
 
-  <rule id='SEQUER_WITHOUT_NEGATIVE' name='[pt-PT] Sequer sem negativa'>
+  <rule id='SEQUER_WITHOUT_NEGATIVE' name='🇵🇹 Sequer sem negativa'>
       <!--      Created by Tiago F. Santos, 2017-03-05      -->
       <antipattern>
           <token regexp='yes' skip='-1'>&negacoes;</token>
@@ -1724,7 +1724,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id='TODOS_FOLLOWED_BY_NOUN_SINGULAR' name="[pt-PT] Expressão: Todo + 'nome sem artigo'">
+    <rule id='TODOS_FOLLOWED_BY_NOUN_SINGULAR' name="🇵🇹 Expressão: Todo + 'nome sem artigo'">
         <!-- FIXME: too many matches -->
         <!-- Created by Tiago F. Santos, 2017-10-12 -->
         <antipattern>
@@ -1769,7 +1769,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </rule>
 
 
-<rule id="VERBO_GENERAL_VERB_AGREEMENT_ERRORS_PT" name="[pt-PT] Erro de concordância verbal">
+<rule id="VERBO_GENERAL_VERB_AGREEMENT_ERRORS_PT" name="🇵🇹 Erro de concordância verbal">
     <antipattern>
         <token regexp='yes' case_sensitive='yes'>e|ou</token>
         <token>tu</token>
@@ -1787,7 +1787,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </rule>
 
 
-<rulegroup id='VERBO_HIFENIZADOR_VERBOS_1' name='[pt-PT] Colocações pronominais: mesóclise'>
+<rulegroup id='VERBO_HIFENIZADOR_VERBOS_1' name='🇵🇹 Colocações pronominais: mesóclise'>
     <!-- Created by Tiago F. Santos , Portuguese rule, 2016-11-04 -->
     <url>https://pt.wikipedia.org/wiki/Coloca%C3%A7%C3%A3o_pronominal</url>
     <short>Erro de colocação pronominal</short>
@@ -1815,7 +1815,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </rulegroup>
 
 
-<rulegroup id='VERBO_HIFENIZADOR_VERBOS_2' name='[pt-PT] Colocações pronominais dois termos'>
+<rulegroup id='VERBO_HIFENIZADOR_VERBOS_2' name='🇵🇹 Colocações pronominais dois termos'>
     <!-- Created by Tiago F. Santos , Portuguese rule, 2016-11-04 -->
     <!-- Brazilian Portuguese has some inverted colocations  -->
     <!--
@@ -2858,7 +2858,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
   </rulegroup>
 
-<rule id="CLITIC_AS_SUBJECT_TE_SER" name="[pt-PT] te → tu (sujeito)">
+<rule id="CLITIC_AS_SUBJECT_TE_SER" name="🇵🇹 te → tu (sujeito)">
   <pattern>
     <token postag="SENT_START" postag_regexp="no"/>
     <marker>
@@ -2871,7 +2871,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   <example correction="Tu"> <marker>Te</marker> és muito inteligente.</example>
 </rule>
 
-<rule id="CLITIC_AS_SUBJECT_ME_SER" name="[pt-PT] me → eu (sujeito)">
+<rule id="CLITIC_AS_SUBJECT_ME_SER" name="🇵🇹 me → eu (sujeito)">
   <pattern>
     <token postag="SENT_START" postag_regexp="no"/>
     <marker>
@@ -2886,7 +2886,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
   <!-- LHE(S)/TE/VOS + VERB verb-lhe(s)/me/te/vos -->
-  <rule id='VERBO_PRONOME_PESSOAL_VERB' name="[pt-PT] Pron. Pessoal + Verbo → Verbo + - + Pron. Pessoal">
+  <rule id='VERBO_PRONOME_PESSOAL_VERB' name="🇵🇹 Pron. Pessoal + Verbo → Verbo + - + Pron. Pessoal">
       <!-- Created by Marco A.G.Pinto, Portuguese rule 2022-09-19 (Checked/Enhanced) (25-JUL-2022+) -->
       <!--
           Lhe amo muito. → Amo-lhe muito.
@@ -2945,7 +2945,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rulegroup id='PRECISAR_DE_PT_PT_V2' name="[pt-PT] Verbo precisar de">
+    <rulegroup id='PRECISAR_DE_PT_PT_V2' name="🇵🇹 Verbo precisar de">
         <!-- ChatGPT 5 and new disambiguator for 2026+ -->
 
         <antipattern> <!-- Verb "ser"/"estar" -->
@@ -3021,7 +3021,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-    <rule id="ZERO_MEDIDA_SINGULAR" name="[pt-PT] Concordância de número: 'zero grau'">
+    <rule id="ZERO_MEDIDA_SINGULAR" name="🇵🇹 Concordância de número: 'zero grau'">
         <!-- Created by Tiago F. Santos, Portuguese rule, 2017-09-23 -->
 
         <!-- MARCOAGPINTO 2022-09-21 (Checked/Enhanced) (25-JUL-2022+) *START* -->
@@ -3065,7 +3065,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <example>Assim, com a divisão de valores mais próximos do zero, o resultado será o zero absoluto.</example>
         <example>Teoricamente, ao cessar a agitação térmica das moléculas a pressão é nula, e atinge-se o zero absoluto.</example>
     </rule>
-    <rule id='DAÍ' name="[pt-PT] Contração: de aí">
+    <rule id='DAÍ' name="🇵🇹 Contração: de aí">
         <!-- Created by Marco A.G. Pinto, Portuguese rule -->
         <pattern>
             <marker>
@@ -3079,7 +3079,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
     <!-- TROCAS-TE trocaste -->
-    <rulegroup id='HIFEN_INTRUSIVO' name="[pt-PT] Verbo com hífen intrusivo">
+    <rulegroup id='HIFEN_INTRUSIVO' name="🇵🇹 Verbo com hífen intrusivo">
         <!--      Created by Marco A.G.Pinto, Portuguese rule 2021-03-30 + 2021-03-31 + 2021-05-31 (17-MAR-2021+)      -->
         <rule>
             <!--
@@ -3121,7 +3121,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
     </rulegroup>
 
-    <rulegroup id='REFLEXIVO_CONJUNTIVO' name='[pt-PT] Confusão de Tempo Verbal: Conjuntivo - Reflexivo' default='off'><!-- XXX rethink rule. too many false positives -->
+    <rulegroup id='REFLEXIVO_CONJUNTIVO' name='🇵🇹 Confusão de Tempo Verbal: Conjuntivo - Reflexivo' default='off'><!-- XXX rethink rule. too many false positives -->
         <!-- Created by Tiago F. Santos, 2017-08-25 -->
         <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/as-formas-verbais-com-sse-ou-com--se/11603</url>
         <rule>
@@ -3174,10 +3174,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </category>
 
 
-<category id="CONTRACTIONS_PT_PT" name="[pt-PT] Contrações">
+<category id="CONTRACTIONS_PT_PT" name="🇵🇹 Contrações">
 
 
-    <rulegroup type='grammar' id="CONTRAÇÕES_2_PT_PT" name="[pt-PT] Contrações" default='on'>
+    <rulegroup type='grammar' id="CONTRAÇÕES_2_PT_PT" name="🇵🇹 Contrações" default='on'>
         <!-- Created by Tiago F. Santos, Portuguese rule, 2016-10-31 -->
         <!-- XXX Default off to avoid alarm fatigue. Reactivate when there is a color code/custom highlight system working on LibreOffice -->
         <url>https://pt.wiktionary.org/wiki/Ap%C3%AAndice:Combina%C3%A7%C3%B5es_e_contra%C3%A7%C3%B5es_do_portugu%C3%AAs</url>
@@ -3200,7 +3200,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <token>de</token>
         </antipattern>
 
-        <rule id='CONTRAÇÃO_DOUTREM_PT_PT' name='[pt-PT][Contração] De outro/outrem → doutro/doutrem' default='off'>
+        <rule id='CONTRAÇÃO_DOUTREM_PT_PT' name='🇵🇹[Contração] De outro/outrem → doutro/doutrem' default='off'>
             <pattern>
                 <token>de</token>
                 <token case_sensitive="yes" regexp='yes'>outrem|outr[ao]s?</token>
@@ -3213,7 +3213,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction='doutras'><marker>de outras</marker>.</example>
         </rule>
 
-        <rule id='CONTRAÇÃO_DUM2_PT_PT' name='[pt-PT][Contração] De um(a)(s)/uns → dum(a)(s)/duns' default='off'>
+        <rule id='CONTRAÇÃO_DUM2_PT_PT' name='🇵🇹[Contração] De um(a)(s)/uns → dum(a)(s)/duns' default='off'>
             <pattern>
                 <marker>
                     <token>de</token>
@@ -3229,7 +3229,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction='duns'><marker>de uns</marker> rios.</example>
         </rule>
 
-        <rule id='CONTRAÇÃO_EM_UM_NUM_PT_PT' name='[pt-PT][Contração] Em um(a) → num(a)' default='on'>
+        <rule id='CONTRAÇÃO_EM_UM_NUM_PT_PT' name='🇵🇹[Contração] Em um(a) → num(a)' default='on'>
             <!-- MARCOAGPINTO 2023-02-03 (Checked/Enhanced) (25-JUL-2022+) *START* -->
             <antipattern>
                 <token regexp="no">em</token>
@@ -3262,7 +3262,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-    <rulegroup id='O_FACTO_DA_AÇÃO' name="[pt-PT] Contração: expressão invariável com contração (p.ex. o facto da/de a)" default='off'>
+    <rulegroup id='O_FACTO_DA_AÇÃO' name="🇵🇹 Contração: expressão invariável com contração (p.ex. o facto da/de a)" default='off'>
         <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/preposicao-seguida-de-artigo-definido-sem-contracao/32586</url>
         <!-- Created by Marco A.G. Pinto, Portuguese rule -->
         <rule>
@@ -3313,10 +3313,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   </category>
 
 
-  <category id='REGIONALISMS_PT_PT' name='[pt-PT] Regionalismos'>
+  <category id='REGIONALISMS_PT_PT' name='🇵🇹 Regionalismos'>
 
 
-      <rule id='BRASILEIRISMO_ATERRISAR' name='[pt-PT][Brasileirismo] aterrisar → aterrar'>
+      <rule id='BRASILEIRISMO_ATERRISAR' name='🇵🇹[Brasileirismo] aterrisar → aterrar'>
           <!-- Created by Tiago F. Santos , Portuguese rule, 2017-04-12 -->
           <pattern>
               <token regexp='yes'>aterri(?:z|ss?).+</token>
@@ -3326,7 +3326,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-      <rule id='BRASILEIRISMO_CONTROLO_CONTROLE' name='[pt-PT][Brasileirismo] controle → controlo'>
+      <rule id='BRASILEIRISMO_CONTROLO_CONTROLE' name='🇵🇹[Brasileirismo] controle → controlo'>
           <!-- Created by Marco A.G.Pinto , Portuguese rule -->
           <pattern>
               <token regexp="yes">(?:d|n|outr|pel)?os?|de|(?:alg|d|n)?(?:um|uns)|em</token>
@@ -3340,7 +3340,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-      <rule id='BRASILEIRISMO_CONTROLO_CONTROLE_SOB' name="[pt-PT][Brasileirismo] 'sob controle' → 'sob controlo'">
+      <rule id='BRASILEIRISMO_CONTROLO_CONTROLE_SOB' name="🇵🇹[Brasileirismo] 'sob controle' → 'sob controlo'">
           <!-- Created by Marco A.G.Pinto , Portuguese rule -->
           <pattern>
               <token>sob</token>
@@ -3351,7 +3351,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-      <rule id='BRASILEIRISMO_DECOLAR' name='[pt-PT][Brasileirismo] decolar → descolar'>
+      <rule id='BRASILEIRISMO_DECOLAR' name='🇵🇹[Brasileirismo] decolar → descolar'>
           <!-- Created by Tiago F. Santos , Portuguese rule, 2017-04-12 -->
           <pattern>
               <token regexp='yes'>decol.+</token>
@@ -3361,7 +3361,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-      <rule id="EQUIPES" name="[pt-PT][Brasileirismo] equipes → equipas">
+      <rule id="EQUIPES" name="🇵🇹[Brasileirismo] equipes → equipas">
           <!-- Created by Marco A.G.Pinto , Portuguese rule -->
           <pattern>
               <token regexp="yes">(?:d|n|outr|pel)?[ao]s?|(?:alg|d|n)?(?:um(a|as)?|uns)|em|(?:sua|[nv]ossa|tua)s?</token>
@@ -3375,7 +3375,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-      <rule id='BRASILEIRISMO_EXPERIMENTO' name='[pt-PT][Brasileirismo] experimento → experiência'>
+      <rule id='BRASILEIRISMO_EXPERIMENTO' name='🇵🇹[Brasileirismo] experimento → experiência'>
           <!-- Created by Tiago F. Santos , Portuguese rule, 2017-04-12 -->
           <pattern>
               <token postag="[AD]..M[SP].+" postag_regexp='yes'/>
@@ -3389,7 +3389,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-     <rule id='BRASILEIRISMO_ESTAR_DE_SACO_CHEIO' name="[pt-PT][Brasileirismo] estar 'de saco cheio' → farto/saturado">
+     <rule id='BRASILEIRISMO_ESTAR_DE_SACO_CHEIO' name="🇵🇹[Brasileirismo] estar 'de saco cheio' → farto/saturado">
           <pattern>
               <token skip='2' postag='VM.+' postag_regexp='yes' inflected='yes' regexp='no'>estar</token>
               <marker>
@@ -3410,7 +3410,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-     <rule id='BRASILEIRISMO_MACHUCAR' name="[pt-PT][Brasileirismo] machucar → magoar/aleijar/ferir">
+     <rule id='BRASILEIRISMO_MACHUCAR' name="🇵🇹[Brasileirismo] machucar → magoar/aleijar/ferir">
           <pattern>
               <token inflected='yes' regexp='no'>machucar</token>
           </pattern>
@@ -3422,7 +3422,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-      <rule id='BRASILEIRISMO_PRIVADA' name="[pt-PT][Brasileirismo] 'privada sanitária', 'vaso sanitário' → retrete">
+      <rule id='BRASILEIRISMO_PRIVADA' name="🇵🇹[Brasileirismo] 'privada sanitária', 'vaso sanitário' → retrete">
           <!-- Created by Tiago F. Santos , Portuguese rule, 2017-04-12 -->
           <pattern>
               <token regexp='yes'>privada|vaso</token>
@@ -3434,7 +3434,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-      <rule id='BRASILEIRISMO_REVISAR' name='[pt-PT][Brasileirismo] revisar → rever'>
+      <rule id='BRASILEIRISMO_REVISAR' name='🇵🇹[Brasileirismo] revisar → rever'>
           <!-- Created by Tiago F. Santos , Portuguese rule, 2017-04-12 -->
           <pattern>
               <token inflected='yes'>revisar</token>
@@ -3444,7 +3444,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-      <rule id="BRASILEIRISMO_SOBRADO" name="[pt-PT][Brasileirismo] sobrado → vivenda">
+      <rule id="BRASILEIRISMO_SOBRADO" name="🇵🇹[Brasileirismo] sobrado → vivenda">
           <!-- Created by Tiago F. Santos , Portuguese rule, 2017-04-12 -->
           <pattern>
               <token case_sensitive='yes'>sobrado
@@ -3455,7 +3455,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   </rule>
 
 
-  <rule id='BRASILEIRISMO_TIMES' name='[pt-PT][Brasileirismo] time → equipa'>
+  <rule id='BRASILEIRISMO_TIMES' name='🇵🇹[Brasileirismo] time → equipa'>
       <!-- Created by Tiago F. Santos , Portuguese rule, 2017-04-12 -->
       <antipattern>
           <token regexp='yes'>part|full</token>
@@ -3471,7 +3471,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   </rule>
 
 
-  <rule id='BRASILEIRISMO_XINGAR' name='[pt-PT][Brasileirismo] xingar → gozar'>
+  <rule id='BRASILEIRISMO_XINGAR' name='🇵🇹[Brasileirismo] xingar → gozar'>
       <!-- Created by Tiago F. Santos , Portuguese rule, 2017-04-12 -->
       <pattern case_sensitive='yes'>
           <token regexp='yes'>xing.+</token>
@@ -3482,7 +3482,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   </rule>
 
 
-  <rule id='ZERO_IN_DAYS_OF_THE_MONTH' name="[pt-PT] Datas: zeros nos dias do mês">
+  <rule id='ZERO_IN_DAYS_OF_THE_MONTH' name="🇵🇹 Datas: zeros nos dias do mês">
       <!--       Created by Tiago F. Santos,  2019-09-05      -->
       <pattern>
           <token regexp='yes'>0\d</token>
@@ -3499,10 +3499,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   </category>
 
 
-  <category id="AO90_RULES_PT_PT" name="[pt-PT] Regras do Acordo Ortográfico de 90 (pós-AO90)" type="misspelling" default='on'>
+  <category id="AO90_RULES_PT_PT" name="🇵🇹 Regras do Acordo Ortográfico de 90 (pós-AO90)" type="misspelling" default='on'>
 
 
-      <rulegroup id="AO90_AVÉ_MARIA" name="[pt-PT][AO90] avé/ave Maria">
+      <rulegroup id="AO90_AVÉ_MARIA" name="🇵🇹[AO90] avé/ave Maria">
       <!-- Created by Marco A.G.Pinto, Portuguese rule 2022-08-13 (Checked/Enhanced) (25-JUL-2022+) -->
           <rule>        
               <pattern>
@@ -3531,7 +3531,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rulegroup>
 
 
-      <rule id="AO90_TONIC_SYLLABLES" name="[pt-PT][AO90] Terminações sem acento">
+      <rule id="AO90_TONIC_SYLLABLES" name="🇵🇹[AO90] Terminações sem acento">
           <pattern>
               <token regexp='yes'>.+((?:óid[oae]|óic[oa]|ói[ao])s?)$
               <exception postag_regexp='yes' postag='NP.+'/></token>
@@ -3547,7 +3547,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   </rule>
 
 
-  <rulegroup id='AO90_COMPOUNDS_GENERIC_PREFIX' name='[pt-PT][AO90] Hifenizador de palavras'>
+  <rulegroup id='AO90_COMPOUNDS_GENERIC_PREFIX' name='🇵🇹[AO90] Hifenizador de palavras'>
       <!--            COMPOSTAS DO NOVO ACORDO ORTOGRÁFICO          -->
       <!-- Created by Tiago F. Santos , Portuguese rule, 2016-12-02 -->
       <!--  <url>http://www.portaldalinguaportuguesa.org/INDEX.PHP?action=vop&page=crit1</url>
@@ -3972,7 +3972,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </rulegroup>
 
 
-<rulegroup id='AO90_ACCENTUATED_PREFIXES' name='[pt-PT][AO90] Prefixos acentuados'>
+<rulegroup id='AO90_ACCENTUATED_PREFIXES' name='🇵🇹[AO90] Prefixos acentuados'>
     <!-- Created by Tiago F. Santos , Portuguese rule, 2017-08-15 -->
     <rule>
         <pattern>
@@ -4013,7 +4013,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </rulegroup>
 
 
-<rule id='AO90_HIPHEN_REMOVALS' name='[pt-PT][AO90] Palavras que deixam de ser hifenizadas'>
+<rule id='AO90_HIPHEN_REMOVALS' name='🇵🇹[AO90] Palavras que deixam de ser hifenizadas'>
     <!-- Created by Tiago F. Santos , Portuguese rule, 2017-04-19 -->
     <regexp>(?:c(?:a(?:b(?:e(?:ça(?:-(?:de-(?:c(?:a(?:r(?:neiro|taz)|valo|sal)|obra)|a(?:(?:lho-choch|sn)o|bóbora|velã)|(?:t(?:remoç|urc)|burr|vent)o|p(?:o(?:nte|rco)|rego|au)|m(?:edusa|otim)|s(?:ecção|érie)|lista)|no-ar)|s-(?:de-(?:c(?:a(?:r(?:neiro|taz)|sal)|obra)|s(?:(?:anto-antóni|ecçã)o|érie)|a(?:lho-chocho|bóbora|velã)|(?:t(?:remoç|urc)|vent)o|p(?:onte|rego|au)|m(?:edusa|otim)|lista)|no-ar))|lo(?:s-d(?:e-(?:raposa|anjo)|as-feiticeiras)|-d(?:as-feiticeiras|e-anjo)))|os?-de-(?:esquad|guer)ra)|(?:p(?:it(?:ão-de-(?:(?:mar-e-guer|bandei)r|(?:corve|fraga)t)|ões-de-(?:(?:mar-e-guer|bandei)r|fragat))|a-de-chuv)|chorros?-da-arei|gas?-na-saquinh)a|ixa(?:-d(?:e-(?:r(?:essonância|ufo)|(?:pirolit|ócul)os|música|ar)|os-pirolitos)|s-de-(?:(?:pirolit|ócul)os|música|rufo|ar))|r(?:a(?:s-de-(?:nó-cego|pau)|-de-(?:nó-cego|pau))|t(?:(?:ões|ão)-de-visita|as?-de-prego)|ne-de-so(?:is|l)|reiras?-de-tiro)|mi(?:sa(?:-d(?:e-(?:(?:onze-vara|vénu)s|forças?)|o-pano)|s-de-(?:(?:onze-var|forç)a|vénu)s)|nhos?-de-ferro)|v(?:alo(?:-d(?:e-(?:batalh|fris)a|o-cão)|s-d(?:e-batalha|o-cão))|eiras?-da-noite)|s(?:ca(?:s-de-(?:carvalho|noz)|-de-(?:carvalho|noz))|acos?-de-couro)|n(?:a(?:(?:is|l)-d[ae]-arei|-de-roc)a|to(?:-d[eo]|s-de)-cisne)|tingas?-de-bode)|o(?:r(?:es-de-(?:(?:tijol|vinh)o|laranja)|-de-(?:(?:tijol|vinh)o|laranja)|po-a-corpo)|nto(?:s-d(?:a-carochinha|o-vigário)|-d(?:a-carochinha|o-vigário))|va(?:-do-ladr(?:ões|ão)|s-do-ladrão)|m(?:idas?-de-urso|es?-e-dorme)|letes?-de-forças)|h(?:a(?:péu(?:-de-(?:so(?:is|l)|chuva)|s-de-(?:chuva|sol))|lotinhas-do-gerês)|uvas?-de-ouro|efe-de-fila)|(?:ent(?:áureas?-menor-perfolhad|ro-de-mes)|éus?-da-boc)a|â(?:nhamos?-de-manila|maras?-de-ar)|u(?:rral-de-trapiche|s?-de-judas)|ravagem-do-centeio)|p(?:a(?:i(?:-d(?:e-(?:(?:velhac|menin|tod)os|santo)|os-meninos)|s-d(?:e-(?:velhacos|santo)|os-meninos))|u(?:-(?:d(?:e-(?:(?:cabe|fi)leira|sabão)|o-ar)|a-pique)|s-(?:de-sabão|a-pique))|po(?:-de-(?:anjo|peru|rola)|s-de-(?:anjo|peru))|l(?:pos-de-aranha|ha-de-abade)|ssarinho-a-olhar|z(?:es)?-de-alma|r-ou-pernão)|e(?:d(?:r(?:a(?:-d(?:e-(?:(?:a(?:mol|fi)|cev)ar|(?:sang|toq)ue|águia|raio)|a(?:s-amazonas|-lua)|o-(?:so(?:is|l)|ar))|s-d(?:e-(?:(?:a(?:mol|fi)|cev)ar|águia|toque|raio)|o-(?:sol|ar)|a-lua))|inha-na-boca)|aços?-de-asno)|rna(?:-de-(?:serra|pau)|s-de-pau)|ito-de-(?:canga|morte)|les?-de-vinho)|é(?:-de-(?:c(?:a(?:n(?:(?:tig)?a|deeiro)|valo|bra)|humbo)|a(?:l(?:feres|tar)|tleta|migo)|(?:galinh|danç)a|(?:molequ|lebr)e|(?:ven|pa)to|b(?:anco|oi))|s-de-(?:(?:galinh|atlet)a|c(?:humbo|abra)|lebre|vento|boi))|ã(?:o-(?:d(?:e-(?:(?:passarinh|gal)o|aç(?:ú|u)car|l(?:eite|ó))|o-chile)|por-Deus)|es-d(?:e-(?:(?:passarinh|gal)o|l(?:eite|ó)|açucar)|o-chile))|i(?:n(?:go(?:-de-tocha|s-de-ovos)|ho-de-flandres)|(?:(?:ões|ão)-das-nica|anos?-dos-preto)s|olho-de-cobra)|o(?:r(?:ta(?:-(?:a-port|da-ru)|s-a-port)a|es-do-sol)|mo(?:-de-ad(?:ões|ão)|s-de-adão)|ntas?-de-lança)|r(?:e(?:ss(?:ões|ão)-de-ar|tos?-e-branco)|ontos?-a-(?:vesti|come)r|íncipe-de-gales)|ó(?:-de-(?:(?:sapat|talc)o|chipre|arroz|goa)|s-de-(?:chipre|arroz|goa))|ôr(?:-do-so(?:is|l)|s-do-sol))|b(?:i(?:c(?:h(?:o(?:s-d(?:o-(?:burac|ouvid|mat)o|e-sete-cabeças)|-d(?:o-(?:burac|ouvid|mat)o|e-sete-cabeças))|a(?:s-de-(?:sete-cabeças|rabear)|-de-(?:sete-cabeças|rabear)))|o(?:-de-(?:p(?:a(?:pagai|t)o|omba)|g(?:avião|ás)|mocho|obra)|s-de-(?:p(?:a(?:pagai|t)o|omba)|g(?:avião|ás)|obra)))|lhete(?:s-de-(?:identidade|visita)|-de-(?:identidade|visita))|fe-de-caneca)|o(?:ca(?:-de-(?:f(?:avas|ogo)|si(?:no|ri)|incêndio)|s-de-(?:(?:incêndi|fog|lob)o|si(?:no|ri)))|(?:t(?:(?:ões|ão)-de-our|as?-de-elástic)|(?:ns|m)-de-bic)o|la(?:s-(?:ao-cesto|de-neve)|-(?:ao-cesto|de-neve))|a-vai-ela)|a(?:r(?:riga(?:s-de-(?:freira|bicho)|-de-(?:freira|bicho))|ba-de-baleia|ca-de-ouro)|ba(?:-de-(?:camelo|moça)|s-de-camelo)|l(?:ões|ão)-de-ensaio|irros?-de-lata)|ra(?:ço(?:-de-(?:preguiça|armas|ferro)|s-de-(?:preguiça|ferro))|vos?-de-mundão|nco-de-baleia)|(?:ênç(?:ões|ão)-de-deu|uchas?-dos-caçadore)s|e(?:xigas?-de-lobo|ijos?-de-moça)|álsamo-do-canadá)|f(?:o(?:go(?:-d(?:e-(?:sant(?:o-ant(?:ões|ão)|elmo)|(?:bengal|vist)a|artifício)|o-ar)|s-d(?:e-(?:(?:sant(?:o-antã|elm)|artifíci)o|(?:bengal|vist)a)|o-ar))|cinho(?:s-de-(?:(?:burr|porc)o|tenca)|-de-(?:(?:burr|porc)o|tenca))|ra(?:s-d(?:e-jogo|a-lei)|-d(?:e-jogo|a-lei))|lh(?:a-de-flandres|os-de-sinhá))|a(?:to(?:-de-(?:(?:saia-e-cas|mac)ac|trein|banh)|s-de-(?:macac|trein|banh))o|c(?:es?-a-face|a-de-mato)|rinhas?-de-pau|zs?-de-conta)|i(?:(?:lho-d(?:e-parid|a-terr)|sca(?:is|l)-de-linh|(?:ns|m)-de-seman)a|o(?:s-de-(?:prumo|ovos)|-de-prumo))|e(?:bre-d(?:os-(?:três-dia|feno)s|e-malta)|rro-de-(?:engomar|romã)|zes-de-ouro)|r(?:adinho-d[ae]-mão-furada|entes?-a-frente|utos-do-mar)|u(?:mos?-da-terra|la-de-gabu)|lor-de-enxofre)|m(?:a(?:r(?:i(?:a-da(?:s-pernas-compridas|-fonte)|do-de-bolas)|c(?:o-de-colónia|a-de-judas)|mita-de-gigante)|nga-de-(?:alpaca|eixo)|çã-de-ad(?:ões|ão)|tutas?-e-meia)|e(?:s(?:tre(?:-de-(?:cerimóni|arm|obr)|s-de-(?:cerimóni|obr))as|(?:inha|as?)-de-cabeceira)|nina-d(?:e-cinco-olhos|o-olho)|adinha-de-ouro|ias?-de-leite)|ã(?:e(?:-d(?:e-(?:aluguer|santo)|a-lua)|s-d(?:e-santo|a-lua))|o(?:-de-(?:(?:barc|obr)a|judas)|s-de-obra))|o(?:scas-de-mil(?:ões|ão)|ços?-de-forcado|ntes?-de-vénus|rtes?-em-pé)|ulhers?-a-dias)|a(?:z(?:u(?:is-d(?:a-prússia|e-metileno)|l-d(?:a-prússia|e-metileno))|eite(?:s-de-(?:cheiro|pau)|-de-(?:cheiro|pau)))|l(?:godão-(?:d(?:as-(?:laranj|oliv)eiras|e-vidro)|em-rama)|m(?:écega-do-brasi[ls]|as?-do-padeiro)|finetes?-de-ama)|r(?:co(?:-d(?:a-(?:alianç|chuv)a|e-deus)|s-da-(?:alianç|chuv)a)|r(?:uda-dos-muros|oz-de-cuxá))|judante(?:s-de-(?:ordens|campo)|-de-(?:ordens|campo))|n(?:gus?-de-caroço|jos?-da-guarda)|m(?:igos?-da-onça|a-de-leite)|çúcar-de-madeira|chas?-de-armas|utos?-de-fé)|t(?:e(?:rra(?:-(?:de-(?:s(?:evilh|ien)a|ninguém)|a-terra)|s-a-terra)|sta(?:s-de-(?:ferro|ponte)|-de-(?:ferro|ponte)))|i(?:nta(?:s-d(?:os-pobres|a-china)|-d(?:os-pobres|a-china))|r(?:as?-que-ti|o-de-guer)ra)|o(?:r(?:rão-de-alicante|nas?-e-torna)|ucinhos?-do-céu|pas?-a-tudo)|r(?:o(?:(?:uxas?|ixa)-de-ovos|mba-de-boi)|intas?-e-um)|êtes?-à-tête|énis-de-mesa)|r(?:abo(?:s-de-(?:(?:a(?:ndorinh|rrai)|sai)a|(?:cav|g)alo|leque|tatu)|-de-(?:(?:a(?:ndorinh|rrai)|sai)a|(?:cav|g)alo|leque|tatu))|e(?:lógio(?:s-d(?:a-morte|e-ponto)|-d(?:a-morte|e-ponto))|sina-de-jalapa)|o(?:sa-d(?:e-o[iu]ro|os-ventos)|upa-de-franceses)|és-do-ch(?:ões|ão))|s(?:a(?:l-de-(?:s(?:eldlitz|aturno)|(?:júpit|glaub)er|azedas|epsom|vichy)|c(?:a-de-carv(?:ões|ão)|o-de-areia)|ída-de-(?:banho|praia)|is-de-azedas)|o(?:p(?:inha-de-massa|a-de-urso)|l-(?:de-gata|e-dó))|ul-rio-grandense)|v(?:i(?:n(?:ho(?:-de-(?:c(?:heiro|aju)|maçãs?|palma)|s-de-(?:cheiro|maçãs))|t(?:e-e-(?:quatro-horas|um)|ém-de-santo-antónio))|ola-d(?:e-a(?:rame|mor)|a-terra)|dro-de-cheiro)|erbos?-de-encher|olta-no-meio)|l(?:i(?:xa(?:s-de-(?:lei|pau)|-de-(?:lei|pau))|mpas?-pára-brisas|nha-de-água)|íngua(?:-de-(?:(?:vead|gat)o|trapos|sogra)|s-de-gato)|ua(?:-de-me(?:is|l)|s-de-mel)|eite-de-ca(?:is|l))|o(?:lho(?:-de-(?:mosquito|sogra|tigre|boi)|s-de-boi)|co(?:-do-coraç(?:ões|ão)|s-do-coração)|ficia(?:is|l)-às-ordens|itavos-de-fina(?:is|l)|relhas-de-abade)|g(?:(?:aitas?-de-(?:beiço|fole)|rosso-de-nápole|ás-dos-pântano|essos?-de-pari)s|u(?:inchos?-da-tainha|arda-de-corpo))|á(?:gua(?:s-de-(?:(?:forç|mes)a|végeto|lume)|-de-(?:(?:forç|mes)a|végeto|lume))|rvores?-da-vida)|d(?:ente(?:s-de-(?:serra|lobo)|-de-coelho)|(?:anças?-de-são-vit|oenças?-do-son)o|ia-a-dia)|zé(?:s-(?:d(?:os-anzóis|a-véstia)|faz-formas)|-(?:d(?:os-anzóis|a-véstia)|faz-formas))|n(?:(?:egros?-de-fum|ós?-de-adã)o|ortes?-rio-grandense|ão-sei-quês?|ariz-de-cera)|j(?:uiz(?:s-de-(?:campo|linha)|-de-(?:campo|linha))|ardi(?:ns|m)-de-infância)|qu(?:arto(?:s-de-fina(?:is|l)|-de-fina(?:is|l))|eijinho-do-céu)|u(?:(?:nhas?-de-fom|p-to-dat)e|mbigo-de-freira)|e(?:aus?-de-toilette|spuma-do-mar)|hás?-de-haver|és-não-és)</regexp>
     <message>Esta palavra já não é hifenizada.</message>
@@ -4024,7 +4024,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </rule>
 
 
-<rule id='AO90_MONTHS_CASING' type='grammar' name='[pt-PT][AO90] Capitalização de Meses e Estações do Ano'>
+<rule id='AO90_MONTHS_CASING' type='grammar' name='🇵🇹[AO90] Capitalização de Meses e Estações do Ano'>
     <!-- Created by Tiago F. Santos , Portuguese rule, 2017-01-25 -->
     <antipattern>
         <token>Rio</token>
@@ -4068,7 +4068,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </rule>
 
 
-<rulegroup id='AO90_WEEKDAYS_CASING_PT_PT' type='grammar' name='[pt-PT][AO90] Capitalização dos Dias da Semana'>
+<rulegroup id='AO90_WEEKDAYS_CASING_PT_PT' type='grammar' name='🇵🇹[AO90] Capitalização dos Dias da Semana'>
     <!-- Created by Tiago F. Santos , Portuguese rule, 2017-01-26 -->
 
     <rule>
@@ -4149,7 +4149,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </rulegroup>
 
 
-<rule id='AO90_CARDINAL_POINTS_CASING' type='grammar' name='[pt-PT][AO90] Capitalização de Pontos Cardeais'>
+<rule id='AO90_CARDINAL_POINTS_CASING' type='grammar' name='🇵🇹[AO90] Capitalização de Pontos Cardeais'>
     <!-- Created by Tiago F. Santos , Portuguese rule, 2017-01-26 -->
     <antipattern case_sensitive='yes'>
         <token>Médio</token>
@@ -4208,7 +4208,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rulegroup id='AO90_BEM_FEITO' name='[pt-PT][AO90] Bem-feito/Bem feito!'>
+    <rulegroup id='AO90_BEM_FEITO' name='🇵🇹[AO90] Bem-feito/Bem feito!'>
         <rule>
             <antipattern>
                 <token postag='SENT_START'/>
@@ -4241,7 +4241,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-    <rulegroup id='AO90_HAVER_DE' name='[pt-PT][AO90] Haver + de'>
+    <rulegroup id='AO90_HAVER_DE' name='🇵🇹[AO90] Haver + de'>
         <!-- Created by Tiago F. Santos , Portuguese rule, 2017-01-07 -->
         <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/sobre-supressao-do-hifen-na-forma-verbal-ha-de-depois-do-novo-acordo/29531</url>
         <rule>
@@ -4294,7 +4294,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-    <rule id="AO90_POLO_CAPITALIZATION" name="[pt-PT][AO90] Polo Norte/Sul">
+    <rule id="AO90_POLO_CAPITALIZATION" name="🇵🇹[AO90] Polo Norte/Sul">
     <!-- Created by Tiago F. Santos , Portuguese rule, 2017-08-08 -->
         <antipattern case_sensitive='yes'>
             <token regexp='yes'>P[oó]lo</token>
@@ -4315,9 +4315,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </category>
 
 
-<category id="AO45_RULES_PT_PT" name="[pt-PT] Regras do Acordo Ortográfico de 45 (pré-AO90)" type="misspelling" default='off'>
+<category id="AO45_RULES_PT_PT" name="🇵🇹 Regras do Acordo Ortográfico de 45 (pré-AO90)" type="misspelling" default='off'>
 
-    <rule id='AO45_MONTHS_CASING' type='grammar' name='[pt-PT][AO45] Capitalização de Meses e Estações do Ano'>
+    <rule id='AO45_MONTHS_CASING' type='grammar' name='🇵🇹[AO45] Capitalização de Meses e Estações do Ano'>
         <!-- Created by Tiago F. Santos , Portuguese rule, 2017-01-26 -->
         <pattern case_sensitive='yes'>
             <token regexp='yes'>(?:&meses_ano_pt_pt;)s?|(?:&meses_ano_abrev_pt_pt;)|invernos?|primaveras?|ver(?:ão|ões)|estios?|outonos?
@@ -4333,7 +4333,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </rule>
 
 
-<rulegroup id='AO45_WEEKDAYS_CASING' type='grammar' name='[pt-PT][AO45] Capitalização dos Dias da Semana'>
+<rulegroup id='AO45_WEEKDAYS_CASING' type='grammar' name='🇵🇹[AO45] Capitalização dos Dias da Semana'>
     <!-- Created by Tiago F. Santos , Portuguese rule, 2017-01-26 -->
     <rule>
         <pattern case_sensitive='yes'>
@@ -4359,7 +4359,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </rulegroup>
 
 
-<rulegroup id='AO45_CARDINAL_POINTS_CASING' type='grammar' name='[pt-PT][AO45] Capitalização de Pontos Cardeais'>
+<rulegroup id='AO45_CARDINAL_POINTS_CASING' type='grammar' name='🇵🇹[AO45] Capitalização de Pontos Cardeais'>
 
               <antipattern>
                   <token regexp='yes'>que|e|ou</token>
@@ -4413,7 +4413,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-    <rule id='AO45_HAVER_DE' name='[pt-PT][AO45] Haver-de'>
+    <rule id='AO45_HAVER_DE' name='🇵🇹[AO45] Haver-de'>
         <pattern>
             <marker>
                 <token regexp='yes'>heis?|hás?|hão</token>
@@ -4428,7 +4428,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id="AO45_PELO_PÊLO" name="[pt-PT][AO45] pelo/pêlo" default="off">
+    <rule id="AO45_PELO_PÊLO" name="🇵🇹[AO45] pelo/pêlo" default="off">
     <!-- Created by Marco A.G. Pinto   -->
         <pattern>
             <token>muito</token>
@@ -4443,9 +4443,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </category>
 
 
-<category id='CONFUSED_WORDS_PT_PT' name="[pt-PT] Confusão de Palavras">
+<category id='CONFUSED_WORDS_PT_PT' name="🇵🇹 Confusão de Palavras">
 
-    <rule id='PARONYM_PREMIO_252_PT' name='[pt-PT] Parónimo: premio'>
+    <rule id='PARONYM_PREMIO_252_PT' name='🇵🇹 Parónimo: premio'>
         <pattern>
             <token regexp='yes'>&art_detecao_paronimos;</token>
             <token min='0' postag='A.+' postag_regexp='yes'/>
@@ -4457,7 +4457,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <example correction='no prémio'><marker>no premio</marker>.</example>
         <example correction='nos prémios'><marker>nos premios</marker>.</example>
     </rule>
-    <rule id='PARONYM_PREMIO_252_PT2' name='[pt-PT] Parónimo: premio'>
+    <rule id='PARONYM_PREMIO_252_PT2' name='🇵🇹 Parónimo: premio'>
         <pattern>
             <token regexp='yes' inflected="yes">&verbos_auxiliares_part_passado;|dever|poder|querer|costumar</token>
             <marker>
@@ -4472,7 +4472,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id='AUTO-FALANTE' name="[pt-PT] Confusão: Auto-falante/Altifalante">
+    <rule id='AUTO-FALANTE' name="🇵🇹 Confusão: Auto-falante/Altifalante">
         <pattern>
             <token>auto</token>
             <token regexp='yes' min='0'>&tracos_de_separacao;</token>
@@ -4486,7 +4486,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id='CRIAR_QUERER' name="[pt-PT] Confusão: Criar/Querer">
+    <rule id='CRIAR_QUERER' name="🇵🇹 Confusão: Criar/Querer">
         <pattern>
             <marker>
                 <token regexp='yes'>cria[ms]?|criamos</token>
@@ -4509,11 +4509,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
 
-    <category id='TRANSLATION_ERRORS_PT_PT' name="[pt-PT] Erros de Tradução" type="mistranslation" tone_tags="academic">
+    <category id='TRANSLATION_ERRORS_PT_PT' name="🇵🇹 Erros de Tradução" type="mistranslation" tone_tags="academic">
         <!-- IDEA foreign_terms -->
 
 
-        <rule id='ERRO_TRADUÇÃO_ESTIMAÇÃO_MÁXIMA_SEMELHANÇA_PT_PT' name="[pt-PT] Erro tradução: estimação máxima 'semelhança' → 'verosimilhança'(PT)">
+        <rule id='ERRO_TRADUÇÃO_ESTIMAÇÃO_MÁXIMA_SEMELHANÇA_PT_PT' name="🇵🇹 Erro tradução: estimação máxima 'semelhança' → 'verosimilhança'(PT)">
             <!--
                 In pt_PT: verosimilhança
                 In pt_BR: verossimilhança
@@ -4531,7 +4531,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='ERRO_TRADUÇÃO_FURTO_ROUBO_IDENTIDADE' name="[pt-PT] Erro tradução: 'furto' de identidade → 'usurpação'">
+        <rule id='ERRO_TRADUÇÃO_FURTO_ROUBO_IDENTIDADE' name="🇵🇹 Erro tradução: 'furto' de identidade → 'usurpação'">
             <pattern>
                 <marker>
                     <token skip="4" inflected='yes' regexp='yes'>furtar|roubar</token>
@@ -4551,8 +4551,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
 
-<category id="TYPOGRAPHY" name="[pt-PT] Tipografia">
-    <rule type="locale-violation" id='CURRENCY_PLACEMENT_PT_FOREIGN' name="[pt-PT] Posição dos símbolos de moeda: '100£ (£100)">
+<category id="TYPOGRAPHY" name="🇵🇹 Tipografia">
+    <rule type="locale-violation" id='CURRENCY_PLACEMENT_PT_FOREIGN' name="🇵🇹 Posição dos símbolos de moeda: '100£ (£100)">
         <pattern>
             <token regexp="yes">\d+([,.]\d+)*</token>
             <token regexp="yes">&currency_symbols;
@@ -4568,7 +4568,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <example>Preciso de 400€.</example>
 </rule>
 
-<rule type="locale-violation" id='CURRENCY_PLACEMENT_EUR' name="[pt-PT] Posição do símbolo do euro: '€100 (100 €)">
+<rule type="locale-violation" id='CURRENCY_PLACEMENT_EUR' name="🇵🇹 Posição do símbolo do euro: '€100 (100 €)">
     <pattern>
         <token>€</token>
         <token regexp="yes">\d+([,.]\d+)*</token>
@@ -4580,7 +4580,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <example correction="100&nbsp;€">Deve <marker>€100</marker>.</example>
 </rule>
 
-<rule type="locale-violation" id='CURRENCY_SPACE_PT_FOREIGN' name="[pt-PT] Espaçamento entre símbolos e valores monetários: '$ 100' ($100)">
+<rule type="locale-violation" id='CURRENCY_SPACE_PT_FOREIGN' name="🇵🇹 Espaçamento entre símbolos e valores monetários: '$ 100' ($100)">
     <pattern>
         <token regexp="yes">&currency_symbols;
         <exception>€</exception>
@@ -4594,7 +4594,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 <example correction="R$100">Custa <marker>R$ 100</marker>.</example>
       </rule>
 
-      <rule type="locale-violation" id='CURRENCY_SPACE_EUR' name="[pt-PT] Espaçamento entre o símbolo do euro e valores monetários: '100€' (100 €)">
+      <rule type="locale-violation" id='CURRENCY_SPACE_EUR' name="🇵🇹 Espaçamento entre o símbolo do euro e valores monetários: '100€' (100 €)">
           <pattern>
               <token regexp="yes">\d+([,.]\d+)*</token>
               <token spacebefore="no">€</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -84,10 +84,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
 <rules lang="pt" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/languagetool-org/languagetool/master/languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <category id="STYLE" name="[pt-PT] Regras de Estilo" type="style">
+    <category id="STYLE" name="🇵🇹 Regras de Estilo" type="style">
 
 
-      <rulegroup id="CONFUSAO_CAIXA_EMBALAGEM_FARMACOS" name="[pt-PT] Confusão: caixa/embalagem (fármacos)" tone_tags='objective'>
+      <rulegroup id="CONFUSAO_CAIXA_EMBALAGEM_FARMACOS" name="🇵🇹 Confusão: caixa/embalagem (fármacos)" tone_tags='objective'>
       <!-- ChatGPT 5 and new disambiguator for 2026+ -->
 
             <!-- #1: (mais comum): verbo + caixa + medicamento (alta precisão) -->
@@ -125,7 +125,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rulegroup>
 
 
-    <rule id='PRAZER_GOSTO' name="[pt-PT] 'prazer' em → 'gosto'" tone_tags="formal">
+    <rule id='PRAZER_GOSTO' name="🇵🇹 'prazer' em → 'gosto'" tone_tags="formal">
         <pattern>
             <token skip='4' regexp='yes' inflected='yes'>ser|ter</token>
             <marker>
@@ -142,7 +142,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id='CICLO_VICIOSO' name="[pt-PT] Calinada: 'ciclo' vicioso → 'círculo'" tone_tags='objective'>
+    <rule id='CICLO_VICIOSO' name="🇵🇹 Calinada: 'ciclo' vicioso → 'círculo'" tone_tags='objective'>
        <!-- ChatGPT 5 and new disambiguator for 2026+ -->
        <pattern>
             <marker>
@@ -159,7 +159,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id='AVOID_GERUND' name='[pt-PT] Evitar o Gerúndio (perifrásico)' type='style' tone_tags='objective'>
+    <rule id='AVOID_GERUND' name='🇵🇹 Evitar o Gerúndio (perifrásico)' type='style' tone_tags='objective'>
         <!-- Created by Tiago F. Santos , Portuguese rule, 2016-11-24 -->
 
         <antipattern> <!-- Add number agreement exceptions so that rule ID:GENERAL_VERB_AGREEMENT_ERRORS is triggered -->
@@ -246,7 +246,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
       <!-- EVITAR O GERÚNDIO Evitar o gerúndio em pt-PT -->
       <!-- Created by Tiago F. Santos , Portuguese rule, 2016-11-24 -->
-      <rule id='AVOID_GERUND_ALL' name='[pt-PT] Evitar o Gerúndio (completo)' default='off' type='style' tone_tags='objective'>
+      <rule id='AVOID_GERUND_ALL' name='🇵🇹 Evitar o Gerúndio (completo)' default='off' type='style' tone_tags='objective'>
           <pattern>
               <token postag='V.G0+' postag_regexp='yes'><exception postag='V.G0+' postag_regexp='yes' negate_pos='yes'/></token>
           </pattern>
@@ -259,7 +259,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- EM DETALHE detalhadamente -->
-        <rule id='EM_DETALHE_DETALHADAMENTE_PT_PT' name="[pt-PT][Simplificar] 'em detalhe' → detalhadamente" type='style' tone_tags="objective">
+        <rule id='EM_DETALHE_DETALHADAMENTE_PT_PT' name="🇵🇹[Simplificar] 'em detalhe' → detalhadamente" type='style' tone_tags="objective">
             <!-- Created by Marco A.G.Pinto, Portuguese rule 2023-03-10 (2-MAR-2023+) -->
             <!--
                 Queira explicar em detalhe o tema. → Queira explicar detalhadamente o tema.
@@ -282,7 +282,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- EM RELAÇÃO À SITUAÇÃO relativamente à situação -->
-        <rulegroup id='EM_RELAÇÃO_RELATIVAMENTE_PT_PT' name="[pt-PT][Simplificar] Em relação → relativamente" type='style' tone_tags='objective'>
+        <rulegroup id='EM_RELAÇÃO_RELATIVAMENTE_PT_PT' name="🇵🇹[Simplificar] Em relação → relativamente" type='style' tone_tags='objective'>
         <!-- Created by Marco A.G.Pinto, Portuguese rule 2023-01-25 + 2023-02-14 (25-JUL-2022+) -->
         <!--
             O que fazer em relação a esta situação? → O que fazer relativamente a esta situação?
@@ -351,7 +351,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </rulegroup>
 
 
-    <rule id='VELHA_ESCOLA_VELHA_GUARDA' name="[pt-PT] Velha 'escola' → guarda" tone_tags='formal'>
+    <rule id='VELHA_ESCOLA_VELHA_GUARDA' name="🇵🇹 Velha 'escola' → guarda" tone_tags='formal'>
         <pattern>
             <token inflected='yes'>ser</token>
             <token>da</token>
@@ -365,7 +365,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rulegroup id="PORTUGUESE_ADDRESSES" name="[pt-PT] Formato de endereços em Portugal" type="style" tone_tags="formal">
+    <rulegroup id="PORTUGUESE_ADDRESSES" name="🇵🇹 Formato de endereços em Portugal" type="style" tone_tags="formal">
         <!--  Localized from French, by Tiago F. Santos, 2017-10-01      -->
         <rule>
             <regexp type="exact" mark="1">\b(?:Rua|R\.|Arruamento|Avenida|Av\.|Praça|Pr\.|Cruzamento|Caminho|Via|Estrada|Piso)[  ][^,\n]+\s*[,\n]\s*(\p{Lu}[^,%\d\n]+[  ]\d{4}(?:\-\d{3})?)\s*[,\n]\s*(?:PORTUGAL|PORTOGALLO|PORTOGALIA)\b</regexp>
@@ -396,7 +396,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-    <rule id='ALUGAR_CASA' name="[pt-PT] 'alugar' imóvel → 'arrendar'" type='style' tone_tags="objective">
+    <rule id='ALUGAR_CASA' name="🇵🇹 'alugar' imóvel → 'arrendar'" type='style' tone_tags="objective">
         <pattern>
             <marker>
                 <token skip='4' inflected='yes'>alugar</token>
@@ -409,7 +409,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id='BARBARISMS_PT_PT_V3' name="[pt-PT] Estrangeirismos específicos pt_PT" type="style">
+    <rule id='BARBARISMS_PT_PT_V3' name="🇵🇹 Estrangeirismos específicos pt_PT" type="style">
         <!-- IDEA foreign_terms -->
         <!--
             This rule is only available to pt-PT. Dissertations, theses and academic papers in European Portuguese use this.
@@ -531,7 +531,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </rule>
 
 
-<rulegroup id='ORDINAL_ABREVIATION' name="[pt-PT] Abreviatura de ordinais: 1º → 1.º" tone_tags="formal">
+<rulegroup id='ORDINAL_ABREVIATION' name="🇵🇹 Abreviatura de ordinais: 1º → 1.º" tone_tags="formal">
     <!--  Created by Tiago F. Santos, 20-07-2017 -->
     <url>https://ciberduvidas.iscte-iul.pt/artigos/rubricas/idioma/ainda-sobre-a-abreviatura-do-numeral-ordinal-com-ou-sem-o-sobrescrito-sublinhado/2680</url>
     <antipattern>
@@ -620,10 +620,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
 
-    <category id='FORMAL_SPEECH_PT_PT' name='[pt-PT] Linguagem Formal' type='register' tone_tags="formal">
+    <category id='FORMAL_SPEECH_PT_PT' name='🇵🇹 Linguagem Formal' type='register' tone_tags="formal">
 
 
-        <rulegroup id='INFORMALITIES' name="[pt-PT][Formal] Evitar linguagem informal" default="on" tags="picky" tone_tags="formal">
+        <rulegroup id='INFORMALITIES' name="🇵🇹[Formal] Evitar linguagem informal" default="on" tags="picky" tone_tags="formal">
             <!-- Created by Tiago F. Santos, Portuguese rule, 2017-05-09 -->
             <url>https://pt.wiktionary.org/wiki/Categoria:Coloquialismo_(Portugu%C3%AAs)</url>
             <rule>
@@ -1300,7 +1300,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </rulegroup>
 
 
-    <rulegroup id='COLOQUIALISMOS_PT_PT' name="[pt-PT][Formal] Coloquialismos: evitar expressões orais" default='on' tone_tags='formal'>
+    <rulegroup id='COLOQUIALISMOS_PT_PT' name="🇵🇹[Formal] Coloquialismos: evitar expressões orais" default='on' tone_tags='formal'>
 
         <rule>
             <pattern>
@@ -2213,7 +2213,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-        <rulegroup id='GASTAR_DESPENDER_DESEMBOLSAR' name='[pt-PT][Formal] gastar → despender/desembolsar' tone_tags='formal' is_goal_specific='true'>
+        <rulegroup id='GASTAR_DESPENDER_DESEMBOLSAR' name='🇵🇹[Formal] gastar → despender/desembolsar' tone_tags='formal' is_goal_specific='true'>
         <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
 
             <rule> <!-- #1: No past participle of "gastar" -->
@@ -2270,7 +2270,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='DIFICULDADES_PROVAÇÕES' name="[pt-PT][Formal] Passar 'dificuldades' → 'provações'" tags='picky' tone_tags='formal'>
+        <rule id='DIFICULDADES_PROVAÇÕES' name="🇵🇹[Formal] Passar 'dificuldades' → 'provações'" tags='picky' tone_tags='formal'>
             <pattern>
                 <token skip='4' inflected='yes'>passar</token>
                 <marker>
@@ -2287,7 +2287,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
          </rule>
 
 
-        <rule id='É_IGUAL_AO_LITRO' name="[pt-PT][Formal] 'igual ao litro' → 'indiferente'" tone_tags="formal">
+        <rule id='É_IGUAL_AO_LITRO' name="🇵🇹[Formal] 'igual ao litro' → 'indiferente'" tone_tags="formal">
             <pattern>
                 <token>é</token>
                 <marker>
@@ -2303,7 +2303,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='CHUMBAR_REPROVAR_PT_PT' name="[pt-PT][Formal] Chumbar → reprovar" type='style' tone_tags='formal' tags='picky'>
+        <rule id='CHUMBAR_REPROVAR_PT_PT' name="🇵🇹[Formal] Chumbar → reprovar" type='style' tone_tags='formal' tags='picky'>
             <antipattern>
                 <token skip='2' regexp='yes'>chumbos?</token>
                 <token regexp='yes' case_sensitive='yes'>Pb|pb|PB</token>
@@ -2351,7 +2351,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-      <rulegroup id='NÃO_TER_REUNIDAS_CONDIÇÕES_PARA' name="[pt-PT][Formal] não 'ter' condições para → 'ver reunidas'" tone_tags='formal'>
+      <rulegroup id='NÃO_TER_REUNIDAS_CONDIÇÕES_PARA' name="🇵🇹[Formal] não 'ter' condições para → 'ver reunidas'" tone_tags='formal'>
           <!-- ChatGPT 5 and new disambiguator for 2026+ -->
           <rule>
               <pattern>
@@ -2389,7 +2389,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rulegroup>
 
 
-    <rule id='PÔR_FIM_TERMO' name="[pt-PT][Formal] pôr 'fim' → 'termo/término'" tags="picky" tone_tags="formal">
+    <rule id='PÔR_FIM_TERMO' name="🇵🇹[Formal] pôr 'fim' → 'termo/término'" tags="picky" tone_tags="formal">
         <pattern>
             <token skip='4' inflected='yes'>pôr</token>
             <marker>
@@ -2410,7 +2410,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-      <rule id='TER_QUE_DE' name="[pt-PT][Formal] Ter 'que' infinitivo → 'de'" tone_tags='formal'>
+      <rule id='TER_QUE_DE' name="🇵🇹[Formal] Ter 'que' infinitivo → 'de'" tone_tags='formal'>
           <!-- ChatGPT 5 and new disambiguator for 2026+ -->
           <pattern>
               <token inflected='yes'>ter</token>
@@ -2425,7 +2425,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-        <rule id='FORMAL_DEPRECIATIVO' name="[pt-PT][Formal] Termos depreciativos">
+        <rule id='FORMAL_DEPRECIATIVO' name="🇵🇹[Formal] Termos depreciativos">
             <!-- IDEA inclusive -->
             <pattern>
                 <token regexp='yes' inflected="yes">&depreciativo_pt_pt;<exception postag_regexp='yes' postag='NP.+'/></token>
@@ -2438,7 +2438,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
     <!-- TODO Add antipattern for dash and quotations -->
-    <rulegroup id='FORMAL_T-V_DISTINCTION' name='[pt-PT][Formal] Tratamento formal: Tu,Você; Vós,Vocês' default='on' tags='picky'>
+    <rulegroup id='FORMAL_T-V_DISTINCTION' name='🇵🇹[Formal] Tratamento formal: Tu,Você; Vós,Vocês' default='on' tags='picky'>
         <!-- Created by Tiago F. Santos , Portuguese rule, 2016-12-28 -->
         <url>https://pt.wikipedia.org/wiki/Distin%C3%A7%C3%A3o_t-v</url>
 
@@ -3253,7 +3253,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
 
-<rulegroup id='FORMAL_T-V_DISTINCTION_ALL' name='[pt-PT][Formal] Tratamento formal: Todas as formas na segunda pessoa, sem salvaguardas' default='off'>
+<rulegroup id='FORMAL_T-V_DISTINCTION_ALL' name='🇵🇹[Formal] Tratamento formal: Todas as formas na segunda pessoa, sem salvaguardas' default='off'>
     <!-- Created by Tiago F. Santos , Portuguese rule, 2016-12-28 -->
     <!-- MARCOAGPINTO inserted global antipatterns for all subrules on top -->
 
@@ -3359,7 +3359,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
 <!-- COM A GENTE connosco COM NÓS connosco -->
-<rulegroup id='FORMAL_COM_A_GENTE_COM_NÓS_CONNOSCO_PT_PT' name="[pt-PT][Formal] 'com a gente'/'com nós' → connosco">
+<rulegroup id='FORMAL_COM_A_GENTE_COM_NÓS_CONNOSCO_PT_PT' name="🇵🇹[Formal] 'com a gente'/'com nós' → connosco">
 <!-- Created by Tiago F. Santos (2016-12-28) and improved by Marco A.G.Pinto, Portuguese rule 2023-04-09 (2-MAR-2023+) -->
 <!--
     MARCOAGPINTO inserted global antipatterns for all subrules on top using the logic (2-MAR-2023+)
@@ -3419,7 +3419,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='FORMAL_MONTES_DE' name="[pt-PT][Formal] 'montes de' → inúmeros/imensos">
+        <rule id='FORMAL_MONTES_DE' name="🇵🇹[Formal] 'montes de' → inúmeros/imensos">
         <!-- Created by Marco A.G.Pinto, Portuguese rule 2023-03-05 (Checked/Enhanced) (2-MAR-2023+) -->
         <!--
             Perdi montes de tempo. → Perdi imenso tempo.
@@ -3441,7 +3441,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='PARA_NADA_DESNECESSARIAMENTE' name="[pt-PT][Formal] Para nada → desnecessariamente" tone_tags='formal'>
+        <rule id='PARA_NADA_DESNECESSARIAMENTE' name="🇵🇹[Formal] Para nada → desnecessariamente" tone_tags='formal'>
             <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
             <antipattern>
                 <token>não</token>
@@ -3466,7 +3466,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='PASSAR_TEMPO_DECORRER_TEMPO' name="[pt-PT][Formal] 'passar' tempo → decorrer">
+        <rulegroup id='PASSAR_TEMPO_DECORRER_TEMPO' name="🇵🇹[Formal] 'passar' tempo → decorrer">
 
             <antipattern>
                 <token regexp='yes'>&expressoes_de_tempo_simples;
@@ -3601,7 +3601,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='PERANTE_O_MESMO_IDENTICO' name="[pt-PT][Formal] Perante 'o mesmo' → idêntico">
+        <rule id='PERANTE_O_MESMO_IDENTICO' name="🇵🇹[Formal] Perante 'o mesmo' → idêntico">
             <pattern>
                 <token regexp='yes'>ante|diante|perante</token>
                 <marker>
@@ -3620,7 +3620,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-      <rule id='FAZER_DESPORTO_V2' name="[pt-PT][Formal] 'Fazer' desporto → Praticar" tone_tags='formal'>
+      <rule id='FAZER_DESPORTO_V2' name="🇵🇹[Formal] 'Fazer' desporto → Praticar" tone_tags='formal'>
           <!-- ChatGPT 5 and new disambiguator for 2026+ -->
           <pattern>
               <marker>
@@ -3636,7 +3636,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-    <rule id='TIVER_ESTIVER' name='[pt-PT][Formal] tiver/estiver' tone_tags="formal">
+    <rule id='TIVER_ESTIVER' name='🇵🇹[Formal] tiver/estiver' tone_tags="formal">
         <antipattern>
             <token postag='NC.+|AQ.+|CS|RG' postag_regexp='yes'/>
             <token regexp='yes'>teve|tiveste|tiver|tiveres|tiverem|tivermos|tiveram</token>
@@ -3672,10 +3672,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
 
-    <category id='ACADEMIC_SCIENTIFIC_PT_PT' name="[pt-PT] Regras académicas e científicas" type="other">
+    <category id='ACADEMIC_SCIENTIFIC_PT_PT' name="🇵🇹 Regras académicas e científicas" type="other">
 
 
-    <rule id='CONCLUIR_UM_CURSO' name="[pt-PT] 'acabar/terminar' um curso → 'concluir'" type='style' tone_tags='academic'>
+    <rule id='CONCLUIR_UM_CURSO' name="🇵🇹 'acabar/terminar' um curso → 'concluir'" type='style' tone_tags='academic'>
         <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
         <pattern>
             <marker>
@@ -3699,7 +3699,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-        <rulegroup id='ENSINO_SUPERIOR_V2' name="[pt-PT][Científico] 'Educação' Superior → 'Ensino'" type="style" tone_tags="academic">
+        <rulegroup id='ENSINO_SUPERIOR_V2' name="🇵🇹[Científico] 'Educação' Superior → 'Ensino'" type="style" tone_tags="academic">
         <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
 
             <rule> <!-- à -->
@@ -3747,7 +3747,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='CIENTÍFICO_DETERMINADAS_ESPECÍFICAS' name="[pt-PT][Científico] Determinados → Específicos" type="style" tone_tags="academic">
+        <rule id='CIENTÍFICO_DETERMINADAS_ESPECÍFICAS' name="🇵🇹[Científico] Determinados → Específicos" type="style" tone_tags="academic">
             <pattern>
                 <token regexp="yes">para|como|por</token>
                 <token skip='4' postag='V.+' postag_regexp='yes'/>
@@ -3762,7 +3762,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='CIENTÍFICO_MAIS_IMPORTANTE_CHAVE_V3' name="[pt-PT][Científico] mais conhecidos/importantes → -chave" type="style">
+        <rule id='CIENTÍFICO_MAIS_IMPORTANTE_CHAVE_V3' name="🇵🇹[Científico] mais conhecidos/importantes → -chave" type="style">
             <pattern>
                 <marker>
                     <token postag='NC.+' postag_regexp='yes' regexp='yes' inflected='yes'>adversário|área|aspec?to|ac?tividade|autor|batalha|carac?terística|categoria|cientista|cineasta|conceito|contribuição|decisão|descoberta|detalhe|domínio|elemento|escritor|escultor|etapa|evento|exemplo|fac?to|fac?tor|feito|ferramenta|figura|homem|ideia|indústria|informação|instituição|investigador|jogador|jornalista|líder|local|lugar|membro|momento|movimento|mulher|objec?tivo|objec?to|palavra|papel|peça|pergunta|período|pessoa|pesquisador|ponto|problema|questão|sec?tor|tarefa|tema|tópico|trabalho|vitória</token>
@@ -3776,7 +3776,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='HABILITAÇÕES_LITERÁRIAS_ACADÉMICAS' name="[pt-PT] Habilitações 'literárias' → 'académicas'" type="style">
+        <rule id='HABILITAÇÕES_LITERÁRIAS_ACADÉMICAS' name="🇵🇹 Habilitações 'literárias' → 'académicas'" type="style">
             <pattern>
                 <token skip='4'>habilitações</token>
                 <marker>
@@ -3789,7 +3789,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='GRANDES_ENORMES_RECURSOS_FINANCEIROS_AVULTADOS' name="[pt-PT][Científico] 'grandes/enormes' recursos financeiros → avultados" type="style" tags="picky">
+        <rulegroup id='GRANDES_ENORMES_RECURSOS_FINANCEIROS_AVULTADOS' name="🇵🇹[Científico] 'grandes/enormes' recursos financeiros → avultados" type="style" tags="picky">
             <rule>
                 <pattern>
                     <token regexp='yes'>recursos?|ganhos?|proveitos?|meios?|quantias?|perdas?|quebras?|prejuízos?</token>
@@ -3827,11 +3827,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
 
-    <category id='REDUNDANCY_PT_PT' name="[pt-PT] Pleonasmos/Redundância" tone_tags="clarity">
+    <category id='REDUNDANCY_PT_PT' name="🇵🇹 Pleonasmos/Redundância" tone_tags="clarity">
         <!-- IDEA shorten_it -->
 
 
-        <rule id='REDUNDANCY_24' name="[pt-PT][Pleonasmo] 24 horas por dia">
+        <rule id='REDUNDANCY_24' name="🇵🇹[Pleonasmo] 24 horas por dia">
             <pattern>
                 <token>24</token>
                 <token regexp='yes'>horas?</token>
@@ -3844,7 +3844,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_5_AGRAVAR' name='[pt-PT][Pleonasmo] agravar ainda mais'>
+        <rule id='REDUNDANCY_5_AGRAVAR' name='🇵🇹[Pleonasmo] agravar ainda mais'>
             <pattern>
                 <token inflected='yes'>agravar</token>
                 <token>ainda</token>
@@ -3856,7 +3856,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_8_AUMENTAR' name='[pt-PT][Pleonasmo] aumentar ainda mais'>
+        <rule id='REDUNDANCY_8_AUMENTAR' name='🇵🇹[Pleonasmo] aumentar ainda mais'>
             <pattern>
                 <token inflected='yes'>aumentar</token>
                 <token>ainda</token>
@@ -3868,7 +3868,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_11_AVISAR' name='[pt-PT][Pleonasmo] avisar com antecedência'>
+        <rule id='REDUNDANCY_11_AVISAR' name='🇵🇹[Pleonasmo] avisar com antecedência'>
             <pattern>
                 <token inflected='yes'>avisar</token>
                 <token>com</token>
@@ -3880,7 +3880,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_PALMAS' name="[pt-PT][Pleonasmo] Bater palmas">
+        <rule id='REDUNDANCY_PALMAS' name="🇵🇹[Pleonasmo] Bater palmas">
             <pattern>
                 <token inflected='yes'>bater</token>
                 <token>palmas</token>
@@ -3894,7 +3894,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_12_CLASSIFICAR' name='[pt-PT][Pleonasmo] classificar em grupos'>
+        <rule id='REDUNDANCY_12_CLASSIFICAR' name='🇵🇹[Pleonasmo] classificar em grupos'>
             <pattern>
                 <token inflected='yes'>classificar</token>
                 <token>em</token>
@@ -3906,7 +3906,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_11_COMPARECER' name='[pt-PT][Pleonasmo] Comparecer em pessoa'>
+        <rule id='REDUNDANCY_11_COMPARECER' name='🇵🇹[Pleonasmo] Comparecer em pessoa'>
             <pattern>
                 <token inflected='yes'>comparecer</token>
                 <token>em</token>
@@ -3918,7 +3918,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_COMPARECER' name="[pt-PT][Pleonasmo] Comparecer pessoalmente">
+        <rule id='REDUNDANCY_COMPARECER' name="🇵🇹[Pleonasmo] Comparecer pessoalmente">
             <pattern>
                 <token inflected='yes'>comparecer</token>
                 <token>pessoalmente</token>
@@ -3929,7 +3929,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_16_COMPETIR' name='[pt-PT][Pleonasmo] competir uns com os outros'>
+        <rule id='REDUNDANCY_16_COMPETIR' name='🇵🇹[Pleonasmo] competir uns com os outros'>
             <pattern>
                 <token inflected='yes'>competir</token>
                 <token>uns</token>
@@ -3943,7 +3943,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_CONVIVER' name="[pt-PT][Pleonasmo] Conviver juntos">
+        <rule id='REDUNDANCY_CONVIVER' name="🇵🇹[Pleonasmo] Conviver juntos">
             <pattern>
                 <token inflected='yes'>conviver</token>
                 <token regexp='yes'>juntos?</token>
@@ -3954,7 +3954,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_CRIAR' name="[pt-PT][Pleonasmo] Criar novas">
+        <rule id='REDUNDANCY_CRIAR' name="🇵🇹[Pleonasmo] Criar novas">
             <pattern>
                 <token inflected='yes'>criar</token>
                 <token min='0' regexp='yes'>u[nm]a?s?</token>
@@ -3967,7 +3967,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_CHAPEU' name="[pt-PT][Pleonasmo] De chapéu">
+        <rule id='REDUNDANCY_CHAPEU' name="🇵🇹[Pleonasmo] De chapéu">
             <pattern>
                 <token>de</token>
                 <token inflected='yes'>chapéu</token>
@@ -3980,7 +3980,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_19_DETALHES' name='[pt-PT][Pleonasmo] Detalhes minuciosos'>
+        <rule id='REDUNDANCY_19_DETALHES' name='🇵🇹[Pleonasmo] Detalhes minuciosos'>
             <pattern>
                 <token regexp='yes'>detalhes?</token>
                 <token regexp='yes'>minuciosos?</token>
@@ -3991,7 +3991,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_ELO' name="[pt-PT][Pleonasmo] Elo de ligação">
+        <rule id='REDUNDANCY_ELO' name="🇵🇹[Pleonasmo] Elo de ligação">
             <pattern>
                 <token inflected='yes'>elo</token>
                 <token>de</token>
@@ -4003,7 +4003,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_27_EXPRESSAMENTE' name='[pt-PT][Pleonasmo] Expressamente proibido'>
+        <rule id='REDUNDANCY_27_EXPRESSAMENTE' name='🇵🇹[Pleonasmo] Expressamente proibido'>
             <pattern>
                 <token>expressamente</token>
                 <token regexp='yes'>proibid[ao]s?</token>
@@ -4014,7 +4014,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_28_EXULTAR' name='[pt-PT][Pleonasmo] Exultar de alegria'>
+        <rule id='REDUNDANCY_28_EXULTAR' name='🇵🇹[Pleonasmo] Exultar de alegria'>
             <pattern>
                 <token regexp='yes'>exult.+</token>
                 <token>de</token>
@@ -4026,7 +4026,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_22_EXULTAR' name='[pt-PT][Pleonasmo] exultar de felicidade'>
+        <rule id='REDUNDANCY_22_EXULTAR' name='🇵🇹[Pleonasmo] exultar de felicidade'>
             <pattern>
                 <token inflected='yes'>exultar</token>
                 <token>de</token>
@@ -4038,7 +4038,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_32_HABITAT' name='[pt-PT][Pleonasmo] Habitat natural'>
+        <rule id='REDUNDANCY_32_HABITAT' name='🇵🇹[Pleonasmo] Habitat natural'>
             <pattern>
                 <token regexp='yes'>habitats?</token>
                 <token regexp='yes'>natura(?:l|is)</token>
@@ -4049,7 +4049,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_NAO_HAVER_MAIS' name="[pt-PT][Pleonasmo] Já não há mais">
+        <rule id='REDUNDANCY_NAO_HAVER_MAIS' name="🇵🇹[Pleonasmo] Já não há mais">
             <pattern>
                 <token>já</token>
                 <token>não</token>
@@ -4062,7 +4062,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_34_JUNTAMENTE' name='[pt-PT][Pleonasmo] Juntamente com'>
+        <rule id='REDUNDANCY_34_JUNTAMENTE' name='🇵🇹[Pleonasmo] Juntamente com'>
             <pattern>
                 <token inflected='yes'>juntamente</token>
                 <token>com</token>
@@ -4073,7 +4073,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_35_LIVRE' name='[pt-PT][Pleonasmo] Livre escolha' default='off'>
+        <rule id='REDUNDANCY_35_LIVRE' name='🇵🇹[Pleonasmo] Livre escolha' default='off'>
             <pattern>
                 <token inflected='yes'>livre</token>
                 <token>escolha</token>
@@ -4084,7 +4084,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_24_MANTER' name='[pt-PT][Pleonasmo] manter a mesma'>
+        <rule id='REDUNDANCY_24_MANTER' name='🇵🇹[Pleonasmo] manter a mesma'>
             <pattern>
                 <token inflected='yes'>manter</token>
                 <token regexp='yes'>[ao]s?</token>
@@ -4096,7 +4096,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_39_OPINIÃO' name='[pt-PT][Pleonasmo] Opinião individual'>
+        <rule id='REDUNDANCY_39_OPINIÃO' name='🇵🇹[Pleonasmo] Opinião individual'>
             <pattern>
                 <token regexp='yes'>opini(?:ão|ões)</token>
                 <token regexp='yes'>individu(?:al|ais)</token>
@@ -4107,7 +4107,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_PAÍSES' name="[pt-PT][Pleonasmo] Países do mundo">
+        <rule id='REDUNDANCY_PAÍSES' name="🇵🇹[Pleonasmo] Países do mundo">
             <antipattern>
                 <token><exception postag='Z.+|DI.+|DA.+' postag_regexp='yes'/></token>
                 <token inflected='yes'>país</token>
@@ -4128,7 +4128,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_48_PROPRIEDADES' name='[pt-PT][Pleonasmo] Propriedades características'>
+        <rule id='REDUNDANCY_48_PROPRIEDADES' name='🇵🇹[Pleonasmo] Propriedades características'>
             <pattern>
                 <token regexp='yes'>propriedades?</token>
                 <token regexp='yes'>carac?terísticas?</token>
@@ -4139,7 +4139,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_32_RECORDAR' name='[pt-PT][Pleonasmo] recordar o passado'>
+        <rule id='REDUNDANCY_32_RECORDAR' name='🇵🇹[Pleonasmo] recordar o passado'>
             <pattern>
                 <token inflected='yes'>recordar</token>
                 <token>o</token>
@@ -4151,7 +4151,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_37_REPETIR' name='[pt-PT][Pleonasmo] repetir novamente'>
+        <rule id='REDUNDANCY_37_REPETIR' name='🇵🇹[Pleonasmo] repetir novamente'>
             <pattern>
                 <token inflected='yes'>repetir</token>
                 <token>novamente</token>
@@ -4162,7 +4162,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_SEGUIR_EM_FRENTE' name="[pt-PT][Pleonasmo] Seguir em frente">
+        <rule id='REDUNDANCY_SEGUIR_EM_FRENTE' name="🇵🇹[Pleonasmo] Seguir em frente">
             <pattern>
                 <marker>
                     <token inflected='yes'>seguir</token>
@@ -4177,7 +4177,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_SI_MESMO' name="[pt-PT][Pleonasmo] Si mesmo" default="off">
+        <rule id='REDUNDANCY_SI_MESMO' name="🇵🇹[Pleonasmo] Si mesmo" default="off">
             <pattern>
                 <token>si</token>
                 <token inflected='yes'>mesmo</token>
@@ -4188,7 +4188,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_41_SOLETRAR' name='[pt-PT][Pleonasmo] soletrar em detalhe'>
+        <rule id='REDUNDANCY_41_SOLETRAR' name='🇵🇹[Pleonasmo] soletrar em detalhe'>
             <pattern>
                 <token inflected='yes'>soletrar</token>
                 <token min='0'>em</token>
@@ -4200,7 +4200,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_42_TESTEMUNHAR' name='[pt-PT][Pleonasmo] testemunhar in loco o facto'>
+        <rule id='REDUNDANCY_42_TESTEMUNHAR' name='🇵🇹[Pleonasmo] testemunhar in loco o facto'>
             <pattern>
                 <token inflected='yes'>testemunhar</token>
                 <token min='0' regexp='yes'>os?</token>
@@ -4216,7 +4216,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='REDUNDANCY_63_VIVER' name='[pt-PT][Pleonasmo] Viver a vida'>
+        <rule id='REDUNDANCY_63_VIVER' name='🇵🇹[Pleonasmo] Viver a vida'>
             <pattern>
                 <token inflected='yes'>viver</token>
                 <token>a</token>
@@ -4230,10 +4230,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
 
-    <category id='SHORTEN_IT_PT_PT' name="[pt-PT] Linguagem concisa" type="style">
+    <category id='SHORTEN_IT_PT_PT' name="🇵🇹 Linguagem concisa" type="style">
 
 
-    <rulegroup id='SIMPLIFICAR_DE_VOCÊS_VOSSO_SEU' name="[pt-PT][Simplificar] 'de vocês' → vosso/seu" tone_tags='objective'>
+    <rulegroup id='SIMPLIFICAR_DE_VOCÊS_VOSSO_SEU' name="🇵🇹[Simplificar] 'de vocês' → vosso/seu" tone_tags='objective'>
         <!-- ChatGPT 5 and new disambiguator for 2026+ -->
 
         <rule> <!-- #1: é/são de você -> é/são sua(s)/seu(s) -->
@@ -4316,7 +4316,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-    <rule id='AVIÃO_DE_COMBATE_PT_PT' name="[pt-PT][Simplificar] Avião de combate → caça" tone_tags="objective">
+    <rule id='AVIÃO_DE_COMBATE_PT_PT' name="🇵🇹[Simplificar] Avião de combate → caça" tone_tags="objective">
         <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
         <!-- With "aeronave" there was the problem of it being a female word messing the suggestions -->
         <pattern>
@@ -4331,7 +4331,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id='CHEGAR_AO_FIM_FINDAR_TERMINAR' name="[pt-PT][Simplificar] Chegar ao fim → findar/terminar/acabar" type='style' tone_tags='objective'>
+    <rule id='CHEGAR_AO_FIM_FINDAR_TERMINAR' name="🇵🇹[Simplificar] Chegar ao fim → findar/terminar/acabar" type='style' tone_tags='objective'>
         <!-- ChatGPT 5 and new disambiguator for 2026+ -->
         <antipattern>
             <token postag='V.+|N.+|AQ.+|UNKNOWN|RN|SPS00' postag_regexp='yes'/>
@@ -4364,7 +4364,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-      <rule id='DEPOIS_É_QUE_VERBO_DEPOIS_VERBO_PT_PT' name="[pt-PT][Simplificar] Depois é que → depois" type='style' tone_tags='objective'>
+      <rule id='DEPOIS_É_QUE_VERBO_DEPOIS_VERBO_PT_PT' name="🇵🇹[Simplificar] Depois é que → depois" type='style' tone_tags='objective'>
           <!-- ChatGPT 5 and new disambiguator for 2026+ -->
           <pattern>
               <token regexp='yes'>só|apenas|somente</token>
@@ -4383,7 +4383,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-    <rulegroup id='SIMPLIFICAR_E_ESTAS_ESTES_QUE_PT_PT' name="[pt-PT][Simplificar] E est(a/e)(s) → que" type='style'>
+    <rulegroup id='SIMPLIFICAR_E_ESTAS_ESTES_QUE_PT_PT' name="🇵🇹[Simplificar] E est(a/e)(s) → que" type='style'>
     <!-- IDEA shorten_it -->
     <!-- Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2022-10-12 (25-JUL-2022+) -->
     <!--
@@ -4460,7 +4460,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-      <rulegroup id='SIMPLIFICAR_É_NECESSÁRIO_TER_REQUER' name="[pt-PT][Simplificar] é necessário ter → requer" type='style'>
+      <rulegroup id='SIMPLIFICAR_É_NECESSÁRIO_TER_REQUER' name="🇵🇹[Simplificar] é necessário ter → requer" type='style'>
           <!-- ChatGPT 5 and new disambiguator for 2026+ -->
 
           <rule> <!-- #1: Remove comma -->
@@ -4500,7 +4500,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rulegroup>
 
 
-<rule id='E_QUE_VERBO_REMOVER_E_PT_PT' name="[pt-PT][Simplificar] E que → que" type="style">
+<rule id='E_QUE_VERBO_REMOVER_E_PT_PT' name="🇵🇹[Simplificar] E que → que" type="style">
     <!-- IDEA shorten_it -->
     <!-- Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2022-11-06 (25-JUL-2022+) -->
     <!--
@@ -4581,7 +4581,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-    <rulegroup id='SIMPLIFICAR_REPETICAO_AUXILIAR_VERBO' name="[pt-PT][Simplificar] Eliminação da redundância de auxiliar" type='style' tone_tags="objective">
+    <rulegroup id='SIMPLIFICAR_REPETICAO_AUXILIAR_VERBO' name="🇵🇹[Simplificar] Eliminação da redundância de auxiliar" type='style' tone_tags="objective">
         <!-- IDEA shorten_it -->
         <!-- Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2022-10-14 (25-JUL-2022+) -->
         <!--
@@ -4633,7 +4633,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-    <rule id='SIMPLIFICAR_TAMBÉM_O_VERBO_PT_PT' name="[pt-PT][Simplificar] Evitar redundância de adjetivos" tone_tags='clarity'>
+    <rule id='SIMPLIFICAR_TAMBÉM_O_VERBO_PT_PT' name="🇵🇹[Simplificar] Evitar redundância de adjetivos" tone_tags='clarity'>
         <!-- IDEA shorten_it -->
         <!-- ChatGPT 5 and new disambiguator for 2026+ -->
         <pattern>
@@ -4656,7 +4656,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id='SIMPLIFICAR_A_SER_PP_A_INF' name="[pt-PT][Simplificar] há + Adv. intensidade + 'a ser Part.P.' → 'a Inf.'" type="style">
+    <rule id='SIMPLIFICAR_A_SER_PP_A_INF' name="🇵🇹[Simplificar] há + Adv. intensidade + 'a ser Part.P.' → 'a Inf.'" type="style">
         <!-- IDEA shorten_it -->
         <pattern>
             <token inflected='yes'>haver</token>
@@ -4675,7 +4675,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id='PARA_SER_MELHORADA_A_MELHORAR' name="[pt-PT][Simplificar] A ser melhorado → a melhorar">
+    <rule id='PARA_SER_MELHORADA_A_MELHORAR' name="🇵🇹[Simplificar] A ser melhorado → a melhorar">
     <!-- IDEA shorten_it -->
         <!-- ChatGPT 5 and new disambiguator for 2026+ -->
         <pattern>
@@ -4693,7 +4693,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rulegroup id='SIMPLIFICAR_POR_ISSO_AÍ_ASSIM_DAÍ_ISSO_PT' name="[pt-PT][Simplificar] por isso → aí/assim/daí/isso" type='style'>
+    <rulegroup id='SIMPLIFICAR_POR_ISSO_AÍ_ASSIM_DAÍ_ISSO_PT' name="🇵🇹[Simplificar] por isso → aí/assim/daí/isso" type='style'>
     <!-- IDEA shorten_it -->
     <!--      Created by Marco A.G.Pinto, Portuguese rule 2022-01-24/25 (Checked/Enhanced) (1-JAN-2022+)      -->
     <!--
@@ -4742,7 +4742,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-    <rulegroup id='SIMPLIFICAR_PP_OBJ_IND_V2' name="[pt-PT][Simplificar] Pronome pessoal no dativo" type='style' tone_tags="objective">
+    <rulegroup id='SIMPLIFICAR_PP_OBJ_IND_V2' name="🇵🇹[Simplificar] Pronome pessoal no dativo" type='style' tone_tags="objective">
         <!-- IDEA shorten_it -->
         <!-- Created by Marco A.G.Pinto, Portuguese rule 2022-09-16/20 (Checked/Enhanced) (25-JUL-2022+) -->
         <!--
@@ -4862,7 +4862,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-    <rule id='SIMPLIFICAR_QUE_VERBO_A_VERBOINFINITIVO' name="[pt-PT][Simplificar] Que + V. → A + V. Infinitivo" type="style">
+    <rule id='SIMPLIFICAR_QUE_VERBO_A_VERBOINFINITIVO' name="🇵🇹[Simplificar] Que + V. → A + V. Infinitivo" type="style">
         <pattern>
             <token postag='NC.+|AQ.+' postag_regexp='yes'><exception scope='previous' postag_regexp='yes' postag='VMN000.+'/></token>
             <marker>
@@ -4888,7 +4888,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-        <rule id='QUE_SE_VERBO_PART_PASSADO' name="[pt-PT][Simplificar] 'Que se Verbo' → Verbo Part. Passado">
+        <rule id='QUE_SE_VERBO_PART_PASSADO' name="🇵🇹[Simplificar] 'Que se Verbo' → Verbo Part. Passado">
            <pattern>
                 <token postag='NC[^C].+' postag_regexp='yes'><exception postag_regexp='yes' postag='RG|SPS0.+'/></token>
                 <marker>
@@ -4907,7 +4907,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-    <rulegroup id='SIMPLIFICAR_SER_IGUAL_IGUALAR' name="[pt-PT][Simplificar] Ser igual a → igualar" type='style'>
+    <rulegroup id='SIMPLIFICAR_SER_IGUAL_IGUALAR' name="🇵🇹[Simplificar] Ser igual a → igualar" type='style'>
         <!-- IDEA shorten_it -->
         <!-- Created by Marco A.G.Pinto, Portuguese rule 2022-10-15 (25-JUL-2022+) -->
         <!--
@@ -5059,7 +5059,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-    <rulegroup id='VERBO_PARA_PRONOME_PESSOAL_V2' name="[pt-PT][Simplificar] Verbo + para + pronome → verbo com pronome hifenizado" type='style' tone_tags='formal'>
+    <rulegroup id='VERBO_PARA_PRONOME_PESSOAL_V2' name="🇵🇹[Simplificar] Verbo + para + pronome → verbo com pronome hifenizado" type='style' tone_tags='formal'>
         <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
         <!-- 2026: Replace the pronouns in the APs with PP.+ and test, also try to use all verbs after disambiguator is all fixed -->
 
@@ -5215,7 +5215,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-    <rule id='VERBO_PRONOMINAL_DE_V3' name="[pt-PT][Simplificar] 'V. Pronominal + de' → V. Pronominal" type="style" tone_tags="formal">
+    <rule id='VERBO_PRONOMINAL_DE_V3' name="🇵🇹[Simplificar] 'V. Pronominal + de' → V. Pronominal" type="style" tone_tags="formal">
         <!-- IDEA shorten_it -->
         <!-- Used ChatGPT 4o for enhancements and extra accuracy -->
         <pattern>
@@ -5245,7 +5245,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id='VERBO_SER_ÚTIL_PARA_SERVIR_PARA' name="[pt-PT][Simplificar] Ser útil para → servir para" type="style">
+    <rule id='VERBO_SER_ÚTIL_PARA_SERVIR_PARA' name="🇵🇹[Simplificar] Ser útil para → servir para" type="style">
         <!-- ChatGPT 5 and new disambiguator for 2026+ -->
         <pattern>
             <marker>


### PR DESCRIPTION
Used the Portuguese flag emoji in the pt-PT rules.

If it works well in the nightly WritingTool, I will do the same for pt-BR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated all Portuguese (Portugal) grammar and style rule names to feature the Portugal flag emoji (🇵🇹) for improved visual clarity and consistency in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->