### PR TITLE
[pt-PT] Replaced rule with more accurate one:PRAZER_GOSTO_V2

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -130,7 +130,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
           <antipattern>
               <token>prazer</token>
               <token skip='-1' regexp='yes'>de|em|que</token>
-              <token regexp='yes' inflected='yes'>sexo|sexual|sexualmente|orgasmo|erótico|excitação|desejo|corpo|tocar|beijo|carícia|sensual|submisso|dominar|foder|fornicar|ejacular|ejaculação|esperma|esporra|langonha|coito|pénis|vagina|clítoris|cona|boceta</token>
+              <token regexp='yes' inflected='yes'>sexo|sexual|sexualmente|orgasmo|erótico|excitação|desejo|corpo|tocar|beijo|carícia|sensual|submisso|dominar|foder|fornicar|ejacular|ejaculação|esperma|esporra|langonha|coito|pénis|vagina|clítoris|clitóris|cona|boceta</token>
               <example>Será que é possível uma mulher ter prazer em sentir-se submissa sexualmente?</example>
           </antipattern>
           <pattern>


### PR DESCRIPTION
Replaced the old rule with a more accurate one, adding an antipattern, and making it of the type: “formal”.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese style checker to avoid incorrect replacements of "prazer" in sexual/erotic contexts, adding disambiguation so suggestions are only offered when appropriate.
  * Refined messaging and formality handling so recommendations (e.g., using "gosto" where suitable) are more accurate and context-aware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->