### PR TITLE
[sv] Remove abbreviations with double meaning

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
@@ -7192,7 +7192,7 @@
 </languagerule>
 <languagerule languagerulename="Swedish">
 <rule break="no">
-<beforebreak>\b(alt|bl\.a|dvs|etc|ev|forts|inkl|fr\.o\.m|[Ff]\.d|m\.a\.o|[Oo]rig|osv|p\.g\.a|prel|[Rr]ef|resp|s\.k|st|t\.ex|[Kk]ol|[Ff]ig|[Aa]rt|[Bb]il)\.\s</beforebreak>
+<beforebreak>\b(alt|bl\.a|dvs|etc|ev|forts|inkl|fr\.o\.m|[Ff]\.d|m\.a\.o|[Oo]rig|osv|p\.g\.a|prel|[Rr]ef|resp|s\.k|st|t\.ex|[Ff]ig)\.\s</beforebreak>
 <afterbreak></afterbreak>
 </rule>
 <rule break="no">

--- a/languagetool-language-modules/sv/src/test/java/org/languagetool/tokenizers/sv/SwedishSRXSentenceTokenizerTest.java
+++ b/languagetool-language-modules/sv/src/test/java/org/languagetool/tokenizers/sv/SwedishSRXSentenceTokenizerTest.java
@@ -33,8 +33,6 @@ public class SwedishSRXSentenceTokenizerTest {
       "Den handlar om slaveriet i USA sett ur slavarnas perspektiv och bidrog starkt till att slaveriet avskaffades 1865 efter amerikanska inbördeskriget.");
     testSplit(
       "Vi kan leverera varorna alt. snabbt med expressfrakt.",
-      "Art. handlar om klimatförändringar i Norden.",
-      "Bil. innehåller mer detaljerad information.",
       "Rapporten innehåller bl.a. statistik och tabeller.",
       "Han kom sent, dvs. att mötet redan hade börjat.",
       "Vi behöver hammare, spik, etc. verktyg för arbetet.",
@@ -44,7 +42,6 @@ public class SwedishSRXSentenceTokenizerTest {
       "Berättelsen slutar med texten “forts. följer”.",
       "Avtalet gäller fr.o.m. måndag.",
       "Priset anges inkl. moms.",
-      "Kol. visar medelvärden för varje grupp.",
       "Resultatet är m.a.o. fel.",
       "Orig. version sparades i arkivet.",
       "Vi diskuterade mål, strategier, osv. detaljer.",


### PR DESCRIPTION
Removed these from the segmentation file:
- bil. — as bil may be used as the word for “car”;
- art. — as art may be used as a word meaning “species” or “type”;
- kol. — as kol may mean “coal” or “carbon” and can also occur as the abbreviation KOL for chronic obstructive pulmonary disease.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Swedish sentence segmentation now treats “kol.”, “art.”, and “bil.” as potential sentence endings instead of always keeping them attached to the following text.

* **Tests**
  * Updated Swedish sentence-tokenization coverage to reflect the revised abbreviation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->