### PR TITLE
[pt] Enabled and improved rule:LOCALIZADA_SITUADA_EM_NA_NO_V2

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -13221,11 +13221,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <category id='SHORTEN_IT' name="✂️ Linguagem concisa" type="style">
 
 
-        <rule id='LOCALIZADA_SITUADA_EM_NA_NO_V2' name="✂️ Localizada/situada em/na(s)/no(s) → em/na(s)/no(s)" tone_tags='objective' default='temp_off'>
+        <rule id='LOCALIZADA_SITUADA_EM_NA_NO_V2' name="✂️ Localizada/situada em/na(s)/no(s) → em/na(s)/no(s)" tone_tags='objective'>
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <pattern>
                 <marker>
-                    <token postag='NC.+|AQ.+' postag_regexp='yes'/>
+                    <token postag='N.+|AQ.+' postag_regexp='yes'/>
                     <token spacebefore='no' min='0' max='1' postag='_PUNCT_COMMA'/>
                     <token regexp='yes'>(situad|localizad)[ao]s?</token>
                     <token regexp='yes'>em|n[ao]s?</token>


### PR DESCRIPTION
Enabled the rule and made it also work with proper names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Portuguese language: Enabled a style rule that provides recommendations for locational expressions in text. The rule is now active by default and will automatically offer style suggestions during analysis and review, recommending "em/na(s)/no(s)" as a preferred alternative to "Localizada/situada em/na(s)/no(s)". Users will receive these recommendations throughout their text checking workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->