### PR TITLE
[pt-PT] Enabled rule:SER_CARO_ONEROSO_DISPENDIOSO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -485,7 +485,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <category id='FORMAL_SPEECH_PT_PT' name='🇵🇹 Linguagem Formal' type='register' tone_tags="formal">
 
 
-        <rule id='SER_CARO_ONEROSO_DISPENDIOSO' name="🤵 Ser 'caro' → oneroso/dispendioso" type='style' tone_tags='formal' tags='picky' default='temp_off'>
+        <rule id='SER_CARO_ONEROSO_DISPENDIOSO' name="🤵 Ser 'caro' → oneroso/dispendioso" type='style' tone_tags='formal' tags='picky'>
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <!-- It is a Portuguese European rule only because "cara(s)" is commonly used in Brazil to address people informally -->
 


### PR DESCRIPTION
Enabled the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled Portuguese language style checking rule that identifies alternative word choices in formal speech contexts, improving grammar and style suggestions for Portuguese users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/languagetool-org/languagetool/pull/11998?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->