### PR TITLE
[pt] Enabled rule:QUESTAO_BOA_PERTINENTE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3746,7 +3746,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rulegroup id='QUESTAO_BOA_PERTINENTE' name="🤵 questão 'boa' → pertinente/relevante" type='style' tone_tags='formal' is_goal_specific='true' default='temp_off'>
+        <rulegroup id='QUESTAO_BOA_PERTINENTE' name="🤵 questão 'boa' → pertinente/relevante" type='style' tone_tags='formal' is_goal_specific='true'>
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
 
             <antipattern>


### PR DESCRIPTION
Enabled the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Re-enabled a Portuguese language style rule for formal language validation that was previously disabled, improving grammar and style checking for Portuguese users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/languagetool-org/languagetool/pull/12016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->