### PR TITLE
[pt] Replaced rule names "[confusão]" with emoji

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -35120,7 +35120,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='SE_SI' name='[Confusão] Se/Si'>
+        <rulegroup id='SE_SI' name='❓ Se/Si'>
             <rule>
                 <pattern>
                     <token postag='V.+' postag_regexp='yes'/>
@@ -35182,7 +35182,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='CENSO_SENSO' name='[Confusão] senso/censo'>
+        <rulegroup id='CENSO_SENSO' name='❓ senso/censo'>
             <!-- Created by Tiago F. Santos, 2017-04-19, based on LightProof rule -->
             <url>https://pt.wiktionary.org/wiki/senso</url>
             <short>Possível confusão de termos</short>
@@ -35733,7 +35733,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- XEQUE(s) cheque(s) -->
-        <rulegroup id='CONFUSÃO_XEQUE_CHEQUE' name='[Confusão] xeque(s)/cheque(s)'>
+        <rulegroup id='CONFUSÃO_XEQUE_CHEQUE' name='❓ xeque(s)/cheque(s)'>
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2022-01-12 (Checked/Enhanced) (1-JAN-2022+)      -->
             <rule>
                 <pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -31802,7 +31802,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <!-- ********************************************************** -->
 
 
-        <rule id="LP_NAO_A" name="[Confusão] A/Há">
+        <rule id="LP_NAO_A" name="❓ A/Há">
             <!-- Based on Lightproof by Tiago F. Santos, 2017-07-05 -->
             <antipattern>
                 <token inflected='yes'>dizer</token>
@@ -31831,7 +31831,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='CONFUSÃO_À_HÁ' name="[Confusão] à/há (expressões de tempo/quantidade)">
+        <rulegroup id='CONFUSÃO_À_HÁ' name="❓ à/há (expressões de tempo/quantidade)">
 
             <antipattern>
                 <token postag='N.+|AQ.+' postag_regexp='yes'><exception postag_regexp='yes' postag='V.+'/></token>
@@ -32180,7 +32180,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="Encharca|Enxerca"><marker>Enxarca</marker> a vida.</example>
         </rule>
 
-        <rule id='À_QUE' name="[Confusão] 'à que'/'há que'">
+        <rule id='À_QUE' name="❓ 'à que'/'há que'">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
                 <token postag_regexp='yes' postag="SENT_START|_PUNCT|''|CC">
@@ -32197,7 +32197,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='HÁ_SUA' name="[Confusão] há/à + DETERMINANTE POSSESSIVO">
+        <rule id='HÁ_SUA' name="❓ há/à + DETERMINANTE POSSESSIVO">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
                 <token>há</token>
@@ -32209,7 +32209,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='HÁ-DIRECTION' name="[Confusão] Há + Direção">
+        <rule id='HÁ-DIRECTION' name="❓ Há + Direção">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <antipattern>
                 <token>há</token>
@@ -32246,7 +32246,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- A CERCA acerca -->
-        <rule id='A_CERCA_ACERCA' name="[Confusão] 'a cerca'/acerca">
+        <rule id='A_CERCA_ACERCA' name="❓ 'a cerca'/acerca">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2021-11-22 (25-JUN-2021+)      -->
             <!--
       Nunca fui avisado a cerca desses alarmes. → Nunca fui avisado acerca desses alarmes.
@@ -32267,7 +32267,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- PELA ESTRADA A FORA pela estrada fora -->
-        <rule id='CONFUSÃO_A_FORA' name="[Confusão] 'a fora'/'afora'">
+        <rule id='CONFUSÃO_A_FORA' name="❓ 'a fora'/'afora'">
             <!--    Created by Tiago F. Santos, 2017-04-19     -->
             <pattern>
                 <token>a</token>
@@ -32280,7 +32280,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- A PREÇO apreço -->
-        <rule id='CONFUSÃO_A_PREÇO_APREÇO' name="[Confusão] 'a preço'/'apreço'">
+        <rule id='CONFUSÃO_A_PREÇO_APREÇO' name="❓ 'a preço'/'apreço'">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2022-01-13 (Checked/Enhanced) (1-JAN-2022+)      -->
             <pattern>
                 <marker>
