### PR TITLE
[pt] Removed FPs and enabled rule:USAR_UTILIZAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3872,7 +3872,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             </antipattern>
             <antipattern>
                 <token skip='5' postag='V.+' postag_regexp='yes' inflected='yes'>usar
-                    <exception case_sensitive='yes' regexp='no'>USA</exception> <!-- United States of America -->
                     <exception scope='next' regexp='yes'>para|em|com|por|como</exception></token>
                 <token postag='NC.+' postag_regexp='yes' regexp='yes' inflected='yes'>aliança|anel|batom|bermuda|blusão|body|boné|bota|bracelete|brinco|bustiê|calça|calçado|calção|calcinha|camisa|camiseta|camisola|casaco|chapéu|chinelo|colar|corpete|creme|cueca|desodorante|desodorizante|gel|jaqueta|lente|lingerie|maquiagem|maquilhagem|meia|óculos|perfume|pulseira|relógio|saia|sandália|sapatilha|sapato|soutien|sutiã|ténis|tênis|vestido</token> <!-- Lista que cobre a grande maioria dos casos -->
                 <example>Como os ângulos que Taeyang faz enquanto dança, e até o modo como move sua boca enquanto usa óculos escuros.</example>
@@ -3895,7 +3894,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
             <pattern>
                 <marker>
-                    <token postag='V.+' postag_regexp='yes' inflected='yes'>usar</token>
+                    <token postag='V.+' postag_regexp='yes' inflected='yes'>usar
+                        <exception case_sensitive='yes' regexp='no'>USA</exception></token> <!-- United States of America -->
                 </marker>
             </pattern>
             <message>Em contexto formal, prefira &quot;utilizar&quot; em vez de &quot;usar&quot; (exceto com roupa, acessórios ou cosmética).</message>


### PR DESCRIPTION
Removed false positives and enabled the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reactivated a Portuguese style rule that checks for preferred usage of "utilizar"/"recorrer" over "usar".
* **Documentation**
  * Added an illustrative Portuguese example sentence to clarify correct usage in negotiation contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->