### PR TITLE
[pt-PT] Improved/rewrote rule:AS_CUSTAS_DE_A_CUSTA_DE

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -800,20 +800,38 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
 
-      <rule id='INVARIABLE_NOUNS_ÀS_CUSTAS_DA_DAS_DO_DOS' name="🇵🇹[Confusão] 'às custas'/'à custa'">
-      <!-- Created by Marco A.G.Pinto, Portuguese rule 2022-09-20 (Checked/Enhanced) (25-JUL-2022+) -->
+      <rule id='AS_CUSTAS_DE_A_CUSTA_DE' name="🇵🇹 'às custas de' → 'à custa de'">
+          <!-- ChatGPT 5.6 and new disambiguator for 2026+ -->
+
           <pattern>
               <marker>
                   <token>às</token>
                   <token>custas</token>
               </marker>
-              <token postag='SPS00|SPS00:D[AI].+' postag_regexp='yes'/>
+              <token regexp='yes'>d[ao]s?|de<exception scope='next' regexp='yes' inflected='yes'>ação|acção|auto|causa|execução|incidente|instância|processo|recurso</exception></token> <!-- Lista exceções ligadas à terminologia processual/jurídica. -->
           </pattern>
-          <message>Esta expressão é invariável.</message>
+          <message>A locução &quot;à custa de&quot; emprega-se no singular.</message>
           <suggestion>à custa</suggestion>
           <example correction="à custa">Ele fê-lo <marker>às custas</marker> do filho.</example>
-          <example>Ele se tornou um aluno brilhante mas somente à custa de sua saúde.</example>
+          <example correction="à custa">Viveu durante anos <marker>às custas</marker> dos pais.</example>
+          <example correction="à custa">Enriqueceu <marker>às custas</marker> dos trabalhadores.</example>
+          <example correction="à custa">A empresa cresceu <marker>às custas</marker> da concorrência.</example>
+          <example correction="à custa">Obteve bons resultados <marker>às custas</marker> de muito esforço.</example>
+          <example correction="à custa">Conseguiu a promoção <marker>às custas</marker> do colega.</example>
+          <example correction="à custa">A produção aumentou <marker>às custas</marker> da qualidade.</example>
+          <example correction="à custa">O projeto foi concluído <marker>às custas</marker> de muitas horas extraordinárias.</example>
+          <example>Ele vive à custa dos pais.</example>
+          <example>A empresa aumentou os lucros à custa da qualidade.</example>
           <example>O consumo de gorduras n-6 aumentou à custa das gorduras n-3.</example>
+          <example>O sucesso foi alcançado à custa de muito trabalho.</example>
+          <example>O montante foi acrescentado às custas do processo.</example>
+          <example>A quantia foi imputada às custas da ação.</example>
+          <example>O valor foi adicionado às custas da execução.</example>
+          <example>Essa despesa foi incluída às custas do recurso.</example>
+          <example>O pagamento foi associado às custas da instância.</example>
+          <example>A verba foi incorporada às custas do incidente.</example>
+          <example>O montante foi somado às custas dos autos.</example>
+          <example>A importância foi adicionada às custas da causa.</example>
       </rule>
 
 

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -808,7 +808,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                   <token>às</token>
                   <token>custas</token>
               </marker>
-              <token regexp='yes'>d[ao]s?|de<exception scope='next' regexp='yes' inflected='yes'>ação|acção|auto|causa|execução|incidente|instância|processo|recurso</exception></token> <!-- Lista exceções ligadas à terminologia processual/jurídica. -->
+              <token regexp='yes'>d[ao]s?|de<exception scope='next' regexp='yes' inflected='yes'>ação|acção|auto|causa|execução|incidente|instância|processo</exception></token> <!-- Lista exceções ligadas à terminologia processual/jurídica. -->
           </pattern>
           <message>A locução &quot;à custa de&quot; emprega-se no singular.</message>
           <suggestion>à custa</suggestion>
@@ -827,7 +827,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
           <example>O montante foi acrescentado às custas do processo.</example>
           <example>A quantia foi imputada às custas da ação.</example>
           <example>O valor foi adicionado às custas da execução.</example>
-          <example>Essa despesa foi incluída às custas do recurso.</example>
           <example>O pagamento foi associado às custas da instância.</example>
           <example>A verba foi incorporada às custas do incidente.</example>
           <example>O montante foi somado às custas dos autos.</example>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -808,7 +808,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                   <token>às</token>
                   <token>custas</token>
               </marker>
-              <token regexp='yes'>d[ao]s?|de<exception scope='next' regexp='yes' inflected='yes'>ação|acção|auto|causa|execução|incidente|instância|processo</exception></token> <!-- Lista exceções ligadas à terminologia processual/jurídica. -->
+              <token regexp='yes'>d[ao]s?|de<exception scope='next' regexp='yes'>aç(ão|ões)|acç(ão|ões)|autos?|causas?|execuç(ão|ões)|incidentes?|instâncias?|processos?|recurso</exception></token> <!-- Lista exceções ligadas à terminologia processual/jurídica. -->
           </pattern>
           <message>A locução &quot;à custa de&quot; emprega-se no singular.</message>
           <suggestion>à custa</suggestion>
@@ -820,6 +820,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
           <example correction="à custa">Conseguiu a promoção <marker>às custas</marker> do colega.</example>
           <example correction="à custa">A produção aumentou <marker>às custas</marker> da qualidade.</example>
           <example correction="à custa">O projeto foi concluído <marker>às custas</marker> de muitas horas extraordinárias.</example>
+          <example correction="à custa">O projeto foi concluído <marker>às custas</marker> dos recursos naturais.</example>
           <example>Ele vive à custa dos pais.</example>
           <example>A empresa aumentou os lucros à custa da qualidade.</example>
           <example>O consumo de gorduras n-6 aumentou à custa das gorduras n-3.</example>
@@ -827,6 +828,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
           <example>O montante foi acrescentado às custas do processo.</example>
           <example>A quantia foi imputada às custas da ação.</example>
           <example>O valor foi adicionado às custas da execução.</example>
+          <example>Essa despesa foi incluída às custas do recurso.</example>
           <example>O pagamento foi associado às custas da instância.</example>
           <example>A verba foi incorporada às custas do incidente.</example>
           <example>O montante foi somado às custas dos autos.</example>


### PR DESCRIPTION
Improved the rule by rewriting part of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese grammar corrections for “às custas de” and “à custa de”.
  * Refined contextual handling in legal and procedural expressions, including “recurso”.
  * Added support for valid phrases such as “às custas dos recursos naturais” and “às custas do recurso”.
  * Updated suggestions to better distinguish correct usage from cases requiring correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->