@@ -32296,7 +32296,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='A_QUANDO' name="[Confusão] 'a quando'/aquando">
+        <rule id='A_QUANDO' name="❓ 'a quando'/aquando">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2021-04-25 (Enhanced) (17-MAR-2021+)      -->
             <!-- MARCOAGPINTO 2021-04-25 (17-MAR-2021+) *START* -->
             <!--
@@ -32318,7 +32318,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='A_TRÁS' name="[Confusão] 'a trás'/atrás">
+        <rule id='A_TRÁS' name="❓ 'a trás'/atrás">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
                 <token>a</token>
@@ -32346,7 +32346,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- AI aí -->
-        <rule id='CP_AI_AÍ' name="[Confusão] ai/aí">
+        <rule id='CP_AI_AÍ' name="❓ ai/aí">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2021-06-06 (Enhanced) (17-MAR-2021+)      -->
             <!--
       A diferença é que aí pagas aos trabalhadores.
@@ -32369,7 +32369,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='CONFUSÃO_AMOSTRA_MOSTRA_DE_ARTE' name="[Confusão] amostra/'mostra de arte'">
+        <rule id='CONFUSÃO_AMOSTRA_MOSTRA_DE_ARTE' name="❓ amostra/'mostra de arte'">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2022-07-15 (Checked/Enhanced) (5-JUN-2022+)      -->
             <pattern>
                 <token postag='[DP][ADIPR].F.+|SPS00:[DP][ADIPR].F.+' postag_regexp='yes'/>
@@ -32387,7 +32387,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='ANTEMAO' name="[Confusão] 'ante mão'/antemão">
+        <rule id='ANTEMAO' name="❓ 'ante mão'/antemão">
             <!--      Created by Tiago F. Santos, Portuguese rule      -->
             <pattern>
                 <token regexp='yes'>ante|diante</token>
@@ -32463,7 +32463,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- ASSISTIR (Ver) -->
-        <rule id='ASSISTIR_VER' name="[Confusão] Assistir/ver">
+        <rule id='ASSISTIR_VER' name="❓ Assistir/ver">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2021-04-08 (17-MAR-2021+)      -->
             <!--
       Todos assistiram o filme de Elizabeth Taylor. → Todos assistiram ao filme de Elizabeth Taylor.
@@ -32491,7 +32491,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- ATE ATÉ -->
-        <rule id='CONFUSÃO_ATE_ATÉ' name="[Confusão] ate/até">
+        <rule id='CONFUSÃO_ATE_ATÉ' name="❓ ate/até">
             <!--      Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2022-04-07/8/11/12 (1-JAN-2022+)      -->
             <!--
       E ate o menino conseguiu fazer isso. → E até o menino conseguiu fazer isso.
@@ -32518,7 +32518,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- BEBER/COMER FÁRMACOS tomar fármacos -->
-        <rule id='CONFUSÃO_BEBER_COMER_TOMAR_FÁRMACOS' name="[Confusão] Beber/comer fármacos → tomar fármacos">
+        <rule id='CONFUSÃO_BEBER_COMER_TOMAR_FÁRMACOS' name="❓ Beber/comer fármacos → tomar fármacos">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2022-04-28 (1-JAN-2022+)      -->
             <!--
       Vou comer os medicamentos. → Vou tomar os medicamentos.
@@ -32539,7 +32539,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- CAPAS capaz -->
-        <rule id='CONFUSÃO_CAPAS_CAPAZ' name="[Confusão] capas/capaz">
+        <rule id='CONFUSÃO_CAPAS_CAPAZ' name="❓ capas/capaz">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2022-01-13 (Checked/Enhanced) (1-JAN-2022+)      -->
             <!--
       Este é capas de ser o pior port de sempre.
@@ -32558,7 +32558,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='CONFUSÃO_TER_CHEGO' name="[Confusão] TER + 'chego' → 'chegado'">
+        <rule id='CONFUSÃO_TER_CHEGO' name="❓ TER + 'chego' → 'chegado'">
             <!--    Created by Tiago F. Santos, 2017-02-27     -->
             <pattern>
                 <token inflected='yes'>ter</token>
@@ -32571,7 +32571,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- TER TANTO COMO ter tanto quanto -->
-        <rule id='CONFUSÃO_COMO_QUANTO' name="[Confusão] como/quanto">
+        <rule id='CONFUSÃO_COMO_QUANTO' name="❓ como/quanto">
             <!-- Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2023-01-28 (25-JUL-2022+) -->
             <!--
       Quem me dera ter tanta Coca-Cola como juízo. → Quem me dera ter tanta Coca-Cola quanto juízo.
