### PR TITLE
[pt] Renamed and improved rule:QUE_ESTAR_ADVERBIO_ADVERBIO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -17269,27 +17269,25 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
 
-        <!-- QUE ESTÁ ATUALMENTE atualmente -->
-        <rule id='QUE_ESTAR_ADVERB_ADVERB' name="✂️ Que + V.Estar + Adv → Adv" type='style' tags='picky'>
+        <rule id='QUE_ESTAR_ADVERBIO_ADVERBIO' name="✂️ 'que está/estão/estava/estavam + advérbio' → advérbio" type='style' tags='picky'>
             <!--IDEA shorten_it-->
-            <!-- Created by Marco A.G.Pinto, Portuguese rule 2023-02-19 (25-JUL-2022+) -->
-            <!--
-      Isto não afeta a equação que está atualmente no quadro. → Isto não afeta a equação atualmente no quadro.
-      Isto não afeta as equações que estão atualmente no quadro. → Isto não afeta as equações atualmente no quadro.
-      -->
+            <!-- ChatGPT 5.6 and new disambiguator for 2026+ -->
 
             <pattern>
+                <token postag='NC.+|AQ.+' postag_regexp='yes'/>
                 <marker>
-                    <token postag='NC.+|AQ.+|DD.+|_PUNCT' postag_regexp='yes'/>
                     <token>que</token>
-                    <token regexp='yes'>está|estão|estava|estavam</token>
-                    <token postag='RM' postag_regexp='no'/>
+                    <token regexp='yes'>está|estão|estavam?</token>
+                    <token postag='RM'/>
                 </marker>
             </pattern>
             <message>&simplify_msg;</message>
-            <suggestion>\1 \4</suggestion>
-            <example correction="equação atualmente">Isto não afeta a <marker>equação que está atualmente</marker> no quadro.</example>
-            <example correction="equações atualmente">Isto não afeta as <marker>equações que estão atualmente</marker> no quadro.</example>
+            <suggestion>\4</suggestion>
+            <example correction="atualmente">Isto não afeta a equação <marker>que está atualmente</marker> no quadro.</example>
+            <example correction="atualmente">Isto não afeta as equações <marker>que estão atualmente</marker> no quadro.</example>
+            <example correction="atualmente">Isto não afetava a equação <marker>que estava atualmente</marker> no quadro.</example>
+            <example correction="atualmente">Isto não afetava as equações <marker>que estavam atualmente</marker> no quadro.</example>
+            <example correction="presentemente">Consulte as regras <marker>que estão presentemente</marker> em vigor.</example>
         </rule>
 
 

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -17278,7 +17278,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <marker>
                     <token>que</token>
                     <token regexp='yes'>está|estão|estavam?</token>
-                    <token postag='RM'/>
+                    <token postag='RM'><exception scope='next' postag='SENT_END|_PUNCT' postag_regexp='yes'/></token>
                 </marker>
             </pattern>
             <message>&simplify_msg;</message>
@@ -17288,6 +17288,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <example correction="atualmente">Isto não afetava a equação <marker>que estava atualmente</marker> no quadro.</example>
             <example correction="atualmente">Isto não afetava as equações <marker>que estavam atualmente</marker> no quadro.</example>
             <example correction="presentemente">Consulte as regras <marker>que estão presentemente</marker> em vigor.</example>
+            <example>A situação que está atualmente.</example>
+            <example>Estas são as regras que estão atualmente.</example>
+            <example>Era a situação que estava anteriormente.</example>
+            <example>Eram as condições que estavam anteriormente.</example>
         </rule>
 
 


### PR DESCRIPTION
Renamed and improved rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese style checking for constructions using “que” with inflected forms of “estar” followed by an adverb.
  * Suggestions now highlight and replace only the adverb, providing more precise corrections.
  * Expanded detection coverage for four verb forms and the adverb “presentemente”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->