### PR TITLE
[es] add MEZCLA_TUTEO_VOSEO: mixing tuteo and voseo in one sentence

### DIFF
--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -20119,6 +20119,57 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <message>Use la forma apocopada <suggestion><match no="1" regexp_match="o$" regexp_replace=""/></suggestion> en vez de '<match no="1"/>' o ponga una coma después: <suggestion><match no="1"/>,</suggestion>.</message>
             <example correction="buen|bueno,">¡Qué <marker>bueno</marker> muchacho!</example>
         </rule>-->
+        <rulegroup id="MEZCLA_TUTEO_VOSEO" name="Mezcla de tuteo y voseo en la misma oración">
+            <url>https://www.rae.es/dpd/voseo</url>
+            <rule>
+                <!-- vos ... ti -->
+                <pattern>
+                    <token skip="-1">vos</token>
+                    <marker>
+                        <token>ti</token>
+                    </marker>
+                </pattern>
+                <message>Con «vos» la forma tónica es «vos», no «ti».</message>
+                <suggestion>vos</suggestion>
+                <example correction="vos">Vos sabés que esto es para <marker>ti</marker>.</example>
+                <example>Vos sabés que esto es para vos.</example>
+                <example>Tú sabes que esto es para ti.</example>
+            </rule>
+            <rule>
+                <!-- vos ... contigo -->
+                <pattern>
+                    <token skip="-1">vos</token>
+                    <marker>
+                        <token>contigo</token>
+                    </marker>
+                </pattern>
+                <message>Con «vos» la forma tónica es «con vos», no «contigo».</message>
+                <suggestion>con vos</suggestion>
+                <example correction="con vos">Vos sabés que quiero ir <marker>contigo</marker>.</example>
+                <example>Vos sabés que quiero ir con vos.</example>
+                <example>Tú sabes que quiero ir contigo.</example>
+            </rule>
+            <rule>
+                <!-- imperativo voseante ... imperativo tuteante -->
+                <pattern>
+                    <token postag="V.M02V0.*" postag_regexp="yes" skip="-1"><exception postag="N.*|SP.*|A.*|RG|LOC_ADV|D.*|P.*" postag_regexp="yes"/></token>
+                    <marker>
+                        <!-- dar y ser tienen el mismo imperativo en tuteo y en voseo: da(le), sé -->
+                        <token postag="V.M02S0.*" postag_regexp="yes"><exception postag="N.*|SP.*|A.*|RG|LOC_ADV|D.*|P.*|V.I.*|V.S.*" postag_regexp="yes"/><exception inflected="yes" regexp="yes">dar|ser</exception></token>
+                    </marker>
+                </pattern>
+                <message>Si el imperativo anterior es voseante, este también debería serlo.</message>
+                <suggestion suppress_misspelled="yes"><match no="2" postag_regexp="yes" postag="(V.M02)S0(.*)" postag_replace="$1V0$2"/></suggestion>
+                <example correction="callate">Vení y <marker>cállate</marker> un rato.</example>
+                <example correction="decime">Escuchame y <marker>dime</marker> la verdad.</example>
+                <example>Vení y callate un rato.</example>
+                <example>Ven y cállate un rato.</example>
+                <example>Mirá, para el auto acá.</example>
+                <example>Dale esto para que se despierte.</example>
+                <example>Tomá esto y dale una de estas.</example>
+                <example>Vení y sé bueno con ella.</example>
+            </rule>
+        </rulegroup>
     </category>
     <category id="AGREEMENT_NOUNS" name="Concordancia en grupos nominales" type="inconsistency">
         <rulegroup id="PRIMERO_PRIMER" name="primero ministro -> primer ministro">

--- a/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
+++ b/languagetool-language-modules/es/src/main/resources/org/languagetool/rules/es/grammar.xml
@@ -20152,7 +20152,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
             <rule>
                 <!-- imperativo voseante ... imperativo tuteante -->
                 <pattern>
