### PR TITLE
[pt] Added AP to rule:GENERAL_VERB_AGREEMENT_ERRORS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -9415,6 +9415,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         <rulegroup id='GENERAL_VERB_AGREEMENT_ERRORS' name="Concordância Verbal: Geral">
 
             <antipattern>
+                <token regexp='yes'>entre|a</token>
+                <token regexp='yes'>nós|vocês|vós</token>
+                <token min='0' max='1' postag='RN'/>
+                <token postag='VM...S.+' postag_regexp='yes'/>
+                <token postag='(SPS00:)?[DP]...[SN].+' postag_regexp='yes'/>
+                <example>Entre nós aconteceu uma magia nunca vista.</example>
+                <example>Entre nós não há nenhum engenheiro.</example>
+                <example>Entre nós nasceu uma agradável cumplicidade.</example>
+                <example>Quando se juntou a nós trouxe o caos de agora.</example>
+            </antipattern>
+
+            <antipattern>
                 <token min='2' postag='(SPS00:)?[DP]...[SN].+' postag_regexp='yes'/>
                 <token postag='AQ..[SN].+|N..[SN].+' postag_regexp='yes'/>
                 <token postag='RN' postag_regexp='no'/>


### PR DESCRIPTION
Added antipattern to fix false positives in rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese grammar checking for verb agreement in phrases involving “entre” and personal pronouns.
  * Reduced incorrect grammar warnings for valid sentence structures in this context.
  * Added example coverage to help ensure consistent checking of similar phrasing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->