### PR TITLE
[pt] Added AP to rule:CHEMICAL_FORMULAS_TYPOGRAPHY

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
@@ -323,6 +323,7 @@ sistémicos	sistémico	AQ0MP0
 sistêmicos	sistêmico	AQ0MP0
 smoothie	smoothie	NCMS000
 smoothies	smoothie	NCMP000
+SNS24	SNS24	NPMS000
 sossegadinha	sossegadinho	NCFS00D
 sossegadinhas	sossegadinho	NCFP00D
 sossegadinho	sossegadinho	NCMS00D

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
@@ -668,6 +668,7 @@ sinoviais
 sinovial
 smoothie
 smoothies
+SNS24
 sociopatia
 sociopatias
 solteirice

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/grammar.xml
@@ -43356,6 +43356,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
                 <example>O novo telemóvel Galaxy S9 da Samsung tem uma câmara mesmo boa.</example>
             </antipattern>
 
+            <antipattern> <!-- Serviço Nacional de Saúde 24 (Portugal) -->
+                <token case_sensitive='yes'>SNS24</token>
+                <example>Na altura liguei para o SNS24 conforme sugerido pelo Centro de Saúde.</example>
+            </antipattern>
+
             <antipattern>
                 <token regexp='yes'>BBB|CC|Y|C2C|B2C|U|V|W|PB|SiO|COP|FS|SnO</token>
                 <token regexp='yes'>\d+</token>


### PR DESCRIPTION
Added antipattern to rule, to fix false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Portuguese grammar and spelling checking to recognize the official `SNS24` service name and prevent false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->