### PR TITLE
Fehlalarm Verb/Adjektiv

### DIFF
--- a/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/VerbAgreementRule.java
+++ b/languagetool-language-modules/de/src/main/java/org/languagetool/rules/de/VerbAgreementRule.java
@@ -872,12 +872,41 @@ public class VerbAgreementRule extends TextLevelRule {
    */
   private boolean isFiniteVerb(AnalyzedTokenReadings token) {
     if (token.getToken().length() == 0
-        || (Character.isUpperCase(token.getToken().charAt(0)) && token.getStartPos() != 0)
-        || !token.hasPosTagStartingWith("VER")
-        || token.hasAnyPartialPosTag("PA2", "PRO:", "ZAL")
-        || "einst".equals(token.getToken())) {
+      || (Character.isUpperCase(token.getToken().charAt(0)) && token.getStartPos() != 0)
+      || !token.hasPosTagStartingWith("VER")
+      || token.hasAnyPartialPosTag("PA2", "PRO:", "ZAL")
+      || "einst".equals(token.getToken())) {
       return false;
     }
+
+    // Ignore words that are primarily adjectives but have incorrect verb readings
+    boolean hasAdjectiveReading = false;
+    boolean hasRealFiniteVerbReading = false;
+
+    for (AnalyzedToken reading : token) {
+      String posTag = reading.getPOSTag();
+
+      if (posTag == null) {
+        continue;
+      }
+
+      if (posTag.startsWith("ADJ:")) {
+        hasAdjectiveReading = true;
+      }
+
+      if (posTag.startsWith("VER:")
+        && (posTag.contains(":1:")
+        || posTag.contains(":2:")
+        || posTag.contains(":3:"))
+        && !posTag.endsWith(":SFT")) {
+        hasRealFiniteVerbReading = true;
+      }
+    }
+
+    if (hasAdjectiveReading && !hasRealFiniteVerbReading) {
+      return false;
+    }
+
     return token.hasAnyPartialPosTag(":1:", ":2:", ":3:");
   }
   

--- a/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/VerbAgreementRuleTest.java
+++ b/languagetool-language-modules/de/src/test/java/org/languagetool/rules/de/VerbAgreementRuleTest.java
@@ -217,6 +217,9 @@ public class VerbAgreementRuleTest {
   @Test
   public void testWrongVerbSubject() throws IOException {
     // correct sentences:
+    assertGood("Während er faul auf der Couch saß, musste ich putzen.");
+    assertGood("Er ist krank und bleibt zu Hause.");
+    assertGood("Das Kind ist müde.");
     assertGood("Auch morgen lebe ich.");
     assertGood("Auch morgen leben wir noch.");
     assertGood("Auch morgen lebst du.");


### PR DESCRIPTION
#12038 https://github.com/languagetool-org/languagetool/issues/12038
Fixes a false positive in VerbAgreementRule where adjective/verb ambiguous
tokens like "faul" were incorrectly detected as finite verbs.

Example:
"Während er faul auf der Couch saß, musste ich putzen."

The rule now ignores adjective readings when no real finite verb reading is
present.

Added regression coverage in VerbAgreementRuleTest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved German grammar checking to avoid incorrectly flagging adjective forms as finite verbs.
  * Reduced false-positive verb agreement warnings in sentences containing adjective readings.

* **Tests**
  * Added coverage for correct sentences involving verbs such as “saß,” “musste,” “ist,” and “bleibt.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->