### PR TITLE
[pt] Enabled rule:COMUNICADO_DIRIGIDO_A

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3803,7 +3803,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='COMUNICADO_DIRIGIDO_A' name="🤵 Comunicado dirigido a alguém" type='style' tone_tags='formal' default='temp_off'>
+        <rule id='COMUNICADO_DIRIGIDO_A' name="🤵 Comunicado dirigido a alguém" type='style' tone_tags='formal'>
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <pattern>
                 <token skip='1' postag='V.+' postag_regexp='yes' regexp='yes' inflected='yes'>fazer|emitir|publicar|divulgar|redigir|apresentar|veicular|difundir|produzir|lançar|elaborar</token>


### PR DESCRIPTION
enabled the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the "Comunicado Dirigido A" style rule for Portuguese language. This rule is now active by default during grammar and style checking operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/languagetool-org/languagetool/pull/11985)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->