@@ -32596,7 +32596,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- PEDIR UM CONCELHO pedir um conselho -->
-        <rule id='PEDIR_UM_CONCELHO' name="[Confusão] concelho/conselho">
+        <rule id='PEDIR_UM_CONCELHO' name="❓ concelho/conselho">
             <pattern>
                 <token inflected='yes'>pedir</token>
                 <token>um</token>
@@ -32607,7 +32607,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='A_UM_CONSERTO' name="[Confusão] conserto/concerto">
+        <rule id='A_UM_CONSERTO' name="❓ conserto/concerto">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
                 <token>a</token>
@@ -32619,7 +32619,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='CONTANTO_CONTANDO' name="[Confusão] contanto/contando">
+        <rule id='CONTANTO_CONTANDO' name="❓ contanto/contando">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
                 <marker>
@@ -32631,7 +32631,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="contando">Isto já <marker>contanto</marker> com o jantar.</example>
         </rule>
 
-        <rule id='DA_DAS_DÁ_DÁS' name="[Confusão] da(s)/dá(s)">
+        <rule id='DA_DAS_DÁ_DÁS' name="❓ da(s)/dá(s)">
             <!-- Created by Marco A.G.Pinto, Portuguese rule 2022-11-23 (Checked/Enhanced) (25-JUL-2022+) -->
             <!--
       Ana, da um beijo ao Rui. → Ana, dá um beijo ao Rui.
@@ -32681,7 +32681,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='DE_DÊ' name="[Confusão] de/dê">
+        <rule id='DE_DÊ' name="❓ de/dê">
             <!-- Created by Marco A.G.Pinto, Portuguese rule 2022-11-22 (Checked/Enhanced) (25-JUL-2022+) -->
             <!--
       Talvez te de mais novidades. → Talvez te dê mais novidades.
@@ -32710,7 +32710,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- DÊS desde -->
-        <rulegroup id='CONFUSÃO_DÊS_DESDE' name="[Confusão] dês/desde">
+        <rulegroup id='CONFUSÃO_DÊS_DESDE' name="❓ dês/desde">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2022-01-03 (1-JAN-2022+)      -->
             <!--
       Faço isso dês que me dê o livro. → Faço isso desde que me dê o livro.
@@ -32751,7 +32751,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='DE_CERTO' name="[Confusão] 'De certo'/Decerto">
+        <rule id='DE_CERTO' name="❓ 'De certo'/Decerto">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2021-09-16 + 2021-09-17 (Enhanced) (25-JUN-2021+)      -->
             <pattern>
                 <token negate_pos='yes' postag="PI.+" postag_regexp='yes'/>
@@ -32774,7 +32774,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='DEMAIS_DE_MAIS' name="[Confusão] 'de mais'/demais">
+        <rule id='DEMAIS_DE_MAIS' name="❓ 'de mais'/demais">
             <!-- Created by Tiago F. Santos, 2017-03-15 -->
             <antipattern>
                 <token regexp='yes'>&hifen;</token>
@@ -32797,7 +32797,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='DE_PRESSA' name="[Confusão] 'de pressa'/depressa">
+        <rule id='DE_PRESSA' name="❓ 'de pressa'/depressa">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
                 <token postag_regexp="yes" postag="(?:N..|A...)S.+|R."/>
@@ -32875,7 +32875,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rulegroup id='DOSE_DOZE' name="[Confusão] dose/doze">
+        <rulegroup id='DOSE_DOZE' name="❓ dose/doze">
             <!-- Created by Tiago F. Santos, Portuguese rule, 2019-03-09 -->
             <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/utilizacao-de-s-ou-z/7335</url>
             <rule>
@@ -32900,7 +32900,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rulegroup id='CONFUSÃO_E_É' name="[Confusão] e/é">
+        <rulegroup id='CONFUSÃO_E_É' name="❓ e/é">
             <short>Possível erro de acentuação.</short>
             <antipattern>
                 <token regexp="yes">qu[eê]|quando|qual|quais|a?onde|quem|quant[oa]s?|como|por[ ]?qu[êe]</token>
