### PR TITLE
[pt-BR] Added Brazilian flag emoji to pt-BR rules names

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/grammar.xml
@@ -50,7 +50,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 <rules lang="pt-BR" xsi:noNamespaceSchemaLocation="../../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-  <category id="MISC" name="Gramática Geral">
+  <category id="MISC" name="🇧🇷 Gramática Geral">
       <rulegroup id='AO90_COMPOUNDS_GENERIC_PREFIX' name='[pt-BR][AO90] Hifenizador de palavras' default="temp_off">
           <url>https://pt.wikipedia.org/wiki/Uso_do_h%C3%ADfen_conforme_o_Acordo_Ortogr%C3%A1fico_de_1990</url>
           <antipattern>
@@ -471,7 +471,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
   </rulegroup>
 
-      <rule id="ATOA_BR" name="Uso de 'atoa' em vez de 'à toa'">
+      <rule id="ATOA_BR" name="🇧🇷 Uso de 'atoa' em vez de 'à toa'">
           <!-- Super rare usage of the verb 'atoar', but let's be cautious. -->
           <antipattern>
               <token>atoa</token>
@@ -489,7 +489,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
       <!-- ORDINAL_ABREVIATION -->
 
-    <rule id='A_NIVEL' name="A nível" default='on'>
+    <rule id='A_NIVEL' name="🇧🇷 A nível" default='on'>
       <!-- Created by Tiago F. Santos, Portuguese rule, 2016-10-28 -->
       <pattern>
         <token regexp='yes'>a|em</token>
@@ -503,7 +503,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
     <!-- CONFUNDIR A GENTE POR AGENTE -->
 
-    <rulegroup id="AGENTE_BR" name="Confusão entre 'agente' e 'a gente'">
+    <rulegroup id="AGENTE_BR" name="🇧🇷 Confusão entre 'agente' e 'a gente'">
         <antipattern>
             <token>a</token>
             <token>agente</token>
@@ -654,7 +654,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
     </rulegroup>
 
-    <rulegroup id="HEIN_BR" name="Ortografia da interjeição 'hein'">
+    <rulegroup id="HEIN_BR" name="🇧🇷 Ortografia da interjeição 'hein'">
         <rule>
             <pattern>
                 <token postag="_PUNCT_COMMA"/>
@@ -666,7 +666,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
     </rulegroup>
 
-    <rulegroup id="CONFUSÃO_POSSO_POÇO" name="Confusão entre poço e posso">
+    <rulegroup id="CONFUSÃO_POSSO_POÇO" name="🇧🇷 Confusão entre poço e posso">
         <short>Possível erro de ortografia.</short>
 
         <antipattern>
@@ -730,7 +730,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR FAÇO POR FASSO -->
 
-    <rule id="FASSO_BR" name="faço">
+    <rule id="FASSO_BR" name="🇧🇷 faço">
       <pattern>
         <token negate="yes" regexp="yes">Burquina|Burkina</token>
         <marker>
@@ -745,7 +745,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR MAIS(QUANTIDADE) POR MAS(CONJUNÇÃO) -->
 
-    <rule id="MAS_BR" name="mais">
+    <rule id="MAS_BR" name="🇧🇷 mais">
       <pattern>
         <token regexp="yes">quanto|quero</token>
         <marker>
@@ -756,7 +756,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <example correction="mais">Quanto <marker>mas</marker> eu falo, pior fica.</example>
     </rule>
 
-    <rule id="QUERO_MAS_BR" name="quero mais">
+    <rule id="QUERO_MAS_BR" name="🇧🇷 quero mais">
       <pattern>
         <token>quero</token>
         <token>mas</token>
@@ -771,7 +771,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR ABENÇOE POR ABENÇÕE -->
 
-    <rule id="ABENCOE_BR" name="abençoe">
+    <rule id="ABENCOE_BR" name="🇧🇷 abençoe">
       <pattern>
         <token>abençõe</token>
       </pattern>
@@ -779,7 +779,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <example correction="abençoe">Deus te <marker>abençõe</marker>.</example>
     </rule>
 
-    <rule id="MIM_BR" name="me" default="off">
+    <rule id="MIM_BR" name="🇧🇷 me" default="off">
       <pattern>
         <marker>
           <token>mim</token>
