### PR TITLE
[pt] Fixed FPs and merged two rules:TORNAR_MAIS_FORTE_FRACO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -12388,33 +12388,35 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <rule> <!-- fortalecer -->
                 <pattern>
                     <marker>
-                        <token inflected='yes'>tornar</token>
+                        <token inflected='yes'>tornar
+                           <exception scope='previous' postag_regexp='yes' postag='PP.C.+'/>
+                           <exception postag_regexp='yes' postag='V.+:PP.C.+'/></token>
                         <token min='0' max='1'>mais</token>
                         <token skip='2' regexp='yes'>fortes?</token>
                     </marker>
-                    <token postag='N.+|AQ.+|_PUNCT|SENT_END' postag_regexp='yes'/>
+                    <token postag='N.+|AQ.+' postag_regexp='yes'><exception scope='previous' postag='CC'/></token>
                 </pattern>
                 <message>&simplify_msg;</message>
                 <suggestion><match no='1' postag='V.+' postag_regexp='yes'>fortalecer</match></suggestion>
                 <example correction="fortalecer">As regras vão <marker>tornar mais forte</marker> o acordo.</example>
                 <example>Isso vai fortalecer o seu estudo sobre a matéria.</example>
-                <example>Isso vai fortalecê-lo.</example>
             </rule>
 
             <rule> <!-- enfraquecer -->
                  <pattern>
                     <marker>
-                        <token inflected='yes'>tornar</token>
+                        <token inflected='yes'>tornar
+                           <exception scope='previous' postag_regexp='yes' postag='PP.C.+'/>
+                           <exception postag_regexp='yes' postag='V.+:PP.C.+'/></token>
                         <token min='0' max='1'>mais</token>
                         <token skip='2' regexp='yes'>frac[ao]s?</token>
                     </marker>
-                    <token postag='N.+|AQ.+|_PUNCT|SENT_END' postag_regexp='yes'/>
+                    <token postag='N.+|AQ.+' postag_regexp='yes'><exception scope='previous' postag='CC'/></token>
                  </pattern>
                  <message>&simplify_msg;</message>
                  <suggestion><match no='1' postag='V.+' postag_regexp='yes'>enfraquecer</match></suggestion>
                  <example correction="enfraquecer">As regras vão <marker>tornar mais fraco</marker> o acordo.</example>
                 <example>Isso vai enfraquecer o seu estudo sobre a matéria.</example>
-                <example>Isso vai enfraquecê-lo.</example>
             </rule>
 
         </rulegroup>


### PR DESCRIPTION
Merged two rules and fixed FPs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Consolidated two Portuguese style checks into a single grouped rule covering both "tornar mais forte" and "tornar mais fraco".
  * Improved pattern matching and contextual disambiguation to reduce false positives.
  * Preserved original suggested replacements ("fortalecer" / "enfraquecer") and added extra example sentences for clearer guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->