@@ -33029,7 +33029,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='ENTRAS_TE' name="[Confusão] 'entras te'/entraste">
+        <rule id='ENTRAS_TE' name="❓ 'entras te'/entraste">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
                 <token>entras</token>
@@ -33041,7 +33041,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='CONFUSÃO_ESTA_ESTÁ' name="[Confusão] Esta/Está">
+        <rulegroup id='CONFUSÃO_ESTA_ESTÁ' name="❓ Esta/Está">
 
             <antipattern>
                 <token postag='RG'><exception regexp='no'>agora</exception></token> <!-- Add more RG exceptions as found -->
@@ -33381,7 +33381,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rulegroup id='ESTA_ESTÁ' name="[Confusão] esta/está">
+        <rulegroup id='ESTA_ESTÁ' name="❓ esta/está">
             <rule>
                 <pattern>
                     <token postag='V.+' postag_regexp='yes'>
@@ -33501,7 +33501,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='CONFUSÃO_FAZES_FASES' name="[Confusão] fazes/fases" default='off'>
+        <rule id='CONFUSÃO_FAZES_FASES' name="❓ fazes/fases" default='off'>
             <pattern>
                 <token>as</token>
                 <marker>
@@ -33517,7 +33517,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- PARA FICA para ficar -->
-        <rule id='PARA_FICA' name="[Confusão] Expressões do tipo: para 'fica'/'ficar'">
+        <rule id='PARA_FICA' name="❓ Expressões do tipo: para 'fica'/'ficar'">
             <!-- Created by Marco A.G.Pinto, Portuguese rule 2023-05-21 (Checked/Enhanced) (2-MAR-2023+) -->
             <!--
       Esforça-te para FICA bem. → Esforça-te para FICAR bem.
@@ -33555,7 +33555,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- NADA HAVER nada a ver -->
-        <rule id='CONFUSÃO_NADA_HAVER' name="[Confusão] haver/'a ver'">
+        <rule id='CONFUSÃO_NADA_HAVER' name="❓ haver/'a ver'">
             <!--    Created by Tiago F. Santos, 2017-03-12     -->
             <pattern>
                 <token regexp='yes' inflected='yes'>ter|ficar|nada|tudo|muito</token>
@@ -33568,7 +33568,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='JÁ_MAIS' name="[Confusão] 'já mais'/jamais">
+        <rule id='JÁ_MAIS' name="❓ 'já mais'/jamais">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
                 <token>
@@ -33588,7 +33588,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- MA na -->
-        <rule id='CONFUSÃO_MA_NA' name="[Confusão] ma/na">
+        <rule id='CONFUSÃO_MA_NA' name="❓ ma/na">
             <!-- Created by Marco A.G.Pinto, Portuguese rule 2022-11-24 (25-JUL-2022+) -->
             <!--
       Isto é encontrado na topologia, ma geometria, e noutras. → Isto é encontrado na topologia, na geometria, e noutras.
@@ -33607,7 +33607,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='MANDATO_MANDADO' name="[Confusão] mandado/mandato">
+        <rulegroup id='MANDATO_MANDADO' name="❓ mandado/mandato">
             <!-- Created by Tiago F. Santos, 2019-08-27 -->
             <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/mandato-e-mandado/694</url>
             <rule>
@@ -33639,7 +33639,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- O MAS o mais -->
-        <rule id='O_MAS' name="[Confusão] mas/mais">
+        <rule id='O_MAS' name="❓ mas/mais">
             <pattern>
                 <token>o</token>
                 <token>mas</token>
@@ -33651,7 +33651,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- MAS mais -->
-        <rule id='CONFUSÃO_MAS_MAIS' name="[Confusão] mas/mais">
+        <rule id='CONFUSÃO_MAS_MAIS' name="❓ mas/mais">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2022-01-26 (Checked/Enhanced) (1-JAN-2022+)      -->
             <!--
       NOTICE THE ANTIPATTERN CREATED IN THE COMMA "MAS" RULE, SO THAT IT TRIGGERS THIS RULE (CONFUSÃO_MAS_MAIS).
@@ -33680,7 +33680,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='MAU_MAL_CONFUSION' name='[Confusão] mau/mal'>
+        <rulegroup id='MAU_MAL_CONFUSION' name='❓ mau/mal'>
             <!--       Created by Tiago F. Santos, 25-01-2017          -->
             <rule>
                 <antipattern>
