### PR TITLE
[pt] Improved rule:O_QUE_TEM_DE_MAL_QUE_MAL_TEM

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -15673,14 +15673,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <!-- O QUE TEM DE MAL que mal tem -->
-        <rule id='O_QUE_TEM_DE_MAL_QUE_MAL_TEM' name="✂️ 'o que tem de mal' → 'que mal tem'" type="style">
+        <rule id='O_QUE_TEM_DE_MAL_QUE_MAL_TEM' name="✂️ 'O que tem de mal' → 'Que mal tem'" type='style'>
             <!--IDEA shorten_it-->
-            <!-- Created by Marco A.G.Pinto with Ricardo Joseh Lima suggestions, Portuguese rule 2023-05-23 (2-MAR-2023+) -->
-            <!--
-      O que tem de mal partir o spaghetti antes de cozer? → Que mal tem partir o spaghetti antes de cozer?
-      O que tem de mal a abordagem holística? → Que mal tem a abordagem holística?
-      -->
+            <!-- ChatGPT 5 and new disambiguator for 2026+ -->
+
             <pattern>
                 <marker>
                     <token>o</token>
@@ -15691,9 +15687,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 </marker>
                 <token postag='V.+|(SPS00:)?D[AI].+' postag_regexp='yes'/>
             </pattern>
-            <message>&simplify_msg;</message>
+            <message>Considere a construção mais concisa &quot;que mal tem&quot;.</message>
             <suggestion>que mal tem</suggestion>
-            <example correction="Que mal tem"><marker>O que tem de mal</marker> partir o spaghetti antes de cozer?</example>
+            <example correction="Que mal tem"><marker>O que tem de mal</marker> partir o esparguete antes de o cozer?</example>
             <example correction="Que mal tem"><marker>O que tem de mal</marker> a abordagem holística?</example>
         </rule>
 


### PR DESCRIPTION
Improved the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese style guidance for the “que mal tem” construction.
  * Replaced a generic simplification message with a clearer Portuguese recommendation.
  * Updated examples and suggestions for improved spelling and contextual accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->