### PR TITLE
[pt] Added AP to rule:COLOCACAO_ADVÉRBIO_VERBO_ANTES

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -245,6 +245,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
             <antipattern>
                 <token>que</token>
+                <token postag='PI.+' postag_regexp='yes'/>
+                <token postag='RG'/>
+                <token postag='VMI.+' postag_regexp='yes'/>
+                <example>A troika provou o que muitos já suspeitavam.</example>
+                <example>Estudos mostram que muitos ainda sonham em fugir das suas casas.</example>
+            </antipattern>
+
+            <antipattern>
+                <token>que</token>
                 <token postag='RG'/>
                 <token postag='RG'/>
                 <token postag='VMI[IPS].S.+' postag_regexp='yes'/>
@@ -323,7 +332,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                         <exception postag_regexp='yes' postag='CC|RN|SPS0.+'/>
                         <exception regexp='yes'>então|sempre</exception> <!-- Force exceptions -->
                     </token>
-                    <token postag='VMI[CFIMPS].+' postag_regexp='yes'>
+                    <token postag='VMI.+' postag_regexp='yes'>
                         <exception scope='next' postag_regexp='yes' postag='VMN0000|VMP00.+|Z0CN0|CS'/>
                         <exception postag='VMIP2P0'/>
                     </token>


### PR DESCRIPTION
Added an antipattern to fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Portuguese language style checking with improved detection patterns
  * Expanded adverb-verb style rule coverage to recognize additional linguistic variations in Portuguese text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->