@@ -790,7 +790,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <example correction="me">Você consegue <marker>mim</marker> ajudar.</example>
     </rule>
 
-    <rule id="COMCERTEZA_BR" name="com certeza">
+    <rule id="COMCERTEZA_BR" name="🇧🇷 com certeza">
       <pattern>
         <token>comcerteza</token>
       </pattern>
@@ -798,7 +798,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <example correction="com certeza">Eu irei na festa <marker>comcerteza</marker>.</example>
     </rule>
 
-    <rule id="CONCERTEZA_BR" name="com certeza">
+    <rule id="CONCERTEZA_BR" name="🇧🇷 com certeza">
       <pattern>
         <token>concerteza</token>
       </pattern>
@@ -810,7 +810,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR MENOS POR MENAS -->
 
-    <rule id="MENAS_BR" name="menos">
+    <rule id="MENAS_BR" name="🇧🇷 menos">
       <pattern>
         <token>menas</token>
       </pattern>
@@ -823,7 +823,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR ÀS VEZES POR AS VEZES || AS VESES -->
 
-    <rule id="AS_VEZES_BR" name="às vezes">
+    <rule id="AS_VEZES_BR" name="🇧🇷 às vezes">
       <pattern>
         <token>as</token>
         <token>vezes</token>
@@ -832,7 +832,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <example correction="às vezes">Eu <marker>as vezes</marker> fico triste.</example>
     </rule>
 
-    <rule id="AS_VESES_BR" name="às vezes">
+    <rule id="AS_VESES_BR" name="🇧🇷 às vezes">
       <pattern>
         <token>as</token>
         <token>veses</token>
@@ -845,7 +845,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR NADA A VER POR NADA HAVER -->
 
-    <rule id="NADA_HAVER_BR" name="nada a ver">
+    <rule id="NADA_HAVER_BR" name="🇧🇷 nada a ver">
       <pattern>
         <token>nada</token>
         <token>haver</token>
@@ -858,7 +858,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR DE REPENTE POR DERREPENTE || DEREPENTE -->
 
-    <rule id="DERREPENTE_BR" name="de repente">
+    <rule id="DERREPENTE_BR" name="🇧🇷 de repente">
       <pattern>
         <token>derrepente</token>
       </pattern>
@@ -866,7 +866,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <example correction="de repente">E <marker>derrepente</marker> você apareceu.</example>
     </rule>
 
-    <rule id="DEREPENTE_BR" name="de repente">
+    <rule id="DEREPENTE_BR" name="🇧🇷 de repente">
       <pattern>
         <token>derepente</token>
       </pattern>
@@ -876,7 +876,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
     <!-- FIM NADA A VER POR NADA HAVER || DEREPENTE -->
 
-    <rule id="AS_PONTUAL_BR" name="Usar 'às' com horas pontuais" default="off">
+    <rule id="AS_PONTUAL_BR" name="🇧🇷 Usar 'às' com horas pontuais" default="off">
       <pattern>
         <token postag="SENT_START"/>
         <marker>
@@ -889,7 +889,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <example correction="Às"><marker>As</marker> duas da tarde.</example>
     </rule>
 
-    <rule id="A_TERRA_FIRME_BR" name="Usar à terra firme" default="off">
+    <rule id="A_TERRA_FIRME_BR" name="🇧🇷 Usar à terra firme" default="off">
       <pattern>
         <token postag="VMI.[21].+|VMI.3P.+" postag_regexp="yes"/>
         <marker>
@@ -903,7 +903,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
     <!-- CONFUNDIR QUER SE POR QUER -->
 
-    <rule id="QUER_SE_BR" name="Quer" default="off">
+    <rule id="QUER_SE_BR" name="🇧🇷 Quer" default="off">
       <pattern>
         <token>quer</token>
         <token>se</token>
@@ -916,7 +916,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR DORMIU NO POR DORMIU AO -->
 
-    <rule id="DORMIU_NO_BR" name="Dormiu ao">
+    <rule id="DORMIU_NO_BR" name="🇧🇷 Dormiu ao">
       <pattern>
         <marker>
           <token inflected="yes">dormir</token>
@@ -932,7 +932,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR PARASITO|S POR PARASITA|S QUANDO FOR PESSOA|ANIMAL -->
 
