### PR TITLE
[es] AGREEMENT_PRONOUNSUBJECT_VERB: flag «tú» with a voseo verb form

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -24942,12 +24942,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                     <token>tú<exception postag="SP.*|CC|LOC_PREP" postag_regexp="yes" scope="previous"/></token>
                     <token postag="RG|LOC_ADV" postag_regexp="yes" min="0" max="3"><exception postag="C.*" postag_regexp="yes"/></token>
                     <marker>
-                        <token postag="V.[^M].[13]..|V.[^M].2P." postag_regexp="yes"><exception postag="V...2S.|AQ.*|RG|LOC_ADV" postag_regexp="yes"/></token>
+                        <token postag="V.[^M].[13]..|V.[^M].2[PV]." postag_regexp="yes"><exception postag="V...2S.|AQ.*|RG|LOC_ADV" postag_regexp="yes"/></token>
                     </marker>
                 </pattern>
                 <message>Posible falta de concordancia entre «\1» y «\3».</message>
                 <suggestion><match no="3" postag="(V.[^M].).*" postag_regexp="yes" postag_replace="$12S."/></suggestion>
                 <example correction="vengas|vienes">Tú <marker>vengo</marker></example>
+                <example correction="tienes">Tú <marker>tenés</marker> que venir.</example>
+                <example correction="eres">Tú <marker>sos</marker> el que se queja.</example>
                 <!-- TODO: it should suggest: estéis 
                 <example correction="estés">Que tu familia y tú <marker>estén</marker>.</example>-->
                 <example>Tú vienes</example>


### PR DESCRIPTION
The rule for «tú» inside `AGREEMENT_PRONOUNSUBJECT_VERB` matches verb forms
tagged `V.[^M].[13]..` or `V.[^M].2P.`. Voseo forms are person 2, number `V`
(`tenés` = `VMIP2V0`), so they fall through the alternation:

- `Vos tienes razón.` → already flagged by the two `vos` rules of the same group.
- `Tú tenés que venir.` → **no match** (this PR).

Mixing «tú» with a voseo verb form is an error in any variant (it is not a
locale preference, both halves belong to different paradigms), so the fix is
just adding `2[PV]` to the existing alternation, plus two examples. The
existing suggestion machinery already produces the tuteo form
(`postag_replace="$12S."` → `tienes`).

Two things stay untouched on purpose:

- Forms that are identical in tuteo and voseo (`estás`, `vas`) are tagged
  `V...2S.` and remain excluded by the rule's existing exception, so
  `Tú estás cansado.` is not flagged.
- Imperatives remain excluded by the group's existing antipattern
  (`<token>tú</token><token postag="VMM02[SV]0"/>`), so `Tú marchá.` — which is
  in the rule's examples as a correct sentence — is untouched.

### Testing

- `mvn -pl languagetool-language-modules/es -am -Dtest=SpanishPatternRuleTest test`
  passes (1670 rules tested).
- Against a local LT 6.8 server with the change applied:
  - flagged, with the tuteo form as the suggestion: `Tú tenés que venir.` →
    `tienes`; `Tú sos el mejor.` → `eres`; `Tú querés ir al cine.` → `quieres`;
    `Tú sabés lo que hiciste.` → `sabes`.
  - not flagged: `Tú tienes que venir.`, `Tú vienes conmigo.`,
    `Tú estás cansado.`, `Tú vas a venir.`, `Tú marchá.`, `Tú siéntate allí.`,
    `Vos tenés que venir.` And `Vos tienes razón.` keeps being flagged as before.
- False positives on real prose: a 783,918-word `es-AR` fiction corpus gives
  **the same 6 matches for this rule group before and after** the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Spanish grammar checking for second-person verb forms, including voseo forms such as “tenés” and “sos.”
  * Preserved existing agreement exceptions while expanding recognition of valid verb forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->