### PR TITLE
[pt] Fix false positives in VERBO_HIFENIZADOR_VERBOS_2 for proper names

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -2732,6 +2732,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </rule>
 
       <rule>
+          <antipattern>
+              <token postag='V.+' postag_regexp='yes'/>
+              <token regexp='yes'>&pronomes_nao_ambiguos_pt_pt;</token>
+              <token postag='VMI.+|VMS.+|VMM.+' postag_regexp='yes'/>
+          </antipattern>
           <pattern>
               <token postag='V.+' postag_regexp='yes'>
                   <exception regexp='yes'>como|para|casa|nada|mortos?</exception></token>
@@ -3033,6 +3038,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
         <rule> <!-- #2b: Verb Infinitive -->
+            <antipattern>
+                <token regexp='yes'>não|nem|nunca|jamais</token>
+                <token min='0' max='2'/>
+                <token inflected='yes'>precisar</token>
+                <token min='0' max='1' regexp='yes' inflected='yes'>&adverbios_de_intensidade;</token>
+                <token postag='VMN000.+' postag_regexp='yes'/>
+                <example>Ela nem precisou chegar perto.</example>
+                <example>Os documentos nunca precisaram ser alterados.</example>
+                <example>Não preciso explicar tudo outra vez.</example>
+            </antipattern>
             <pattern>
                 <marker>
                     <token postag='V.+' postag_regexp='yes' inflected='yes'>precisar</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -2733,9 +2733,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
       <rule>
           <antipattern>
-              <token postag='V.+' postag_regexp='yes'/>
+              <token case_sensitive='yes' regexp='yes'>Mia|Pedro</token>
               <token regexp='yes'>&pronomes_nao_ambiguos_pt_pt;</token>
               <token postag='VMI.+|VMS.+|VMM.+' postag_regexp='yes'/>
+              <example>Mia me olhou, sorrindo.</example>
+              <example>Pedro me mostrou o relatório.</example>
           </antipattern>
           <pattern>
               <token postag='V.+' postag_regexp='yes'>
@@ -3038,16 +3040,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
         </rule>
 
         <rule> <!-- #2b: Verb Infinitive -->
-            <antipattern>
-                <token regexp='yes'>não|nem|nunca|jamais</token>
-                <token min='0' max='2'/>
-                <token inflected='yes'>precisar</token>
-                <token min='0' max='1' regexp='yes' inflected='yes'>&adverbios_de_intensidade;</token>
-                <token postag='VMN000.+' postag_regexp='yes'/>
-                <example>Ela nem precisou chegar perto.</example>
-                <example>Os documentos nunca precisaram ser alterados.</example>
-                <example>Não preciso explicar tudo outra vez.</example>
-            </antipattern>
             <pattern>
                 <marker>
                     <token postag='V.+' postag_regexp='yes' inflected='yes'>precisar</token>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -2673,6 +2673,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
           <token regexp='yes'>&pronomes_nao_ambiguos_pt_pt;</token>
           <token postag='V.[PG].*' postag_regexp='yes'/>
       </antipattern>
+      <antipattern>
+          <token case_sensitive='yes' regexp='yes'>Mia|Pedro</token>
+          <token regexp='yes'>&pronomes_nao_ambiguos_pt_pt;</token>
+          <token postag='V.+' postag_regexp='yes'/>
+          <example>Mia me olhou, sorrindo.</example>
+      </antipattern>
       <pattern>
           <token postag='V.+' postag_regexp='yes'>
               <exception regexp='yes'>como|para|casa|nada</exception></token>


### PR DESCRIPTION
VERBO_HIFENIZADOR_VERBOS_2 incorrectly interprets some proper names as verbs because of ambiguous POS tagging. This produces invalid hyphenation suggestions.

**Solution**

Added targeted antipatterns for the ambiguous proper names Mia and Pedro to the affected subrules of VERBO_HIFENIZADOR_VERBOS_2.

The antipatterns prevent these names from being interpreted as verbs in proper name + pronoun + verb constructions, while keeping the existing hyphenation rule active for genuine verb constructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese grammar checking for sentences containing the names “Mia” or “Pedro” followed by ambiguous object pronouns and verbs.
  * Prevented these valid name-based expressions from being incorrectly processed by clitic-placement rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->