-    <rule id="PARASITO_BR" name="Parasita">
+    <rule id="PARASITO_BR" name="🇧🇷 Parasita">
       <pattern>
         <token regexp="yes">um|autêntico|uma|de</token>
         <marker>
@@ -944,7 +944,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rule>
 
 
-    <rule id="PARASITOS_BR" name="Parasita">
+    <rule id="PARASITOS_BR" name="🇧🇷 Parasita">
       <pattern>
         <token regexp="yes">um|autênticos|uma|de</token>
         <marker>
@@ -959,7 +959,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR ALERTA POR ALERTAS -->
 
-    <rule id="ALERTAS_BR" name="Alerta">
+    <rule id="ALERTAS_BR" name="🇧🇷 Alerta">
       <pattern>
         <token negate_pos="yes" postag="D...P.+|SPS00:....P.+" postag_regexp="yes"/>
         <marker>
@@ -976,7 +976,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR MENOR DE IDADE POR MENOR -->
 
-    <rule id="MENOR_IDADE_BR" name="Menor de idade">
+    <rule id="MENOR_IDADE_BR" name="🇧🇷 Menor de idade">
       <pattern>
         <token>de</token>
         <token>menor</token>
@@ -990,7 +990,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR O|A 3o, 4o, 5o por Os|As -->
 
-    <rule id="OS_PARAGRAFOS_BR" name="Usar o">
+    <rule id="OS_PARAGRAFOS_BR" name="🇧🇷 Usar o">
       <pattern>
         <marker>
           <token>os</token>
@@ -1001,7 +1001,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <example correction="o">O juiz leu <marker>os</marker> 3º, 4º e 5º parágrafos.</example>
     </rule>
 
-    <rule id="AS_PARAGRAFOS_BR" name="Usar a">
+    <rule id="AS_PARAGRAFOS_BR" name="🇧🇷 Usar a">
       <pattern>
         <marker>
           <token>as</token>
@@ -1016,7 +1016,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR MIL POR UM MIL -->
 
-    <rule id="UM_MIL_BR" name="Mil">
+    <rule id="UM_MIL_BR" name="🇧🇷 Mil">
       <pattern>
         <token>um</token>
         <token>mil</token>
@@ -1029,7 +1029,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR TODA A AGUARDENTE POR TODO O -->
 
-    <rule id="O_AGUARDENTE_BR" name="A aguardente">
+    <rule id="O_AGUARDENTE_BR" name="🇧🇷 A aguardente">
       <pattern>
         <token>todo</token>
         <token>o</token>
@@ -1043,7 +1043,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR NÃO É ADEQUEADO POR ÁDEQUA -->
 
-    <rule id="ADEQUA_BR" name="Não é adequado">
+    <rule id="ADEQUA_BR" name="🇧🇷 Não é adequado">
       <pattern>
         <token>não</token>
         <token>se</token>
@@ -1057,7 +1057,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR CHEGAMOS A POR CHEGAMOS EM -->
 
-    <rule id="CHEGAMOS_EM_BR" name="Chegamos a">
+    <rule id="CHEGAMOS_EM_BR" name="🇧🇷 Chegamos a">
       <pattern>
         <marker>
           <token>chegamos</token>
@@ -1073,7 +1073,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR ONDE POR AONDE -->
 
-    <rule id="AONDE_BR" name="Onde" default="off">
+    <rule id="AONDE_BR" name="🇧🇷 Onde" default="off">
     <!-- p-goulart@2024-02-13 - DESC: disable completely, this causes more FPs than fixes actual issues -->
       <pattern>
         <token>aonde</token>
@@ -1087,7 +1087,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR ANEXOS POR ANEXO QUANDO É PLURAL -->
 
-    <rule id="ANEXO_P_BR" name="Anexos">
+    <rule id="ANEXO_P_BR" name="🇧🇷 Anexos">
       <pattern>
         <token negate="yes">em</token>
         <marker>
@@ -1103,7 +1103,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR ESTÁ QUITE COM ESTÁ QUITES SINGULAR -->
 
-    <rule id="QUITE_P_BR" name="está quite">
+    <rule id="QUITE_P_BR" name="🇧🇷 está quite">
       <pattern>
         <token>está</token>
         <token>quites</token>
