### PR TITLE
[pt-PT] Added rule to detect Brazilian:BRASILEIRISMO_GALERA

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -3395,6 +3395,26 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   <category id='REGIONALISMS_PT_PT' name='🇵🇹 Regionalismos'>
 
 
+      <rule id='BRASILEIRISMO_GALERA' name='🇵🇹🇧🇷 galera → pessoal'>
+          <!-- ChatGPT 5.6 and new disambiguator for 2026+ -->
+
+          <pattern>
+              <token skip='2' regexp='yes'>a[ií]|como|então|que</token>
+              <marker>
+                  <token>galera</token>
+              </marker>
+          </pattern>
+          <message>Brasileirismo. Em português europeu, prefira <suggestion>pessoal</suggestion>.</message>
+          <example correction='pessoal'>E aí, <marker>galera</marker>?</example>
+          <example correction='pessoal'>Como é, <marker>galera</marker>?</example>
+          <example correction='pessoal'>Como estão, <marker>galera</marker>?</example>
+          <example correction='pessoal'>Então, <marker>galera</marker>?</example>
+          <example correction='pessoal'>Que querem, <marker>galera</marker>?</example>
+          <example type='correct'>A galera atracou no porto.</example>
+          <example type='correct'>A antiga galera transportava mercadorias.</example>
+      </rule>
+
+
       <rule id='BRASILEIRISMO_ATERRISAR' name='🇵🇹🇧🇷 aterrisar → aterrar'>
           <!-- Created by Tiago F. Santos , Portuguese rule, 2017-04-12 -->
           <pattern>

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/pt-PT/grammar.xml
@@ -3395,24 +3395,43 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
   <category id='REGIONALISMS_PT_PT' name='🇵🇹 Regionalismos'>
 
 
-      <rule id='BRASILEIRISMO_GALERA' name='🇵🇹🇧🇷 galera → pessoal'>
+      <rulegroup id='BRASILEIRISMO_GALERA' name='🇵🇹🇧🇷 galera → pessoal'>
           <!-- ChatGPT 5.6 and new disambiguator for 2026+ -->
 
-          <pattern>
-              <token skip='2' regexp='yes'>a[ií]|como|então|que</token>
-              <marker>
-                  <token>galera</token>
-              </marker>
-          </pattern>
-          <message>Brasileirismo. Em português europeu, prefira <suggestion>pessoal</suggestion>.</message>
-          <example correction='pessoal'>E aí, <marker>galera</marker>?</example>
-          <example correction='pessoal'>Como é, <marker>galera</marker>?</example>
-          <example correction='pessoal'>Como estão, <marker>galera</marker>?</example>
-          <example correction='pessoal'>Então, <marker>galera</marker>?</example>
-          <example correction='pessoal'>Que querem, <marker>galera</marker>?</example>
-          <example type='correct'>A galera atracou no porto.</example>
-          <example type='correct'>A antiga galera transportava mercadorias.</example>
-      </rule>
+          <rule> <!-- #1: "aí/então, galera" -->
+              <pattern>
+                  <token regexp='yes'>a[ií]|então</token>
+                  <token postag='_PUNCT_COMMA'/>
+                  <marker>
+                      <token>galera</token>
+                  </marker>
+              </pattern>
+              <message>Brasileirismo. Em português europeu, prefira <suggestion>pessoal</suggestion>.</message>
+              <example correction='pessoal'>E aí, <marker>galera</marker>?</example>
+              <example correction='pessoal'>Então, <marker>galera</marker>?</example>
+              <example type='correct'>Aí, a galera começou a cantar.</example>
+              <example type='correct'>Então a galera saiu.</example>
+          </rule>
+
+          <rule> <!-- #2: "como/que + verbo, galera" -->
+              <pattern>
+                  <token regexp='yes'>como|que</token>
+                  <token postag='V.+' postag_regexp='yes'/>
+                  <token postag='_PUNCT_COMMA'/>
+                  <marker>
+                      <token>galera</token>
+                  </marker>
+              </pattern>
+              <message>Brasileirismo. Em português europeu, prefira <suggestion>pessoal</suggestion>.</message>
+              <example correction='pessoal'>Como é, <marker>galera</marker>?</example>
+              <example correction='pessoal'>Como estão, <marker>galera</marker>?</example>
+              <example correction='pessoal'>Que querem, <marker>galera</marker>?</example>
+              <example correction='pessoal'>Que acham, <marker>galera</marker>?</example>
+              <example type='correct'>Como a galera atracou no porto?</example>
+              <example type='correct'>Que galera é essa?</example>
+              <example type='correct'>Disse que a galera chegou.</example>
+          </rule>
+      </rulegroup>
 
 
       <rule id='BRASILEIRISMO_ATERRISAR' name='🇵🇹🇧🇷 aterrisar → aterrar'>


### PR DESCRIPTION
Added a new rule to detect Brazilian Portuguese in European Portuguese.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined the Portuguese (Portugal) grammar check for Brazilian conversational uses of “galera” in vocative expressions.
  * Improved detection for greetings and questions where “galera” follows specific conversational patterns.
  * Reduced false positives by preserving determiner-and-noun phrases and interrogative constructions that use “galera” correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->