### PR TITLE
[pt] Added AP to disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4060,6 +4060,26 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
   <rulegroup id="SIM_NOUN" name="Remover substantivo da palavra 'sim'">
     <!-- ChatGPT 5 -->
+    <!-- TO-DO: With the AP below maybe the rulegroup should be reduced to all "sim" with "RG" instead of adding exceptions - 2026-08-27 -->
+
+    <antipattern>
+      <token regexp='yes'>cart(ão|ões)</token>
+      <token case_sensitive='yes'>SIM</token>
+      <!--
+      Examples:
+               Temos um cartão SIM.
+               Temos os cartões SIM.
+      -->
+    </antipattern>
+    <antipattern>
+      <token skip='1' case_sensitive='yes'>SIM</token>
+      <token regexp='yes'>cart(ão|ões)</token>
+      <!--
+      Examples:
+               Os SIM são cartões para telemóvel.
+      -->
+    </antipattern>
+
     <rule> <!-- #1: "sim" at start of sentence, after a verb, or after punctuation -->
       <pattern>
         <token postag='V.+|SENT_START|_PUNCT' postag_regexp='yes'>


### PR DESCRIPTION
Added an antipattern to the disambiguator for mobile phone cards “SIM”.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese language analysis for “SIM” in SIM card-related phrases.
  * Prevented valid references such as “cartão SIM” and “cartões SIM” from being incorrectly processed as the Portuguese noun “sim.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->