### PR TITLE
[sk] Modify message to align with the rule

### DIFF
--- a/languagetool-language-modules/sk/src/main/resources/org/languagetool/rules/sk/grammar.xml
+++ b/languagetool-language-modules/sk/src/main/resources/org/languagetool/rules/sk/grammar.xml
@@ -3069,7 +3069,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
           </pattern>
 
           <message>
-            Dajte čiarku pred „že“: <suggestion>, <match no="2"/></suggestion>.
+            Dajte čiarku pred „ako“: <suggestion>, <match no="2"/></suggestion>.
           </message>
 
           <short>Gramatická chyba. Dajte čiarku pred „že“.</short>

--- a/languagetool-language-modules/sk/src/main/resources/org/languagetool/rules/sk/grammar.xml
+++ b/languagetool-language-modules/sk/src/main/resources/org/languagetool/rules/sk/grammar.xml
@@ -3072,7 +3072,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             Dajte čiarku pred „ako“: <suggestion>, <match no="2"/></suggestion>.
           </message>
 
-          <short>Gramatická chyba. Dajte čiarku pred „že“.</short>
+          <short>Gramatická chyba. Dajte čiarku pred „ako".</short>
           <example correction=", ako" type="incorrect">
             Neviem<marker> ako</marker> sa to mohlo stať.
           </example>


### PR DESCRIPTION
AKO: Modified message as it was duplicated from the previous rule: "ZE" 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the user-facing message and short description for the Slovak grammar rule that detects missing commas before the conjunction "ako". The guidance and short summary now reference "ako" (including a minor punctuation adjustment), improving clarity for Slovak users when suggesting comma insertion. No changes were made to examples or suggested corrections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->