### PR TITLE
[pt-PT] Moved rule and changed its type:CIENTÍFICO_ROUBAR_FURTAR_IDENTIDADE_USURPAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -4597,7 +4597,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
 
-    <category id='TRANSLATION_ERRORS_PT_PT' name="🇵🇹🇺🇸 Erros de Tradução" type="mistranslation" tone_tags="academic">
+  <category id='TRANSLATION_ERRORS_PT_PT' name="🇵🇹🇺🇸 Erros de Tradução" type="mistranslation" tone_tags="academic">
         <!-- IDEA foreign_terms -->
 
 
@@ -4624,28 +4624,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-        <rule id='ERRO_TRADUÇÃO_FURTO_ROUBO_IDENTIDADE' name="🇵🇹🇺🇸 Erro de tradução: 'furto' de identidade → 'usurpação'">
-            <pattern>
-                <marker>
-                    <token skip="4" inflected='yes' regexp='yes'>furtar|roubar</token>
-                </marker>
-                <token regexp='yes'>identidades?</token>
-            </pattern>
-            <message>Expressão não pode ser traduzida literalmente.</message>
-            <suggestion><match no='1' postag='V.+' postag_regexp='yes'>usurpar</match></suggestion>
-            <example correction="usurpou">Alguém <marker>roubou</marker> a identidade do dono da empresa.</example>
-            <example>Alguém <marker>usurpou</marker> a minha identidade.</example>
-            <example>Achamos que este cara <marker>usurpou</marker> a identidade dele.</example>
-            <example>Este senhor <marker>usurpou</marker> ao Rui a identidade dele.</example>
-        </rule>
-
-
-    </category>
+  </category>
 
 
 
   <category id="TYPOGRAPHY" name="🇵🇹 Tipografia">
-
 
 
       <rule type="locale-violation" id='CURRENCY_PLACEMENT_PT_FOREIGN' name="🇵🇹$ Posição dos símbolos de moeda: '100£ (£100)">
@@ -4700,7 +4683,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
           <short>Adicionar um espaço</short>
           <example correction="100&nbsp;€">Custa <marker>100€</marker>.</example>
       </rule>
-
 
 
   </category>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -3723,7 +3723,26 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
 
-    <category id='ACADEMIC_SCIENTIFIC_PT_PT' name="🇵🇹🎓🔬 Regras académicas e científicas" type="other">
+  <category id='ACADEMIC_SCIENTIFIC_PT_PT' name="🇵🇹🎓🔬 Regras académicas e científicas" type="other">
+
+
+      <rule id='CIENTÍFICO_ROUBAR_FURTAR_IDENTIDADE_USURPAR' name="🇵🇹🔬 Roubar/furtar identidade → usurpar" type='style' tone_tags='academic'>
+          <!-- ChatGPT 5.6 and new disambiguator for 2026+ -->
+
+          <pattern>
+              <marker>
+                  <token skip='4' postag='V.+' postag_regexp='yes' inflected='yes' regexp='yes'>furtar|roubar</token>
+              </marker>
+              <token regexp='yes'>identidades?</token>
+          </pattern>
+          <message>Num contexto formal/científico, considere usar o verbo &quot;usurpar&quot;.</message>
+          <suggestion><match no='1' postag='V.+' postag_regexp='yes'>usurpar</match></suggestion>
+          <example correction="usurpou">Alguém <marker>furtou</marker> as identidades dos funcionários da empresa.</example>
+          <example correction="usurpou">Alguém <marker>roubou</marker> a identidade do dono da empresa.</example>
+          <example>Alguém usurpou a minha identidade.</example>
+          <example>Achamos que este indivíduo usurpou a identidade dele.</example>
+          <example>Este senhor usurpou a identidade do Rui.</example>
+      </rule>
 
 
       <rule id='BARBARISMS_PT_PT_V4' name="🇵🇹🎓 Estrangeirismos específicos pt_PT" type='style' tone_tags='academic' is_goal_specific='true'>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/style.xml
@@ -3731,7 +3731,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
           <pattern>
               <marker>
-                  <token skip='4' postag='V.+' postag_regexp='yes' inflected='yes' regexp='yes'>furtar|roubar</token>
+                  <token skip='3' postag='V.+' postag_regexp='yes' inflected='yes' regexp='yes'>furtar|roubar</token>
               </marker>
               <token regexp='yes'>identidades?</token>
           </pattern>
@@ -3742,6 +3742,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
           <example>Alguém usurpou a minha identidade.</example>
           <example>Achamos que este indivíduo usurpou a identidade dele.</example>
           <example>Este senhor usurpou a identidade do Rui.</example>
+          <example>Ele roubou muita atenção e a identidade do suspeito foi confirmada.</example>
       </rule>
 
 


### PR DESCRIPTION
Moved the rule to scientific/academic since some official sites use “furtar/roubar” for the general public.

The term “usurpar” is the technical one used by the Federal Police of Portugal in official documents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a formal and scientific writing check for “furtar/roubar identidade(s),” suggesting the more appropriate verb “usurpar.”
  - Introduced a dedicated academic and scientific style category for Portuguese (Portugal).

- **Bug Fixes**
  - Removed the outdated translation suggestion for replacing “furto/roubo de identidade” with “usurpação.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->