### PR TITLE
[en] spelling.txt: add antizionism, antizionist(s)

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
@@ -475,3 +475,6 @@ morticians
 Öcalan
 disbalance
 comfortability
+antizionism
+antizionist
+antizionists


### PR DESCRIPTION
Adds the unhyphenated forms *antizionism*, *antizionist*, *antizionists* to the English spelling additions.

Rationale: the file already accepts parallel anti- compounds (*antiblackness*, *antiwhiteness*), and *antisemitism* is accepted by the base dictionary. The fused form is attested in edited publishing, including an academic journal with an explicit unhyphenated house rule (Journal of Contemporary Antisemitism, Academic Studies Press) and a Library of Congress Subject Headings variant (*Antizionism*, UF under *Anti-Zionism*). LanguageTool currently flags it as a misspelling with no useful suggestion.

Hyphenated *anti-Zionism* is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added “antizionism,” “antizionist,” and “antizionists” to the English spell-checker dictionary.
  * Retained “comfortability” as a recognized spelling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->