### PR TITLE
[pt] Added AP to rule:USAR_UTILIZAR

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/rules/pt/style.xml
@@ -4199,6 +4199,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
             <!-- Disambiguator must be improved in order to fix some of the words that appear as verbs - 2026-03-04 -->
 
             <antipattern>
+                <!-- "usar (a) força" is idiomatic, including in formal, legal, police and military contexts -->
+                <token postag='V.+' postag_regexp='yes' inflected='yes'>usar</token>
+                <token min='0' max='1'>a</token>
+                <token inflected='yes'>força</token>
+                <example>A polícia só deve usar a força quando estritamente necessário.</example>
+                <example>O agente usou força excessiva.</example>
+                <example>Não será necessário usar a força.</example>
+            </antipattern>
+
+            <antipattern>
                 <token skip='5' postag='NC.+|AQ.+' postag_regexp='yes' regexp='yes' inflected='yes'>aliança|anel|batom|bermuda|blusão|body|boné|bota|bracelete|brinco|bustiê|calça|calçado|calção|calcinha|camisa|camiseta|camisola|casaco|chapéu|chinelo|colar|corpete|creme|cueca|desodorante|desodorizante|gel|jaqueta|lente|lingerie|maquiagem|maquilhagem|meia|óculos|perfume|pulseira|relógio|roupa|saia|sandália|sapatilha|sapato|soutien|sutiã|ténis|tênis|vestido<exception regexp='yes'>calçadas?</exception></token> <!-- Lista que cobre a grande maioria dos casos -->
                 <token postag='V.+' postag_regexp='yes' inflected='yes'>usar</token>
                 <example>Para o homem, compre a bota ou o sapato que ele irá usar para ir ao trabalho.</example>


### PR DESCRIPTION
Added an antipattern to fix false positives in idiomatic expressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Portuguese style checking now recognizes the idiomatic expression “usar (a) força” and avoids incorrectly flagging it in formal, legal, police, and military contexts.
  - Coverage includes common inflected forms and example usages to improve accuracy across relevant sentence variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->