### PR TITLE
sv: add missing abbreviations to sentence segmentation

### DIFF
--- a/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
+++ b/languagetool-core/src/main/resources/org/languagetool/resource/segment.srx
@@ -7207,7 +7207,7 @@
 </languagerule>
 <languagerule languagerulename="Swedish">
 <rule break="no">
-<beforebreak>\b(alt|bl\.a|dvs|etc|ev|forts|inkl|fr\.o\.m|[Ff]\.d|m\.a\.o|[Oo]rig|osv|p\.g\.a|prel|[Rr]ef|resp|s\.k|st|t\.ex|[Ff]ig)\.\s</beforebreak>
+<beforebreak>\b(alt|bl\.a|dvs|d\.v\.s|etc|ev|forts|inkl|fr\.o\.m|[Ff]\.d|kl|m\.a\.o|m\.fl|m\.m|[Oo]rig|osv|p\.g\.a|prel|[Rr]ef|resp|s\.k|st|t\.ex|t\.o\.m|[Ff]ig)\.\s</beforebreak>
 <afterbreak></afterbreak>
 </rule>
 <rule break="no">

--- a/languagetool-language-modules/sv/src/test/java/org/languagetool/tokenizers/sv/SwedishSRXSentenceTokenizerTest.java
+++ b/languagetool-language-modules/sv/src/test/java/org/languagetool/tokenizers/sv/SwedishSRXSentenceTokenizerTest.java
@@ -52,7 +52,12 @@ public class SwedishSRXSentenceTokenizerTest {
       "Han kallar sig en s.k. expert.",
       "Varje exemplar st. kostar fem kronor.",
       "Jag gillar djur, t.ex. hundar och katter.",
-      "Vi tar upp övr. frågor på nästa möte."
+      "Vi tar upp övr. frågor på nästa möte.",
+      "Vi bjuder på kaffe, te, m.fl. drycker.",
+      "Mötet varar t.o.m. fredag.",
+      "Vi träffas kl. tre.",
+      "Han tog med sig kartor, kompass, m.m. utrustning.",
+      "Det var kallt, d.v.s. under noll grader."
     );
   }
 


### PR DESCRIPTION
\`t.ex\`, \`dvs\`, and most other common Swedish abbreviations were already handled in \`segment.srx\`, but \`m.fl.\`, \`t.o.m.\`, \`kl.\`, \`m.m.\`, and the dotted \`d.v.s.\` variant were missing, causing LanguageTool to incorrectly split sentences mid-clause at those points.

Added the missing abbreviations to the existing Swedish pattern in \`segment.srx\`, and extended \`SwedishSRXSentenceTokenizerTest\` with a case for each so a regression here is caught by CI rather than only by manual inspection.

Verified locally: a sentence with an agreement-rule match on either side of "m.fl." now reports as one unsplit sentence instead of two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jkGEcuUpswgxbozN3PBLy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Swedish sentence segmentation so common abbreviations—including “kl.”, “m.fl.”, “m.m.”, “t.o.m.”, “övr.”, and “d.v.s.”—no longer incorrectly trigger sentence breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->