@@ -33778,7 +33778,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- MEIA CHEIA meio cheio -->
-        <rule id='CONFUSÃO_MEIA_MEIO_ADJETIVO' name="[Confusão] meia/meio">
+        <rule id='CONFUSÃO_MEIA_MEIO_ADJETIVO' name="❓ meia/meio">
             <!-- Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2022-11-10 (25-JUL-2022+) -->
             <!--
       A garrafa está meia cheia. → A garrafa está meio cheia.
@@ -33804,7 +33804,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='MESTRE_MESTRA' name='[Confusão] mestre/mestra'>
+        <rulegroup id='MESTRE_MESTRA' name='❓ mestre/mestra'>
             <!-- Created by Tiago F. Santos, 2017-04-13, based on LightProof rule -->
             <rule>
                 <pattern>
@@ -33830,7 +33830,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
         <!-- NA não -->
         <!--      Created by Marco A.G.Pinto, Portuguese rule 2020-12-07 (21-OCT-2020+)  *START*   -->
-        <rule id='NA_NÃO' name="[Confusão] na/não">
+        <rule id='NA_NÃO' name="❓ na/não">
             <pattern>
                 <token postag='RG'/>
                 <marker>
@@ -33849,7 +33849,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- NADA DEMAIS nada de mais -->
-        <rule id='CONFUSÃO_NADA_DEMAIS' name="[Confusão] 'nada demais'/'nada de mais'">
+        <rule id='CONFUSÃO_NADA_DEMAIS' name="❓ 'nada demais'/'nada de mais'">
             <!--    Created by Tiago F. Santos, 2019-03-11     -->
             <pattern>
                 <token>nada</token>
@@ -33861,7 +33861,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='CONFUSÃO_NOS_NÓS' name="[Confusão] nos/nós" default="off">
+        <rulegroup id='CONFUSÃO_NOS_NÓS' name="❓ nos/nós" default="off">
             <rule>
                 <antipattern>
                     <token>nos</token>
@@ -33936,7 +33936,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='CONFUSÃO_ESTÁ_ESTA' name="[Confusão] está/esta">
+        <rule id='CONFUSÃO_ESTÁ_ESTA' name="❓ está/esta">
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <!-- The rare verbs were causing FPs, so I had to limit the scope. Later fix the rare verbs and try again. -->
             <pattern>
@@ -33954,7 +33954,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='O_AO' name="[Confusão] o/ao" >
+        <rule id='O_AO' name="❓ o/ao" >
             <!--      Created by Marco A.G.Pinto, Portuguese rule - 2020-07-04 (2-JUL-2020+) -->
             <pattern>
                 <token postag='V.+' postag_regexp='yes'/>
@@ -33969,7 +33969,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='OLA_OLÁ' name="[Confusão] ola/olá">
+        <rulegroup id='OLA_OLÁ' name="❓ ola/olá">
             <!--      Created by Marco A.G.Pinto, Portuguese rule - 2020-09-15 (2-JUL-2020+)   -->
             <rule>
                 <pattern>
@@ -33996,7 +33996,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rulegroup id='CONFUSÃO_AONDE_ONDE' name="[Confusão] onde/aonde/donde">
+        <rulegroup id='CONFUSÃO_AONDE_ONDE' name="❓ onde/aonde/donde">
             <!-- Created by Tiago F. Santos, Portuguese rule, 2019-03-10 -->
             <!--      Improved by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2022-04-15/16/17/19 (1-JAN-2022+)      -->
             <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/onde-e-aonde/548</url>
@@ -34069,7 +34069,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='ORA_DE_REFEIÇÃO' name="[Confusão] ora/hora">
+        <rule id='ORA_DE_REFEIÇÃO' name="❓ ora/hora">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
                 <token regexp="yes">a|na|da</token>
@@ -34085,7 +34085,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='PARCEIRA_PARCERIA' name="[Confusão] parceira/parceria">
+        <rulegroup id='PARCEIRA_PARCERIA' name="❓ parceira/parceria">
             <!-- Created by Tiago F. Santos, 2019-03-19 -->
             <rule>
                 <pattern>