@@ -1116,7 +1116,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR A MEU VER COM AO MEU VER -->
 
-    <rule id="AO_MEU_VER_BR" name="A meu ver">
+    <rule id="AO_MEU_VER_BR" name="🇧🇷 A meu ver">
       <pattern>
         <token>Ao</token>
         <token>meu</token>
@@ -1130,7 +1130,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR SOMOS COM SOMOS EM -->
 
-    <rule id="SOMOS_EM_BR" name="Somos">
+    <rule id="SOMOS_EM_BR" name="🇧🇷 Somos">
       <pattern>
         <marker>
           <token>Somos</token>
@@ -1149,7 +1149,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR CHEGARAM A POR CHEGARAM EM (VERBO DE MOVIMENTO EXIGE A) -->
 
-    <rule id="CHEGARAM_EM_BR" name="Chegaram a">
+    <rule id="CHEGARAM_EM_BR" name="🇧🇷 Chegaram a">
       <pattern>
         <marker>
           <token>chegaram</token>
@@ -1165,7 +1165,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR EXISTEM (VARIOS) COM EXISTE (UM) -->
 
-    <rule id="EXISTE_VARIOS_BR" name="Existem vários">
+    <rule id="EXISTE_VARIOS_BR" name="🇧🇷 Existem vários">
       <pattern>
         <marker>
           <token>existe</token>
@@ -1180,7 +1180,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR ASSISTIU AO (SENTIDO DE VER) ASSISTIU O -->
 
-    <rule id="ASSISTIU_O_BR" name="Assistiu ao">
+    <rule id="ASSISTIU_O_BR" name="🇧🇷 Assistiu ao">
       <pattern>
         <marker>
           <token>assistiu</token>
@@ -1192,7 +1192,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <example correction="assistiu ao">Ele <marker>assistiu o</marker> o filme.</example>
     </rule>
     <!-- CONFUNDIR HAVIA MUITAS COM HAVIAM MUITAS -->
-    <rule id="HAVIAM_MUITAS_BR" name="Havia muitas">
+    <rule id="HAVIAM_MUITAS_BR" name="🇧🇷 Havia muitas">
       <pattern>
         <token>haviam</token>
         <token>muitas</token>
@@ -1205,7 +1205,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR NA RUA COM À RUA -->
 
-    <rule id="A_RUA_BR" name="Na rua">
+    <rule id="A_RUA_BR" name="🇧🇷 Na rua">
       <pattern>
         <token regexp="yes">residente|vive|estabelecido</token>
         <marker>
@@ -1221,7 +1221,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR CAIU (AUMENTAR E DIMINUIR) COM CAIU EM -->
 
-    <rule id="CAIU_EM_BR" name="Caiu">
+    <rule id="CAIU_EM_BR" name="🇧🇷 Caiu">
       <antipattern>
           <token postag="DI.+" postag_regexp="yes"/>
           <token postag="[AN].+" postag_regexp="yes"/>
@@ -1246,7 +1246,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR CONSISTE EM POR CONSISTE DE -->
 
-    <rule id="CONSISTE_DE_BR" name="Consiste em">
+    <rule id="CONSISTE_DE_BR" name="🇧🇷 Consiste em">
         <antipattern>
             <token inflected="yes">consistir</token>
             <token postag_regexp="yes" postag="R.">de</token>
@@ -1269,7 +1269,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR DAQUI A COM DAQUI -->
 
-    <rule id="DAQUI_BR" name="Daqui a">
+    <rule id="DAQUI_BR" name="🇧🇷 Daqui a">
       <!-- MARCOAGPINTO 2021-04-05 (17-MAR-2021+) *START* -->
       <!--
       Todos os garotos daqui têm namorada.
@@ -1309,7 +1309,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR QUANTO ANTES COM O QUANTO ANTES  -->
 
-    <rule id="O_QUANTO_ANTES_BR" name="Quanto antes">
+    <rule id="O_QUANTO_ANTES_BR" name="🇧🇷 Quanto antes">
       <pattern>
         <token>o</token>
         <token>quanto</token>
@@ -1323,7 +1323,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ********************************************************** -->
     <!-- CONFUNDIR MAIS INFORMAÇÕES COM MAIORES INFORMAÇÕES  -->
 