-                    <token postag="V.M02V0.*" postag_regexp="yes" skip="-1"><exception postag="N.*|SP.*|A.*|RG|LOC_ADV|D.*|P.*" postag_regexp="yes"/></token>
+                    <!-- «tú» explícito entre los dos imperativos = cambio de interlocutor -->
+                    <token postag="V.M02V0.*" postag_regexp="yes" skip="-1"><exception postag="N.*|SP.*|A.*|RG|LOC_ADV|D.*|P.*" postag_regexp="yes"/><exception scope="next">tú</exception></token>
                     <marker>
                         <!-- dar y ser tienen el mismo imperativo en tuteo y en voseo: da(le), sé -->
                         <token postag="V.M02S0.*" postag_regexp="yes"><exception postag="N.*|SP.*|A.*|RG|LOC_ADV|D.*|P.*|V.I.*|V.S.*" postag_regexp="yes"/><exception inflected="yes" regexp="yes">dar|ser</exception></token>
@@ -20166,6 +20167,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
                 <example>Ven y cállate un rato.</example>
                 <example>Mirá, para el auto acá.</example>
                 <example>Dale esto para que se despierte.</example>
+                <example>Vos vení conmigo y tú cállate un rato.</example>
                 <example>Tomá esto y dale una de estas.</example>
                 <example>Vení y sé bueno con ella.</example>
             </rule>


### PR DESCRIPTION
Voseo and tuteo are both correct, but **mixing them inside one sentence** is
not: a single sentence has one speaker addressing one person. Nothing covers
this today — the `VOSEO` group flags voseo forms as a variant issue (and is
exactly what users in River Plate countries turn off), and
`AGREEMENT_PRONOUNSUBJECT_VERB` only looks at pronoun + verb pairs.

New rulegroup `MEZCLA_TUTEO_VOSEO` in the `GRAMMAR` category (deliberately not
in `LANGUAGE_VARIANTS`: this is an error in any variant, so it should stay on
for the users who write in voseo), with three intra-sentence rules:

| input | suggestion |
|---|---|
| `Vos sabés que esto es para ti.` | `vos` |
| `Vos sabés que quiero ir contigo.` | `con vos` |
| `Vení y cállate un rato.` | `callate` |
| `Escuchame y dime la verdad.` | `decime` |

### Avoiding the obvious false positives

The imperative rule matches by POS tag, never by a word list, and the matched
tuteo token excludes anything that also reads as noun, preposition, adjective,
adverb, determiner, pronoun, indicative or subjunctive. That is what keeps
`para`, `mira`, `toma` and `ven` out — they are far more often a preposition,
a noun or a third person than an imperative:

- `Mirá, para el auto acá.` → no match
- `Dale esto para que se despierte.` → no match
- `Mirá el pasillo y toma agua.` → no match

Forms of `dar` and `ser` are excluded as well, because their imperative is
identical in both paradigms (`da`/`dale`, `sé`), so there is nothing to
correct: `Tomá esto y dale una de estas.` and `Vení y sé bueno con ella.` are
not flagged. (Without that exception the rule produced a match with an empty
suggestion.)

### Testing

- `mvn -pl languagetool-language-modules/es -am -Dtest=SpanishPatternRuleTest test`
  passes (1673 rules tested).
- Against a local LT 6.8 server: 4 positives match with the expected
  suggestion, and 8 near-miss sentences do not match, including
  `Vos sabés que esto es para vos.`, `Tú sabes que esto es para ti.`,
  `Ven y cállate un rato.` and `Vení y callate un rato.`
- False positives on real prose: over a 783,918-word `es-AR` fiction corpus the
  whole group produces **one** match, and it is a real error —
  `Apretá… al distribuidor para que entregue; si no, sácale el trabajo.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Spanish grammar checks for mixing voseo and tuteo within the same sentence.
  * Provides corrective suggestions for inconsistent forms such as “vos … ti,” “vos … contigo,” and mixed imperative constructions.
  * Excludes ambiguous or invariant verb forms to reduce false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->