### PR TITLE
[pt] Enabled rule:CASO_INDICATIVO_CONJUNTIVO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -841,7 +841,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='CASO_INDICATIVO_CONJUNTIVO' name="caso + 'indicativo' → conjuntivo" default='temp_off'>
+        <rule id='CASO_INDICATIVO_CONJUNTIVO' name="caso + 'indicativo' → conjuntivo">
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <pattern>
                 <token postag_regexp='yes' postag='SENT_START|_PUNCT|CC'><exception postag='RG'/></token> <!-- exception "segundo" -->


### PR DESCRIPTION
Enabled the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Re-enabled a Portuguese grammar checking rule that was previously disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->