### PR TITLE
[pt] Added medical terms to added.txt and spelling.txt

### DIFF
--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
@@ -248,6 +248,10 @@ coorientação	coorientação	NCFS000
 coorientações	coorientação	NCFP000
 crioablação	crioablação	NCFS000
 default	default	NCCN000
+dermatoscopia	dermatoscopia	NCFS000
+dermatoscopias	dermatoscopia	NCFP000
+dermatoscópio	dermatoscópio	NCMP000
+dermatoscópios	dermatoscópio	NCMS000
 descontracção	descontracção	NCFS000
 descontracções	descontracção	NCFP000
 euromilhões	euromilhões	NCMN000

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/added.txt
@@ -250,8 +250,8 @@ crioablação	crioablação	NCFS000
 default	default	NCCN000
 dermatoscopia	dermatoscopia	NCFS000
 dermatoscopias	dermatoscopia	NCFP000
-dermatoscópio	dermatoscópio	NCMP000
-dermatoscópios	dermatoscópio	NCMS000
+dermatoscópio	dermatoscópio	NCMS000
+dermatoscópios	dermatoscópio	NCMP000
 descontracção	descontracção	NCFS000
 descontracções	descontracção	NCFP000
 euromilhões	euromilhões	NCMN000

--- a/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
+++ b/languagetool-language-modules/pt/src/main/resources/org/languagetool/resource/pt/spelling.txt
@@ -437,6 +437,10 @@ delusória
 delusórias
 delusório
 delusórios
+dermatoscopia
+dermatoscopias
+dermatoscópio
+dermatoscópios
 descendentemente
 deslembrança
 deslembranças


### PR DESCRIPTION
Added medical words.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added four dermatology-related Portuguese terms to spelling support: “dermatoscopia,” “dermatoscopias,” “dermatoscópio,” and “dermatoscópios.”
- **Bug Fixes**
  - Corrected grammatical number and gender tagging for “dermatoscópio” and “dermatoscópios,” improving singular and plural analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->