### PR TITLE
[core] make regexp and SRX patterns Unicode-aware for JDK 19/21 migration

### DIFF
--- a/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleHandler.java
+++ b/languagetool-core/src/main/java/org/languagetool/rules/patterns/PatternRuleHandler.java
@@ -780,7 +780,11 @@ public class PatternRuleHandler extends XMLRuleHandler {
         rule.setDistanceTokens(distanceTokens);
         rule.setXmlLineNumber(xmlLineNumber);
       } else if (regex.length() > 0) {
-        int flags = regexCaseSensitive ? 0 : Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE;
+        // UNICODE_CHARACTER_CLASS (equivalent to the inline (?U) flag) makes \b, \w, \d and \s
+        // Unicode-aware. Without it the behavior of word boundaries next to non-ASCII letters
+        // depends on the JDK version (it changed between JDK 17 and JDK 21), which breaks many
+        // <regexp> rules. Setting it here avoids adding (?U) by hand to every <regexp> pattern.
+        int flags = Pattern.UNICODE_CHARACTER_CLASS | (regexCaseSensitive ? 0 : Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
         String regexStr = regex.toString();
         if (regexMode == RegexpMode.SMART) {
           // Note: it's not that easy to add \b because the regex might look like '(foo)' or '\d' so we cannot just look at the last character

--- a/languagetool-core/src/main/java/org/languagetool/tokenizers/SRXSentenceTokenizer.java
+++ b/languagetool-core/src/main/java/org/languagetool/tokenizers/SRXSentenceTokenizer.java
@@ -66,7 +66,7 @@ public class SRXSentenceTokenizer implements SentenceTokenizer {
 
   /**
    * @param lineBreakParagraphs if <code>true</code>, single lines breaks are assumed to end a
-   *   paragraph; if <code>false</code>, only two ore more consecutive line breaks end a paragraph
+   *   paragraph; if <code>false</code>, only two or more consecutive line breaks end a paragraph
    */
   @Override
   public final void setSingleLineBreaksMarksParagraph(boolean lineBreakParagraphs) {

--- a/languagetool-core/src/main/java/org/languagetool/tokenizers/SrxTools.java
+++ b/languagetool-core/src/main/java/org/languagetool/tokenizers/SrxTools.java
@@ -45,7 +45,8 @@ final class SrxTools {
     try {
       String srx;
       try (InputStream inputStream = JLanguageTool.getDataBroker().getFromResourceDirAsStream(path)) {
-        srx = readFully(inputStream).replaceAll("<(beforebreak|afterbreak)>(?!</)", "<$1>(?U)");
+        srx = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8)
+          .replaceAll("<(beforebreak|afterbreak)>(?!</)", "<$1>(?U)");
       }
       Map<String, Object> parserParameters = new HashMap<>();
       parserParameters.put(Srx2SaxParser.VALIDATE_PARAMETER, true);
@@ -54,16 +55,6 @@ final class SrxTools {
     } catch (IOException e) {
       throw new RuntimeException("Could not load SRX rules", e);
     }
-  }
-
-  private static String readFully(InputStream inputStream) throws IOException {
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    byte[] chunk = new byte[8192];
-    int read;
-    while ((read = inputStream.read(chunk)) != -1) {
-      buffer.write(chunk, 0, read);
-    }
-    return buffer.toString(StandardCharsets.UTF_8.name());
   }
 
   static List<String> tokenize(String text, SrxDocument srxDocument, String code) {

--- a/languagetool-core/src/main/java/org/languagetool/tokenizers/SrxTools.java
+++ b/languagetool-core/src/main/java/org/languagetool/tokenizers/SrxTools.java
@@ -1,6 +1,6 @@
-/* LanguageTool, a natural language style checker 
+/* LanguageTool, a natural language style checker
  * Copyright (C) 2014 Daniel Naber (http://www.danielnaber.de)
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -28,38 +28,42 @@ import org.languagetool.JLanguageTool;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Tools for loading an SRX tokenizer file.
+ *
  * @since 2.6
  */
 final class SrxTools {
+
+  private static final Map<String, Object> VALIDATION_PARAMETERS = Map.of(Srx2SaxParser.VALIDATE_PARAMETER, true);
+
+  private static final Map<String, Object> TOKENIZE_PARAMETERS =
+    Map.of(SrxTextIterator.DEFAULT_PATTERN_FLAGS_PARAMETER, Pattern.UNICODE_CHARACTER_CLASS);
 
   private SrxTools() {
   }
 
   static SrxDocument createSrxDocument(String path) {
     try {
-      String srx;
-      try (InputStream inputStream = JLanguageTool.getDataBroker().getFromResourceDirAsStream(path)) {
-        srx = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8)
-          .replaceAll("<(beforebreak|afterbreak)>(?!</)", "<$1>(?U)");
+      try (
+        InputStream inputStream = JLanguageTool.getDataBroker().getFromResourceDirAsStream(path);
+        BufferedReader srxReader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+      ) {
+        SrxParser srxParser = new Srx2SaxParser(VALIDATION_PARAMETERS);
+        return srxParser.parse(srxReader);
       }
-      Map<String, Object> parserParameters = new HashMap<>();
-      parserParameters.put(Srx2SaxParser.VALIDATE_PARAMETER, true);
-      SrxParser srxParser = new Srx2SaxParser(parserParameters);
-      return srxParser.parse(new StringReader(srx));
     } catch (IOException e) {
       throw new RuntimeException("Could not load SRX rules", e);
     }
   }
 
-  static List<String> tokenize(String text, SrxDocument srxDocument, String code) {
+  static List<String> tokenize(String text, SrxDocument srxDocument, String languageCode) {
     List<String> segments = new ArrayList<>();
-    TextIterator textIterator = new SrxTextIterator(srxDocument, code, text);
+    TextIterator textIterator = new SrxTextIterator(srxDocument, languageCode, text, TOKENIZE_PARAMETERS);
     while (textIterator.hasNext()) {
       segments.add(textIterator.next());
     }

--- a/languagetool-core/src/main/java/org/languagetool/tokenizers/SrxTools.java
+++ b/languagetool-core/src/main/java/org/languagetool/tokenizers/SrxTools.java
@@ -43,18 +43,27 @@ final class SrxTools {
 
   static SrxDocument createSrxDocument(String path) {
     try {
-      try (
-        InputStream inputStream = JLanguageTool.getDataBroker().getFromResourceDirAsStream(path);
-        BufferedReader srxReader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
-      ) {
-        Map<String, Object> parserParameters = new HashMap<>();
-        parserParameters.put(Srx2SaxParser.VALIDATE_PARAMETER, true);
-        SrxParser srxParser = new Srx2SaxParser(parserParameters);
-        return srxParser.parse(srxReader);
+      String srx;
+      try (InputStream inputStream = JLanguageTool.getDataBroker().getFromResourceDirAsStream(path)) {
+        srx = readFully(inputStream).replaceAll("<(beforebreak|afterbreak)>(?!</)", "<$1>(?U)");
       }
+      Map<String, Object> parserParameters = new HashMap<>();
+      parserParameters.put(Srx2SaxParser.VALIDATE_PARAMETER, true);
+      SrxParser srxParser = new Srx2SaxParser(parserParameters);
+      return srxParser.parse(new StringReader(srx));
     } catch (IOException e) {
       throw new RuntimeException("Could not load SRX rules", e);
     }
+  }
+
+  private static String readFully(InputStream inputStream) throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    byte[] chunk = new byte[8192];
+    int read;
+    while ((read = inputStream.read(chunk)) != -1) {
+      buffer.write(chunk, 0, read);
+    }
+    return buffer.toString(StandardCharsets.UTF_8.name());
   }
 
   static List<String> tokenize(String text, SrxDocument srxDocument, String code) {

--- a/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
@@ -4641,7 +4641,7 @@
 </languagerule>
 <languagerule languagerulename="ByTwoLineBreaks">
 <rule break="yes">
-<beforebreak>\r?\n\s*\r?\n[\t]*</beforebreak>
+<beforebreak>\r?\n[ \t\n\x0B\f\r]*\r?\n[\t]*</beforebreak>
 <afterbreak></afterbreak>
 </rule>
 <rule break="yes">

--- a/languagetool-language-modules/ca/src/main/java/org/languagetool/tokenizers/ca/CatalanWordTokenizer.java
+++ b/languagetool-language-modules/ca/src/main/java/org/languagetool/tokenizers/ca/CatalanWordTokenizer.java
@@ -56,60 +56,60 @@ public class CatalanWordTokenizer extends WordTokenizer {
 
   //Patterns to avoid splitting words in certain special cases
   // allows correcting typographical errors in "ela geminada"
-  private static final Pattern ELA_GEMINADA = Pattern.compile("([aeiouàéèíóòúïüAEIOUÀÈÉÍÒÓÚÏÜ])l[\\.\u2022\u22C5\u2219\uF0D7]l([aeiouàéèíóòúïü])",Pattern.UNICODE_CASE);
-  private static final Pattern ELA_GEMINADA_UPPERCASE = Pattern.compile("([AEIOUÀÈÉÍÒÓÚÏÜ])L[\\.\u2022\u22C5\u2219\uF0D7]L([AEIOUÀÈÉÍÒÓÚÏÜ])",Pattern.UNICODE_CASE);
+  private static final Pattern ELA_GEMINADA = Pattern.compile("([aeiouàéèíóòúïüAEIOUÀÈÉÍÒÓÚÏÜ])l[\\.\u2022\u22C5\u2219\uF0D7]l([aeiouàéèíóòúïü])",Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
+  private static final Pattern ELA_GEMINADA_UPPERCASE = Pattern.compile("([AEIOUÀÈÉÍÒÓÚÏÜ])L[\\.\u2022\u22C5\u2219\uF0D7]L([AEIOUÀÈÉÍÒÓÚÏÜ])",Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
   // apostrophe 
-  private static final Pattern APOSTROF_RECTE = Pattern.compile("([\\p{L}])'([\\p{L}\"‘“«])",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
-  private static final Pattern APOSTROF_RODO = Pattern.compile("([\\p{L}])’([\\p{L}\"‘“«])",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
+  private static final Pattern APOSTROF_RECTE = Pattern.compile("([\\p{L}])'([\\p{L}\"‘“«])",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
+  private static final Pattern APOSTROF_RODO = Pattern.compile("([\\p{L}])’([\\p{L}\"‘“«])",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
   // apostrophe before number 1. Ex.: d'1 km, és l'1 de gener, és d'1.4 kg
-  private static final Pattern APOSTROF_RECTE_1 = Pattern.compile("([dlDL])'(\\d[\\d\\s\\.,]?)",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
-  private static final Pattern APOSTROF_RODO_1 = Pattern.compile("([dlDL])’(\\d[\\d\\s\\.,]?)",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
+  private static final Pattern APOSTROF_RECTE_1 = Pattern.compile("([dlDL])'(\\d[\\d\\s\\.,]?)",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
+  private static final Pattern APOSTROF_RODO_1 = Pattern.compile("([dlDL])’(\\d[\\d\\s\\.,]?)",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
   // decimal point between digits
-  private static final Pattern DECIMAL_POINT= Pattern.compile("([\\d])\\.([\\d])",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
+  private static final Pattern DECIMAL_POINT= Pattern.compile("([\\d])\\.([\\d])",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
   // decimal comma between digits
-  private static final Pattern DECIMAL_COMMA= Pattern.compile("([\\d]),([\\d])",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
+  private static final Pattern DECIMAL_COMMA= Pattern.compile("([\\d]),([\\d])",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
   // space between digits
   // the first is an exception to the two next patterns
-  private static final Pattern SPACE_DIGITS0= Pattern.compile("([\\d]{4}) ",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
-  private static final Pattern SPACE_DIGITS= Pattern.compile("([\\d]) ([\\d][\\d][\\d])",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
-  private static final Pattern SPACE_DIGITS2= Pattern.compile("([\\d]) ([\\d][\\d][\\d]) ([\\d][\\d][\\d])",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
+  private static final Pattern SPACE_DIGITS0= Pattern.compile("([\\d]{4}) ",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
+  private static final Pattern SPACE_DIGITS= Pattern.compile("([\\d]) ([\\d][\\d][\\d])",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
+  private static final Pattern SPACE_DIGITS2= Pattern.compile("([\\d]) ([\\d][\\d][\\d]) ([\\d][\\d][\\d])",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
   // Sàsser-l'Alguer
-  private static final Pattern HYPHEN_L= Pattern.compile("([\\p{L}]+)(-)([Ll]['’])([\\p{L}]+)",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
+  private static final Pattern HYPHEN_L= Pattern.compile("([\\p{L}]+)(-)([Ll]['’])([\\p{L}]+)",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
 
   public CatalanWordTokenizer() {
 
     // Apostrophe at the beginning of a word. Ex.: l'home, s'estima, n'omple, hivern, etc.
     // It creates 2 tokens: <token>l'</token><token>home</token>
-    patterns[0] = Pattern.compile("^([lnmtsd]['’])([^'’\\-]*)$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
+    patterns[0] = Pattern.compile("^([lnmtsd]['’])([^'’\\-]*)$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
 
     // Exceptions to (Match verb+1 pronom feble)
     // It creates 1 token: <token>qui-sap-lo</token>
-    patterns[1] = Pattern.compile("^(qui-sap-lo|qui-sap-la|qui-sap-los|qui-sap-les)|(Castella)(-)(la)$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
+    patterns[1] = Pattern.compile("^(qui-sap-lo|qui-sap-la|qui-sap-los|qui-sap-les)|(Castella)(-)(la)$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
 
     // Match verb+3 pronoms febles (rare but possible!). Ex: Emporta-te'ls-hi.
     // It creates 4 tokens: <token>Emporta</token><token>-te</token><token>'ls</token><token>-hi</token>
-    patterns[2] = Pattern.compile("^([lnmtsd]['’])(.{2,})"+PF+PF+PF+"$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
-    patterns[3] = Pattern.compile("^(.{2,})"+PF+PF+PF+"$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
+    patterns[2] = Pattern.compile("^([lnmtsd]['’])(.{2,})"+PF+PF+PF+"$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
+    patterns[3] = Pattern.compile("^(.{2,})"+PF+PF+PF+"$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
 
     // Match verb+2 pronoms febles. Ex: Emporta-te'ls. 
     // It creates 3 tokens: <token>Emporta</token><token>-te</token><token>'ls</token>
-    patterns[4] = Pattern.compile("^([lnmtsd]['’])(.{2,})"+PF+PF+"$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
-    patterns[5] = Pattern.compile("^(.{2,})"+PF+PF+"$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
+    patterns[4] = Pattern.compile("^([lnmtsd]['’])(.{2,})"+PF+PF+"$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
+    patterns[5] = Pattern.compile("^(.{2,})"+PF+PF+"$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
 
     // match verb+1 pronom feble. Ex: Emporta't, vés-hi, porta'm.
     // It creates 2 tokens: <token>Emporta</token><token>'t</token>
     // ^(.+[^cbfhjkovwyzCBFHJKOVWYZ])
-    patterns[6] = Pattern.compile("^([lnmtsd]['’])(.{2,})"+PF+"$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
-    patterns[7] = Pattern.compile("^(.+[^wo])"+PF+"$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
+    patterns[6] = Pattern.compile("^([lnmtsd]['’])(.{2,})"+PF+"$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
+    patterns[7] = Pattern.compile("^(.+[^wo])"+PF+"$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
 
     // d'emportar
-    patterns[8] = Pattern.compile("^([lnmtsd]['’])(.*)$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
+    patterns[8] = Pattern.compile("^([lnmtsd]['’])(.*)$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
 
     //contractions: al, als, pel, pels, del, dels, cal (!), cals (!) 
-    patterns[9] = Pattern.compile("^(a|de|pe)(ls?)$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
+    patterns[9] = Pattern.compile("^(a|de|pe)(ls?)$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
 
     //contraction: can
-    patterns[10] = Pattern.compile("^(ca)(n)$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
+    patterns[10] = Pattern.compile("^(ca)(n)$",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
 
   }
 

--- a/languagetool-language-modules/es/src/main/java/org/languagetool/tokenizers/es/SpanishWordTokenizer.java
+++ b/languagetool-language-modules/es/src/main/java/org/languagetool/tokenizers/es/SpanishWordTokenizer.java
@@ -43,7 +43,8 @@ public class SpanishWordTokenizer extends WordTokenizer {
   // decimal comma between digits
   private static final Pattern DECIMAL_COMMA= Pattern.compile("([\\d]),([\\d])",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE);
   // ordinals
-  private static final Pattern ORDINAL_POINT= Pattern.compile("\\b([\\d]+)\\.(º|ª|o|a|er|os|as)\\b",Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
+  private static final Pattern ORDINAL_POINT= Pattern.compile("\\b([\\d]+)\\.(º|ª|o|a|er|os|as)\\b",
+    Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE|Pattern.UNICODE_CHARACTER_CLASS);
   private static final Pattern PATTERN_1 = Pattern.compile("xxES_DECIMAL_POINTxx", Pattern.LITERAL);
   private static final Pattern PATTERN_2 = Pattern.compile("xxES_DECIMAL_COMMAxx", Pattern.LITERAL);
   private static final Pattern PATTERN_3 = Pattern.compile("xxES_ORDINAL_POINTxx", Pattern.LITERAL);

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -41612,7 +41612,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
         <rulegroup id="GRAU_EM_COORDENADAS_ESPACAMENTO" name="Dar espaçamento entre o símbolo de grau e pontos cardeais em coordenadas geográficas" tags="picky">
             <rule>
-                <regexp case_sensitive="yes" type="exact">\b(&number_token;)\s?&deg;\s?(&cardinal_points;)\b</regexp>
+                <regexp case_sensitive="yes" type="exact">\b(&number_token;)[ \t]?&deg;[ \t]?(&cardinal_points;)\b</regexp>
                 <filter class="org.languagetool.rules.patterns.RegexAntiPatternFilter" args="antipatterns:\d&deg;\s&cardinal_points;"/>
                 <message>Em coordenadas geográficas, prefira a formato <suggestion>\1&deg;&nbsp;\2</suggestion>.</message>
                 <example correction="60&deg;&nbsp;N">Fica a <marker>60 &deg;N</marker>.</example>

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <javax.measure.unit-api.version>1.0</javax.measure.unit-api.version>
         <javax.xml.bind.jaxb-api.version>2.3.1</javax.xml.bind.jaxb-api.version>
 
-        <net.loomchild.segment.version>2.0.3</net.loomchild.segment.version>
+        <net.loomchild.segment.version>2.0.4</net.loomchild.segment.version>
 
         <org.apache.commons.commons-collections4.version>4.4</org.apache.commons.commons-collections4.version>
         <org.apache.commons.commons-csv.version>1.12.0</org.apache.commons.commons-csv.version>


### PR DESCRIPTION
Migrating the build/runtime from JDK 17 to JDK 19/21. Between those JDK versions, the behavior of \b, \w, \d and \s next to non-ASCII characters changed unless the pattern is compiled Unicode-aware (UNICODE_CHARACTER_CLASS / the inline (?U) flag). Without it, many rules and the sentence segmentation behave differently across JDKs. The migration forces Unicode-aware matching everywhere, and then fixes the one place where that new \s semantics has an unwanted side effect.

1. **PatternRuleHandler.java** XML <regexp> rules are now compiled with Pattern.UNICODE_CHARACTER_CLASS added to the flags. This makes \b/\w/\d/\s Unicode-aware for every <regexp> rule, so word-boundary matching next to non-ASCII letters is stable across JDKs — without having to add (?U) by hand to each pattern.

2. **SrxTools.java** Updated `loomchild.segment` to 2.0.4,  and the patterns are compiled with UNICODE_CHARACTER_CLASS. This applies the same Unicode-aware matching to the thousands of sentence-tokenizer patterns without editing them individually.

3. **segment.srx** Side-effect fix for the above. Making \s Unicode-aware means it now also matches \u00A0 (non-breaking space). The ByTwoLineBreaks paragraph rule \r?\n\s*\r?\n[\t]* then greedily swallowed \u00A0 and merged paragraph breaks that must stay separate. That rule now uses an explicit ASCII-whitespace class ([ \t\n\x0B\f\r]) instead of \s, so paragraph-break detection is unaffected by the new Unicode-aware \s. Everywhere else in segment.srx, the broader \s (including \u00A0) is intentional. This restores SentenceRangeTest.testSpecialCase (and keeps all 5 SentenceRangeTest cases green).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unicode-aware regex compilation for more consistent Unicode boundary behavior across pattern matching and tokenization.
  * Updated sentence/segment SRX rules so whitespace around line breaks and in split/abbreviation contexts is handled more precisely.
  * Tightened multiple language grammar and pattern rules to treat optional whitespace as space/tab rather than broader whitespace.
* **Documentation**
  * Corrected a Javadoc typo in the sentence tokenizer.
* **Chores**
  * Bumped the managed `segment` dependency version (2.0.3 → 2.0.4).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->