### PR TITLE
[pt] Added AP to rule:VERB_QUE_É_VERB_SER

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -16699,7 +16699,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <token postag='VMSF.+' postag_regexp='yes'/>
                 <token>que</token>
                 <token inflected='yes'>ser</token>
-                <token postag='VMP00.+' postag_regexp='yes'/>
+                <token postag='VMP00.+' postag_regexp='yes'><exception postag_regexp='yes' postag='AQ.+'/></token>
                 <example>Se me garantir que é publicado este ano letivo.</example>
             </antipattern>
 

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -16677,6 +16677,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       -->
 
             <antipattern>
+                <token postag='VMSF.+' postag_regexp='yes'/>
+                <token>que</token>
+                <token inflected='yes'>ser</token>
+                <token postag='VMP00.+' postag_regexp='yes'/>
+                <example>Se me garantir que é publicado este ano letivo.</example>
+            </antipattern>
+
+            <antipattern>
                 <token postag='SPS00:DA.+' postag_regexp='yes'/>
                 <token skip='4' postag='DP.+' postag_regexp='yes'/>
                 <token>que</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -9680,6 +9680,25 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <category id='ACADEMIC' name='🎓 Linguagem acadêmica' type='style' tone_tags="academic">
 
 
+        <rule id='COISA_DE_CERCA_DE_APROXIMADAMENTE' name="🎓🤵 Há 'coisa de' → 'cerca de'/aproximadamente" type='style' tone_tags='formal' default='temp_off'>
+            <!-- ChatGPT 5 and new disambiguator for 2026+ -->
+            <pattern>
+                <token>há</token>
+                <marker>
+                    <token>coisa</token>
+                    <token>de</token>
+                </marker>
+                <token postag='Z0.+' postag_regexp='yes'/>
+                <token regexp='yes' inflected='yes'>&expressoes_de_tempo;</token>
+            </pattern>
+            <message>Expressão coloquial. Em textos formais ou académicos, prefira &quot;há cerca de&quot; ou &quot;há aproximadamente&quot;.</message>
+            <suggestion>cerca de</suggestion>
+            <suggestion>aproximadamente</suggestion>
+            <example correction="cerca de|aproximadamente">Há <marker>coisa de</marker> um mês fui lá.</example>
+            <example correction="cerca de|aproximadamente">Há <marker>coisa de</marker> dois dias fui lá.</example>
+        </rule>
+
+
         <rule id='AO_LONGO_DO_TEMPO' name="🎓 Ao longo do tempo → gradualmente/progressivamente" type='style' tone_tags='academic' is_goal_specific='true'>
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <pattern>


### PR DESCRIPTION
Added antipattern to fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portuguese style checker suggests replacing constructions like “há … coisa de” with “cerca de” or “aproximadamente”, including example corrections.
* **Bug Fixes**
  * Reduced false positives by excluding specific “que … ser …” constructions from style suggestions, improving accuracy in Portuguese texts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->