### PR TITLE
[pt-PT] Added AP to rule:POSSESSIVE_WITHOUT_ARTICLE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -934,6 +934,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <!-- 31-DEC-2025: entity pronomes_possessivos_pt_pt had "minhas?" missing, this may affect several APs here and in other parts -->
 
       <antipattern>
+          <token postag='RM' postag_regexp='no'/>
+          <token postag='RG' postag_regexp='no'/>
+          <token regexp='yes'>&pronomes_possessivos_pt_pt;</token>
+          <token postag='_PUNCT|SENT_END' postag_regexp='yes'/>
+          <example>Como ficaria ligeiramente mais minha?</example>
+      </antipattern>
+
+      <antipattern>
           <token postag='V.+' postag_regexp='yes'/>
           <token regexp='yes'>&pronomes_possessivos_pt_pt;</token>
           <token regexp='yes'>[ao]s?</token>


### PR DESCRIPTION
Added an antipattern to fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese (PT) grammar checking accuracy by reducing false-positive errors when possessive pronouns are used in interrogative contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->