-    <rule id="DUZENTAS_GRAMAS_NUMERAL" name="Duzentos gramas">
+    <rule id="DUZENTAS_GRAMAS_NUMERAL" name="🇧🇷 Duzentos gramas">
         <pattern>
             <token regexp="yes">(duz|trez|quatroc|quinh|seic|setec|oitoc|novec)entas</token>
             <token>gramas</token>
@@ -1333,7 +1333,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <example correction="Oitocentos gramas"><marker>Oitocentas gramas</marker> de alfalfa, por favor.</example>
     </rule>
 
-    <rule id="FAZEM_TEMPO" name="Faz tempo">
+    <rule id="FAZEM_TEMPO" name="🇧🇷 Faz tempo">
         <antipattern>
             <token postag_regexp="yes" postag="N..P.+|PP3.P.+"/>
             <token inflected="yes" postag_regexp="yes" postag="VM..3P.">fazer</token>
@@ -1366,7 +1366,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <example correction="fizesse">Achei que <marker>fizessem</marker> algumas décadas!</example>
     </rule>
 
-    <rule id="VAO_FAZER_TEMPO" name="Vai fazer tempo">
+    <rule id="VAO_FAZER_TEMPO" name="🇧🇷 Vai fazer tempo">
         <antipattern>
             <token postag_regexp="yes" postag="N..P.+|PP3.P.+"/>
             <token inflected="yes" postag_regexp="yes" postag="VMI.3P.">ir</token>
@@ -1399,7 +1399,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <example correction="vai fazer">Já <marker>vão fazer</marker> 10 minutos que estamos esperando!</example>
     </rule>
 
-    <rule id="NAO_E_ADJ" name="Não e + adjetivo, falta de acento">
+    <rule id="NAO_E_ADJ" name="🇧🇷 Não e + adjetivo, falta de acento">
         <pattern>
             <token>não</token>
             <marker>
@@ -1418,7 +1418,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   </category>
 
   <category id='CASING' name='Capitalização' type='grammar'>
-    <rule id='IRAO_IRA' name="Irão vs Irã" default="on">
+    <rule id='IRAO_IRA' name="🇧🇷 Irão vs Irã" default="on">
       <antipattern>
         <token postag='SENT_START'/>
         <marker>
@@ -1744,7 +1744,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
     </rulegroup>
 
-    <rulegroup id='HIFEN_INTRUSIVO' name="Verbo com hífen intrusivo">
+    <rulegroup id='HIFEN_INTRUSIVO' name="🇧🇷 Verbo com hífen intrusivo">
         <short>Possível erro de digitação.</short>
         <rule>
             <pattern>
@@ -1778,7 +1778,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
   </category>
 
-  <category id="BR_SPELLING" name="ortografia brasileira" type="misspelling">
+  <category id="BR_SPELLING" name="🇧🇷 ortografia brasileira" type="misspelling">
     <rule id='PARONYM_PREMIO_252_PT' name='Parónimo: premio'>
       <pattern>
         <token regexp='yes'>&art_detecao_paronimos;</token>
@@ -1806,7 +1806,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <example correction='prêmios'>E tem <marker>premios</marker> para todos.</example>
     </rule>
 
-    <rule id="PRETERITO_PERFEITO" name="Pretérito perfeito: provámos -> provamos" default="on">
+    <rule id="PRETERITO_PERFEITO" name="🇧🇷 Pretérito perfeito: provámos -> provamos" default="on">
       <pattern>
         <token postag="VMIS1P0P" regexp="yes">.*ámos</token>
       </pattern>
@@ -1817,8 +1817,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
   </category>
 
-  <category id="TYPOGRAPHY" name="Tipografia">
-      <rule type="locale-violation" id='CURRENCY_PLACEMENT_BR' name="Posição dos símbolos de moeda: '100£ (£100)">
+  <category id="TYPOGRAPHY" name="🇧🇷 Tipografia">
+      <rule type="locale-violation" id='CURRENCY_PLACEMENT_BR' name="🇧🇷 Posição dos símbolos de moeda: '100£ (£100)">
           <pattern>
               <token regexp="yes">\d+([,.]\d+)*</token>
               <token regexp="yes">&currency_symbols;</token>
