### PR TITLE
[pt-PT] Added formal rule:SER_CARO_ONEROSO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -490,6 +490,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <!-- It is a Portuguese European rule only because "cara(s)" is commonly used in Brazil to address people informally -->
 
             <antipattern>
+                <token postag='V.+' postag_regexp='yes' inflected='yes'>ser</token>
+                <token spacebefore='no' postag='_PUNCT_COMMA'/>
+                <token regexp='yes'>car[ao]s?</token>
+                <token postag='N.+|AQ.+' postag_regexp='yes'/>
+                <example>É, caro leitor, o melhor livro de sempre.</example>
+                <example>Foi, caros colegas, um gosto imenso.</example>
+            </antipattern>
+
+            <antipattern>
                 <token skip='1' postag='V.+' postag_regexp='yes' inflected='yes'>ser</token>
                 <token regexp='yes'>caras?</token>
                 <token regexp='yes'>d[aeo]s?</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -485,6 +485,63 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <category id='FORMAL_SPEECH_PT_PT' name='🇵🇹 Linguagem Formal' type='register' tone_tags="formal">
 
 
+        <rule id='SER_CARO_ONEROSO' name="🤵 Ser 'caro' → oneroso" type='style' tone_tags='formal' default='temp_off'>
+            <!-- ChatGPT 5 and new disambiguator for 2026+ -->
+            <!-- It is a Portuguese European rule only because "cara(s)" is commonly used in Brazil to address people informally -->
+
+            <antipattern>
+                <token skip='1' postag='V.+' postag_regexp='yes' inflected='yes'>ser</token>
+                <token regexp='yes'>caras?</token>
+                <token regexp='yes'>d[aeo]s?</token>
+                <token min='0' max='1' postag='_QUOT'/>
+                <token postag='N.+|AQ.+|[DP].+' postag_regexp='yes'/>
+                <example>Coitado , foi pego de surpresa, o melhor foi a cara dos coreanos.Gostei!</example>
+                <example>Foi cara da campanha “Friends for change”, também na Disney Channel Escandinávia.</example>
+                <example>Luciana foi também cara da "Missão Sorriso", visitando muitas instituições e unidades hospitalares do país.</example>
+                <example>Tem que ser muito cara de pau!</example>
+                <example>Sim, elas são a cara de outra estação, mas já podem ser encontradas em diversas lojas por aí.</example>
+                <example>Você é cara da sua irmã.</example>
+            </antipattern>
+
+            <antipattern>
+                <token skip='1' postag='V.+' postag_regexp='yes' inflected='yes'>ser</token>
+                <token postag='(SPS00:)?[DP].+|AQ.M.+|NCM.+|VMN000.+|_PUNCT_COMMA' postag_regexp='yes'><exception postag_regexp='yes' postag='RG|PI.+'/></token>
+                <token regexp='yes'>caras?</token>
+                <example>Ele é o mesmo cara de sempre.</example>
+                <example>A próposito essa matéria é minha cara!!!</example>
+                <example>Bob realmente é a cara do pai.</example>
+                <example>Para Tom, o que importa é uma cara bonita.</example>
+                <example>Rir de seus próprios problemas é a cara dele.</example>
+                <example>"Quem é o cara na foto?" "Não sei quem é."</example>
+                <example>- É um cara legal.</example>
+                <example>Acho que o Tom é um cara muito estranho.</example>
+                <example>Aposto que foi um cara pessimista e de um braço só.</example>
+                <example>É esse cara cantando?</example>
+                <example>O Tom era um cara mau.</example>
+                <example>Quem é este cara todo alaranjado?</example>
+                <example>Quem era aquele cara?</example>
+                <example>Você sempre será aquele cara.</example>
+            </antipattern>
+
+            <pattern>
+                <token skip='1' postag='V.+' postag_regexp='yes' inflected='yes'>ser</token>
+                <marker>
+                    <token regexp='yes'>car[ao]s?</token>
+                </marker>
+            </pattern>
+            <message>Em registo formal, pode preferir &quot;oneroso&quot;.</message>
+            <suggestion><match no='2' postag='AQ0(..)0' postag_replace='AQ0$10'>oneroso</match></suggestion>
+            <example correction="oneroso">O processo é <marker>caro</marker>.</example>
+            <example correction="oneroso">O processo é extremamente <marker>caro</marker>.</example>
+            <example correction="onerosos">Os procedimentos são <marker>caros</marker>.</example>
+            <example correction="onerosos">Os procedimentos são bastante <marker>caros</marker>.</example>
+            <example correction="onerosa">A manutenção é <marker>cara</marker>.</example>
+            <example correction="onerosa">A manutenção é bastante <marker>cara</marker>.</example>
+            <example correction="onerosas">As licenças são <marker>caras</marker>.</example>
+            <example correction="onerosas">As licenças são muito <marker>caras</marker>.</example>
+        </rule>
+
+
       <rule id='COM_OS_MELHORES_CUMPRIMENTOS' name="🇵🇹🤵 Uniformização de despedidas formais" type='style' tone_tags='formal'>
           <!-- ChatGPT 5 and new disambiguator for 2026+ -->
           <pattern>


### PR DESCRIPTION
Added a Portuguese European formal rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pt-PT style rule for formal language that detects "ser + caro/caras" and suggests replacing it with "oneroso" (with correct gender/number variants: oneroso/onerosa/onerosos/onerosas) and includes formal-correction examples. The rule is disabled by default (temp off).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/languagetool-org/languagetool/pull/11996)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->