### PR TITLE
[pt] Fixed tons of FPs in rule:USAR_UTILIZAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3857,7 +3857,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <!-- Disambiguator must be improved in order to fix some of the words that appear as verbs - 2026-03-04 -->
 
             <antipattern>
-                <token skip='5' regexp='yes' inflected='yes'>aliança|anel|batom|bermuda|blusão|body|boné|bota|bracelete|brinco|bustiê|calça|calçado|calção|calcinha|camisa|camiseta|camisola|casaco|chapéu|chinelo|colar|corpete|creme|cueca|desodorante|desodorizante|gel|jaqueta|lente|lingerie|maquiagem|maquilhagem|meia|óculos|perfume|pulseira|relógio|saia|sandália|sapatilha|sapato|soutien|sutiã|ténis|tênis|vestido</token> <!-- Lista que cobre a grande maioria dos casos -->
+                <token skip='5' postag='NC.+|AQ.+' postag_regexp='yes' regexp='yes' inflected='yes'>aliança|anel|batom|bermuda|blusão|body|boné|bota|bracelete|brinco|bustiê|calça|calçado|calção|calcinha|camisa|camiseta|camisola|casaco|chapéu|chinelo|colar|corpete|creme|cueca|desodorante|desodorizante|gel|jaqueta|lente|lingerie|maquiagem|maquilhagem|meia|óculos|perfume|pulseira|relógio|saia|sandália|sapatilha|sapato|soutien|sutiã|ténis|tênis|vestido</token> <!-- Lista que cobre a grande maioria dos casos -->
                 <token postag='V.+' postag_regexp='yes' inflected='yes'>usar</token>
                 <example>Para o homem, compre a bota ou o sapato que ele irá usar para ir ao trabalho.</example>
                 <example>Amigas dizem que rejuvenesci, perguntam se fiz cirurgia plástica ou que creme de beleza estou usando.</example>
@@ -3873,7 +3873,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <antipattern>
                 <token skip='5' postag='V.+' postag_regexp='yes' inflected='yes'>usar
                     <exception scope='next' regexp='yes'>para|em|com|por|como</exception></token>
-                <token postag='NC.+' postag_regexp='yes' regexp='yes' inflected='yes'>aliança|anel|batom|bermuda|blusão|body|boné|bota|bracelete|brinco|bustiê|calça|calçado|calção|calcinha|camisa|camiseta|camisola|casaco|chapéu|chinelo|colar|corpete|creme|cueca|desodorante|desodorizante|gel|jaqueta|lente|lingerie|maquiagem|maquilhagem|meia|óculos|perfume|pulseira|relógio|saia|sandália|sapatilha|sapato|soutien|sutiã|ténis|tênis|vestido</token> <!-- Lista que cobre a grande maioria dos casos -->
+                <token postag='NC.+|AQ.+' postag_regexp='yes' regexp='yes' inflected='yes'>aliança|anel|batom|bermuda|blusão|body|boné|bota|bracelete|brinco|bustiê|calça|calçado|calção|calcinha|camisa|camiseta|camisola|casaco|chapéu|chinelo|colar|corpete|creme|cueca|desodorante|desodorizante|gel|jaqueta|lente|lingerie|maquiagem|maquilhagem|meia|óculos|perfume|pulseira|relógio|saia|sandália|sapatilha|sapato|soutien|sutiã|ténis|tênis|vestido</token> <!-- Lista que cobre a grande maioria dos casos -->
                 <example>Como os ângulos que Taeyang faz enquanto dança, e até o modo como move sua boca enquanto usa óculos escuros.</example>
                 <example>do tipo que sempre usa a mesma saia com a mesma blusa sabe?</example>
                 <example>Eu só não uso camisa de força porque branco marca muito.</example>


### PR DESCRIPTION
Fixed false positives by also using AQ.+ and not only NC.+, since some words would be recognised as AQ.+ .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese grammar style rule detection to reduce false positives and enhance accuracy when checking for redundant word patterns in sentence structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->