@@ -1830,7 +1830,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
           <example correction="£&nbsp;100.00">Deve <marker>100.00£</marker>.</example>
       </rule>
 
-      <rule type="locale-violation" id='CURRENCY_SPACE_BR' name="Espaçamento entre símbolos e valores monetários: '$100' ($ 100)">
+      <rule type="locale-violation" id='CURRENCY_SPACE_BR' name="🇧🇷 Espaçamento entre símbolos e valores monetários: '$100' ($ 100)">
           <pattern>
               <token regexp="yes">&currency_symbols;</token>
               <token regexp="yes" spacebefore="no">\d+([,.]\d+)*</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-BR/style.xml
@@ -49,9 +49,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 ]>
 
 <rules lang="pt" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/languagetool-org/languagetool/master/languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <category id="STYLE" name="Style" type="style">
+    <category id="STYLE" name="🇧🇷 Style" type="style">
 
-        <rule id="ENTRAR_DENTRO_BR" name="Entrar" tone_tags="objective">
+        <rule id="ENTRAR_DENTRO_BR" name="🇧🇷 Entrar" tone_tags="objective">
             <!-- IDEA shorten_it -->
             <pattern>
                 <token inflected="yes">entrar</token>
@@ -61,7 +61,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="Entrar"><marker>Entrar dentro</marker> na casa.</example>
         </rule>
 
-        <rule id="MAIORES_INFORMACOES_BR" name="Mais informações" tone_tags="objective">
+        <rule id="MAIORES_INFORMACOES_BR" name="🇧🇷 Mais informações" tone_tags="objective">
             <pattern>
                 <marker>
                     <token>maiores</token>
@@ -72,7 +72,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="mais">Para <marker>maiores</marker> informações.</example>
         </rule>
 
-        <rule id='E_QUE_VERBO_REMOVER_QUE_PT_BR' name="Simplificar: E que → e" type="style" tone_tags="objective">
+        <rule id='E_QUE_VERBO_REMOVER_QUE_PT_BR' name="🇧🇷 Simplificar: E que → e" type="style" tone_tags="objective">
             <!-- IDEA shorten_it -->
             <antipattern>
                 <token>vitamina</token>
@@ -110,7 +110,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction=" e|, e| que|, que">Um romance eterno, perfeito para adolescentes<marker> e que</marker> conta com um jovem elenco.</example>
         </rule>
 
-        <rule id="EXPORTOU_PARA_FORA" name="Exportou " tone_tags="objective">
+        <rule id="EXPORTOU_PARA_FORA" name="🇧🇷 Exportou " tone_tags="objective">
             <!-- IDEA shorten_it -->
             <pattern>
                 <token inflected="yes">exportar</token>
@@ -121,7 +121,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="exportou">O estado <marker>exportou para fora</marker> menos calçados este ano.</example>
         </rule>
 
-        <rule id="ENCAROU_DE_FRENTE" name="Encarou" tone_tags="objective">
+        <rule id="ENCAROU_DE_FRENTE" name="🇧🇷 Encarou" tone_tags="objective">
             <!-- IDEA shorten_it -->
             <pattern>
                 <token inflected="yes">encarar</token>
@@ -132,7 +132,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="encarou">O casal <marker>encarou de frente</marker> o problema.</example>
         </rule>
 
-        <rule id="GELO_GELADO" name="Gelo" tone_tags="clarity">
+        <rule id="GELO_GELADO" name="🇧🇷 Gelo" tone_tags="clarity">
             <!-- IDEA shorten_it -->
             <pattern>
                 <token>gelo</token>
@@ -142,7 +142,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="gelo">Vendemos uma pedra de <marker>gelo gelado</marker>.</example>
         </rule>
 
-        <rule id="GANHAR_Gratis" name="Ganhar" tone_tags="clarity">
+        <rule id="GANHAR_Gratis" name="🇧🇷 Ganhar" tone_tags="clarity">
             <!-- IDEA shorten_it -->
             <pattern>
                 <token inflected="yes">ganhar</token>
@@ -152,7 +152,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="ganhar">Você vai <marker>ganhar grátis</marker> um livro.</example>
         </rule>
 
