### PR TITLE
[pt-PT] Added/Improved APs in rule:ZERO_MEDIDA_SINGULAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -3052,6 +3052,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example>Whey Protein concentrado zero lactose?</example>
             <example>Podemos jantar entre as nove e zero hora.</example>
             <example>Foi o primeiro diretor-presidente do jornal "Zero Hora" e durante muitos anos colaborou como articulista.</example>
+            <example>A temperatura não pode descer abaixo de zero kelvin.</example>
         </antipattern>
 
         <antipattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -3024,22 +3024,34 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <rule id="ZERO_MEDIDA_SINGULAR" name="🇵🇹 Concordância de número: 'zero grau'">
         <!-- Created by Tiago F. Santos, Portuguese rule, 2017-09-23 -->
 
-        <!-- MARCOAGPINTO 2022-09-21 (Checked/Enhanced) (25-JUL-2022+) *START* -->
         <antipattern>
+            <token postag='N.+|AQ.+' postag_regexp='yes'/>
             <token>zero</token>
-            <token>player</token>
-            <token>game</token>
-            <example>O Jogo da Vida de John Conway é também conhecido por “zero player game”.</example>
+            <token postag='NP.+' postag_regexp='yes'/>
+            <example>Eles beberam muita Cola Zero Auchan.</example>
         </antipattern>
 
         <antipattern>
             <token>zero</token>
-            <token postag='NC.+|AQ.+' postag_regexp='yes'/>
-            <token postag='CC|_PUNCT' postag_regexp='yes'/>
-            <token postag='NC.+|AQ.+' postag_regexp='yes'/>
-            <example>...procuradas pelos adeptos das dietas Paleo e Baixo Carbo pois apresentam baixo teor de carboidratos, zero glúten e boas quantidades de proteínas!</example>
-            <example>BENEFÍCIOS: Zero glúten, elaborado com waxy maize e farinha de arroz, alto teor proteico, pode ser consumido com opções sal...</example>
+            <token>player</token>
+            <token regexp='yes'>games?</token>
+            <example>O Jogo da Vida de John Conway é também conhecido por “zero player game”.</example>
+            <example>Temos vários “zero player games”.</example>
+        </antipattern>
+
+        <antipattern>
+            <token>zero</token>
+            <token regexp='yes'>sódio|açúcar|glúten|sal|gordura|colesterol|fibra|proteína|carboidrato|energia|mineral|mineralização|ferro|cálcio|potássio|magnésio|fósforo|zinco|iodo|selénio|cafeína|álcool|etanol|lactose|frutose|glicose|sacarose|amido|colagénio|caseína|albumina|água|leite|vinho|absoluto|kelvin|nulo|hora</token>
+            <example>Apresentam baixo teor de carboidratos, zero glúten e boas quantidades de proteínas!</example>
+            <example>BENEFÍCIOS: Zero glúten, elaborado com waxy maize e farinha de arroz.</example>
             <example>BENEFÍCIOS: pronto para o consumo, zero sódio, açúcar e calorias, efetiva o emagrecimento.</example>
+            <example>Assim, com a divisão de valores mais próximos do zero, o resultado será o zero absoluto.</example>
+            <example>Teoricamente, ao cessar a agitação térmica das moléculas a pressão é nula, e atinge-se o zero absoluto.</example>
+            <example>Ambas são muito usadas em receitas zero glúten como panquecas, bolos, muffins e biscoitos.</example>
+            <example>Nascia assim, o Chocolate Zero Açúcar Amargo, produzido sem adição de açúcares.</example>
+            <example>Whey Protein concentrado zero lactose?</example>
+            <example>Podemos jantar entre as nove e zero hora.</example>
+            <example>Foi o primeiro diretor-presidente do jornal "Zero Hora" e durante muitos anos colaborou como articulista.</example>
         </antipattern>
 
         <antipattern>
@@ -3048,23 +3060,21 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <token postag='VMP00S.+' postag_regexp='yes'/>
             <example>A temperatura ficou abaixo de zero noite passada.</example>
         </antipattern> 
-        <!-- MARCOAGPINTO 2022-09-21 (Checked/Enhanced) (25-JUL-2022+) *END* -->
 
         <pattern>
             <token>zero</token>
             <token postag='(?:N..|A...)S.+' postag_regexp='yes'>
                 <exception postag='(?:N..|A...)S.+' postag_regexp='yes' negate_pos='yes'/>
-                <exception regexp="yes">absoluto|kelvin|nulo</exception> <!-- "perto do zero ABSOLUTO/KELVIN/NULO" MARCOAGPINTO 2022-09-21 (25-JUL-2022+) -->
                 <exception postag='VMP00S.+' postag_regexp='yes'/> <!-- "perto do zero CONHECIDO" MARCOAGPINTO 2022-09-21 (25-JUL-2022+) -->
             </token>
         </pattern>
         <message>Em Português Europeu medidas com zero escrevem-se no plural.</message>
-        <suggestion>\1 <match no="2" postag="(N..|A...)S(.+)" postag_replace='$1P$2' postag_regexp="yes"/></suggestion>
+        <suggestion>\1 <match no='2' postag='(N..|A...)S(.+)' postag_replace='$1P$2' postag_regexp='yes'/></suggestion>
         <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/zero-graus--zero-grau/15274</url>
         <example correction="zero graus">Lá fora estão <marker>zero grau</marker>.</example>
-        <example>Assim, com a divisão de valores mais próximos do zero, o resultado será o zero absoluto.</example>
-        <example>Teoricamente, ao cessar a agitação térmica das moléculas a pressão é nula, e atinge-se o zero absoluto.</example>
     </rule>
+
+
     <rule id='DAÍ' name="🇵🇹 Contração: de aí">
         <!-- Created by Marco A.G. Pinto, Portuguese rule -->
         <pattern>


### PR DESCRIPTION
Added and improved antipatterns in the rule to fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese grammar rule handling of phrases with "zero" to reduce false positives and better recognize plural/brand forms and common “zero/near-zero” expressions.
  * Expanded pattern coverage for more natural examples (including food/nutrition terms) and cleaned up duplicate examples.
  * Reformatted correction suggestions for clearer, more consistent guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->