### PR TITLE
[es] Add antipattern to fix FPs in medical texts

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -33370,11 +33370,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             </rule>
         </rulegroup>
         <rulegroup id="PUNTO_EN_ABREVIATURAS" name="Punto en abreviaturas: pág., núm., etc." default="on">
+            <url>https://languagetool.org/insights/es/publicacion/abreviaturas/</url>
             <antipattern>
                 <token regexp="yes">I{1,3}[a-zA-Z]</token>
                 <example>Se advierten ganglios  con eje corto de hasta 6.6 mm en nivel Ib derecho.</example>
             </antipattern>
-            <url>https://languagetool.org/insights/es/publicacion/abreviaturas/</url>
             <antipattern>
                 <token/>
                 <token spacebefore="no" regexp="yes">\.|…</token>

--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -5409,6 +5409,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         </rulegroup>
         <rulegroup id="SE_CREO2" name="confusión: se creo/creó">
             <antipattern>
+                <token>atención</token>
+                <token min="0" max="2"/>
+                <token>incremento</token>
+                <token regexp="yes">en|de</token>
+                <example>Llama la atención incremento en el volumen en los tejidos blandos.</example>
+            </antipattern>
+            <antipattern>
                 <token>modelo</token>
                 <token regexp="yes">[A-Z0-9].*</token>
                 <example>Se realizó estudio solicitado mediante Unidad de Tomografía de la marca: PHILIPS modelo ACCESS. </example>
@@ -6648,6 +6655,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             </rule>
         </rulegroup>
         <rulegroup id="SUBJUNTIVO_INCORRECTO" name="verbo en modo subjuntivo incorrecto">
+            <antipattern case_sensitive="yes">
+                <token postag="SENT_START"/>
+                <token regexp="yes">Lesiones|Contusiones</token>
+                <token postag="A.*" postag_regexp="yes"/>
+                <example>Contusiones hemorrágica conocidas a nivel frontal.</example>
+            </antipattern>
             <antipattern>
                 <token postag="_english_ignore_"/>
                 <token postag="_english_ignore_"/>
@@ -30118,6 +30131,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example correction="con">El gobierno cumple <marker>son</marker> su función.</example>
         </rule>
         <rulegroup id="ANO" name="ano/año">
+            <antipattern>
+                <token regexp="yes">músculo|músculos|esfínter|esfínteres|elevador|dolor|lesión|lesiones|fisura|cáncer|tumor|absceso|inflamación|región|zona|canal|margen</token>
+                <token regexp="yes">del|en|de</token>
+                <token min="0" max="1">el</token>
+                <token>ano</token>
+                <example>Se muestra extensión extraprostática en donde contacta con el músculo elevador del ano de lado izquierdo.</example>
+            </antipattern>
             <rule>
                 <antipattern>
                     <token>-</token>
@@ -32271,6 +32291,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         </rule>
         <!--TODO: idem with ", pues"-->
         <rule id="COMMA_ADVERB" name="coma en adverbio al principio de frase">
+            <antipattern>
+                <token postag="SENT_START"/>
+                <token regexp="yes" min="0" max="3">\p{P}</token>
+                <token postag="RG" regexp="yes">ecográficamente|radiológicamente|clínicamente|histológicamente|sonográficamente|mamográficamente|experimentalmente</token>
+                <token min="0" max="1">se</token>
+                <token postag="V.*" postag_regexp="yes"/>
+                <example>Ecográficamente corresponde con isoecoico al tejido mamario.</example>
+                <example>Experimentalmente se comprobó la hipótesis inicial.</example>
+            </antipattern>
             <antipattern>
                 <token postag="SENT_START"/>
                 <token regexp="yes" min="0" max="3">\p{P}</token>

--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -33371,9 +33371,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         </rulegroup>
         <rulegroup id="PUNTO_EN_ABREVIATURAS" name="Punto en abreviaturas: pág., núm., etc." default="on">
             <antipattern>
-                <token regexp=""yes"">I{1,3}[a-zA-Z]</token>
+                <token regexp="yes">I{1,3}[a-zA-Z]</token>
                 <example>Se advierten ganglios  con eje corto de hasta 6.6 mm en nivel Ib derecho.</example>
-            </antipattern>"
+            </antipattern>
             <url>https://languagetool.org/insights/es/publicacion/abreviaturas/</url>
             <antipattern>
                 <token/>

--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -16602,12 +16602,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example>¿Tomas café?</example>
         </rule>
         <rulegroup id="SINGLE_CHARACTER" name="carácter único en minúscula">
-            <antipattern>
+            <antipattern case_sensitive="no">
                 <token>tipo</token>
-                <token regexp="yes">[a-z]</token>
-                <token>del</token>
+                <token regexp="yes">[a-d]</token>
+                <token regexp="yes">del|según</token>
                 <token>ACR</token>
-                 <example>Mamas con un patrón fibroglandular homogéneo tipo b del ACR.</example>
             </antipattern>
             <!-- copied and adapted from English rule -->
             <antipattern>

--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -16602,13 +16602,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example>¿Tomas café?</example>
         </rule>
         <rulegroup id="SINGLE_CHARACTER" name="carácter único en minúscula">
-            "<antipattern>
+            <antipattern>
                 <token>tipo</token>
-                <token regexp=""yes"">[a-z]</token>
+                <token regexp="yes">[a-z]</token>
                 <token>del</token>
                 <token>ACR</token>
                  <example>Mamas con un patrón fibroglandular homogéneo tipo b del ACR.</example>
