### PR TITLE
[pt-PT] Rewrote rule:O_FACTO_DA_AÇÃO

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -4491,6 +4491,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 </category>
 
 
+
   <category id='CONFUSED_WORDS_PT_PT' name="🇵🇹 Confusão de Palavras">
 
 
@@ -4524,7 +4525,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rulegroup>
 
 
-      <rule id='AUTO-FALANTE' name="🇵🇹 Auto-falante/altifalante">
+      <rule id='AUTO-FALANTE' name="🇵🇹❓ Auto-falante/altifalante">
           <!-- ChatGPT 5.6 and new disambiguator for 2026+ -->
 
           <pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -3286,55 +3286,39 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </rulegroup>
 
 
-    <rulegroup id='O_FACTO_DA_AÇÃO' name="🇵🇹 Contração: expressão invariável com contração (p.ex. o facto da/de a)" default='off'>
-        <url>https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/preposicao-seguida-de-artigo-definido-sem-contracao/32586</url>
-        <!-- Created by Marco A.G. Pinto, Portuguese rule -->
-        <rule>
+      <rule id='O_FACTO_DA_AÇÃO' name="🇵🇹 Contração: 'do/da' → 'de o/de a' antes de infinitivo" default='on'>
+          <!-- ChatGPT 5.6 and new disambiguator for 2026+ -->
 
-            <!-- MARCOAGPINTO 2022-09-09 (Checked/Enhanced) (25-JUL-2022+) *START* -->
-            <!-- It has no hits in 600 000 sentences, it just removes one false positive in my thesis -->
-            <antipattern>
-                <token postag='AQ..+|NC.+' postag_regexp='yes'/>
-                <token regexp='yes'>d[ao]s?</token>
-                <token postag='[DP][ADIPR].+|SPS00:[DP][ADIPR].+' postag_regexp='yes'/>
-                <example>E assim reforçando a necessidade do nosso estudo.</example>
-            </antipattern>
-            <!-- MARCOAGPINTO 2022-09-09 (Checked/Enhanced) (25-JUL-2022+) *END* -->
-            <antipattern>
-                <token regexp='yes'>&expressao_invariavel_com_DE;</token>
-                <token skip='-1' regexp='yes'>d[ao]s?</token>
-                <token postag='SPS00|C.+' postag_regexp='yes'/>
-                <token postag_regexp='yes' postag='VMN.+'/>
-                <example>Isto reafirma a necessidade da existência da nossa equação para fazer face às necessidades científicas.</example>
-            </antipattern>
-            <pattern>
-                <marker>
-                    <token regexp='yes'>&expressao_invariavel_com_DE;</token>
-                    <token skip='-1' regexp='yes'>d[ao]s?
-                    <exception scope='next' postag='_PUNCT|V.[^N].+' postag_regexp='yes'/></token>
-            </marker>
-            <token postag_regexp='yes' postag='VMN.+'/>
-        </pattern>
-        <message>Nesta expressão não deve utilizar a contração.</message>
-        <suggestion>\1 de <match no='2' regexp_match='d(.+)' regexp_replace='$1'/></suggestion>
-        <example correction="facto de a">Ter em conta o <marker>facto da</marker> aluna não saber.</example>
-        <example correction="facto de as">Ter em conta o <marker>facto das</marker> alunas não saberem.</example>
-        <example correction="facto de o">Ter em conta o <marker>facto do</marker> aluno não saber.</example>
-        <example correction="facto de os">Ter em conta o <marker>facto dos</marker> alunos não saberem.</example>
-        <example>Esta é a intenção da senhora.</example>
-        <example>…Tancredo Neves, morto antes da posse, sendo substituído pelo seu vice…</example>
-        <example><marker>Muito antes da</marker> chegada de Cristóvão Colombo à América.</example>
-        <example>O problema resultou de a secção de contabilidade ter enviado o NIB errado.</example>
-        <example>Preocupa-me o facto de ele não estar preocupado.</example>
-        <example>O cão pôs-se a rosnar pouco antes de uma rapariga ter aparecido.</example>
-        <example>O problema está em o homem não querer pagar impostos.</example>
-        <example>Esperou por o João chegar.</example>
-        <example>Depois das várias aplicações que tem sido instaladas para impedir malware…</example>
-    </rule>
-</rulegroup>
+          <pattern>
+              <marker>
+                  <token regexp='yes'>&expressao_invariavel_com_DE;</token>
+                  <token regexp='yes'>d[ao]s?</token>
+              </marker>
+              <token min='1' max='3' postag_regexp='yes' postag='N.+|AQ.+'><exception postag_regexp='yes' postag='V.+'/></token>
+              <token min='0' max='2' postag_regexp='yes' postag='RN|RG'/>
+              <token postag_regexp='yes' postag='VMN.+'/>
+          </pattern>
+          <message>Antes do sujeito de uma construção de infinitivo, a preposição &quot;de&quot; não deve contrair-se com o artigo.</message>
+          <suggestion>\1 de <match no='2' regexp_match='d(.+)' regexp_replace='$1'/></suggestion>
+          <example correction="facto de a">Ter em conta o <marker>facto da</marker> aluna saber.</example>
+          <example correction="facto de as">Ter em conta o <marker>facto das</marker> alunas saberem.</example>
+          <example correction="facto de o">Ter em conta o <marker>facto do</marker> aluno saber.</example>
+          <example correction="facto de os">Ter em conta o <marker>facto dos</marker> alunos saberem.</example>
+          <example correction="facto de a">Ter em conta o <marker>facto da</marker> aluna não saber.</example>
+          <example correction="facto de as">Ter em conta o <marker>facto das</marker> alunas não saberem.</example>
+          <example correction="facto de o">Ter em conta o <marker>facto do</marker> aluno não saber.</example>
+          <example correction="facto de os">Ter em conta o <marker>facto dos</marker> alunos não saberem.</example>
+          <example correction="facto de o">O <marker>facto do</marker> João saber causou surpresa.</example>
+          <example correction="facto de o">O <marker>facto do</marker> João não saber causou surpresa.</example>
+          <example correction="facto de a">O <marker>facto da</marker> aluna ainda saber a resposta causou surpresa.</example>
+          <example>Foi confirmada a veracidade do facto da agressão.</example>
+          <example>Falámos do facto da semana passada.</example>
+          <example>Discutimos a importância do saber.</example>
+      </rule>
 
 
   </category>
+
 
 
   <category id='REGIONALISMS_PT_PT' name='🇵🇹 Regionalismos'>


### PR DESCRIPTION
Rewrote the rule and made it default=on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled detection of incorrect contracted articles before infinitive constructions in European Portuguese.
  * Suggestions now recommend the appropriate uncontracted forms, including “de a”, “de o”, “de as” and “de os”.
  * Improved identification of “auto-falante” as a potentially confused term.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->