### PR TITLE
[pt] Added formal rule:BAIXAR_DOSE_REDUZIR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3700,6 +3700,28 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
 
+        <rule id='BAIXAR_DOSE_REDUZIR' name="🤵 'Baixar' dose/quantidade → reduzir" type='style' tone_tags='formal' tags='picky' default='temp_off'>
+            <!-- ChatGPT 5 and new disambiguator for 2026+ -->
+            <!-- Evita o sentido informático de "baixar", equivalente a transferir/descarregar. -->
+
+            <pattern>
+                <marker>
+                    <token inflected='yes'>baixar</token>
+                </marker>
+                <token min='0' regexp='yes'>[ao]s?|um(?:a)?|est[ae]s?|ess[ae]s?|su[ae]s?|minh[ao]s?|noss[ao]s?</token>
+                <token inflected='yes' regexp='yes'>concentração|dosagem|dose|frequência|intensidade|nível|quantidade|ritmo|valor|velocidade|volume</token>
+            </pattern>
+            <message>Se a expressão indicar uma redução deliberada, considere &quot;reduzir&quot;.</message>
+            <suggestion><match no='1' postag='V.+' postag_regexp='yes'>reduzir</match></suggestion>
+            <example correction="reduzi">Eu <marker>baixei</marker> a dose.</example>
+            <example correction="reduziu">O médico <marker>baixou</marker> a dosagem.</example>
+            <example correction="reduziram">Eles <marker>baixaram</marker> os níveis de ruído.</example>
+            <example correction="reduzi">Eu <marker>baixei</marker> doses e quantidades.</example>
+            <example>Eu baixei o ficheiro ontem.</example>
+            <example>Ela baixou a aplicação para o telemóvel.</example>
+        </rule>
+
+
         <rule id='POUCO_IMPORTA_IRRELEVANTE' name="🤵 Pouco importa → é irrelevante" type='style' tone_tags='formal'>
             <!-- ChatGPT 5 and new disambiguator for 2026+ -->
 

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -3706,10 +3706,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
             <pattern>
                 <marker>
-                    <token inflected='yes'>baixar</token>
+                    <token postag='V.+' postag_regexp='yes' inflected='yes'>baixar<exception postag='RG'/></token>
                 </marker>
                 <token min='0' regexp='yes'>[ao]s?|um(?:a)?|est[ae]s?|ess[ae]s?|su[ae]s?|minh[ao]s?|noss[ao]s?</token>
-                <token inflected='yes' regexp='yes'>concentração|dosagem|dose|frequência|intensidade|nível|quantidade|ritmo|valor|velocidade|volume</token>
+                <token inflected='yes' regexp='yes'>concentração|dosagem|dose|frequência|intensidade|nível|quantidade|ritmo|valor|velocidade</token>
             </pattern>
             <message>Se a expressão indicar uma redução deliberada, considere &quot;reduzir&quot;.</message>
             <suggestion><match no='1' postag='V.+' postag_regexp='yes'>reduzir</match></suggestion>
@@ -3719,6 +3719,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="reduzi">Eu <marker>baixei</marker> doses e quantidades.</example>
             <example>Eu baixei o ficheiro ontem.</example>
             <example>Ela baixou a aplicação para o telemóvel.</example>
+            <example>Baixa o volume da televisão.</example>
         </rule>
 
 


### PR DESCRIPTION
A formal rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Portuguese style rule that flags uses of **“baixar”** when they refer to reducing **dose/dosage**, **frequency**, **quantity/amount**, **levels**, and related measurements.
  * The rule suggests **“reduzir”** and provides relevant context-specific examples, including guidance for common verb forms (e.g., “baixei/baixou/baixaram”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->