### PR TITLE
[pt-PT] Added AP to rule:POSSESSIVE_WITHOUT_ARTICLE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/multiwords.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/multiwords.txt
@@ -975,6 +975,7 @@ La Digue	NPCNG00_
 La Grande-Motte	NPCNG00_
 La Línea de la Concepción	NPCNG00_
 La Mosquitia	NPCNG00_
+La Palice	NPMSSP0_
 La Paz	NPCSG00_
 La Pequeña Habana	NPCNG00_
 La Tour	NPCNG00_

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -934,6 +934,25 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <!-- 31-DEC-2025: entity pronomes_possessivos_pt_pt had "minhas?" missing, this may affect several APs here and in other parts -->
 
       <antipattern>
+          <token>em</token>
+          <token regexp='yes'>&pronomes_possessivos_pt_pt;</token>
+          <token regexp='yes' inflected='yes'>homenagem|honra|memória|lembrança|louvor|defesa|benefício|favor|proveito|interesse|vantagem|desvantagem|prejuízo|detrimento|nome|lugar|representação|substituição|companhia|presença|ausência|posse|poder|auxílio|socorro|apoio|ajuda|serviço|conhecimento|opinião|entendimento</token> <!-- ChatGPT 5.5 - 2026-06-25 -->
+          <example>"Você não deveria ter ido lá." "Ok, e o que você teria feito em meu lugar?"</example>
+          <example>- O que tem a dizer em sua defesa?</example>
+          <example>A carta 2 pode estar presente contanto que esteja em seu lugar de costume (entre o ás e o 3).</example>
+          <example>A cena ficou claramente gravada em minha memória.</example>
+          <example>A cratera lunar Airy (cratera lunar) e outra em marte são denominadas em sua homenagem.</example>
+          <example>A Escola de Educação da "California State University Northridge" é nomeado em sua honra.</example>
+          <example>A espécie "Anthus berthelotii" foi nomeada em sua homenagem pelo seu amigo Carl Bolle.</example>
+          <example>A lealdade a uma causa aúna aos numerosos seguidores da causa, unindo em seu serviço.</example>
+          <example>A lei antifumo é justa, em minha opinião.</example>
+          <example>A morte paira sobre ti. Enquanto viveres, enquanto isto estiver em teu poder, sê bom.</example>
+          <example>A padroeira é a nossa senhora do Carmo e há festas em sua honra no mês de agosto.</example>
+          <example>A PIDE é extinta em 1969, sendo criada em sua substituição a Direcção-Geral de Segurança (DGS).</example>
+          <example>Em seu lugar, JavaScript utiliza escopo a nível de função.</example>
+      </antipattern>
+
+      <antipattern>
           <token postag='RM' postag_regexp='no'/>
           <token postag='RG' postag_regexp='no'/>
           <token regexp='yes'>&pronomes_possessivos_pt_pt;</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -4672,6 +4672,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <rule id='PEDIR_SOLICITAR_V3' name="Pedir → solicitar" tone_tags='formal' tags='picky'>
+
+            <antipattern> <!-- Expressão idiomática -->
+                <token regexp='yes'>[ao]s?|el[ea]s?|tu|vocês?</token>
+                <token min='0' max='2' postag_regexp='yes' postag='N.+|AQ.+|RM'/>
+                <token regexp='yes' inflected='yes'>andar|estar</token>
+                <token>a</token>
+                <token min='0' max='1' postag='_QUOT'/>
+                <token>pedi-las</token>
+                <example>Ele andava a pedi-las.</example>
+                <example>Os batoteiros estavam a pedi-las.</example>
+                <example>O jornalista andava a "pedi-las"…</example>
+                <example>Ela deliberadamente andava a pedi-las.</example>
+            </antipattern>
+
             <antipattern>
                 <token postag='SENT_START|Z0.+|DI.+|_PUNCT|VMN0000|VMG0000|_QUOT' postag_regexp='yes'>
                     <exception regexp='yes' inflected='yes'>estar|ter|ser</exception>


### PR DESCRIPTION
Added an antipattern to fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese grammar checking to reduce incorrect warnings for possessive-determiner constructions like “em + (pronome possessivo) + substantivo”.
  * Enhanced style guidance to flag non-recommended “andar/estar a … pedi-las” patterns with targeted pronoun contexts.
  * Added new example sentences to support the updated checks.
* **New Features**
  * Added the multiword proper noun “La Palice” to the Portuguese language rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->