### PR TITLE
[pt-PT] Improved rule:SIMPLIFICAR_QUE_VERBO_A_VERBOINFINITIVO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -3926,7 +3926,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       <pattern>
           <token regexp='yes'>extra|infra|intra|supra|ultra|mega|tele|&prefixos_i;|&prefixos_o;|&prefixos_o_2;|arqui
           <exception case_sensitive='yes'>Homo</exception>
-          <exception regexp='yes' case_sensitive='yes'>\p{Lu}{2,}</exception></token>
+          <exception regexp='yes' case_sensitive='yes'>\p{Lu}{2,30}</exception></token>
       <token min='0' regexp='yes' spacebefore='no'>&hifen;</token>
       <token regexp='yes'>r.+</token>
   </pattern>
@@ -3947,7 +3947,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
           <pattern>
               <token regexp='yes'>extra|infra|intra|supra|ultra|mega|tele|&prefixos_i;|&prefixos_o;|&prefixos_o_2;|arqui
               <exception case_sensitive='yes'>Homo</exception>
-              <exception regexp='yes' case_sensitive='yes'>\p{Lu}{2,}</exception></token>
+              <exception regexp='yes' case_sensitive='yes'>\p{Lu}{2,30}</exception></token>
           <token min='0' regexp='yes' spacebefore='no'>&hifen;</token>
           <token regexp='yes'>s.+</token>
       </pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -5162,30 +5162,24 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-    <rule id='SIMPLIFICAR_QUE_VERBO_A_VERBOINFINITIVO' name="🇵🇹✂️ Que + V. → A + V. Infinitivo" type="style">
-        <pattern>
-            <token postag='NC.+|AQ.+' postag_regexp='yes'><exception scope='previous' postag_regexp='yes' postag='VMN000.+'/></token>
-            <marker>
-                <token>que</token>
-                <token skip='2' postag='VMIP3P0' postag_regexp='no'> <!-- It only works with plural, using singular generates lots of FPs -->
-                    <exception postag_regexp='yes' postag='NP.+'/>
-                    <exception inflected='yes' regexp='yes'>haver|estar|existir|ser|ter</exception>
-                    <exception scope='next' postag_regexp='yes' postag='VMN000.+'/>
-                </token>
-            </marker>
-            <token regexp='yes'>conforme|sobre <!-- Obtained with: NC.+ AND SPS00 -->
-                <exception scope='previous' postag_regexp='yes' postag='VMN000.+|RG'/>
-            </token>
-        </pattern>
-        <message>&simplify_msg;</message>
-        <suggestion>a <match no='3' postag='VMIP3.+' postag_regexp="yes" postag_replace='VMN0000'/></suggestion>
-        <example correction="a atuar">Isto resume todas as forças <marker>que atuam</marker> sobre o objeto.</example>
-        <example>Em cujas ruas se localizam casas que parecem despenhar-se sobre o Cantábrico.</example>
-        <example>Principalmente sobre o impacto que podem causar sobre a natureza colaborativa da internet.</example>
-        <example>Até lá vamos baloiçando a nossa amizade por tempos indeterminados que determinam muito sobre quem nos quer bem.</example>
-        <example>Durante o curso, os alunos de Logística podem aprender disciplinas que oferecem conhecimento sobre administração.</example>
-        <example>A publicação reúne uma série de pesquisas que procuram jogar luz sobre os diferentes nós do problema educacional.</example>
-    </rule>
+      <rule id='SIMPLIFICAR_QUE_VERBO_A_VERBOINFINITIVO' name="🇵🇹✂️ 'que + verbo + sobre' → 'a + infinitivo + sobre'" type='style' tags='picky'>
+          <!--IDEA shorten_it-->
+          <!-- ChatGPT 5.6 and new disambiguator for 2026+ -->
+
+          <pattern>
+              <token postag='NC.+|AQ.+' postag_regexp='yes'/>
+              <marker>
+                  <token>que</token>
+                  <token postag='VMIP3.+' postag_regexp='yes' inflected='yes' regexp='yes'>atuar|agir|incidir|recair</token>
+              </marker>
+              <token>sobre</token>
+          </pattern>
+          <message>&simplify_msg;</message>
+          <suggestion>a <match no='3' postag='VMIP3.+' postag_regexp='yes' postag_replace='VMN0000'/></suggestion>
+          <example correction="a atuar">Isto resume toda a força <marker>que atua</marker> sobre o objeto.</example>
+          <example correction="a atuar">Isto resume todas as forças <marker>que atuam</marker> sobre o objeto.</example>
+          <example correction="a incidir">Analise a pressão <marker>que incide</marker> sobre a superfície.</example>
+      </rule>
 
 
         <rule id='QUE_SE_VERBO_PART_PASSADO' name="🇵🇹✂️ 'Que se Verbo' → Verbo Part. Passado">

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -5179,6 +5179,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
           <example correction="a atuar">Isto resume toda a força <marker>que atua</marker> sobre o objeto.</example>
           <example correction="a atuar">Isto resume todas as forças <marker>que atuam</marker> sobre o objeto.</example>
           <example correction="a incidir">Analise a pressão <marker>que incide</marker> sobre a superfície.</example>
+          <example correction="a agir">As forças <marker>que agem</marker> sobre o corpo.</example>
+          <example correction="a recair">Os encargos <marker>que recaem</marker> sobre a empresa.</example>
+          <example correction="a incidir">As pressões <marker>que incidem</marker> sobre a superfície.</example>
       </rule>
 
 


### PR DESCRIPTION
Improved the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved Portuguese (Portugal) style suggestions for constructions using “que” followed by “atuar”, “agir”, “incidir” or “recair” with “sobre”.
  * Added support for singular and plural verb forms.
  * Suggestions now convert these constructions to “a” plus the corresponding infinitive and “sobre”.
  * Marked the suggestions as picky style recommendations.

* **Bug Fixes**
  * Limited uppercase-token exceptions in Portuguese AO90 prefix rules to words between 2 and 30 characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->