@@ -34108,7 +34108,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rulegroup id="PECO_PECSO" name="[Confusão] peco/peço">
+        <rulegroup id="PECO_PECSO" name="❓ peco/peço">
             <rule>
                 <pattern>
                     <token regexp='yes'>&pronomes_nao_ambiguos;</token>
@@ -34134,7 +34134,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='PERCA_PERDA' name='[Confusão] perca/perda'>
+        <rule id='PERCA_PERDA' name='❓ perca/perda'>
             <!-- Created by Tiago F. Santos, 2017-04-21, based on LightProof rule -->
             <pattern>
                 <token regexp='yes'>percas?</token>
@@ -34149,7 +34149,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='POR_QUE_PORQUE' name="[Confusão] 'Por que', 'Por quê', Porquê e 'Porque'" default='on'>
+        <rulegroup id='POR_QUE_PORQUE' name="❓ 'Por que', 'Por quê', Porquê e 'Porque'" default='on'>
             <!--    Created by Tiago F. Santos, 2017-02-27     -->
             <short>Possível confusão de termos</short>
             <rule>
@@ -34769,7 +34769,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- QUANDO PODER quando puder -->
-        <rule id='QUANDO_PODER' name="[Confusão] poder/puder">
+        <rule id='QUANDO_PODER' name="❓ poder/puder">
             <pattern>
                 <token>quando</token>
                 <token>poder</token>
@@ -34780,7 +34780,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- POR DINHEIRO E PUDER por dinheiro e poder -->
-        <rule id='POR_DINHEIRO_E_PUDER' name="[Confusão] puder/poder">
+        <rule id='POR_DINHEIRO_E_PUDER' name="❓ puder/poder">
             <pattern>
                 <token>por</token>
                 <token>dinheiro</token>
@@ -34793,7 +34793,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- VAMOS POR A MÁSCARA vamos pôr a máscara -->
-        <rulegroup id='CONFUSION_POR_PÔR_V2' name="[Confusão] por/pôr">
+        <rulegroup id='CONFUSION_POR_PÔR_V2' name="❓ por/pôr">
             <!-- Created by Marco A.G.Pinto, Portuguese rule 2023-03-15/16 (2-MAR-2023+) -->
             <!--
 
@@ -34953,7 +34953,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- QUANTO MUITO quando muito -->
-        <rule id='QUANTO_MUITO' name="[Confusão] quanto/quando">
+        <rule id='QUANTO_MUITO' name="❓ quanto/quando">
             <!--      Created by Marco A.G.Pinto      -->
             <pattern>
                 <token>quanto</token>
@@ -34965,7 +34965,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='QUE_QUÊ' name="[Confusão] que/quê">
+        <rule id='QUE_QUÊ' name="❓ que/quê">
             <!--      Created by Marco A.G.Pinto, Portuguese rule - 2020-07-02 (2-JUL-2020+) -->
             <pattern>
                 <marker>
@@ -34979,7 +34979,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- RAIS raiz -->
-        <rule id='RAIS_RAIZ' name="[Confusão] rais/raiz">
+        <rule id='RAIS_RAIZ' name="❓ rais/raiz">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2021-07-27 (25-JUN-2021+)      -->
             <!--
       A rais da árvore está podre. → A raiz da árvore está podre.
@@ -34996,7 +34996,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='TAO_TÃO' name="[Confusão] tao/tão">
+        <rule id='TAO_TÃO' name="❓ tao/tão">
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <pattern>
                 <token postag='V.+' postag_regexp='yes'/>
@@ -35012,7 +35012,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- COM MAIS REALIDADE com mais realismo -->
-        <rule id='CONFUSÃO_REALIDADE_REALISMO' name="[Confusão] realidade/realismo">
+        <rule id='CONFUSÃO_REALIDADE_REALISMO' name="❓ realidade/realismo">
             <!-- Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2022-10-31 + 2022-11-01 (25-JUL-2022+) -->
             <!--
       A equação dá mais realidade aos modelos. → A equação dá mais realismo aos modelos.
@@ -35111,7 +35111,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='RIU-ME' name="[Confusão] riu-me/rio-me">
+        <rule id='RIU-ME' name="❓ riu-me/rio-me">
             <pattern>
                 <token>riu-me</token>
             </pattern>
