### PR TITLE
Allow longer command-line option lists

### DIFF
--- a/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineParser.java
+++ b/languagetool-commandline/src/main/java/org/languagetool/commandline/CommandLineParser.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 class CommandLineParser {
 
   CommandLineOptions parseOptions(String[] args) {
-    if (args.length < 1 || args.length > 14) {
+    if (args.length < 1) {
       throw new WrongParameterNumberException();
     }
     CommandLineOptions options = new CommandLineOptions();
@@ -54,6 +54,7 @@ class CommandLineParser {
       } else if (args[i].equals("--clean-overlapping")) {
         options.setCleanOverlapping(true);
       } else if (args[i].equals("--level")) {
+        checkArguments("--level", i, args);
         String level = args[++i];
         try {
           options.setLevel(JLanguageTool.Level.valueOf(level));

--- a/languagetool-commandline/src/test/java/org/languagetool/commandline/CommandLineParserTest.java
+++ b/languagetool-commandline/src/test/java/org/languagetool/commandline/CommandLineParserTest.java
@@ -19,6 +19,7 @@
 package org.languagetool.commandline;
 
 import org.junit.Test;
+import org.languagetool.JLanguageTool;
 
 import static org.junit.Assert.*;
 
@@ -43,6 +44,13 @@ public class CommandLineParserTest {
       parser.parseOptions(new String[]{"--apply", "--taggeronly"});
       fail();
     } catch (IllegalArgumentException ignored) {}
+
+    try {
+      parser.parseOptions(new String[]{"--level"});
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Missing argument to --level command line option.", e.getMessage());
+    }
   }
 
   @Test
@@ -75,6 +83,38 @@ public class CommandLineParserTest {
 
     options = parser.parseOptions(new String[]{"--list"});
     assertTrue(options.isPrintLanguages());
+  }
+
+  @Test
+  public void testLongOptionList() throws Exception {
+    CommandLineParser parser = new CommandLineParser();
+    CommandLineOptions options = parser.parseOptions(new String[]{
+            "--language", "xx",
+            "--mothertongue", "xx",
+            "--encoding", "utf-8",
+            "--disable", "RULE_ONE,RULE_TWO",
+            "--enable", "RULE_THREE",
+            "--enablecategories", "CAT_ONE",
+            "--disablecategories", "CAT_TWO",
+            "--line-by-line",
+            "--enable-temp-off",
+            "--clean-overlapping",
+            "--level", "PICKY",
+            "filename.txt"
+    });
+
+    assertEquals("xx", options.getLanguage().getShortCode());
+    assertEquals("xx", options.getMotherTongue().getShortCode());
+    assertEquals("utf-8", options.getEncoding());
+    assertEquals("filename.txt", options.getFilename());
+    assertEquals(JLanguageTool.Level.PICKY, options.getLevel());
+    assertEquals(2, options.getDisabledRules().size());
+    assertEquals(1, options.getEnabledRules().size());
+    assertEquals(1, options.getEnabledCategories().size());
+    assertEquals(1, options.getDisabledCategories().size());
+    assertTrue(options.isLineByLine());
+    assertTrue(options.isEnableTempOff());
+    assertTrue(options.isCleanOverlapping());
   }
 
 }


### PR DESCRIPTION
Summary
- Remove the hard-coded 14-argument limit in the command-line parser so valid longer option combinations are accepted.
- Validate a missing --level argument with the existing missing-argument error path.
- Add parser tests for long valid option lists and missing --level.

Testing
- git diff --check
- Not run: mvn -Dmaven.repo.local=/private/tmp/lt-m2 -pl languagetool-commandline -Dtest=CommandLineParserTest test (local environment only has Java 8; LanguageTool requires Java 17).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line validation so missing values for `--level` are now detected and reported clearly.
  * Removed an unnecessary limit on the number of command-line arguments, allowing longer option lists to be parsed correctly.
  * Added coverage for long option combinations to confirm parsing works as expected across language, rule, category, and mode settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->