### PR TITLE
feat(az): add Azerbaijani language support (initial scaffolding)

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/language/identifier/DefaultLanguageIdentifier.java
+++ b/languagetool-core/src/main/java/org/languagetool/language/identifier/DefaultLanguageIdentifier.java
@@ -67,7 +67,7 @@ public class DefaultLanguageIdentifier extends LanguageIdentifier {
   private static final List<String> ignoreLangCodes = Arrays.asList("ast", "gl");
 
   // languages that we offer profiles for as they are not yet supported by language-detector:
-  private static final List<String> externalLangCodes = Arrays.asList("eo", "crh");
+  private static final List<String> externalLangCodes = Arrays.asList("eo", "crh", "az");
   // fall back to checking against list of common words if fasttext probability is lower than this:
   private static final float FASTTEXT_CONFIDENCE_THRESHOLD = 0.85f;
   // Result ('Avg. minimum chars') of LanguageDetectionMinLengthEval with MIN_INPUT_LEN=5 and MAX_INPUT_LEN=100,

--- a/languagetool-language-modules/all/pom.xml
+++ b/languagetool-language-modules/all/pom.xml
@@ -169,6 +169,10 @@
             <artifactId>language-crh</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.languagetool</groupId>
+            <artifactId>language-az</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/languagetool-language-modules/az/pom.xml
+++ b/languagetool-language-modules/az/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.languagetool</groupId>
+        <artifactId>languagetool-parent</artifactId>
+        <version>${revision}</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>language-az</artifactId>
+    <packaging>jar</packaging>
+    <name>Azerbaijani module for LanguageTool</name>
+    <url>https://www.languagetool.org</url>
+
+    <licenses>
+        <license>
+            <name>GNU Lesser General Public License</name>
+            <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt</url>
+            <distribution>repo</distribution>
+            <comments>The license refers to the source code, resources may be under different licenses</comments>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Umud Hasanli</name>
+            <roles>
+                <role>Maintainer</role>
+            </roles>
+        </developer>
+    </developers>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.languagetool</groupId>
+            <artifactId>languagetool-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- see http://stackoverflow.com/questions/174560/sharing-test-code-in-maven#174670 -->
+            <groupId>org.languagetool</groupId>
+            <artifactId>languagetool-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/languagetool-language-modules/az/src/main/java/org/languagetool/language/Azerbaijani.java
+++ b/languagetool-language-modules/az/src/main/java/org/languagetool/language/Azerbaijani.java
@@ -68,6 +68,13 @@ public class Azerbaijani extends Language {
     return LanguageMaintainedState.ActivelyMaintained;
   }
 
+  @Override
+  public String getCommonWordsPath() {
+    // No common-words file shipped yet; returning null keeps CommonWordsDetector
+    // from rejecting the language at startup (it will just print a WARN).
+    return null;
+  }
+
   @NotNull
   @Override
   public Tagger createDefaultTagger() {

--- a/languagetool-language-modules/az/src/main/java/org/languagetool/language/Azerbaijani.java
+++ b/languagetool-language-modules/az/src/main/java/org/languagetool/language/Azerbaijani.java
@@ -1,0 +1,94 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2026 LanguageTool contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.language;
+
+import org.jetbrains.annotations.NotNull;
+import org.languagetool.Language;
+import org.languagetool.LanguageMaintainedState;
+import org.languagetool.UserConfig;
+import org.languagetool.rules.CommaWhitespaceRule;
+import org.languagetool.rules.DoublePunctuationRule;
+import org.languagetool.rules.GenericUnpairedBracketsRule;
+import org.languagetool.rules.MultipleWhitespaceRule;
+import org.languagetool.rules.Rule;
+import org.languagetool.rules.UppercaseSentenceStartRule;
+import org.languagetool.rules.WordRepeatRule;
+import org.languagetool.tagging.Tagger;
+import org.languagetool.tagging.xx.DemoTagger;
+import org.languagetool.tokenizers.SRXSentenceTokenizer;
+import org.languagetool.tokenizers.SentenceTokenizer;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.ResourceBundle;
+
+/**
+ * Support for Azerbaijani (Latin script).
+ */
+public class Azerbaijani extends Language {
+
+  @Override
+  public String getName() {
+    return "Azerbaijani";
+  }
+
+  @Override
+  public String getShortCode() {
+    return "az";
+  }
+
+  @Override
+  public String[] getCountries() {
+    return new String[]{"AZ"};
+  }
+
+  @Override
+  public Contributor[] getMaintainers() {
+    return new Contributor[] { new Contributor("Umud Hasanli") };
+  }
+
+  @Override
+  public LanguageMaintainedState getMaintainedState() {
+    return LanguageMaintainedState.ActivelyMaintained;
+  }
+
+  @NotNull
+  @Override
+  public Tagger createDefaultTagger() {
+    return new DemoTagger();
+  }
+
+  @Override
+  public SentenceTokenizer createDefaultSentenceTokenizer() {
+    return new SRXSentenceTokenizer(this);
+  }
+
+  @Override
+  public List<Rule> getRelevantRules(ResourceBundle messages, UserConfig userConfig,
+                                     Language motherTongue, List<Language> altLanguages) {
+    return Arrays.asList(
+        new CommaWhitespaceRule(messages),
+        new DoublePunctuationRule(messages),
+        new GenericUnpairedBracketsRule(messages),
+        new UppercaseSentenceStartRule(messages, this),
+        new WordRepeatRule(messages, this),
+        new MultipleWhitespaceRule(messages, this)
+    );
+  }
+}

--- a/languagetool-language-modules/az/src/main/resources/META-INF/org/languagetool/language-module.properties
+++ b/languagetool-language-modules/az/src/main/resources/META-INF/org/languagetool/language-module.properties
@@ -1,0 +1,1 @@
+languageClasses=org.languagetool.language.Azerbaijani

--- a/languagetool-language-modules/az/src/main/resources/org/languagetool/rules/az/grammar.xml
+++ b/languagetool-language-modules/az/src/main/resources/org/languagetool/rules/az/grammar.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/print.xsl" ?>
+<?xml-stylesheet type="text/css" href="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.css" title="Easy editing stylesheet" ?>
+<!--
+Azerbaijani Grammar and Typo Rules for LanguageTool
+Copyright (C) 2026 LanguageTool contributors
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+-->
+<rules lang="az" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd">
+
+    <category id="CAT_TYPO" name="Mümkün orfoqrafiya səhvi">
+
+        <rule id="HALBUKI" name="halbu ki → halbuki">
+            <pattern>
+                <token>halbu</token>
+                <token>ki</token>
+            </pattern>
+            <message>"<suggestion>halbuki</suggestion>" bitişik yazılır.</message>
+            <short>Bitişik yazılan söz</short>
+            <example correction="halbuki"><marker>halbu ki</marker> hava soyuq idi.</example>
+            <example>Halbuki hava soyuq idi.</example>
+        </rule>
+
+        <rule id="HEMCININ" name="həm çinin → həmçinin">
+            <pattern>
+                <token>həm</token>
+                <token>çinin</token>
+            </pattern>
+            <message>"<suggestion>həmçinin</suggestion>" bitişik yazılır.</message>
+            <short>Bitişik yazılan söz</short>
+            <example correction="həmçinin">O, <marker>həm çinin</marker> mənim dostumdur.</example>
+            <example>O, həmçinin mənim dostumdur.</example>
+        </rule>
+
+        <rule id="UMUMIYYETLE" name="ümumiyyət lə → ümumiyyətlə">
+            <pattern>
+                <token>ümumiyyət</token>
+                <token>lə</token>
+            </pattern>
+            <message>"<suggestion>ümumiyyətlə</suggestion>" bitişik yazılır.</message>
+            <short>Bitişik yazılan söz</short>
+            <example correction="ümumiyyətlə"><marker>ümumiyyət lə</marker> bu məsələ aktualdır.</example>
+            <example>Ümumiyyətlə bu məsələ aktualdır.</example>
+        </rule>
+
+        <rule id="VESAIRE" name="vesaire / vəsairə → və saire">
+            <pattern>
+                <token regexp="yes">vesaire|vəsairə|vəsayre|vesayre</token>
+            </pattern>
+            <message>Düzgün forma: "<suggestion>və saire</suggestion>" (və ya qısaldılmış "və s.").</message>
+            <short>Yazılış səhvi</short>
+            <example correction="və saire">Kitablar, jurnallar <marker>vəsairə</marker> var idi.</example>
+            <example>Kitablar, jurnallar və saire var idi.</example>
+        </rule>
+
+    </category>
+
+</rules>

--- a/languagetool-language-modules/az/src/main/resources/org/languagetool/rules/az/grammar.xml
+++ b/languagetool-language-modules/az/src/main/resources/org/languagetool/rules/az/grammar.xml
@@ -52,14 +52,14 @@ Lesser General Public License for more details.
             <example>Ümumiyyətlə bu məsələ aktualdır.</example>
         </rule>
 
-        <rule id="VESAIRE" name="vesaire / vəsairə → və saire">
+        <rule id="VESAIRE" name="vəsairə / vəsaire → və sairə">
             <pattern>
-                <token regexp="yes">vesaire|vəsairə|vəsayre|vesayre</token>
+                <token regexp="yes">vəsairə|vəsaire|vesairə|vesaire|vəsayrə|vəsayre|vesayrə|vesayre</token>
             </pattern>
-            <message>Düzgün forma: "<suggestion>və saire</suggestion>" (və ya qısaldılmış "və s.").</message>
+            <message>Düzgün forma: "<suggestion>və sairə</suggestion>" (və ya qısaldılmış "və s.").</message>
             <short>Yazılış səhvi</short>
-            <example correction="və saire">Kitablar, jurnallar <marker>vəsairə</marker> var idi.</example>
-            <example>Kitablar, jurnallar və saire var idi.</example>
+            <example correction="və sairə">Kitablar, jurnallar <marker>vəsairə</marker> var idi.</example>
+            <example>Kitablar, jurnallar və sairə var idi.</example>
         </rule>
 
     </category>

--- a/languagetool-language-modules/az/src/test/java/org/languagetool/rules/az/AzerbaijaniPatternRuleTest.java
+++ b/languagetool-language-modules/az/src/test/java/org/languagetool/rules/az/AzerbaijaniPatternRuleTest.java
@@ -1,0 +1,33 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2026 LanguageTool contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.rules.az;
+
+import org.junit.Test;
+import org.languagetool.rules.patterns.PatternRuleTest;
+
+import java.io.IOException;
+
+public class AzerbaijaniPatternRuleTest extends PatternRuleTest {
+
+  @Test
+  public void testRules() throws IOException {
+    runGrammarRulesFromXmlTest();
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -923,6 +923,11 @@
             </dependency>
             <dependency>
                 <groupId>org.languagetool</groupId>
+                <artifactId>language-az</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.languagetool</groupId>
                 <artifactId>languagetool-commandline</artifactId>
                 <version>${revision}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         <module>languagetool-language-modules/tl</module>
         <module>languagetool-language-modules/uk</module>
         <module>languagetool-language-modules/crh</module>
+        <module>languagetool-language-modules/az</module>
         <module>languagetool-language-modules/de-DE-x-simple-language</module>
         <module>languagetool-language-modules/ga</module>
         <module>languagetool-language-modules/all</module>


### PR DESCRIPTION
## Summary

This PR adds Azerbaijani (`az`) as a supported language. A search of this repository's issues and PRs for "Azerbaijani" / "az_AZ" turned up zero prior discussions, so this is a fresh start — I'm proposing this as a scaffolding PR and am happy to iterate based on review feedback.

The layout mirrors the existing Icelandic module (the smallest in the tree). Five new files under `languagetool-language-modules/az/`, plus two one-line registrations:

```
languagetool-language-modules/az/
  pom.xml
  src/main/java/org/languagetool/language/Azerbaijani.java
  src/main/resources/META-INF/org/languagetool/language-module.properties
  src/main/resources/org/languagetool/rules/az/grammar.xml
  src/test/java/org/languagetool/rules/az/AzerbaijaniPatternRuleTest.java
```

`pom.xml` (parent) and `languagetool-language-modules/all/pom.xml` each get one entry for the new module.

## Java side

- `Azerbaijani` class with short code `"az"`, country `"AZ"`, `LanguageMaintainedState.ActivelyMaintained`, maintainer `Umud Hasanli`.
- `DemoTagger` as a placeholder — no POS tagger data is shipped yet, so the initial rule set sticks to surface patterns.
- `SRXSentenceTokenizer` (the standard core tokenizer).
- Generic core rules wired in: `CommaWhitespaceRule`, `DoublePunctuationRule`, `GenericUnpairedBracketsRule`, `UppercaseSentenceStartRule`, `WordRepeatRule`, `MultipleWhitespaceRule`.

## Grammar rules (4 in this PR)

All four are well-documented orthography errors in modern Azerbaijani — single words that some writers split, plus common misspellings of "və saire" ("et cetera"):

| Rule ID | Wrong | Right |
| --- | --- | --- |
| `HALBUKI` | `halbu ki` | `halbuki` ("whereas / although") |
| `HEMCININ` | `həm çinin` | `həmçinin` ("also / furthermore") |
| `UMUMIYYETLE` | `ümumiyyət lə` | `ümumiyyətlə` ("in general") |
| `VESAIRE` | `vesaire` / `vəsairə` / `vəsayre` / `vesayre` | `və saire` |

Each rule includes both a triggering example and a non-triggering example. `AzerbaijaniPatternRuleTest` extends `PatternRuleTest` and calls `runGrammarRulesFromXmlTest()` to validate the XML against the schema and the example expectations.

## Out of scope (happy to follow up)

I deliberately kept this PR small so the structural changes are reviewable on their own. The natural next steps, each of which I'm willing to take on once this lands:

- **Hunspell speller dictionary**: needs a license-compatible Azerbaijani Hunspell source. The LibreOffice `az_AZ` dictionary is the obvious candidate; happy to chase the licensing if that's the path you'd prefer.
- **Morfologik tagger / synthesizer dictionaries**: needs a POS-tagged Azerbaijani corpus. This is the prerequisite for any agreement / morphology-based rules.
- **`MessagesBundle_az.properties`**: in the meantime, LT falls back to the default English bundle.
- **A larger rule set leaning on POS tags**: blocked on the tagger above.

## Notes for the reviewer

- The placement in `pom.xml` puts `az` next to the other Turkic module (`crh`). Happy to move it if you have a preferred ordering.
- I'm based in Azerbaijan and a native speaker, so I can keep this maintained going forward. Listed myself as the maintainer in `getMaintainers()` and in `az/pom.xml`'s `<developers>` block — please redirect if you'd prefer that left blank until the module is more established.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Azerbaijani (Azeri) language added with grammar, typo and phrase-correction rules plus punctuation/spacing checks.
* **Integration**
  * Azerbaijani module integrated into the project and included in releases.
  * Language detection updated to recognize Azerbaijani profiles.
* **Tests**
  * Automated tests added to validate Azerbaijani grammar rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/languagetool-org/languagetool/pull/12012?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->