### PR TITLE
[pt] Added AP to rule:CONFUSÃO_À_HÁ

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -31832,6 +31832,17 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <rulegroup id='CONFUSÃO_À_HÁ' name="[Confusão] à/há (expressões de tempo/quantidade)">
+
+            <antipattern>
+                <token postag='N.+|AQ.+' postag_regexp='yes'><exception postag_regexp='yes' postag='V.+'/></token>
+                <token>a</token>
+                <token postag='[DP].+|Z0.+' postag_regexp='yes'/>
+                <token regexp='yes' inflected='yes'>&expressoes_de_tempo;</token>
+                <token postag='RG'/>
+                <token postag='N.+|AQ.+' postag_regexp='yes'/>
+                <example>Para prestar o meu contributo a um dia tão especial como este.</example>
+            </antipattern>
+
             <antipattern>
                 <token postag='SPS.+|_PUNCT|V.+|NC.+|AQ.+|RG|DI.+|DP.+|PP.+|AO.+|CC|NP.+|UNKNOWN|CS|I|Z0.+|PI.+|_QUOT|RM|DD.+' postag_regexp='yes'/>
                 <token postag='NC.+|AQ.+|_PUNCT|UNKNOWN|NP.+|DP.+|I|V.+|PP.+|RM|DD.+|_QUOT' postag_regexp='yes'/>


### PR DESCRIPTION
An antipattern to fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Portuguese grammar checking has been enhanced with improved pattern recognition to better distinguish between "à" and "há" in contexts involving time expressions and quantities. Additional validation examples have been added to reduce false positives when detecting these commonly confused grammatical terms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/languagetool-org/languagetool/pull/12008?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->