-            </antipattern>"
+            </antipattern>
             <!-- copied and adapted from English rule -->
             <antipattern>
                 <token regexp="yes">[a-z]</token>

--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -16617,9 +16617,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         <rulegroup id="SINGLE_CHARACTER" name="carácter único en minúscula">
             <antipattern case_sensitive="no">
                 <token regexp="yes">tipo|categoría</token>
-                <token min="0" max="3" postag="A.*|RG" postag_regexp="yes"/>
                 <token regexp="yes">[a-d]</token>
-                <token min="0" max="4"/>
+                <token min="0" max="3"/>
+                <token regexp="yes">del|de|según</token>
                 <token>ACR</token>
                 <example>Mamas con un patrón fibroglandular homogéneo tipo b del ACR.</example>
             </antipattern>

--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -16616,10 +16616,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         </rule>
         <rulegroup id="SINGLE_CHARACTER" name="carácter único en minúscula">
             <antipattern case_sensitive="no">
-                <token>tipo</token>
+                <token regexp="yes">tipo|categoría</token>
+                <token min="0" max="3" postag="A.*|RG" postag_regexp="yes"/>
                 <token regexp="yes">[a-d]</token>
-                <token regexp="yes">del|según</token>
+                <token min="0" max="4"/>
                 <token>ACR</token>
+                <example>Mamas con un patrón fibroglandular homogéneo tipo b del ACR.</example>
             </antipattern>
             <!-- copied and adapted from English rule -->
             <antipattern>
@@ -30132,7 +30134,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         </rule>
         <rulegroup id="ANO" name="ano/año">
             <antipattern>
-                <token regexp="yes">músculo|músculos|esfínter|esfínteres|elevador|dolor|lesión|lesiones|fisura|cáncer|tumor|absceso|inflamación|región|zona|canal|margen</token>
+                <token regexp="yes">músculo|músculos|esfínter|esfínteres|elevador|dolor|lesión|lesiones|fisura|cáncer|tumor|absceso|inflamación|región|zona|canal|margen|pared|trayecto|afectación|alteración|evalución|cambio|cambios</token>
                 <token regexp="yes">del|en|de</token>
                 <token min="0" max="1">el</token>
                 <token>ano</token>
@@ -33400,7 +33402,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
         <rulegroup id="PUNTO_EN_ABREVIATURAS" name="Punto en abreviaturas: pág., núm., etc." default="on">
             <url>https://languagetool.org/insights/es/publicacion/abreviaturas/</url>
             <antipattern>
-                <token regexp="yes">I{1,3}[a-zA-Z]</token>
+                <token regexp="yes">Ib|IIa|IIb</token>
                 <example>Se advierten ganglios  con eje corto de hasta 6.6 mm en nivel Ib derecho.</example>
             </antipattern>
             <antipattern>

--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -16602,6 +16602,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <example>¿Tomas café?</example>
         </rule>
         <rulegroup id="SINGLE_CHARACTER" name="carácter único en minúscula">
+            "<antipattern>
+                <token>tipo</token>
+                <token regexp=""yes"">[a-z]</token>
+                <token>del</token>
+                <token>ACR</token>
+                 <example>Mamas con un patrón fibroglandular homogéneo tipo b del ACR.</example>
+            </antipattern>"
             <!-- copied and adapted from English rule -->
             <antipattern>
                 <token regexp="yes">[a-z]</token>
@@ -33363,6 +33370,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             </rule>
         </rulegroup>
         <rulegroup id="PUNTO_EN_ABREVIATURAS" name="Punto en abreviaturas: pág., núm., etc." default="on">
+            <antipattern>
+                <token regexp=""yes"">I{1,3}[a-zA-Z]</token>
+                <example>Se advierten ganglios  con eje corto de hasta 6.6 mm en nivel Ib derecho.</example>
+            </antipattern>"
             <url>https://languagetool.org/insights/es/publicacion/abreviaturas/</url>
             <antipattern>
                 <token/>
@@ -35433,7 +35444,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 <!--NUMBER_DAYS_MONTH[11]-->
                 <antipattern>
                     <token regexp="yes">31\.(11|0?[469])</token>
-                    <token regexp="yes">UH|HU|mm|cm|ml|mg|g|kg|%</token>
+                    <token regexp="yes">UH|HU|mm|cm|ml|mg|g|kg|%|cc</token>
                     <example>En el centro muestra una densidad de 31.6 UH a considerar absceso de etiología.</example>
                 </antipattern>
                 <antipattern>


### PR DESCRIPTION
COMMA_ADVERB: antipattern to fix cases in constructions where adverb enging in -mente goes with finite/reflexive verb.

SE_CREO2: antipattern for "incremento" which is  also a noun
https://dptm.es/dptm/?k=incremento

ANO: antipattern to cover cases where "ano" -  is a medical noun
https://dptm.es/dptm/?k=ano

NUMBER_DAYS_MONTH: extended existing antipattern by add "cc"
cc = cm³ (cubic centimeters)

PUNTO_EN_ABREVIATURAS: antipattern to cover clinical classification levels

SINGLE_CHARACTER: antipattern to cover single characters which cover types (a-d)

SUBJUNTIVO_INCORRECTO: antipattern to cover plural nouns (treated as subjunctives)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded Spanish grammar rules with multiple new and updated antipattern detections to cover additional linguistic cases including medical terminology, complex sentence structures, and specialized formatting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->