### PR TITLE
[pt] Modify AO90_COMPOUNDS_GENERIC_PREFIX rule

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -3925,8 +3925,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </antipattern>
       <pattern>
           <token regexp='yes'>extra|infra|intra|supra|ultra|mega|tele|&prefixos_i;|&prefixos_o;|&prefixos_o_2;|arqui
-          <exception case_sensitive='yes'>Homo</exception></token>
-          <exception regexp='yes' case_sensitive='yes'>\p{Lu}{2,}</exception></token>
+          <exception case_sensitive='yes'>Homo</exception>
+          <exception regexp='yes' case_sensitive='yes'>\p{Lu}{2,}</exception>
+          </token>
       <token min='0' regexp='yes' spacebefore='no'>&hifen;</token>
       <token regexp='yes'>r.+</token>
   </pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -3710,13 +3710,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
               <token regexp='yes'>ex|sota|soto|vice|vizo|grã|pós|pré|pró|recém</token>
               <!-- além|aquém|bem|sem|grão are better dealt by PortugueseCompoundRule.java -->
               <token>
-                  <exception regexp='yes'>[-,.!?\(\)]</exception>
+                  <exception regexp='yes'>[-‑‐,.!?\(\)]</exception>
                   <exception postag='C.|R.|S.+' postag_regexp='yes'/>
               </token>
           </pattern>
           <message>Palavra hifenizada.</message>
           <suggestion>\1-\2</suggestion>
           <example correction='vice-diretor'>Tem uma reunião marcada com o <marker>vice diretor</marker>.</example>
+          <example type='correct'>Fez uma <marker>Pós‑Graduação</marker> em Direito.</example>
       </rule>
       <rule>
           <pattern>
@@ -3925,12 +3926,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <pattern>
           <token regexp='yes'>extra|infra|intra|supra|ultra|mega|tele|&prefixos_i;|&prefixos_o;|&prefixos_o_2;|arqui
           <exception case_sensitive='yes'>Homo</exception></token>
+          <exception regexp='yes' case_sensitive='yes'>\p{Lu}{2,}</exception></token>
       <token min='0' regexp='yes' spacebefore='no'>&hifen;</token>
       <token regexp='yes'>r.+</token>
   </pattern>
   <message>Este prefixo não é hifenizado neste contexto.</message>
   <suggestion>\1r<match no='3' case_conversion="startlower"/></suggestion>
   <example correction='arquirrival'>O F.C. Porto é <marker>arqui-rival</marker> do S.L.Benfica.</example>
+  <example type='correct'>Domínio de ferramentas como Excel e <marker>Power BI será</marker> valorizado.</example>
       </rule>
       <rule>
           <antipattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -3926,8 +3926,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <pattern>
           <token regexp='yes'>extra|infra|intra|supra|ultra|mega|tele|&prefixos_i;|&prefixos_o;|&prefixos_o_2;|arqui
           <exception case_sensitive='yes'>Homo</exception>
-          <exception regexp='yes' case_sensitive='yes'>\p{Lu}{2,}</exception>
-          </token>
+          <exception regexp='yes' case_sensitive='yes'>\p{Lu}{2,}</exception></token>
       <token min='0' regexp='yes' spacebefore='no'>&hifen;</token>
       <token regexp='yes'>r.+</token>
   </pattern>
@@ -3947,7 +3946,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
           </antipattern>
           <pattern>
               <token regexp='yes'>extra|infra|intra|supra|ultra|mega|tele|&prefixos_i;|&prefixos_o;|&prefixos_o_2;|arqui
-              <exception case_sensitive='yes'>Homo</exception></token>
+              <exception case_sensitive='yes'>Homo</exception>
+              <exception regexp='yes' case_sensitive='yes'>\p{Lu}{2,}</exception></token>
           <token min='0' regexp='yes' spacebefore='no'>&hifen;</token>
           <token regexp='yes'>s.+</token>
       </pattern>


### PR DESCRIPTION
First: exclude all-uppercase tokens from the prefix slot
Second: add non-breaking and hyphen to the exception list to avoid double hyphen in suggestions

<img width="227" height="196" alt="Screenshot 2026-08-13 at 16 03 39" src="https://github.com/user-attachments/assets/c0a5a5f0-0d14-4939-882d-bd7b8a8334a2" />
<img width="396" height="209" alt="Screenshot 2026-08-13 at 16 03 50" src="https://github.com/user-attachments/assets/0d03d8f4-dfaa-49c8-8e64-1b8209c40012" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese hyphenation checks for words containing non-breaking hyphens.
  * Corrected prefix handling for terms such as “Pós‑Graduação,” “Power BI,” and uppercase words.
  * Prevented prefix rules from incorrectly matching all-uppercase terms with at least two characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->