@@ -35161,7 +35161,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- JÁ SI RECUPEROU já se recuperou -->
-        <rule id='CONFUSÃO_SI_SE' name="[Confusão] Si/Se">
+        <rule id='CONFUSÃO_SI_SE' name="❓ Si/Se">
             <!-- Created by Marco A.G.Pinto, Portuguese rule 2023-02-22 (25-JUL-2022+) -->
             <!--
       Tudo bem, o fã já si recuperou. → Tudo bem, o fã já se recuperou.
@@ -35227,7 +35227,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
         <!-- EM SIM em si -->
         <!--      Created by Marco A.G.Pinto, Portuguese rule 2020-11-25 (21-OCT-2020+)     -->
-        <rule id='EM_SIM_em_si' name="[Confusão] sim/si">
+        <rule id='EM_SIM_em_si' name="❓ sim/si">
             <pattern>
                 <token>em</token>
                 <marker>
@@ -35239,7 +35239,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='DE_DA_A_SOBRE_MESA' name="[Confusão] 'sobre mesa'/sobremesa">
+        <rule id='DE_DA_A_SOBRE_MESA' name="❓ 'sobre mesa'/sobremesa">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
                 <token regexp="yes">d[ae]s?</token>
@@ -35254,7 +35254,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- SOU só -->
-        <rule id='CONFUSÃO_SOU_SÓ' name="[Confusão] sou/só">
+        <rule id='CONFUSÃO_SOU_SÓ' name="❓ sou/só">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2022-06-09 (5-JUN-2022+)      -->
             <!--
       Abri o álbum, é sou fotos de carros. → Abri o álbum, é só fotos de carros.
@@ -35290,7 +35290,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='TAL_VEZ' name="[Confusão] 'tal vez'/talvez">
+        <rule id='TAL_VEZ' name="❓ 'tal vez'/talvez">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
                 <token>tal</token>
@@ -35302,7 +35302,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- SER TANTO RICO COMO ser tão rico como -->
-        <rulegroup id='CONFUSÃO_TANTO_TÃO' name="[Confusão] tanto/tão">
+        <rulegroup id='CONFUSÃO_TANTO_TÃO' name="❓ tanto/tão">
             <!-- Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2023-01-29 (25-JUL-2022+) -->
             <!--
                 Quero ser tanto rico como ele é. → Quero ser tão rico como ele é.
@@ -35346,7 +35346,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- TANTO tão -->
-        <rule id='CONFUSÃO_TANTO_TÃO_' name="[Confusão] tanto/tão">
+        <rule id='CONFUSÃO_TANTO_TÃO_' name="❓ tanto/tão">
             <!--      Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2022-05-04 (1-JAN-2022+)      -->
             <!--
       O que aconteceu para andares tanto carregado? → O que aconteceu para andares tão carregado?
@@ -35385,7 +35385,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='CONFUSÃO_TEM_TÊM' name="[Confusão] tem/têm">
+        <rule id='CONFUSÃO_TEM_TÊM' name="❓ tem/têm">
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <!-- Later expand also to "(SPS00:)?" -->
             <antipattern>
@@ -35437,7 +35437,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- TIVE DE FÉRIAS estive de férias -->
-        <rule id='CONFUSÃO_TIVE_ESTIVE' name="[Confusão] Ter/estar">
+        <rule id='CONFUSÃO_TIVE_ESTIVE' name="❓ Ter/estar">
             <!--      Created by Marco A.G.Pinto, Portuguese 2021-10-11 (25-JUN-2021+)      -->
             <!--
       Em janeiro tive de férias. → Em janeiro estive de férias.
@@ -35457,7 +35457,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- TER estar -->
-        <rule id='CONFUSÃO_TER_ESTAR' name="[Confusão] ter/estar">
+        <rule id='CONFUSÃO_TER_ESTAR' name="❓ ter/estar">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2022-01-17 (Checked/Enhanced) (1-JAN-2022+)      -->
             <!--
       Eu tive com a Ana ontem. → Eu estive com a Ana ontem.
@@ -35483,7 +35483,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- TERA terá -->
-        <rule id='CONFUSÃO_TERA_TERÁ' name="[Confusão] tera/terá">
+        <rule id='CONFUSÃO_TERA_TERÁ' name="❓ tera/terá">
             <!--      Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2022-03-10 (1-JAN-2022+)      -->
             <!--
       Ele tera problemas com isso. → Ele terá problemas com isso.
