### PR TITLE
[pt] More rare verbs fixes in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
@@ -305,6 +305,8 @@ sistêmico	sistêmico	AQ0MS0
 sistémico	sistémico	AQ0MS0
 sistémicos	sistémico	AQ0MP0
 sistêmicos	sistêmico	AQ0MP0
+smoothie	smoothie	NCMS000
+smoothies	smoothie	NCMP000
 sossegadinha	sossegadinho	NCFS00D
 sossegadinhas	sossegadinho	NCFP00D
 sossegadinho	sossegadinho	NCMS00D

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4115,6 +4115,26 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <disambig postag="NCMP000"/>
   </rule>
 
+  <rule id="VERBS_THIRD_PERSON_NOT_SECOND_20260511" name="These verbs aren't VMM02S0:PP1CSO00">
+    <pattern>
+      <marker>
+        <and>
+          <token postag='VMIP3S0:PP1CSO00' regexp='yes'>parece-me|ocorre-me|consta-me|compete-me|cabe-me|apraz-me</token>
+          <token postag='VMM02S0:PP1CSO00'/>
+        </and>
+      </marker>
+    </pattern>
+    <disambig action="remove" postag="VMM02S0:PP1CSO00"/>
+    <!--
+    Examples:
+             Dado este ponto da situação, parece-me impossível ter grau algum este ano letivo.
+             A mim, parece-me a única opção.
+             Compete-me testemunhar e eternizar cada instante, para que possa ser revivido sem limites.
+             Contestação a esse verso parece-me bem mais compreensível que uma mera rima forçada.
+             Este livro parece-me muito interessante.
+    -->
+  </rule>
+
   <rule id="SÃO_VERB_20260115" name="In this case SÃO is VMIP3P0">
     <pattern>
       <token postag='AQ..P.+|NC.P.+|(SPS00:)?[DP].+' postag_regexp='yes'/>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
@@ -622,6 +622,8 @@ semiacabado
 semiacabados
 sinoviais
 sinovial
+smoothie
+smoothies
 sociopatia
 sociopatias
 solteirice


### PR DESCRIPTION
More verbs fixed in disambiguator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese verb disambiguation: certain "me" constructions (parece‑me, ocorre‑me, consta‑me, compete‑me, cabe‑me, apraz‑me) are now interpreted correctly, reducing false positives in grammar checks.
* **New Dictionary Entries**
  * Added "smoothie" and "smoothies" to Portuguese vocabulary/spelling lists to avoid flagging them as foreign or misspelled.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/languagetool-org/languagetool/pull/11987)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->