### PR TITLE
[pt-PT] Improved rule:CIENTÍFICO_DETERMINADAS_ESPECÍFICAS

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -4060,19 +4060,26 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rulegroup>
 
 
-        <rule id='CIENTÍFICO_DETERMINADAS_ESPECÍFICAS' name="🇵🇹🔬 Determinados → Específicos" type="style" tone_tags="academic">
-            <pattern>
-                <token regexp="yes">para|como|por</token>
-                <token skip='4' postag='V.+' postag_regexp='yes'/>
-                <marker>
-                    <token regexp="yes">determinad[ao]s</token>
-                    <token postag='AQ..P.+|NC.P.+' postag_regexp='yes'/>
-                </marker>
-            </pattern>
-            <message>Num contexto formal/científico, é preferível escrever &quot;específico&quot;.</message>
-            <suggestion>\4 <match no='3' postag='AQ0(..)0' postag_replace='AQ0$10'>específico</match></suggestion>
-            <example correction="funções específicas">Estes foram criados para desempenhar <marker>determinadas funções</marker>.</example>
-        </rule>
+      <rule id='CIENTÍFICO_DETERMINADAS_ESPECÍFICAS' name="🇵🇹🔬 Determinados → específicos" type='style' tone_tags='academic'>
+          <!-- ChatGPT 5.6 and new disambiguator for 2026+ -->
+
+          <pattern>
+              <token skip='2' regexp='yes' inflected='yes'>cumprir|desempenhar|exercer</token>
+              <marker>
+                  <token regexp='yes'>determinad[ao]s</token>
+                  <token postag='NC.P.+' postag_regexp='yes'/>
+              </marker>
+          </pattern>
+          <message>Num contexto formal/científico, é preferível escrever &quot;específico&quot;.</message>
+          <suggestion>\3 <match no='2' postag='AQ0(..)0' postag_replace='AQ0$10'>específico</match></suggestion>
+          <example correction="funções específicas">Estes foram criados para desempenhar <marker>determinadas funções</marker>.</example>
+          <example correction="funções específicas">Cada componente foi concebido para cumprir <marker>determinadas funções</marker>.</example>
+          <example correction="funções específicas">Os diferentes módulos permitem exercer <marker>determinadas funções</marker>.</example>
+          <example>O estudo foi realizado em determinadas condições.</example>
+          <example>Os resultados variam para determinados parâmetros.</example>
+          <example>A decisão foi tomada por determinadas razões.</example>
+          <example>Determinados participantes abandonaram o estudo.</example>
+      </rule>
 
 
       <rule id='CIENTÍFICO_MAIS_IMPORTANTE_CHAVE_V4' name="🇵🇹🔬 'mais importante(s)' → -chave" type='style' tone_tags='academic'>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -4075,6 +4075,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
           <example correction="funções específicas">Estes foram criados para desempenhar <marker>determinadas funções</marker>.</example>
           <example correction="funções específicas">Cada componente foi concebido para cumprir <marker>determinadas funções</marker>.</example>
           <example correction="funções específicas">Os diferentes módulos permitem exercer <marker>determinadas funções</marker>.</example>
+          <example correction="objetivos específicos">A equipa foi criada para cumprir <marker>determinados objetivos</marker>.</example>
+          <example correction="papéis específicos">Os agentes foram concebidos para desempenhar <marker>determinados papéis</marker>.</example>
+          <example correction="cargos específicos">Os membros foram selecionados para exercer <marker>determinados cargos</marker>.</example>
           <example>O estudo foi realizado em determinadas condições.</example>
           <example>Os resultados variam para determinados parâmetros.</example>
           <example>A decisão foi tomada por determinadas razões.</example>


### PR DESCRIPTION
Improved the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese (Portugal) style checking for plural “determinados/determinadas” in academic writing.
  * The rule now identifies potentially preferable wording after “cumprir”, “desempenhar” and “exercer”.
  * Refined detection to reduce incorrect suggestions in other sentence contexts.
  * Updated the suggestion label to use clearer, lowercase wording.
  * Added examples covering both flagged and non-flagged usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->