@@ -35505,7 +35505,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- TOMARÁ LUGAR terá lugar -->
-        <rule id='TOMAR_TER_LUGAR' name="[Confusão] Tomar/ter lugar">
+        <rule id='TOMAR_TER_LUGAR' name="❓ Tomar/ter lugar">
             <!-- Created by Marco A.G.Pinto, Portuguese rule 2022-11-22 (Checked/Enhanced) (25-JUL-2022+) -->
             <!--
       O evento tomará lugar em Lisboa. → O evento terá lugar em Lisboa.
@@ -35523,7 +35523,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='TRADUZIR_EM_PARA' name="[Confusão] Traduzir em/para">
+        <rule id='TRADUZIR_EM_PARA' name="❓ Traduzir em/para">
             <!-- Created by Marco A.G.Pinto, Portuguese rule 2023-01-18 (Checked/Enhanced) (25-JUL-2022+) -->
             <!--
       Temos de traduzir em inglês. → Temos de traduzir para inglês.
@@ -35544,7 +35544,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id='TRAZ_TRÁS' name="[Confusão] traz/trás">
+        <rulegroup id='TRAZ_TRÁS' name="❓ traz/trás">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <rule>
                 <pattern>
@@ -35578,7 +35578,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- UNA(S) uma(s) -->
-        <rulegroup id='UNA_UNAS_UMA_UMAS_CONFUSÃO' name="[Confusão] una(s)/uma(s)">
+        <rulegroup id='UNA_UNAS_UMA_UMAS_CONFUSÃO' name="❓ una(s)/uma(s)">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2021-02-16 (1-JAN-2021+)      -->
             <!--
       Queria comprar una rosa. → Queria comprar uma rosa.
@@ -35610,7 +35610,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- VARIAS várias -->
-        <rule id='CONFUSÃO_VARIAS_VÁRIAS' name="[Confusão] varias/várias">
+        <rule id='CONFUSÃO_VARIAS_VÁRIAS' name="❓ varias/várias">
             <!--      Created by Marco A.G.Pinto, Portuguese rule 2022-04-30 (1-JAN-2022+)      -->
             <!--
       Vi varias queixas do jornal. → Vi várias queixas do jornal.
@@ -35627,7 +35627,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rulegroup id="VEM_BEM" name="[Confusão] vem/bem">
+        <rulegroup id="VEM_BEM" name="❓ vem/bem">
             <rule>
                 <!-- Localized from Galician by Tiago F. Santos, 2017-11-26 -->
                 <pattern>
@@ -35665,7 +35665,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='EM_VÊS_DE_DA_DAS_DO_DOS' name="[Confusão] vês/vez">
+        <rule id='EM_VÊS_DE_DA_DAS_DO_DOS' name="❓ vês/vez">
             <!--      Created by Marco A.G.Pinto, Portuguese rule      -->
             <pattern>
                 <token>em</token>
@@ -35678,7 +35678,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- VEZ vês -->
-        <rule id='CONFUSÃO_VEZ_VÊS' name="[Confusão] vez/vês">
+        <rule id='CONFUSÃO_VEZ_VÊS' name="❓ vez/vês">
             <!-- Created by Marco A.G.Pinto, Portuguese rule 2023-02-19 (25-JUL-2022+) -->
             <!--
       Pai, não vez que ele está errado? → Pai, não vês que ele está errado?
@@ -35704,7 +35704,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <!-- VOZ vós -->
-        <rule id='CONFUSÃO_VOZ_VÓS' name="[Confusão] Voz/vós" default='off'>
+        <rule id='CONFUSÃO_VOZ_VÓS' name="❓ Voz/vós" default='off'>
             <!--      Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2022-05-27 (Checked/Enhanced) (24-MAY-2022+)      -->
             <!--
       Posso pedir a uma de voz que o faça? → Posso pedir a uma de vós que o faça?


### PR DESCRIPTION
Used emoji in confusion rules names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated Portuguese grammar rule labels to use a question-mark visual prefix (❓) and refined label formatting.
  * Improves clarity of correction suggestions by making confusing/misleading labels more immediately recognizable while preserving existing rule behavior and examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/languagetool-org/languagetool/pull/12011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->