### PR TITLE
Bump opennlp-tools from 1.9.4 to 2.5.9 to fix CVEs

### DIFF
--- a/languagetool-language-modules/en/src/main/java/org/languagetool/chunking/EnglishChunker.java
+++ b/languagetool-language-modules/en/src/main/java/org/languagetool/chunking/EnglishChunker.java
@@ -21,6 +21,7 @@ package org.languagetool.chunking;
 import opennlp.tools.chunker.ChunkerME;
 import opennlp.tools.chunker.ChunkerModel;
 import opennlp.tools.postag.POSModel;
+import opennlp.tools.postag.POSTagFormat;
 import opennlp.tools.postag.POSTaggerME;
 import opennlp.tools.tokenize.TokenizerME;
 import opennlp.tools.tokenize.TokenizerModel;
@@ -118,7 +119,10 @@ public class EnglishChunker implements Chunker {
   }
 
   private String[] posTag(String[] tokens) {
-    POSTaggerME posTagger = new POSTaggerME(posModel);
+    // The bundled model uses Penn Treebank tags. Since OpenNLP 2.x, POSTaggerME maps tags to
+    // Universal Dependencies by default, which breaks the chunker and our Penn-based rules, so
+    // we pin the format to PENN to keep the original tag set.
+    POSTaggerME posTagger = new POSTaggerME(posModel, POSTagFormat.PENN);
     return posTagger.tag(tokens);
   }
 

--- a/languagetool-standalone/CHANGES.md
+++ b/languagetool-standalone/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 6.8 (2026-05-??)
 
+#### General
+  * Apache OpenNLP (opennlp-tools) has been updated from 1.9.4 to 2.5.9 to fix
+    CVE-2026-42027, CVE-2026-40682 and CVE-2026-42440.
+
 #### Ukrainian
   * new words in the POS dictionary
   * new rules

--- a/languagetool-standalone/src/main/resources/third-party-licenses/README.txt
+++ b/languagetool-standalone/src/main/resources/third-party-licenses/README.txt
@@ -95,7 +95,7 @@ org.apache.commons:commons-pool2:2.9.0 - Apache License, Version 2.0
 org.apache.commons:commons-text:1.9 - Apache License, Version 2.0
 org.apache.lucene:lucene-backward-codecs:5.5.5 - Apache 2
 org.apache.lucene:lucene-core:5.5.5 - Apache 2
-org.apache.opennlp:opennlp-tools:1.9.4 - Apache License, Version 2.0
+org.apache.opennlp:opennlp-tools:2.5.9 - Apache License, Version 2.0
 org.carrot2:morfologik-fsa:2.1.7 - BSD
 org.carrot2:morfologik-fsa-builders:2.1.7 - BSD
 org.carrot2:morfologik-speller:2.1.7 - BSD

--- a/languagetool-wikipedia/src/main/resources/third-party-licenses/README.txt
+++ b/languagetool-wikipedia/src/main/resources/third-party-licenses/README.txt
@@ -95,7 +95,7 @@ org.apache.commons:commons-pool2:2.9.0 - Apache License, Version 2.0
 org.apache.commons:commons-text:1.9 - Apache License, Version 2.0
 org.apache.lucene:lucene-backward-codecs:5.5.5 - Apache 2
 org.apache.lucene:lucene-core:5.5.5 - Apache 2
-org.apache.opennlp:opennlp-tools:1.9.4 - Apache License, Version 2.0
+org.apache.opennlp:opennlp-tools:2.5.9 - Apache License, Version 2.0
 org.carrot2:morfologik-fsa:2.1.7 - BSD
 org.carrot2:morfologik-fsa-builders:2.1.7 - BSD
 org.carrot2:morfologik-speller:2.1.7 - BSD

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
         <org.apache.commons.commons-pool2.version>2.12.0</org.apache.commons.commons-pool2.version>
         <org.apache.commons.lang3.version>3.18.0</org.apache.commons.lang3.version>
         <org.apache.commons.text.version>1.12.0</org.apache.commons.text.version>
-        <org.apache.opennlp.opennlp-tools.version>1.9.4</org.apache.opennlp.opennlp-tools.version>
+        <org.apache.opennlp.opennlp-tools.version>2.5.9</org.apache.opennlp.opennlp-tools.version>
 
         <org.glassfish.jaxb.jaxb-runtime.version>4.0.5</org.glassfish.jaxb.jaxb-runtime.version>
         <org.ioperm.morphology-el.version>1.0.0</org.ioperm.morphology-el.version>


### PR DESCRIPTION
## Summary
- Updates Apache OpenNLP (`opennlp-tools`) from `1.9.4` to `2.5.9` to fix
  CVE-2026-42027, CVE-2026-40682 (Critical) and CVE-2026-42440 (High).
- Pins `POSTagFormat.PENN` in `EnglishChunker`: since OpenNLP 2.x, `POSTaggerME`
  maps the bundled model's native Penn Treebank tags to Universal Dependencies
  by default, which would otherwise break the chunker and all Penn-based English rules.

## Compatibility notes / request for guidance (RFC)
- The bundled 1.5-era models (`en-token.bin`, `en-pos-maxent.bin`,
  `en-chunker.bin` from `edu.washington.cs.knowitall`) still load fine under
  2.5.9 - no `InvalidFormatException`.
- With the `POSTagFormat.PENN` fix, POS-tagging output is byte-identical to 1.9.4.
- However, OpenNLP 2.x's `ChunkerME` produces slightly different chunk
  boundaries for the **same model and identical Penn POS input** (e.g.
  coordinated adjectives "X and Y" become `NP` instead of `ADJP`; comparative
  "as" becomes `SBAR` instead of `PP`). The default beam size is identical (10)
  in both versions, so this is an internal ML-decoding change and is not
  configurable.
- As a result, the embedded examples of ~18-19 chunk-dependent English rules
  change behavior (e.g. `SERIAL_COMMA_ON`, `IT_IS`, `IT_IS_2`,
  `COMPOUND_NNP_AGREEMENT`, `THERE_S_MANY`, `MD_BASEFORM`, `JJ_NN_JJ`,
  `AI_HYDRA_LEO_CP_YOUR_YOU`, ...).

I'd appreciate maintainers' guidance on the preferred path (retrain/replace the
chunker model vs. adjust the affected rules), since this touches rule quality.

## Test plan
- [x] `EnglishChunkerTest` passes with the `POSTagFormat.PENN` fix
- [ ] Full `language-en` test suite - currently fails on the chunk-dependent
      rules listed above (expected; see notes)

Made with [Cursor](https://cursor.com)