### PR TITLE
[pt] Enabled rule:SUBST_DE_QUE_TER_DIREITO_A_QUE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -174,7 +174,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <category id='GRAMMAR' name="Gramática Geral" type="grammar">
 
 
-        <rule id="SUBST_DE_QUE_TER_DIREITO_A_QUE" name="Substantivo 'de que' … tem direito' → 'a que'" default='temp_off'>
+        <rule id="SUBST_DE_QUE_TER_DIREITO_A_QUE" name="Substantivo 'de que' … tem direito' → 'a que'">
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
             <pattern>
                 <token postag_regexp='yes' postag='NC.+|AQ.+'><exception regexp='yes' inflected='yes'>suposição|certeza|ideia|convicção|noção|hipótese|possibilidade|facto|fato|afirmação|alegação|crença|opinião|teoria</exception></token>


### PR DESCRIPTION
Enabled the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese grammar checking by enabling a previously disabled rule by default, so more issues can now be detected automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->