### PR TITLE
[pt] Enabled rule:POR_FAVOR_FACAM_INFINITIVO_FORMAL

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3858,7 +3858,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='POR_FAVOR_FACAM_INFINITIVO_FORMAL' name="🤵 Sugestão de formalidade: Peço, por favor, que façam" type='style' tone_tags='formal'  is_goal_specific='true' default='temp_off'>
+        <rule id='POR_FAVOR_FACAM_INFINITIVO_FORMAL' name="🤵 Sugestão de formalidade: Peço, por favor, que façam" type='style' tone_tags='formal'  is_goal_specific='true'>
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <pattern>
                 <marker>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -18959,6 +18959,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             Recebemos um documento escrito em francês e que revelou uma lista de restaurantes. → Recebemos um documento escrito em francês que revelou uma lista de restaurantes.
             -->
             <antipattern>
+                <token postag='NC.+|AQ.+' postag_regexp='yes'/>
+                <token>e</token>
+                <token>que</token>
+                <token postag='VMII.+' postag_regexp='yes'/>
+                <token postag='SPS00|RG' postag_regexp='yes'/>
+                <example>A chefe de lá disse para lhe mostrar o meu cartão de doutorando e que andava de olho em mim.</example>
+            </antipattern>
+
+            <antipattern>
                 <token skip='-1'>que</token>
                 <token postag='V.+' postag_regexp='yes' skip='-1'/>
                 <token>que</token>
@@ -18966,6 +18975,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>Não há evidências de que seja melhor para o ambiente ou que contribua para o conceito.</example>
                 <example>Afirmou que ainda não foi intimada sobre a decisão e que vai entrar com um recurso.</example>
             </antipattern>
+
             <pattern>
                 <token postag='RG|SPS00' postag_regexp='yes'/>
                 <token postag='AQ.+|NC.+' postag_regexp='yes'/>
@@ -18977,7 +18987,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                     <exception postag_regexp='yes' postag='VMIS.+|VMSI.+'/>
                 </token>
             </pattern>
-            <message>Pode omitir a conjunção ‘e’ para tornar o texto mais fluido.</message>
+            <message>Pode omitir a conjunção &quot;e&quot; para tornar o texto mais fluído.</message>
             <suggestion>que</suggestion>
             <example correction="que">São regras muito simples <marker>e que</marker> permitem agir corretamente.</example>
             <example>Índio me disse que interpretou a pergunta como uma brecha aberta para uma negociação de propina e que tratou de fechá-la no mesmo instante.</example>


### PR DESCRIPTION
Enabled the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Portuguese formal-infinitive grammar check is now enabled by default, improving detection and suggestions.
  * The rule’s matching was refined for more accurate identification of the conjunction "e", and its example/message text was standardized for clearer guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->