-        <rule id="REPETIR_De_Novo" name="Repetir" tone_tags="clarity">
+        <rule id="REPETIR_De_Novo" name="🇧🇷 Repetir" tone_tags="clarity">
             <!-- IDEA shorten_it -->
             <pattern>
                 <token inflected="yes">repetir</token>
@@ -164,7 +164,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="repetiremos">Mais uma vez, <marker>repetiremos de novo</marker> as instruções.</example>
         </rule>
 
-        <rule id="PLANEJAR_Antecipadamente" name="Planejar" tone_tags="clarity">
+        <rule id="PLANEJAR_Antecipadamente" name="🇧🇷 Planejar" tone_tags="clarity">
             <!-- IDEA shorten_it -->
             <pattern>
                 <token inflected="yes">planejar</token>
@@ -174,7 +174,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="planejar">Vamos <marker>planejar antecipadamente</marker> como será feito.</example>
         </rule>
 
-        <rule id="PEQUENOS_Detalhes" name="Pequenos" tone_tags="clarity">
+        <rule id="PEQUENOS_Detalhes" name="🇧🇷 Pequenos" tone_tags="clarity">
             <!-- IDEA shorten_it -->
             <pattern>
                 <token>pequenos</token>
@@ -184,7 +184,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="detalhes">Repare os <marker>pequenos detalhes</marker> do projeto.</example>
         </rule>
 
-        <rule id="ELO_De_Ligacao" name="Elo" tone_tags="clarity">
+        <rule id="ELO_De_Ligacao" name="🇧🇷 Elo" tone_tags="clarity">
             <!-- IDEA shorten_it -->
             <pattern>
                 <token>elo</token>
@@ -195,7 +195,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="elo">Eu e você temos um <marker>elo de ligação</marker>.</example>
         </rule>
 
-        <rule id="ANTECIPAR_Para_Antes" name="Antecipar" tone_tags="clarity">
+        <rule id="ANTECIPAR_Para_Antes" name="🇧🇷 Antecipar" tone_tags="clarity">
             <!-- IDEA shorten_it -->
             <pattern>
                 <marker>
@@ -210,7 +210,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="antecipar">Vamos <marker>antecipar para antes</marker> nossa reunião.</example>
         </rule>
 
-        <rule id="SUBIR_para_cima" name="Subir" tone_tags="clarity">
+        <rule id="SUBIR_para_cima" name="🇧🇷 Subir" tone_tags="clarity">
             <!-- IDEA shorten_it -->
             <pattern>
                 <token inflected="yes">subir</token>
@@ -221,7 +221,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="subir">Vamos <marker>subir para cima</marker>.</example>
         </rule>
 
-        <rule id="AVISO_BREVE" name="Aviso prévio" tone_tags="professional">
+        <rule id="AVISO_BREVE" name="🇧🇷 Aviso prévio" tone_tags="professional">
             <pattern>
                 <token>aviso</token>
                 <token>breve</token>
@@ -230,7 +230,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="aviso prévio">O <marker>aviso breve</marker> é um direito.</example>
         </rule>
 
-        <rule id='ESTIMAÇÃO_MÁXIMA_SEMELHANÇA_PT_BR' name="Erro de tradução: 'estimação máxima verossimilhança" tone_tags="academic">
+        <rule id='ESTIMAÇÃO_MÁXIMA_SEMELHANÇA_PT_BR' name="🇧🇷 Erro de tradução: 'estimação máxima verossimilhança" tone_tags="academic">
             <pattern>
                 <token regexp="yes">estimativas?|estimação|estimações|estimador|estimadores</token>
                 <token regexp="yes">d[ae]|pela|por</token>
@@ -244,7 +244,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction='verossimilhança'>A estimativa de máxima <marker>semelhança</marker> é usada em Estatística.</example>
         </rule>
 
-        <rule id='TAMBÉM_O_VERBO_PT_BR' name="Evitar redundância de adjetivos" tone_tags="clarity">
+        <rule id='TAMBÉM_O_VERBO_PT_BR' name="🇧🇷 Evitar redundância de adjetivos" tone_tags="clarity">
             <pattern>
                 <token postag='NC.+|AQ.+|NP.+' postag_regexp='yes'/>
                 <token>que</token>
@@ -263,7 +263,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="esta também é">Eu fiz a formação MULTIBANCO que é obrigatória; <marker>esta também é obrigatória</marker>?</example>
         </rule>
 
