### PR TITLE
closes-12093

### DIFF
--- a/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
+++ b/languagetool-language-modules/en/src/main/resources/org/languagetool/resource/en/hunspell/spelling.txt
@@ -333,6 +333,7 @@ ringfence
 ringfenced
 ringfences
 ringfencing
+secateurs
 server-side
 serverless
 shinbone


### PR DESCRIPTION
Fixes #12093.

Added "secateurs" to the English spelling dictionary.

## Testing

- Built the project locally
- Ran the existing tests successfully
- Rebuilt the standalone application
- Verified that "secateurs" is recognized after rebuilding

## Notes to Reviewers

This is a small dictionary update to address the missing spelling entry reported in #12093.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved English spell-checking by recognizing “secateurs” and “comfortability” as valid words.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->