### PR TITLE
Updated some URLs from FundéuRAE to RAE

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -15974,7 +15974,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             </rule>
         </rulegroup>
         <rulegroup id="HIPER" name="híper/hiper-">
-            <url>https://rae.es/dpd/super-</url>
+            <url>https://rae.es/dpd/hiper-</url>
             <rule>
                 <pattern>
                     <token regexp="yes">hiper|híper</token>


### PR DESCRIPTION
FundéuRAE is advised by RAE. Then, the best source of information is RAE, and FundéuRAE would be second. Therefore, I updated some URLs to link to RAE pages instead of the FundéuRAE ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated reference links for Spanish grammar rules: replaced older external citations with links to the RAE Leia consultation pages for source attribution. No rule logic, examples, or suggestions were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->