### PR TITLE
[pt] Improved rule:ESTAR_LIXADO_ZANGADO_COM_PROBLEMAS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -4874,18 +4874,22 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <rule id='ESTAR_CONSTAR' name="Estar → constar" tone_tags='formal' tags='picky'>
-            <!-- Used DeepSeek-V3 -->
+        <rule id='ESTAR_CONSTAR' name="🤵 Estar em documento/registo → constar" type='style' tone_tags='formal' tags='picky'>
+            <!-- ChatGPT 5 and new disambiguator for 2026+ -->
+
             <pattern>
                 <marker>
-                    <token inflected='yes' regexp='no'>estar</token>
+                    <token inflected='yes'>estar</token>
                 </marker>
-                <token regexp='yes'>n[ao]s?</token>
-                <token inflected='yes' regexp='yes'>anais|anexo|artigo|autos|bibliografia|biografia|carta|contrato|cr[óô]nica|currículo|CV|dissertação|documento|edital|ensaio|escritos|Europass|guia|licença|livro|manual|memorial|memórias|monografia|parecer|pesquisa|plano|projeto|publicação|referências|registo|relatório|revista|sentença|tese|texto|tratado</token>
+                <token regexp='yes'>n[ao]s?|em</token>
+                <token inflected='yes' regexp='yes'>auto|bibliografia|contrato|edital|dissertação|monografia|plano|projeto|projecto|registo|relatório|sentença|tese</token> <!-- Lista conservadora -->
             </pattern>
-            <message>Substitua &quot;está&quot; por &quot;consta&quot; para indicar registo oficial ou dar um tom mais formal.</message>
+            <message>Em textos formais, considere &quot;constar&quot; para indicar que a informação faz parte da fonte, do documento ou do registo referido.</message>
             <suggestion><match no='1' postag='V.+' postag_regexp='yes'>constar</match></suggestion>
             <example correction="consta">O conteúdo que <marker>está</marker> na tese é relevante.</example>
+            <example correction="consta">A informação <marker>está</marker> no relatório final.</example>
+            <example correction="consta">O conteúdo que <marker>está</marker> em edital é relevante.</example>
+            <example correction="constam">As condições <marker>estão</marker> no contrato.</example>
             <example>O que consta nos autos deve ser bastante levado em conta.</example>
         </rule>
 

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -4832,12 +4832,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
         <rule id='ESTAR_LIXADO_ZANGADO_COM_PROBLEMAS' name="Lixado → zangado/'com problemas'" tone_tags='formal'>
+            <!-- ChatGPT 5 and new disambiguator for 2026+ -->
+
             <pattern>
-                <token skip='2' inflected='yes' regexp='no'>estar</token>
+                <token skip='2' inflected='yes' regexp='yes'>andar|estar</token>
                 <marker>
                     <token skip='1' regexp='yes'>lixad[ao]s?</token>
                 </marker>
-                <token postag='SPS00' postag_regexp='no'/> <!-- com|para|por -->
+                <token regexp='yes'>com|comigo|contigo|consigo</token>
             </pattern>
             <message>&informal_msg;</message>
             <suggestion><match no='2' postag='V.+' postag_regexp='yes'>zangar</match></suggestion>
@@ -4846,10 +4848,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <suggestion><match no='2' postag='V.+' postag_regexp='yes'>aborrecer</match></suggestion>
             <suggestion>com problemas</suggestion>
             <example correction="zangado|irritado|descontente|aborrecido|com problemas">Estou <marker>lixado</marker> com o meu chefe.</example>
+            <example correction="zangado|irritado|descontente|aborrecido|com problemas">Ando <marker>lixado</marker> com o meu chefe.</example>
+            <example correction="zangadas|irritadas|descontentes|aborrecidas|com problemas">Elas andam <marker>lixadas</marker> com a tarefa.</example>
+            <example>A chefe está zangada comigo.</example> 
             <example>O Rui está zangado com a Ana.</example>
             <example>A Ana está mais que aborrecida com a Rute.</example>
             <example>O Rui está bastante descontente com a Ana.</example>
             <example>Estou com problemas com o meu PC novo.</example>
+            <example>Ando com problemas com o meu PC novo.</example>
         </rule>
 
 


### PR DESCRIPTION
Improved the rule to make it more accurate and to deal with more situations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese grammar checking for constructions using “lixado(s)” with both “andar” and “estar.”
  * Expanded valid complement handling, including “com,” “comigo,” “contigo,” and “consigo.”
  * Updated and broadened detection for “estar” + “consta/constam” patterns (including added singular/plural examples).
  * Refreshed correction examples to better reflect correct usage in practice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->