### PR TITLE
[pt] Small enhancement in AP in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4062,7 +4062,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <!-- ChatGPT 5 -->
 
     <antipattern>
-      <token skip='1' regexp='yes'>cart(ão|ões)</token>
+      <token skip='1' regexp='yes'>cart(ão|ões)<exception postag='_PUNCT'/></token>
       <token case_sensitive='yes'>SIM</token>
       <!--
       Examples:
@@ -4072,7 +4072,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       -->
     </antipattern>
     <antipattern>
-      <token skip='1' case_sensitive='yes'>SIM</token>
+      <token skip='1' case_sensitive='yes'>SIM<exception postag='_PUNCT'/></token>
       <token regexp='yes'>cart(ão|ões)</token>
       <!--
       Examples:

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4060,14 +4060,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
   <rulegroup id="SIM_NOUN" name="Remover substantivo da palavra 'sim'">
     <!-- ChatGPT 5 -->
-    <!-- TO-DO: With the AP below maybe the rulegroup should be reduced to all "sim" with "RG" instead of adding exceptions - 2026-08-27 -->
 
     <antipattern>
-      <token regexp='yes'>cart(ão|ões)</token>
+      <token skip='1' regexp='yes'>cart(ão|ões)</token>
       <token case_sensitive='yes'>SIM</token>
       <!--
       Examples:
                Temos um cartão SIM.
+               Temos um cartão tipo SIM.
                Temos os cartões SIM.
       -->
     </antipattern>


### PR DESCRIPTION
Just a tiny enhancement in the previous antipattern to deal with more cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese grammar analysis for phrases such as “cartão tipo SIM.”
  * Expanded coverage for singular and plural forms of “cartão” and “cartões” when followed by “SIM.”
  * Prevented punctuation from incorrectly triggering related grammar checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->