### PR TITLE
fix: use stream factory to create dictionary from temp files

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/Hunspell.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/spelling/hunspell/Hunspell.java
@@ -53,10 +53,11 @@ public final class Hunspell {
 
       @Override
       public HunspellDictionary createFromStreams(String language, InputStream dictionaryStream, InputStream affixStream) throws IOException {
-        // Create temp files from streams - must clean up when dictionary is closed
+        // Resources are in JARs or other non-file sources - must create temp files
+        // These temp files live for the JVM lifetime (deleteOnClose=false)
         var tempFiles = createTempFilesFromStreams(language, dictionaryStream, affixStream);
         log.trace("Created temp files for language {}: {} and {}", language, tempFiles.dictionary, tempFiles.affix);
-        return new DumontsHunspellDictionary(tempFiles.dictionary, tempFiles.affix, true);
+        return new DumontsHunspellDictionary(tempFiles.dictionary, tempFiles.affix, false);
       }
     };
   }
@@ -158,21 +159,17 @@ public final class Hunspell {
       }
     }
 
-    // Resources are in JARs or other non-file sources - must create temp files
-    // These temp files live for the JVM lifetime (deleteOnClose=false)
     try (var dictionaryStream = broker.getFromResourceDirAsStream(dicPath);
          var affixStream = broker.getFromResourceDirAsStream(affPath)) {
       if (dictionaryStream == null || affixStream == null) {
         throw new RuntimeException("Could not find the dictionary for language \"" + language + "\" in the classpath");
       }
 
-      var tempFiles = createTempFilesFromStreams(language, dictionaryStream, affixStream);
-      var dict = new DumontsHunspellDictionary(tempFiles.dictionary, tempFiles.affix, false);
+      var dict = hunspellDictionaryStreamFactory.createFromStreams(language, dictionaryStream, affixStream);
 
       // Cache by resource path for future lookups (fixes #11380)
       resourceCache.put(key, dict);
-      log.trace("Created and cached dictionary from JAR resource for language {}: {} and {}",
-                language, tempFiles.dictionary, tempFiles.affix);
+      log.trace("Created and cached dictionary from JAR resource for language {}: {} and {}", language, dicPath, affPath);
 
       return dict;
     } catch (IOException e) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of dictionary resources, especially when they come from packaged or bundled locations.
  * Made temporary file handling more reliable so dictionary files stay available for the app session and are cleaned up when the app exits.
  * Added caching for loaded dictionaries to help reduce repeated loading and improve stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->