### PR TITLE
[es] DETRAS_PX: add atrás, adelante, arriba, abajo to adverbio_lugar

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/resource/es/entities.ent
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/resource/es/entities.ent
@@ -17,7 +17,7 @@
 <!ENTITY sometlds "com|de|net|edu|uk|org|info|nl|eu|cn|biz|at|ch|fr|tv|to|fm|es|it|gov|mil|mx|pt|dev|us|sg|me|io|app|shop|club|games|in|co|cloud|no|se|dk|ie|cc|tk|ai|au|nz|za|cm|ng|tw|jp|kg|ag|site|int|my|ir|pk|mobi|asia|hk|mz|xyz|design|ventures|services|cat|ly|name|world|online|consulting|digital|be|is|sex|web|lab|local|bio|live|ngo">
 <!ENTITY exceptions_unidadestiempo_adj "siguiente|próximo|futuro|venidero|anterior|pasado|precedente|subsiguiente|previo|último|primero">
 <!ENTITY apostrophe "['’´`]">
-<!ENTITY adverbio_lugar "detr&#225;s|delante|debajo|encima|cerca">
+<!ENTITY adverbio_lugar "detr&#225;s|atr&#225;s|delante|adelante|debajo|abajo|encima|arriba|cerca">
 <!ENTITY pronombre_personal_atono_POS "PP3..A.*|PP[123]C[SP][0D]00|P0[123].*">
 <!ENTITY pronombre_personal_atono "me|te|se|nos|os|le|les|lo|los|la|las">
 <!ENTITY pronombre_personal_no_articulo "me|te|se|nos|os|le|les|lo"> <!--|los-->

--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -19561,6 +19561,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 <message>Es preferible usar otra expresión.</message>
                 <suggestion>\1 de <match no="2" postag="PX(\d).S0S0" postag_regexp="yes" postag_replace="PP$1CSO00">mí</match></suggestion>
                 <example correction="detrás de mí">Venían <marker>detrás mío</marker>.</example>
+                <example correction="atrás de mí">Venían <marker>atrás mío</marker>.</example>
                 <example>Tengo a los niños encima de mí.</example>
             </rule>
             <rule>
@@ -19571,6 +19572,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 <message>Es preferible usar otra expresión.</message>
                 <suggestion>\1 de <match no="2" postag="PX(\d).S0S0" postag_regexp="yes" postag_replace="PP$1CSO00">ti</match></suggestion>
                 <example correction="detrás de ti">Venían <marker>detrás tuyo</marker>.</example>
+                <example correction="adelante de ti">Iba <marker>adelante tuyo</marker>.</example>
                 <example>Tienes a los niños encima de ti.</example>
             </rule>
             <rule>
@@ -19582,6 +19584,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 <suggestion>\1 de nosotros</suggestion>
                 <suggestion>\1 de nosotras</suggestion>
                 <example correction="detrás de nosotros|detrás de nosotras">Venían <marker>detrás nuestro</marker>.</example>
+                <example correction="arriba de nosotros|arriba de nosotras">Vivían <marker>arriba nuestro</marker>.</example>
                 <example>Tenemos a los niños encima de nosotros.</example>
             </rule>
             <rule>
@@ -19609,6 +19612,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 <suggestion>\1 de usted</suggestion>
                 <suggestion>\1 de ustedes</suggestion>
                 <example correction="detrás de él|detrás de ella|detrás de ello|detrás de ellos|detrás de ellas|detrás de usted|detrás de ustedes">Venían <marker>detrás suya</marker>.</example>
+                <example correction="abajo de él|abajo de ella|abajo de ello|abajo de ellos|abajo de ellas|abajo de usted|abajo de ustedes">Vivían <marker>abajo suyo</marker>.</example>
                 <example>Tienen a los niños encima de ellos.</example>
             </rule>
         </rulegroup>


### PR DESCRIPTION
The `DETRAS_PX` rule group flags the colloquial *adverb of place + possessive*
construction (`detrás mío`) and suggests the standard form (`detrás de mí`).
Its five rules don't list the adverbs themselves — they all share the
`adverbio_lugar` entity, which only had five of them:

```
<!ENTITY adverbio_lugar "detrás|delante|debajo|encima|cerca">
```

Four very frequent ones were missing, and they are exactly the most common in
River Plate Spanish: `atrás mío`, `adelante tuyo`, `arriba nuestro`,
`abajo suyo`. This PR adds them to the entity, plus one `<example>` per new
adverb (spread across the four rules that have a distinct suggestion set).

The entity is used **only** by this rule group (5 occurrences, all inside
`DETRAS_PX`), so no other rule changes behaviour.

### Testing

- `mvn -pl languagetool-language-modules/es -am -Dtest=SpanishPatternRuleTest test`
  passes (1670 rules tested, 0 failures).
- Checked against a local LT 6.8 server with the patched entity:
  - matches, with the expected suggestion: `Venían atrás mío.` → `atrás de mí`;
    `Iba adelante tuyo.` → `adelante de ti`; `Vivían arriba nuestro.` →
    `arriba de nosotros / nosotras`; `El tipo de abajo suyo se quejó.` →
    `abajo de él / …`.
  - no match, as expected: `Venían detrás de mí.`, `Siguió adelante con el
    plan.`, `Miró hacia arriba y sonrió.`, `De arriba abajo, todo roto.`,
    `Se echó para atrás en la silla.`
- False positives on real prose: none. A scan of a 783,918-word `es-AR` fiction
  corpus (rule enabled via `enabledOnly`) goes from 2 to 11 matches, and all 9
  new ones are genuine instances of the construction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Spanish grammar checking for location adverbs such as “atrás,” “abajo,” and “arriba.”
  - Added support for detecting possessive-pronoun usage in expressions like “atrás mío,” “adelante tuyo,” “arriba nuestro,” and “abajo suyo.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->