-        <rule id='LHE_S_ME_TE_VOS_VERB' name="Lhe(s)/me/te/vos + Verbo" tone_tags="formal">
+        <rule id='LHE_S_ME_TE_VOS_VERB' name="🇧🇷 Lhe(s)/me/te/vos + Verbo" tone_tags="formal">
             <!--
             Lhe amo muito. → Amo-lhe muito.
             Te vejo amanhã na biblioteca. → Vejo-te amanhã na biblioteca.
@@ -283,7 +283,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="Amo-lhes"><marker>Lhes amo</marker> muito.</example>
         </rule>
 
-        <rule id='FAZER_DESPORTO' name="Praticar desporto" tone_tags="formal">
+        <rule id='FAZER_DESPORTO' name="🇧🇷 Praticar desporto" tone_tags="formal">
             <pattern>
                 <marker>
                     <token inflected='yes'>fazer</token>
@@ -296,7 +296,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="praticar">Vou <marker>fazer</marker> muito desporto.</example>
         </rule>
 
-        <rule id='FAZER_ESPORTE' name="Praticar esporte" tone_tags="formal">
+        <rule id='FAZER_ESPORTE' name="🇧🇷 Praticar esporte" tone_tags="formal">
             <pattern>
                 <marker>
                     <token inflected='yes'>fazer</token>
@@ -309,7 +309,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="praticar">Vou <marker>fazer</marker> muito esporte.</example>
         </rule>
 
-        <rulegroup id="EMAIL" name="E-mail (correio eletrônico)" tone_tags="formal">
+        <rulegroup id="EMAIL" name="🇧🇷 E-mail (correio eletrônico)" tone_tags="formal">
             <rule>
                 <pattern>
                     <token regexp="yes">e-books?</token>
@@ -331,9 +331,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
     </category>
 
-    <category id='FORMAL_SPEECH_PT_BR' name="Linguagem Formal" type="register" tone_tags="formal">
+    <category id='FORMAL_SPEECH_PT_BR' name="🇧🇷 Linguagem Formal" type="register" tone_tags="formal">
         <!-- COM A GENTE connosco/conosco -->
-        <rule id='COM_A_GENTE_CONNOSCO_CONOSCO_PT_BR' name="Com a gente → Conosco" tags="picky">
+        <rule id='COM_A_GENTE_CONNOSCO_CONOSCO_PT_BR' name="🇧🇷 Com a gente → Conosco" tags="picky">
             <!-- IDEA shorten_it -->
             <!--      Created by Tiago Santos and localised by Marco A.G.Pinto, Portuguese rule 2021-06-03 (17-MAR-2021+)      -->
             <!--
@@ -351,7 +351,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="conosco">Ele veio <marker>com a gente</marker> para o revéillon.</example>
         </rule>
 
-        <rule id='FORMAL_COM_NÓS_PT_BR' name="Expressões 'com nós'">
+        <rule id='FORMAL_COM_NÓS_PT_BR' name="🇧🇷 Expressões 'com nós'">
             <!-- IDEA shorten_it -->
             <!--    Created by Tiago F. Santos, Portuguese rule, 2016-12-28      -->
             <!-- MARCOAGPINTO 2021-06-09 (17-MAR-2021+) *START* -->
@@ -375,7 +375,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="conosco">Ele veio <marker>com nós</marker> para o revéillon.</example>
         </rule>
 
-        <rulegroup id='DEPRECIATIVO_PT_BR' name="Termos depreciativos" type="style" tags="picky">
+        <rulegroup id='DEPRECIATIVO_PT_BR' name="🇧🇷 Termos depreciativos" type="style" tags="picky">
             <!-- IDEA inclusive -->
             <rule>
                 <antipattern>


### PR DESCRIPTION
Now the Brazilian rules names have the Brazilian flag emoji, just like I did for European Portuguese.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Added Brazilian flag emoji (🇧🇷) prefix to Portuguese Brazilian grammar rule names, rule groups, and categories for enhanced visual identification.
  * Added Brazilian flag emoji (🇧🇷) prefix to Portuguese Brazilian style rule names, rule groups, and categories for enhanced visual identification.
  * All underlying rule functionality and logic remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->