### PR TITLE
[pt] Rare verbs fix in disambiguation.xml

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
@@ -273,6 +273,7 @@ limpezazinha	limpezazinha	NCFS000
 limpezazinhas	limpezazinha	NCFP000
 mecanorrecetor	mecanorrecetor	NCMS000
 mecanorrecetores	mecanorrecetor	NCMP000
+Mia	Mia	NPCS000
 microgestão	microgestão	NCFS000
 microtom	microtom	NCMS000
 microtons	microtom	NCMP000

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/disambiguation.xml
@@ -4135,6 +4135,27 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     <disambig postag="NCMP000"/>
   </rule>
 
+  <rule id="NP_VERBO_NP_NÃO_VERBO_20260828_RARE" name="É NP.+ não V.+">
+    <pattern>
+      <marker>
+        <and>
+          <token postag_regexp='yes' postag='V.+'/>
+          <token postag_regexp='yes' postag='NP.+'/>
+        </and>
+      </marker>
+      <token regexp='yes'>lha|lhas|lhe|lhes|lho|lhos|ma|me|mo|mos|ta|tas|te|to|tos|vos</token> <!-- &pronomes_nao_ambiguos_pt_pt; -->
+      <token postag_regexp='yes' postag='V.+'/>
+    </pattern>
+    <disambig action="remove" postag="V.*"/>
+    <!--
+    Examples:
+             Pedro me olhou.
+             Asa me disse que você estava aqui.
+             Jane me perguntou se eu gostaria de cozinhar.
+             Marina me emocionou até às lágrimas.
+    -->
+  </rule>
+
   <rule id="VERBS_THIRD_PERSON_NOT_SECOND_20260511" name="These verbs aren't VMM02S0:PP1CSO00">
     <pattern>
       <marker>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
@@ -558,6 +558,7 @@ melanócito
 melanócitos
 Meta
 mg
+Mia
 microgestão
 microscopicamente
 microtom


### PR DESCRIPTION
Rare verbs fixed in disambiguator (proper names that appear as verbs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portuguese language analysis in sentences where a proper name is followed by a clitic pronoun and a verb.
  * Proper names such as “Pedro” are now less likely to be incorrectly identified as verbs.

* **Language Support**
  * Added “Mia” as a recognized Portuguese proper name.
  * “Mia” is no longer flagged as a spelling error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->